### PR TITLE
feat: track-aware drag selection and modal interaction fixes

### DIFF
--- a/src/components/generation/MultiTrackGenerateModal.tsx
+++ b/src/components/generation/MultiTrackGenerateModal.tsx
@@ -7,8 +7,8 @@ import { extractContextAudio } from '../../services/contextAudioExtractor';
 const VOCAL_TRACKS = new Set(['vocals', 'backing_vocals']);
 
 interface Props {
-  selectWindow: { startTime: number; endTime: number };
-  contextWindow: { startTime: number; endTime: number } | null;
+  selectWindow: { startTime: number; endTime: number; trackIds?: string[] };
+  contextWindow: { startTime: number; endTime: number; trackIds?: string[] } | null;
   onClose: () => void;
 }
 
@@ -64,18 +64,21 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
     if (rowsInitRef.current || !project) return;
     rowsInitRef.current = true;
     const sorted = [...project.tracks].sort((a, b) => a.order - b.order);
+    const preCheckedIds = selectWindow.trackIds && selectWindow.trackIds.length > 0
+      ? new Set(selectWindow.trackIds)
+      : null;
     setRows(
       sorted.map((t) => ({
         trackId: t.id,
         trackName: t.trackName,
         displayName: t.displayName,
-        checked: true,
+        checked: preCheckedIds ? preCheckedIds.has(t.id) : true,
         localDescription: t.localCaption ?? t.displayName,
         lyrics: '',
         isVocal: VOCAL_TRACKS.has(t.trackName),
       })),
     );
-  }, [project]);
+  }, [project, selectWindow.trackIds]);
 
   const [globalCaption, setGlobalCaption] = useState(() => project?.globalCaption ?? '');
   const [chunkMaskMode, setChunkMaskMode] = useState<'auto' | 'explicit'>('auto');

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -12,6 +12,44 @@ export const TRACK_INSPECTOR_HEIGHT = 220; // px — must match TrackInspector h
 
 const DRAG_THRESHOLD_PX = 4;
 
