### PR TITLE
feat: track-aware drag selection, modal fixes, and audio isolation fix

### DIFF
--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -3,7 +3,6 @@ import { useTransportStore } from '../store/transportStore';
 import { useProjectStore } from '../store/projectStore';
 import { getAudioEngine } from './useAudioEngine';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
-import { isolateTrackAudio } from '../engine/waveSubtraction';
 
 /**
  * Trim an AudioBuffer to a specific project-time region.
@@ -58,26 +57,7 @@ export function useTransport() {
     }
     const clipBuffers: ScheduleEntry[] = [];
 
-    // -----------------------------------------------------------------------
-    // On-the-fly isolation in DESC generation order
-    //
-    // Sort tracks by order DESC (mirrors the batch-generation order: the
-    // highest-order track was generated FIRST from silence; each subsequent
-    // lower-order track was generated with the previous cumulative as context).
-    //
-    // Chain:
-    //   Track N (order=2, generated 1st): isolated = cumulative_N - null        = track N audio
-    //   Track N-1 (order=1, generated 2nd): isolated = cumulative_N-1 - cumulative_N = track N-1 audio
-    //
-    // Example: guitar(order=2) + drums(order=1), generated in context mode:
-    //   guitar cumulative = guitar only     → isolated = guitar - null = guitar  ✓
-    //   drums  cumulative = guitar + drums  → isolated = (guitar+drums) - guitar = drums  ✓
-    // -----------------------------------------------------------------------
-    const tracksDesc = [...proj.tracks].sort((a, b) => b.order - a.order);
-    let previousCumBuffer: AudioBuffer | null = null;
-
-    for (const track of tracksDesc) {
-      // Sync channel-strip params to the TrackNode
+    for (const track of proj.tracks) {
       const trackNode = engine.getOrCreateTrackNode(track.id);
       trackNode.volume = track.volume;
       trackNode.muted = track.muted;
@@ -94,42 +74,35 @@ export function useTransport() {
       trackNode.setReverb(track.reverbMix ?? 0, track.reverbRoomSize ?? 0.5);
 
       for (const clip of track.clips) {
-        if (clip.generationStatus !== 'ready' || !clip.cumulativeMixKey) continue;
+        if (clip.generationStatus !== 'ready') continue;
 
-        const cumBlob = await loadAudioBlobByKey(clip.cumulativeMixKey);
-        if (!cumBlob) continue;
+        // Try isolated audio first (pre-trimmed to clip region at generation),
+        // fall back to cumulative mix (full project-length, needs trimming).
+        let blob: Blob | undefined;
+        let alreadyTrimmed = false;
 
-        const cumBuffer = await engine.decodeAudioData(cumBlob);
+        if (clip.isolatedAudioKey) {
+          blob = await loadAudioBlobByKey(clip.isolatedAudioKey);
+          if (blob) alreadyTrimmed = true;
+        }
+        if (!blob && clip.cumulativeMixKey) {
+          blob = await loadAudioBlobByKey(clip.cumulativeMixKey);
+        }
+        if (!blob) continue;
 
-        // Compute isolated audio on the fly.
-        //
-        // If the clip was generated FROM CONTEXT, its cumulativeMixKey is a
-        // cumulative mix (this track + all previously generated tracks), so we
-        // must subtract the previous cumulative to isolate just this track.
-        //
-        // If the clip was generated FROM SILENCE, its cumulativeMixKey contains
-        // ONLY this track's own audio.  Subtracting the previous buffer would
-        // corrupt it (adds inverted audio from another track), so use it directly.
-        const fullIsolated = (clip.generatedFromContext && previousCumBuffer !== null)
-          ? isolateTrackAudio(engine.ctx, cumBuffer, previousCumBuffer)
-          : cumBuffer;
-
-        // Trim the full-project-length isolated buffer to just the clip region.
-        const clipStart = clip.startTime;
-        const clipDur = clip.duration;
-        const trimmed = trimBuffer(engine.ctx, fullIsolated, clipStart, clipDur);
+        const rawBuffer = await engine.decodeAudioData(blob);
+        const buffer = alreadyTrimmed
+          ? rawBuffer
+          : trimBuffer(engine.ctx, rawBuffer, clip.startTime, clip.duration);
 
         clipBuffers.push({
           clipId: clip.id,
           trackId: track.id,
-          startTime: clipStart,
-          buffer: trimmed,
+          startTime: clip.startTime,
+          buffer,
           audioOffset: 0,
-          clipDuration: clipDur,
+          clipDuration: clip.duration,
         });
-
-        // This track's cumulative becomes the "previous" for the next (lower-order) track
-        previousCumBuffer = cumBuffer;
       }
     }
 

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -551,6 +551,12 @@ export async function generateFromAddLayer(opts: AddLayerOptions): Promise<void>
       lyrics: opts.lyrics,
     });
 
+    // Sync local description to the track-level localCaption so the
+    // TrackInspector reflects it
+    if (opts.localDescription) {
+      store.setTrackLocalCaption(opts.trackId, opts.localDescription);
+    }
+
     let contextBlob: Blob | null = null;
 
     if (opts.contextWindow) {
@@ -620,6 +626,9 @@ export async function generateFromMultiTrack(opts: MultiTrackGenerateOptions): P
         globalCaption: opts.globalCaption,
         lyrics: entry.lyrics,
       });
+      if (entry.localDescription) {
+        store.setTrackLocalCaption(entry.trackId, entry.localDescription);
+      }
       batchTracks.push({
         clipId: clip.id,
         localDescription: entry.localDescription,


### PR DESCRIPTION
## Summary

- **Track-aware drag selection**: Both Cmd+drag (context window) and non-Cmd drag (select window) now track Y-axis position to determine which track lanes are spanned, enabling both single-track and multi-track selections. Overlays render with correct vertical scoping based on selected track IDs.
- **Modal interaction fixes**: Moved `MultiTrackGenerateModal` outside the Timeline scroll container so `onMouseDownCapture` no longer intercepts modal events. Added `.fixed` class guard for defense-in-depth. Fixes thumbnail drag and input editing in the Generate Tracks modal.
- **Audio isolation fix**: Replaced broken on-the-fly wave subtraction (which chained a single `previousCumBuffer` across unrelated tracks, corrupting solo/mute) with pre-computed `isolatedAudioKey` lookup per clip, falling back to `cumulativeMixKey`. Correctly handles trim: isolated blobs are already trimmed, cumulative blobs need `trimBuffer`.
- **Local caption sync**: Generation now syncs the local description to the track-level `localCaption` so the TrackInspector panel reflects it.

## Test plan

- [ ] Create multiple tracks, use Cmd+drag to select a context window spanning 2+ tracks
- [ ] Use non-Cmd drag to select a single-track select window within the context
- [ ] Use non-Cmd drag to select a multi-track select window
- [ ] Verify the Generate Tracks modal allows dragging context/select thumbnails and editing per-track descriptions
- [ ] Generate a single track from silence and verify playback produces sound
- [ ] Generate multiple tracks from context and verify solo/mute work correctly (soloing one track should silence others)
- [ ] Enter a local description during generation and verify it appears in the TrackInspector LOCAL CAPTION field


Made with [Cursor](https://cursor.com)