### PR TITLE
fix: remove wave subtraction, use backend output directly as isolated track

### DIFF
--- a/src/services/contextAudioExtractor.ts
+++ b/src/services/contextAudioExtractor.ts
@@ -7,7 +7,6 @@
  */
 import { useProjectStore } from '../store/projectStore';
 import { loadAudioBlobByKey } from './audioFileManager';
-import { isolateTrackAudio } from '../engine/waveSubtraction';
 import { audioBufferToWavBlob } from '../utils/wav';
 
 export interface ContextWindow {
@@ -31,79 +30,81 @@ export async function extractContextAudio(ctx: ContextWindow): Promise<Blob | nu
   const ctxDuration = ctxEnd - ctxStart;
   if (ctxDuration <= 0) return null;
 
-  // Use an OfflineAudioContext so we don't need a live AudioContext
   const sampleRate = 48000;
   const frameLength = Math.ceil(ctxDuration * sampleRate);
   const offlineCtx = new OfflineAudioContext(2, frameLength, sampleRate);
 
-  // Sort tracks DESC by order (mirrors playback isolation order)
-  const tracksDesc = [...project.tracks].sort((a, b) => b.order - a.order);
-
-  // Determine which tracks are effectively audible (respect mute/solo just like playback)
   const soloActive = project.tracks.some((t) => t.soloed);
 
   let anyScheduled = false;
-  let previousCumBuffer: AudioBuffer | null = null;
 
-  for (const track of tracksDesc) {
-    // Whether this track's audio should be included in the final mix
+  for (const track of project.tracks) {
     const isAudible = !track.muted && (!soloActive || track.soloed);
+    if (!isAudible) continue;
 
     for (const clip of track.clips) {
-      if (clip.generationStatus !== 'ready' || !clip.cumulativeMixKey) continue;
+      if (clip.generationStatus !== 'ready') continue;
 
-      // Only include clips that overlap the context window
       const clipEnd = clip.startTime + clip.duration;
       if (clip.startTime >= ctxEnd || clipEnd <= ctxStart) continue;
 
-      const cumBlob = await loadAudioBlobByKey(clip.cumulativeMixKey);
-      if (!cumBlob) continue;
+      // Prefer isolatedAudioKey (pre-trimmed to clip region at generation),
+      // fall back to cumulativeMixKey (full project-length).
+      let blob: Blob | undefined;
+      let alreadyTrimmed = false;
 
-      const arrayBuffer = await cumBlob.arrayBuffer();
-      const cumBuffer = await offlineCtx.decodeAudioData(arrayBuffer);
+      if (clip.isolatedAudioKey) {
+        blob = await loadAudioBlobByKey(clip.isolatedAudioKey);
+        if (blob) alreadyTrimmed = true;
+      }
+      if (!blob && clip.cumulativeMixKey) {
+        blob = await loadAudioBlobByKey(clip.cumulativeMixKey);
+      }
+      if (!blob) continue;
 
-      // Isolate this track's contribution using the same DESC-chain logic as playback.
-      // We always compute the isolation to keep `previousCumBuffer` advancing correctly,
-      // even for muted/non-soloed tracks. We just don't schedule their audio output.
-      const fullIsolated = (clip.generatedFromContext && previousCumBuffer !== null)
-        ? isolateTrackAudio(offlineCtx, cumBuffer, previousCumBuffer)
-        : cumBuffer;
+      const arrayBuffer = await blob.arrayBuffer();
+      const buffer = await offlineCtx.decodeAudioData(arrayBuffer);
 
-      previousCumBuffer = cumBuffer;
+      // Compute the overlap between this clip and the context window.
+      // isolatedAudioKey buffers start at sample 0 = clip.startTime;
+      // cumulativeMixKey buffers start at sample 0 = project time 0.
+      const overlapStart = Math.max(clip.startTime, ctxStart);
+      const overlapEnd = Math.min(clipEnd, ctxEnd);
+      if (overlapEnd <= overlapStart) continue;
 
-      // Skip scheduling if the track is muted or silenced by solo
-      if (!isAudible) continue;
+      let srcStartSample: number;
+      let srcEndSample: number;
+      if (alreadyTrimmed) {
+        srcStartSample = Math.floor((overlapStart - clip.startTime) * sampleRate);
+        srcEndSample = Math.min(
+          Math.floor((overlapEnd - clip.startTime) * sampleRate),
+          buffer.length,
+        );
+      } else {
+        srcStartSample = Math.floor(overlapStart * sampleRate);
+        srcEndSample = Math.min(
+          Math.floor(overlapEnd * sampleRate),
+          buffer.length,
+        );
+      }
+      if (srcEndSample <= srcStartSample) continue;
 
-      // The isolated buffer covers the full project duration from time 0.
-      // We need to crop it to the context window range [ctxStart, ctxEnd].
-      const sr = fullIsolated.sampleRate;
-      const bufferStartSample = Math.floor(ctxStart * sr);
-      const bufferEndSample = Math.min(
-        Math.floor(ctxEnd * sr),
-        fullIsolated.length,
-      );
-      if (bufferEndSample <= bufferStartSample) continue;
-
-      const cropLength = bufferEndSample - bufferStartSample;
-      const cropped = offlineCtx.createBuffer(
-        fullIsolated.numberOfChannels,
-        cropLength,
-        sr,
-      );
-      for (let ch = 0; ch < fullIsolated.numberOfChannels; ch++) {
-        const src = fullIsolated.getChannelData(ch);
+      const cropLength = srcEndSample - srcStartSample;
+      const cropped = offlineCtx.createBuffer(buffer.numberOfChannels, cropLength, sampleRate);
+      for (let ch = 0; ch < buffer.numberOfChannels; ch++) {
+        const src = buffer.getChannelData(ch);
         const dst = cropped.getChannelData(ch);
         for (let i = 0; i < cropLength; i++) {
-          dst[i] = src[bufferStartSample + i] ?? 0;
+          dst[i] = src[srcStartSample + i] ?? 0;
         }
       }
 
-      // Schedule this clip's contribution at time 0 in the offline render
-      // (the crop already aligns it to start at 0)
+      // Schedule at the correct offset within the context window
+      const scheduleTime = overlapStart - ctxStart;
       const source = offlineCtx.createBufferSource();
       source.buffer = cropped;
       source.connect(offlineCtx.destination);
-      source.start(0);
+      source.start(scheduleTime);
       anyScheduled = true;
     }
   }

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -7,7 +7,6 @@ import * as api from './aceStepApi';
 import { generateSilenceWav } from './silenceGenerator';
 import { saveAudioBlob, loadAudioBlobByKey } from './audioFileManager';
 import { getAudioEngine } from '../hooks/useAudioEngine';
-import { isolateTrackAudio } from '../engine/waveSubtraction';
 import { audioBufferToWavBlob } from '../utils/wav';
 import { computeWaveformPeaks } from '../utils/waveformPeaks';
 import { POLL_INTERVAL_MS, MAX_POLL_DURATION_MS } from '../constants/defaults';
@@ -340,38 +339,32 @@ async function generateClipInternal(
     // Store cumulative mix
     const cumulativeKey = await saveAudioBlob(project.id, clipId, 'cumulative', cumulativeBlob);
 
-    // Wave subtraction: isolate this track
+    // The backend output contains the isolated track in the generation region
+    // (repainting_start to repainting_end) and the original context mix outside
+    // it.  Since clipStart/clipDuration match the generation region, trimming to
+    // the clip region extracts exactly the isolated track -- no wave subtraction
+    // needed.
     const engine = getAudioEngine();
-    const cumulativeBuffer = await engine.decodeAudioData(cumulativeBlob);
+    const fullBuffer = await engine.decodeAudioData(cumulativeBlob);
 
-    let previousBuffer: AudioBuffer | null = null;
-    if (previousCumulativeBlob) {
-      previousBuffer = await engine.decodeAudioData(previousCumulativeBlob);
-    }
-
-    const fullIsolatedBuffer = isolateTrackAudio(engine.ctx, cumulativeBuffer, previousBuffer);
-
-    // Re-read clip from store in case the user moved/resized it during generation
     const currentClip = useProjectStore.getState().getClipById(clipId);
     const clipStart = currentClip?.startTime ?? clip.startTime;
     const clipDuration = currentClip?.duration ?? clip.duration;
 
-    // Trim isolated audio to just the clip's time region so the buffer
-    // represents only the clip's audio (not the full project duration).
-    const sampleRate = fullIsolatedBuffer.sampleRate;
+    const sampleRate = fullBuffer.sampleRate;
     const startSample = Math.floor(clipStart * sampleRate);
     const endSample = Math.min(
       Math.floor((clipStart + clipDuration) * sampleRate),
-      fullIsolatedBuffer.length,
+      fullBuffer.length,
     );
     const trimmedLength = Math.max(1, endSample - startSample);
     const trimmedBuffer = engine.ctx.createBuffer(
-      fullIsolatedBuffer.numberOfChannels,
+      fullBuffer.numberOfChannels,
       trimmedLength,
       sampleRate,
     );
-    for (let ch = 0; ch < fullIsolatedBuffer.numberOfChannels; ch++) {
-      const src = fullIsolatedBuffer.getChannelData(ch);
+    for (let ch = 0; ch < fullBuffer.numberOfChannels; ch++) {
+      const src = fullBuffer.getChannelData(ch);
       const dst = trimmedBuffer.getChannelData(ch);
       for (let i = 0; i < trimmedLength; i++) {
         dst[i] = src[startSample + i];


### PR DESCRIPTION
## Summary

- The model is trained to predict the **isolated track** (not a cumulative mix). The backend's `repaint_waveform_splice` puts the original context mix in non-repaint regions and the model's isolated prediction in the repaint region.
- Trimming to `[clipStart, clipDuration]` (which matches the repaint region) extracts the pure isolated track directly -- no wave subtraction needed.
- The previous wave subtraction (`output - previousCumulative`) was corrupting the repaint region by subtracting context audio from a signal that only contained the isolated track, causing context audio to bleed into soloed tracks.

### Changes
- **generationPipeline.ts**: Remove `isolateTrackAudio` import and call; trim backend output to clip region directly as isolated audio
- **contextAudioExtractor.ts**: Use `isolatedAudioKey` (pre-trimmed) directly instead of re-doing broken wave subtraction chain across tracks

## Test plan

- [ ] Generate a track from context (e.g., vocals over drums), solo the new track -- should hear only the new instrument, no context bleed
- [ ] Generate from silence -- should play correctly as before
- [ ] Use "from context" multi-track generation -- each track should be properly isolated
- [ ] Verify context audio preview in AddLayerModal still works

Made with [Cursor](https://cursor.com)