+interface DragRect { left: number; width: number; top: number; height: number }
+
+function getIntersectedTrackIds(container: HTMLElement, minY: number, maxY: number): string[] {
+  const lanes = container.querySelectorAll<HTMLElement>('[data-track-id]');
+  const cRect = container.getBoundingClientRect();
+  const ids: string[] = [];
+  for (const lane of lanes) {
+    const r = lane.getBoundingClientRect();
+    const laneTop = r.top - cRect.top + container.scrollTop;
+    const laneBot = laneTop + r.height;
+    if (laneBot > minY && laneTop < maxY) {
+      ids.push(lane.dataset.trackId!);
+    }
+  }
+  return ids;
+}
+
+function getTrackVerticalRange(
+  container: HTMLElement, trackIds: string[],
+): { top: number; height: number } | null {
+  if (trackIds.length === 0) return null;
+  const cRect = container.getBoundingClientRect();
+  let minTop = Infinity;
+  let maxBot = -Infinity;
+  const idSet = new Set(trackIds);
+  const lanes = container.querySelectorAll<HTMLElement>('[data-track-id]');
+  for (const lane of lanes) {
+    if (!idSet.has(lane.dataset.trackId!)) continue;
+    const r = lane.getBoundingClientRect();
+    const laneTop = r.top - cRect.top + container.scrollTop;
+    const laneBot = laneTop + r.height;
+    if (laneTop < minTop) minTop = laneTop;
+    if (laneBot > maxBot) maxBot = laneBot;
+  }
+  if (minTop === Infinity) return null;
+  return { top: minTop, height: maxBot - minTop };
+}
+
 export function Timeline() {
   const project = useProjectStore((s) => s.project);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
@@ -22,13 +60,10 @@ export function Timeline() {
   const setSelectWindow = useUIStore((s) => s.setSelectWindow);
   const expandedTrackId = useUIStore((s) => s.expandedTrackId);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const trackAreaRef = useRef<HTMLDivElement>(null);
 
-  // Cmd+drag live selection state (blue = context)
-  const [ctxDrag, setCtxDrag] = useState<{ left: number; width: number } | null>(null);
-  // Non-Cmd drag live selection state (orange = select)
-  const [selDrag, setSelDrag] = useState<{ left: number; width: number } | null>(null);
-  // Show multi-track modal
-  const [showMultiTrackModal, setShowMultiTrackModal] = useState(false);
+  const [ctxDrag, setCtxDrag] = useState<DragRect | null>(null);
+  const [selDrag, setSelDrag] = useState<DragRect | null>(null);
 
   const sortedTracks = project
     ? [...project.tracks].sort((a, b) => a.order - b.order)
@@ -52,29 +87,30 @@ export function Timeline() {
     [pixelsPerSecond, setPixelsPerSecond],
   );
 
-  // Drag handler (capture phase so it fires before children):
-  //   Cmd+drag  = context window (blue)
-  //   plain drag = select window (orange) — works across all track lanes
-  const handleMouseDown = useCallback(
+  const handleMouseDownCapture = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
 
-      // Skip if the click landed on a clip element (clips handle their own move/resize)
       const target = e.target as HTMLElement;
       if (target.closest?.('[data-clip-block]')) return;
+      if (target.closest?.('.fixed')) return;
 
       const isCtx = e.metaKey || e.ctrlKey;
 
       e.preventDefault();
+      e.stopPropagation();
 
       const container = scrollRef.current;
-      if (!container) return;
+      const trackArea = trackAreaRef.current;
+      if (!container || !trackArea) return;
 
       const bpm = project?.bpm ?? 120;
       const scrollLeft = container.scrollLeft;
-      const rect = container.getBoundingClientRect();
+      const cRect = container.getBoundingClientRect();
       const startClientX = e.clientX;
-      const startViewX = startClientX - rect.left;
+      const startClientY = e.clientY;
+      const startViewX = startClientX - cRect.left;
+      const startViewY = startClientY - cRect.top + container.scrollTop;
 
       let hasDragged = false;
       const setDrag = isCtx ? setCtxDrag : setSelDrag;
@@ -84,10 +120,22 @@ export function Timeline() {
         if (!hasDragged && Math.abs(dx) < DRAG_THRESHOLD_PX) return;
         hasDragged = true;
 
-        const curViewX = ev.clientX - rect.left;
+        const curViewX = ev.clientX - cRect.left;
+        const curViewY = ev.clientY - cRect.top + container.scrollTop;
+
         const left = Math.min(startViewX, curViewX) + scrollLeft;
         const width = Math.abs(curViewX - startViewX);
-        setDrag({ left, width });
+
+        const minY = Math.min(startViewY, curViewY);
+        const maxY = Math.max(startViewY, curViewY);
+        const vRange = getTrackVerticalRange(
+          container, getIntersectedTrackIds(container, minY, maxY),
+        );
+        const trackAreaTop = trackArea.getBoundingClientRect().top - cRect.top + container.scrollTop;
+        const top = vRange ? vRange.top - trackAreaTop : minY - trackAreaTop;
+        const height = vRange ? vRange.height : maxY - minY;
+
+        setDrag({ left, width, top, height });
       };
 
       const onMouseUp = (ev: MouseEvent) => {
@@ -99,21 +147,25 @@ export function Timeline() {
           return;
         }
 
-        const endViewX = ev.clientX - rect.left;
+        const endViewX = ev.clientX - cRect.left;
+        const endViewY = ev.clientY - cRect.top + container.scrollTop;
+
         const leftPx = Math.min(startViewX, endViewX) + scrollLeft;
         const rightPx = Math.max(startViewX, endViewX) + scrollLeft;
+        const minY = Math.min(startViewY, endViewY);
+        const maxY = Math.max(startViewY, endViewY);
 
         const rawStart = leftPx / pixelsPerSecond;
         const rawEnd = rightPx / pixelsPerSecond;
         const startTime = Math.max(0, snapToGrid(rawStart, bpm, 1));
         const endTime = snapToGrid(rawEnd, bpm, 1);
+        const trackIds = getIntersectedTrackIds(container, minY, maxY);
 
-        if (endTime > startTime) {
+        if (endTime > startTime && trackIds.length > 0) {
           if (isCtx) {
-            setContextWindow({ startTime, endTime });
+            setContextWindow({ startTime, endTime, trackIds });
           } else {
-            setSelectWindow({ startTime, endTime });
-            setShowMultiTrackModal(true);
+            setSelectWindow({ startTime, endTime, trackIds });
           }
         }
         setDrag(null);
@@ -134,140 +186,166 @@ export function Timeline() {
     );
   }
 
-  // Context window pixels (for the persistent overlay once committed)
   const ctxLeft = contextWindow ? contextWindow.startTime * pixelsPerSecond : null;
   const ctxWidth = contextWindow
     ? (contextWindow.endTime - contextWindow.startTime) * pixelsPerSecond
     : null;
+  const ctxVRange = contextWindow && scrollRef.current && trackAreaRef.current
+    ? (() => {
+        const vr = getTrackVerticalRange(scrollRef.current!, contextWindow.trackIds);
+        if (!vr) return null;
+        const cRect = scrollRef.current!.getBoundingClientRect();
+        const taTop = trackAreaRef.current!.getBoundingClientRect().top - cRect.top + scrollRef.current!.scrollTop;
+        return { top: vr.top - taTop, height: vr.height };
+      })()
+    : null;
 
-  // Select window pixels (for the persistent overlay once committed)
   const selLeft = selectWindow ? selectWindow.startTime * pixelsPerSecond : null;
   const selWidth = selectWindow
     ? (selectWindow.endTime - selectWindow.startTime) * pixelsPerSecond
     : null;
-
-  // Live drag overlay pixels (relative to scroll container viewport)
-  const dragLeft = ctxDrag ? ctxDrag.left : null;
-  const dragWidth = ctxDrag ? ctxDrag.width : null;
-  const selDragLeft = selDrag ? selDrag.left : null;
-  const selDragWidth = selDrag ? selDrag.width : null;
+  const selVRange = selectWindow && scrollRef.current && trackAreaRef.current
+    ? (() => {
+        const vr = getTrackVerticalRange(scrollRef.current!, selectWindow.trackIds);
+        if (!vr) return null;
+        const cRect = scrollRef.current!.getBoundingClientRect();
+        const taTop = trackAreaRef.current!.getBoundingClientRect().top - cRect.top + scrollRef.current!.scrollTop;
+        return { top: vr.top - taTop, height: vr.height };
+      })()
+    : null;
 
   return (
-    <div
-      ref={scrollRef}
-      className="flex-1 overflow-auto bg-daw-bg"
-      onWheel={handleWheel}
-      onMouseDownCapture={handleMouseDown}
-      style={{ cursor: 'default' }}
-    >
-      <div className="relative" style={{ width: totalWidth, minWidth: '100%' }}>
-        <TimeRuler />
+    <>
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-auto bg-daw-bg"
+        onWheel={handleWheel}
+        onMouseDownCapture={handleMouseDownCapture}
+        style={{ cursor: 'default' }}
+      >
+        <div className="relative" style={{ width: totalWidth, minWidth: '100%' }}>
+          <TimeRuler />
 
-        <div className="relative">
-          <GridOverlay />
-          <Playhead />
+          <div ref={trackAreaRef} className="relative">
+            <GridOverlay />
+            <Playhead />
 
-          {/* Committed context window overlay — spans all track lanes */}
-          {ctxLeft !== null && ctxWidth !== null && (
-            <div
-              className="absolute top-0 bottom-0 pointer-events-none z-10"
-              style={{
-                left: ctxLeft,
-                width: ctxWidth,
-                background: 'rgba(59, 130, 246, 0.10)',
-                borderLeft: '2px solid rgba(96, 165, 250, 0.7)',
-                borderRight: '2px solid rgba(96, 165, 250, 0.7)',
-              }}
-            >
-              <span
-                className="absolute top-0.5 left-1 text-[9px] font-mono text-blue-300 select-none"
-                style={{ background: 'rgba(30,30,50,0.7)', padding: '0 3px', borderRadius: 3 }}
+            {/* Committed context window overlay — scoped to selected track lanes */}
+            {ctxLeft !== null && ctxWidth !== null && ctxVRange && (
+              <div
+                className="absolute pointer-events-none z-10"
+                style={{
+                  left: ctxLeft,
+                  width: ctxWidth,
+                  top: ctxVRange.top,
+                  height: ctxVRange.height,
+                  background: 'rgba(59, 130, 246, 0.10)',
+                  borderLeft: '2px solid rgba(96, 165, 250, 0.7)',
+                  borderRight: '2px solid rgba(96, 165, 250, 0.7)',
+                  borderTop: '2px solid rgba(96, 165, 250, 0.4)',
+                  borderBottom: '2px solid rgba(96, 165, 250, 0.4)',
+                }}
               >
-                context window
-              </span>
-            </div>
-          )}
+                <span
+                  className="absolute top-0.5 left-1 text-[9px] font-mono text-blue-300 select-none"
+                  style={{ background: 'rgba(30,30,50,0.7)', padding: '0 3px', borderRadius: 3 }}
+                >
+                  context window
+                </span>
+              </div>
+            )}
 
-          {/* Committed select window overlay — spans all track lanes (orange) */}
-          {selLeft !== null && selWidth !== null && (
-            <div
-              className="absolute top-0 bottom-0 pointer-events-none z-10"
-              style={{
-                left: selLeft,
-                width: selWidth,
-                background: 'rgba(251, 146, 60, 0.10)',
-                borderLeft: '2px solid rgba(251, 146, 60, 0.7)',
-                borderRight: '2px solid rgba(251, 146, 60, 0.7)',
-              }}
-            >
-              <span
-                className="absolute top-0.5 right-1 text-[9px] font-mono text-orange-300 select-none"
-                style={{ background: 'rgba(30,30,50,0.7)', padding: '0 3px', borderRadius: 3 }}
+            {/* Committed select window overlay — scoped to selected track lanes */}
+            {selLeft !== null && selWidth !== null && selVRange && (
+              <div
+                className="absolute pointer-events-none z-10"
+                style={{
+                  left: selLeft,
+                  width: selWidth,
+                  top: selVRange.top,
+                  height: selVRange.height,
+                  background: 'rgba(251, 146, 60, 0.10)',
+                  borderLeft: '2px solid rgba(251, 146, 60, 0.7)',
+                  borderRight: '2px solid rgba(251, 146, 60, 0.7)',
+                  borderTop: '2px solid rgba(251, 146, 60, 0.4)',
+                  borderBottom: '2px solid rgba(251, 146, 60, 0.4)',
+                }}
               >
-                select window
-              </span>
-            </div>
-          )}
+                <span
+                  className="absolute top-0.5 right-1 text-[9px] font-mono text-orange-300 select-none"
+                  style={{ background: 'rgba(30,30,50,0.7)', padding: '0 3px', borderRadius: 3 }}
+                >
+                  select window
+                </span>
+              </div>
+            )}
 
-          {/* Live context drag overlay (blue) */}
-          {dragLeft !== null && dragWidth !== null && (
-            <div
-              className="absolute top-0 bottom-0 pointer-events-none z-10"
-              style={{
-                left: dragLeft,
-                width: dragWidth,
-                background: 'rgba(59, 130, 246, 0.15)',
-                borderLeft: '1px solid rgba(96, 165, 250, 0.5)',
-                borderRight: '1px solid rgba(96, 165, 250, 0.5)',
-              }}
-            />
-          )}
+            {/* Live context drag overlay (blue) — vertically scoped */}
+            {ctxDrag && (
+              <div
+                className="absolute pointer-events-none z-10"
+                style={{
+                  left: ctxDrag.left,
+                  width: ctxDrag.width,
+                  top: ctxDrag.top,
+                  height: ctxDrag.height,
+                  background: 'rgba(59, 130, 246, 0.15)',
+                  borderLeft: '1px solid rgba(96, 165, 250, 0.5)',
+                  borderRight: '1px solid rgba(96, 165, 250, 0.5)',
+                  borderTop: '1px solid rgba(96, 165, 250, 0.3)',
+                  borderBottom: '1px solid rgba(96, 165, 250, 0.3)',
+                }}
+              />
+            )}
 
-          {/* Live select drag overlay (orange) */}
-          {selDragLeft !== null && selDragWidth !== null && (
-            <div
-              className="absolute top-0 bottom-0 pointer-events-none z-10"
-              style={{
-                left: selDragLeft,
-                width: selDragWidth,
-                background: 'rgba(251, 146, 60, 0.15)',
-                borderLeft: '1px solid rgba(251, 146, 60, 0.5)',
-                borderRight: '1px solid rgba(251, 146, 60, 0.5)',
-              }}
-            />
-          )}
+            {/* Live select drag overlay (orange) — vertically scoped */}
+            {selDrag && (
+              <div
+                className="absolute pointer-events-none z-10"
+                style={{
+                  left: selDrag.left,
+                  width: selDrag.width,
+                  top: selDrag.top,
+                  height: selDrag.height,
+                  background: 'rgba(251, 146, 60, 0.15)',
+                  borderLeft: '1px solid rgba(251, 146, 60, 0.5)',
+                  borderRight: '1px solid rgba(251, 146, 60, 0.5)',
+                  borderTop: '1px solid rgba(251, 146, 60, 0.3)',
+                  borderBottom: '1px solid rgba(251, 146, 60, 0.3)',
+                }}
+              />
+            )}
 
-          {sortedTracks.map((track) => (
-            <div key={track.id}>
-              <TrackLane track={track} />
-              {expandedTrackId === track.id && (
-                <div
-                  className="border-b border-daw-border bg-zinc-950/60"
-                  style={{ height: TRACK_INSPECTOR_HEIGHT }}
-                />
-              )}
-            </div>
-          ))}
+            {sortedTracks.map((track) => (
+              <div key={track.id}>
+                <TrackLane track={track} />
+                {expandedTrackId === track.id && (
+                  <div
+                    className="border-b border-daw-border bg-zinc-950/60"
+                    style={{ height: TRACK_INSPECTOR_HEIGHT }}
+                  />
+                )}
+              </div>
+            ))}
 
-          {sortedTracks.length === 0 && (
-            <div className="flex items-center justify-center h-32 text-zinc-600 text-xs">
-              Add a track to begin
-            </div>
-          )}
+            {sortedTracks.length === 0 && (
+              <div className="flex items-center justify-center h-32 text-zinc-600 text-xs">
+                Add a track to begin
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
-      {/* Multi-track generation modal — opens after select window drag */}
-      {showMultiTrackModal && selectWindow && (
+      {selectWindow && (
         <MultiTrackGenerateModal
           selectWindow={selectWindow}
           contextWindow={contextWindow}
           onClose={() => {
-            setShowMultiTrackModal(false);
             setSelectWindow(null);
           }}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -50,8 +50,6 @@ function LaneContextMenu({ x, y, onAddLayer, onClose }: LaneContextMenuProps) {
 // TrackLane
 // ─────────────────────────────────────────────────────────────────────────────
 
-const DRAG_THRESHOLD_PX = 6;
-
 export function TrackLane({ track }: TrackLaneProps) {
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const contextWindow = useUIStore((s) => s.contextWindow);
@@ -110,10 +108,6 @@ export function TrackLane({ track }: TrackLaneProps) {
     setAddLayerTarget(null);
   }, [pixelsPerSecond, project.bpm, project.totalDuration, hitsClip]);
 
-  // Drag-select is now handled globally by Timeline (capture phase) so that
-  // drags in any direction work across multiple track lanes. TrackLane no
-  // longer needs its own drag-select handler.
-
   const clearSel = useCallback(() => {
     setAddLayerTarget(null);
   }, []);
@@ -121,6 +115,7 @@ export function TrackLane({ track }: TrackLaneProps) {
   return (
     <>
       <div
+        data-track-id={track.id}
         className="relative h-16 border-b border-daw-border"
         style={{ width: totalWidth }}
         onContextMenu={handleContextMenu}

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -19,9 +19,9 @@ interface UIState {
   showMixer: boolean;
   mixerHeight: number;
   /** Global context window set by Cmd+drag on the timeline. */
-  contextWindow: { startTime: number; endTime: number } | null;
+  contextWindow: { startTime: number; endTime: number; trackIds: string[] } | null;
   /** Multi-track select window set by non-Cmd drag on the timeline. */
-  selectWindow: { startTime: number; endTime: number } | null;
+  selectWindow: { startTime: number; endTime: number; trackIds: string[] } | null;
   /** Track whose inspector panel is currently expanded. */
   expandedTrackId: string | null;
 
@@ -43,8 +43,8 @@ interface UIState {
   setShowKeyboardShortcutsDialog: (v: boolean) => void;
   setShowMixer: (v: boolean) => void;
   setMixerHeight: (v: number) => void;
-  setContextWindow: (v: { startTime: number; endTime: number } | null) => void;
-  setSelectWindow: (v: { startTime: number; endTime: number } | null) => void;
+  setContextWindow: (v: { startTime: number; endTime: number; trackIds: string[] } | null) => void;
+  setSelectWindow: (v: { startTime: number; endTime: number; trackIds: string[] } | null) => void;
   setExpandedTrackId: (id: string | null) => void;
 }
 


### PR DESCRIPTION
## Summary

- **Track-aware drag selection**: Both Cmd+drag (context window) and plain drag (select window) now track the Y-axis during drags, computing which track lanes the cursor covers. Overlays are rendered scoped to the exact vertical range of matched tracks, enabling single-track and multi-track selection in both modes and both drag directions.
- **Modal interaction fixes**: Moved `MultiTrackGenerateModal` outside the Timeline scroll container so the capture-phase drag handler no longer intercepts clicks inside the modal. This fixes two bugs: (1) textarea/input focus was broken (couldn't edit track descriptions, global caption, lyrics, or seed), and (2) clicking the timeline diagram caused the context/select windows to jump.
- **Pre-check UX**: The Generate Tracks modal now pre-checks only the tracks that were dragged over (via `selectWindow.trackIds`), instead of checking all tracks by default.

## Changes

- `uiStore.ts`: Added `trackIds: string[]` to `contextWindow` and `selectWindow` types
- `TrackLane.tsx`: Added `data-track-id` attribute for DOM-based lane detection
- `Timeline.tsx`: Y-axis tracking in drag handler, vertically-scoped overlays, modal moved outside scroll container, `.fixed` guard in capture handler
- `MultiTrackGenerateModal.tsx`: Updated Props to accept `trackIds`, pre-check logic uses `selectWindow.trackIds`

## Test plan

- [ ] Cmd+drag on a single track lane creates a context window scoped to that lane only
- [ ] Cmd+drag across 2-3 lanes creates a context window spanning those lanes
- [ ] Plain drag on a single track lane creates a select window scoped to that lane, opens Generate Tracks modal with that track pre-checked
- [ ] Plain drag across multiple lanes creates a select window spanning those lanes, modal pre-checks only covered tracks
- [ ] Dragging in any direction (top-left to bottom-right, bottom-right to top-left) works correctly
- [ ] In the Generate Tracks modal: can edit track descriptions, global caption, lyrics, and seed
- [ ] In the Generate Tracks modal: the timeline diagram does not cause window jumping
- [ ] Escape key still clears select window, then context window

Made with [Cursor](https://cursor.com)