### PR TITLE
feat: DAW layout redesign with docked panels, resizable tracks, and cross-track drag

### DIFF
--- a/src/components/assets/AssetsPanel.tsx
+++ b/src/components/assets/AssetsPanel.tsx
@@ -1,0 +1,200 @@
+import { useState, useMemo, useCallback, useRef } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import type { Clip, Track } from '../../types/project';
+
+
+type Tab = 'starred' | 'generated' | 'uploaded';
+
+interface AssetEntry {
+  clip: Clip;
+  track: Track;
+}
+
+function MiniWaveform({ peaks, color }: { peaks: number[] | null; color: string }) {
+  if (!peaks || peaks.length === 0) return <div className="w-full h-full bg-zinc-800 rounded-sm" />;
+  const w = 60;
+  const h = 20;
+  const step = w / peaks.length;
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" className="rounded-sm bg-zinc-800/60">
+      {peaks.map((p, i) => {
+        const barH = Math.max(p * (h - 2), 0.5);
+        return (
+          <rect
+            key={i}
+            x={i * step}
+            y={(h - barH) / 2}
+            width={Math.max(step * 0.7, 0.5)}
+            height={barH}
+            fill={color}
+            opacity={0.7}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function fmtDuration(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function AssetsPanel() {
+  const showAssetsPanel = useUIStore((s) => s.showAssetsPanel);
+  const assetsPanelWidth = useUIStore((s) => s.assetsPanelWidth);
+  const setAssetsPanelWidth = useUIStore((s) => s.setAssetsPanelWidth);
+  const selectClip = useUIStore((s) => s.selectClip);
+  const project = useProjectStore((s) => s.project);
+  const toggleClipStar = useProjectStore((s) => s.toggleClipStar);
+
+  const [activeTab, setActiveTab] = useState<Tab>('starred');
+
+  const resizeDragRef = useRef<{ startX: number; startW: number } | null>(null);
+  const onResizeMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    resizeDragRef.current = { startX: e.clientX, startW: assetsPanelWidth };
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!resizeDragRef.current) return;
+      const delta = resizeDragRef.current.startX - ev.clientX;
+      setAssetsPanelWidth(resizeDragRef.current.startW + delta);
+    };
+    const onMouseUp = () => {
+      resizeDragRef.current = null;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+  }, [assetsPanelWidth, setAssetsPanelWidth]);
+
+  const allEntries = useMemo<AssetEntry[]>(() => {
+    if (!project) return [];
+    const entries: AssetEntry[] = [];
+    for (const track of project.tracks) {
+      for (const clip of track.clips) {
+        if (clip.generationStatus === 'ready') {
+          entries.push({ clip, track });
+        }
+      }
+    }
+    return entries;
+  }, [project]);
+
+  const starredEntries = useMemo(() => allEntries.filter((e) => e.clip.starred), [allEntries]);
+  const generatedEntries = useMemo(() => allEntries.filter((e) => e.clip.source !== 'uploaded'), [allEntries]);
+  const uploadedEntries = useMemo(() => allEntries.filter((e) => e.clip.source === 'uploaded'), [allEntries]);
+
+  const activeEntries = activeTab === 'starred' ? starredEntries
+    : activeTab === 'generated' ? generatedEntries
+    : uploadedEntries;
+
+  const handleClick = useCallback((clipId: string) => {
+    selectClip(clipId, false);
+  }, [selectClip]);
+
+  const handleStar = useCallback((e: React.MouseEvent, clipId: string) => {
+    e.stopPropagation();
+    toggleClipStar(clipId);
+  }, [toggleClipStar]);
+
+  if (!showAssetsPanel || !project) return null;
+
+  const tabs: { id: Tab; label: string; count: number }[] = [
+    { id: 'starred', label: 'Starred', count: starredEntries.length },
+    { id: 'generated', label: 'Generated', count: generatedEntries.length },
+    { id: 'uploaded', label: 'Uploaded', count: uploadedEntries.length },
+  ];
+
+  return (
+    <div className="bg-daw-surface border-l border-daw-border flex flex-col shrink-0 relative" style={{ width: assetsPanelWidth }}>
+      {/* Left-edge resize handle */}
+      <div
+        className="absolute top-0 left-0 w-1.5 h-full cursor-col-resize bg-transparent hover:bg-indigo-500/40 transition-colors z-10"
+        onMouseDown={onResizeMouseDown}
+      />
+      {/* Header */}
+      <div className="flex items-center justify-between h-6 px-3 border-b border-daw-border shrink-0">
+        <span className="text-[10px] font-medium text-zinc-400 uppercase tracking-wider">Assets</span>
+      </div>
+      {/* Tabs */}
+      <div className="flex border-b border-daw-border shrink-0">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex-1 px-1 py-1.5 text-[10px] font-medium transition-colors ${
+              activeTab === tab.id
+                ? 'text-white border-b-2 border-indigo-500'
+                : 'text-zinc-500 hover:text-zinc-300'
+            }`}
+          >
+            {tab.label}
+            {tab.count > 0 && (
+              <span className="ml-1 text-[9px] text-zinc-600">{tab.count}</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* List */}
+      <div className="flex-1 overflow-y-auto min-h-0">
+        {activeEntries.length === 0 ? (
+          <div className="flex items-center justify-center h-24 text-[10px] text-zinc-600">
+            {activeTab === 'starred' ? 'No starred clips yet' :
+             activeTab === 'uploaded' ? 'No uploaded audio yet' :
+             'No generated clips yet'}
+          </div>
+        ) : (
+          <div className="py-1">
+            {activeEntries.map(({ clip, track }) => (
+              <button
+                key={clip.id}
+                onClick={() => handleClick(clip.id)}
+                className="w-full flex items-start gap-2 px-3 py-1.5 hover:bg-zinc-800/60 transition-colors text-left group"
+              >
+                <div className="shrink-0 mt-0.5">
+                  <MiniWaveform peaks={clip.waveformPeaks} color={track.color} />
+                </div>
+
+                <div className="flex-1 min-w-0 overflow-hidden">
+                  <div className="flex items-center gap-1">
+                    <span className={`shrink-0 text-[8px] px-1 py-px rounded ${
+                      clip.source === 'uploaded'
+                        ? 'bg-amber-900/40 text-amber-400'
+                        : 'bg-violet-900/40 text-violet-400'
+                    }`}>
+                      {clip.source === 'uploaded' ? '↑' : 'AI'}
+                    </span>
+                    <span className="text-[10px] text-zinc-300 truncate">
+                      {clip.prompt || track.displayName}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1 mt-0.5">
+                    <span className="text-[9px] text-zinc-600 truncate">{track.displayName}</span>
+                    <span className="text-[9px] text-zinc-700">·</span>
+                    <span className="text-[9px] text-zinc-600">{fmtDuration(clip.duration)}</span>
+                  </div>
+                </div>
+
+                <button
+                  onClick={(e) => handleStar(e, clip.id)}
+                  className={`shrink-0 w-5 h-5 flex items-center justify-center rounded text-[10px] transition-colors ${
+                    clip.starred
+                      ? 'text-yellow-400 hover:text-yellow-300'
+                      : 'text-zinc-700 hover:text-zinc-500 opacity-0 group-hover:opacity-100'
+                  }`}
+                  title={clip.starred ? 'Remove star' : 'Star this clip'}
+                >
+                  {clip.starred ? '★' : '☆'}
+                </button>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -388,7 +388,7 @@ export function SettingsDialog() {
           )}
         </div>
 
-        <div className="px-4 pt-3 pb-1">
+        <div className="px-4 pt-3 pb-1 space-y-2">
           <a
             href="http://acestudio.ai/"
             target="_blank"

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useCallback } from 'react';
 import { Toolbar } from './Toolbar';
 import { StatusBar } from './StatusBar';
-import { TransportBar } from '../transport/TransportBar';
 import { TrackList } from '../tracks/TrackList';
 import { Timeline } from '../timeline/Timeline';
 import { GenerationPanel } from '../generation/GenerationPanel';
@@ -12,6 +11,7 @@ import { SettingsDialog } from '../dialogs/SettingsDialog';
 import { ProjectListDialog } from '../dialogs/ProjectListDialog';
 import { KeyboardShortcutsDialog } from '../dialogs/KeyboardShortcutsDialog';
 import { MixerPanel } from '../mixer/MixerPanel';
+import { AssetsPanel } from '../assets/AssetsPanel';
 import { useAudioEngine } from '../../hooks/useAudioEngine';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
@@ -22,29 +22,26 @@ export function AppShell() {
   const project = useProjectStore((s) => s.project);
   const setShowNewProjectDialog = useUIStore((s) => s.setShowNewProjectDialog);
 
-  // Resume AudioContext on first user interaction
   const handleClick = useCallback(() => {
     resumeOnGesture();
   }, [resumeOnGesture]);
 
-  // Show new project dialog on first load if no project
   useEffect(() => {
     if (!project) {
       setShowNewProjectDialog(true);
     }
   }, []);
 
-  // All keyboard shortcuts
   useKeyboardShortcuts();
 
   return (
     <div className="flex flex-col h-screen" onClick={handleClick}>
       <Toolbar />
-      <TransportBar />
 
       <div className="flex flex-1 min-h-0">
         {project && <TrackList />}
         <Timeline />
+        {project && <AssetsPanel />}
       </div>
 
       {project && <MixerPanel />}

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -1,5 +1,7 @@
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
+import { useAudioImport } from '../../hooks/useAudioImport';
+import { TransportBar } from '../transport/TransportBar';
 
 export function Toolbar() {
   const project = useProjectStore((s) => s.project);
@@ -10,9 +12,13 @@ export function Toolbar() {
   const setShowKeyboardShortcutsDialog = useUIStore((s) => s.setShowKeyboardShortcutsDialog);
   const showMixer = useUIStore((s) => s.showMixer);
   const setShowMixer = useUIStore((s) => s.setShowMixer);
+  const showAssetsPanel = useUIStore((s) => s.showAssetsPanel);
+  const setShowAssetsPanel = useUIStore((s) => s.setShowAssetsPanel);
+  const { openFilePicker } = useAudioImport();
 
   return (
-    <div className="flex items-center h-10 px-3 gap-2 bg-daw-surface border-b border-daw-border">
+    <div className="flex items-center h-10 px-3 gap-2 bg-daw-surface border-b border-daw-border shrink-0">
+      {/* Left section */}
       <button
         onClick={() => setShowProjectListDialog(true)}
         className="px-3 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
@@ -32,6 +38,24 @@ export function Toolbar() {
       >
         Export
       </button>
+
+      <div className="w-px h-5 bg-daw-border" />
+
+      <button
+        onClick={openFilePicker}
+        disabled={!project}
+        className="px-3 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-40"
+        title="Import audio file"
+      >
+        Import
+      </button>
+
+      {/* Center section: Transport controls */}
+      <div className="flex-1 flex items-center justify-center">
+        <TransportBar />
+      </div>
+
+      {/* Right section: panel toggles + settings */}
       <button
         onClick={() => setShowMixer(!showMixer)}
         disabled={!project}
@@ -44,12 +68,20 @@ export function Toolbar() {
       >
         Mixer
       </button>
+      <button
+        onClick={() => setShowAssetsPanel(!showAssetsPanel)}
+        disabled={!project}
+        className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+          showAssetsPanel
+            ? 'bg-indigo-600 text-white hover:bg-indigo-500'
+            : 'bg-daw-surface-2 hover:bg-zinc-600 text-zinc-300 disabled:opacity-40'
+        }`}
+        title="Toggle Assets Panel"
+      >
+        Assets
+      </button>
 
-      <div className="flex-1 text-center">
-        <span className="text-sm font-medium text-zinc-300">
-          {project?.name ?? 'ACE-Step DAW'}
-        </span>
-      </div>
+      <div className="w-px h-5 bg-daw-border" />
 
       <button
         onClick={() => setShowSettingsDialog(true)}

--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -5,19 +5,11 @@ import { getAudioEngine } from '../../hooks/useAudioEngine';
 import { Knob } from '../ui/Knob';
 import type { Track } from '../../types/project';
 
-// -------------------------------------------------------------------------
-// Helpers
-// -------------------------------------------------------------------------
-
 function volumeToDb(v: number): string {
-  if (v <= 0) return '-∞';
+  if (v <= 0) return '-inf';
   const db = 20 * Math.log10(v);
   return (db >= 0 ? '+' : '') + db.toFixed(1);
 }
-
-// -------------------------------------------------------------------------
-// Channel strip
-// -------------------------------------------------------------------------
 
 interface ChannelStripProps {
   track: Track;
@@ -38,149 +30,61 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
   const compRatio = track.compressorRatio ?? 4;
 
   return (
-    <div className="flex flex-col items-center gap-1.5 px-2 py-2 bg-daw-surface border-r border-daw-border min-w-[104px]">
-      {/* Color bar + name */}
-      <div
-        className="w-full h-1 rounded-full mb-0.5"
-        style={{ backgroundColor: track.color }}
-      />
-      <span
-        className="text-[11px] text-zinc-300 font-medium leading-none truncate w-full text-center uppercase tracking-wide"
-        title={track.displayName}
-      >
+    <div className="flex flex-col items-center gap-1.5 px-3 py-2 bg-daw-surface border-r border-daw-border min-w-[120px]">
+      <div className="w-full h-1.5 rounded-full mb-0.5" style={{ backgroundColor: track.color }} />
+      <span className="text-xs text-zinc-300 font-medium leading-none truncate w-full text-center uppercase tracking-wide" title={track.displayName}>
         {track.displayName}
       </span>
 
-      {/* Mute / Solo */}
-      <div className="flex gap-1.5 mt-0.5">
+      <div className="flex gap-2 mt-0.5">
         <button
           onClick={() => updateTrack(track.id, { muted: !track.muted })}
-          className={`text-xs font-bold px-2 py-1 rounded transition-colors ${
-            track.muted
-              ? 'bg-amber-500 text-black'
-              : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600'
+          className={`text-xs font-bold px-2.5 py-1 rounded transition-colors ${
+            track.muted ? 'bg-amber-500 text-black' : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600'
           }`}
         >
           M
         </button>
         <button
           onClick={() => updateTrack(track.id, { soloed: !track.soloed })}
-          className={`text-xs font-bold px-2 py-1 rounded transition-colors ${
-            track.soloed
-              ? 'bg-emerald-500 text-black'
-              : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600'
+          className={`text-xs font-bold px-2.5 py-1 rounded transition-colors ${
+            track.soloed ? 'bg-emerald-500 text-black' : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600'
           }`}
         >
           S
         </button>
       </div>
 
-      {/* Pan */}
-      <Knob
-        value={pan}
-        min={-1}
-        max={1}
-        defaultValue={0}
-        onChange={(v) => updateTrackMixer(track.id, { pan: v })}
-        label="Pan"
-        size={34}
-        step={0.01}
-      />
+      <Knob value={pan} min={-1} max={1} defaultValue={0} onChange={(v) => updateTrackMixer(track.id, { pan: v })} label="Pan" size={36} step={0.01} />
 
-      {/* EQ section */}
       <div className="text-[10px] text-zinc-500 uppercase tracking-widest mt-0.5">EQ</div>
-      <div className="flex gap-1">
-        <Knob
-          value={eqLow}
-          min={-15}
-          max={15}
-          defaultValue={0}
-          onChange={(v) => updateTrackMixer(track.id, { eqLowGain: v })}
-          label="Lo"
-          unit="dB"
-          size={30}
-          step={0.5}
-        />
-        <Knob
-          value={eqMid}
-          min={-15}
-          max={15}
-          defaultValue={0}
-          onChange={(v) => updateTrackMixer(track.id, { eqMidGain: v })}
-          label="Mid"
-          unit="dB"
-          size={30}
-          step={0.5}
-        />
-        <Knob
-          value={eqHigh}
-          min={-15}
-          max={15}
-          defaultValue={0}
-          onChange={(v) => updateTrackMixer(track.id, { eqHighGain: v })}
-          label="Hi"
-          unit="dB"
-          size={30}
-          step={0.5}
-        />
+      <div className="flex gap-1.5">
+        <Knob value={eqLow} min={-15} max={15} defaultValue={0} onChange={(v) => updateTrackMixer(track.id, { eqLowGain: v })} label="Lo" unit="dB" size={34} step={0.5} />
+        <Knob value={eqMid} min={-15} max={15} defaultValue={0} onChange={(v) => updateTrackMixer(track.id, { eqMidGain: v })} label="Mid" unit="dB" size={34} step={0.5} />
+        <Knob value={eqHigh} min={-15} max={15} defaultValue={0} onChange={(v) => updateTrackMixer(track.id, { eqHighGain: v })} label="Hi" unit="dB" size={34} step={0.5} />
       </div>
 
-      {/* Compressor */}
       <div className="text-[10px] text-zinc-500 uppercase tracking-widest mt-0.5">Comp</div>
       <button
         onClick={() => updateTrackMixer(track.id, { compressorEnabled: !compEnabled })}
         className={`text-xs font-semibold px-2 py-1 rounded w-full transition-colors ${
-          compEnabled
-            ? 'bg-indigo-600 text-white'
-            : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600'
+          compEnabled ? 'bg-indigo-600 text-white' : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600'
         }`}
       >
         {compEnabled ? 'ON' : 'OFF'}
       </button>
-      <div className="flex gap-1">
-        <Knob
-          value={compThresh}
-          min={-60}
-          max={0}
-          defaultValue={-24}
-          onChange={(v) => updateTrackMixer(track.id, { compressorThreshold: v })}
-          label="Thr"
-          unit="dB"
-          size={30}
-          step={1}
-          disabled={!compEnabled}
-        />
-        <Knob
-          value={compRatio}
-          min={1}
-          max={20}
-          defaultValue={4}
-          onChange={(v) => updateTrackMixer(track.id, { compressorRatio: v })}
-          label="Rat"
-          size={30}
-          step={0.5}
-          disabled={!compEnabled}
-        />
+      <div className="flex gap-1.5">
+        <Knob value={compThresh} min={-60} max={0} defaultValue={-24} onChange={(v) => updateTrackMixer(track.id, { compressorThreshold: v })} label="Thr" unit="dB" size={34} step={1} disabled={!compEnabled} />
+        <Knob value={compRatio} min={1} max={20} defaultValue={4} onChange={(v) => updateTrackMixer(track.id, { compressorRatio: v })} label="Rat" size={34} step={0.5} disabled={!compEnabled} />
       </div>
 
-      {/* Volume fader */}
       <div className="flex-1 flex flex-col items-center gap-1 mt-1 min-h-0 w-full">
         <div className="relative flex justify-center" style={{ height: faderHeight }}>
           <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.01}
-            value={vol}
+            type="range" min={0} max={1} step={0.01} value={vol}
             onChange={(e) => updateTrack(track.id, { volume: parseFloat(e.target.value) })}
             className="appearance-none bg-transparent cursor-pointer"
-            style={{
-              writingMode: 'vertical-lr',
-              direction: 'rtl',
-              width: 28,
-              height: faderHeight,
-              accentColor: track.color,
-            }}
+            style={{ writingMode: 'vertical-lr', direction: 'rtl', width: 28, height: faderHeight, accentColor: track.color }}
           />
         </div>
         <span className="text-xs font-mono text-zinc-400">{volumeToDb(vol)}</span>
@@ -189,51 +93,25 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
   );
 }
 
-// -------------------------------------------------------------------------
-// Master strip
-// -------------------------------------------------------------------------
-
-interface MasterStripProps {
-  faderHeight: number;
-}
+interface MasterStripProps { faderHeight: number; }
 
 function MasterStrip({ faderHeight }: MasterStripProps) {
   const project = useProjectStore((s) => s.project);
   const updateProject = useProjectStore((s) => s.updateProject);
-
   if (!project) return null;
-
   const masterVol = project.masterVolume ?? 1.0;
-
-  const handleChange = (v: number) => {
-    updateProject({ masterVolume: v });
-    getAudioEngine().masterVolume = v;
-  };
+  const handleChange = (v: number) => { updateProject({ masterVolume: v }); getAudioEngine().masterVolume = v; };
 
   return (
-    <div className="flex flex-col items-center gap-1.5 px-3 py-2 bg-zinc-900 border-l-2 border-zinc-600 min-w-[104px]">
-      <span className="text-[11px] font-bold text-zinc-300 uppercase tracking-widest">
-        Master
-      </span>
-
-      {/* Spacer to align fader with track faders — fixed content height above fader */}
+    <div className="flex flex-col items-center gap-1.5 px-4 py-2 bg-zinc-900 border-l-2 border-zinc-600 min-w-[120px]">
+      <span className="text-xs font-bold text-zinc-300 uppercase tracking-widest">Master</span>
       <div className="flex-1 flex flex-col items-center justify-end gap-1 w-full">
         <div className="relative flex justify-center" style={{ height: faderHeight }}>
           <input
-            type="range"
-            min={0}
-            max={1.5}
-            step={0.01}
-            value={masterVol}
+            type="range" min={0} max={1.5} step={0.01} value={masterVol}
             onChange={(e) => handleChange(parseFloat(e.target.value))}
             className="appearance-none bg-transparent cursor-pointer"
-            style={{
-              writingMode: 'vertical-lr',
-              direction: 'rtl',
-              width: 32,
-              height: faderHeight,
-              accentColor: '#6366f1',
-            }}
+            style={{ writingMode: 'vertical-lr', direction: 'rtl', width: 32, height: faderHeight, accentColor: '#6366f1' }}
           />
         </div>
         <span className="text-xs font-mono text-zinc-400">{volumeToDb(masterVol)}</span>
@@ -241,10 +119,6 @@ function MasterStrip({ faderHeight }: MasterStripProps) {
     </div>
   );
 }
-
-// -------------------------------------------------------------------------
-// Panel
-// -------------------------------------------------------------------------
 
 export function MixerPanel() {
   const showMixer = useUIStore((s) => s.showMixer);
@@ -258,20 +132,16 @@ export function MixerPanel() {
     (e: React.MouseEvent) => {
       e.preventDefault();
       dragState.current = { startY: e.clientY, startH: mixerHeight };
-
       const onMouseMove = (ev: MouseEvent) => {
         if (!dragState.current) return;
-        // Drag upward → increase height (panel grows upward)
         const delta = dragState.current.startY - ev.clientY;
         setMixerHeight(dragState.current.startH + delta);
       };
-
       const onMouseUp = () => {
         dragState.current = null;
         window.removeEventListener('mousemove', onMouseMove);
         window.removeEventListener('mouseup', onMouseUp);
       };
-
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onMouseUp);
     },
@@ -280,23 +150,15 @@ export function MixerPanel() {
 
   if (!showMixer || !project) return null;
 
-  // The fader height scales proportionally with the panel height.
-  // Reserve ~160px for strip header (name, mute/solo, knobs, eq, comp).
-  const faderHeight = Math.max(60, mixerHeight - 195);
+  const faderHeight = Math.max(60, mixerHeight - 300);
 
   return (
-    <div
-      className="border-t border-daw-border bg-daw-surface flex flex-col select-none"
-      style={{ height: mixerHeight }}
-    >
-      {/* Drag-to-resize handle */}
+    <div className="border-t border-daw-border bg-daw-surface flex flex-col select-none shrink-0" style={{ height: mixerHeight }}>
       <div
         className="h-1.5 w-full cursor-ns-resize bg-zinc-700 hover:bg-indigo-500 transition-colors flex-shrink-0"
         onMouseDown={onResizeMouseDown}
         title="Drag to resize mixer"
       />
-
-      {/* Scrollable strip area */}
       <div className="flex-1 overflow-x-auto overflow-y-hidden">
         <div className="flex items-stretch h-full">
           {project.tracks.map((track) => (

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -18,6 +18,15 @@ const MIN_CLIP_DURATION = 0.5;
 
 type DragMode = 'move' | 'resize-left' | 'resize-right';
 
+interface DragGhostInfo {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  targetTrackId: string | null;
+  targetLaneRect: { top: number; height: number } | null;
+}
+
 export function ClipBlock({ clip, track }: ClipBlockProps) {
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const selectedClipIds = useUIStore((s) => s.selectedClipIds);
@@ -31,9 +40,9 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const project = useProjectStore((s) => s.project);
   const { generateClip } = useGeneration();
 
-  // AddLayerModal trigger (from clip context menu "Add Layer here" or "Edit Clip")
   const [addLayerOpen, setAddLayerOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
+  const [dragGhost, setDragGhost] = useState<DragGhostInfo | null>(null);
 
   // Listen for external "edit clip" signal (keyboard shortcut E)
   const editingClipId = useUIStore((s) => s.editingClipId);
@@ -68,6 +77,23 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     return 'move';
   }, []);
 
+  const moveClipToTrack = useProjectStore((s) => s.moveClipToTrack);
+  const clipBlockRef = useRef<HTMLDivElement>(null);
+
+  const findClosestLane = useCallback((clientY: number): { trackId: string; rect: DOMRect } | null => {
+    const lanes = document.querySelectorAll<HTMLElement>('[data-track-id]');
+    let best: { trackId: string; rect: DOMRect; dist: number } | null = null;
+    for (const lane of lanes) {
+      const r = lane.getBoundingClientRect();
+      const centerY = r.top + r.height / 2;
+      const dist = Math.abs(clientY - centerY);
+      if (!best || dist < best.dist) {
+        best = { trackId: lane.dataset.trackId!, rect: r, dist };
+      }
+    }
+    return best ? { trackId: best.trackId, rect: best.rect } : null;
+  }, []);
+
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (e.button !== 0) return;
     e.stopPropagation();
@@ -75,6 +101,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
     const mode = getDragMode(e);
     const startX = e.clientX;
+    const startY = e.clientY;
     const origStart = clip.startTime;
     const origDuration = clip.duration;
     const origAudioOffset = clip.audioOffset ?? 0;
@@ -83,9 +110,13 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     const totalDuration = project?.totalDuration ?? 600;
     dragRef.current = false;
 
+    const clipW = clip.duration * pixelsPerSecond;
+    const clipH = clipBlockRef.current?.offsetHeight ?? 48;
+
     const onMouseMove = (ev: MouseEvent) => {
       const dx = ev.clientX - startX;
-      if (Math.abs(dx) < 3 && !dragRef.current) return;
+      const dy = ev.clientY - startY;
+      if (Math.abs(dx) < 3 && Math.abs(dy) < 3 && !dragRef.current) return;
       dragRef.current = true;
 
       const deltaSec = dx / pixelsPerSecond;
@@ -94,15 +125,27 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         let newStart = snapToGrid(origStart + deltaSec, bpm, 1);
         newStart = Math.max(0, Math.min(newStart, totalDuration - origDuration));
         updateClip(clip.id, { startTime: newStart });
+
+        const closest = findClosestLane(ev.clientY);
+        if (closest) {
+          setDragGhost({
+            x: ev.clientX - clipW / 2,
+            y: ev.clientY - clipH / 2,
+            width: clipW,
+            height: clipH,
+            targetTrackId: closest.trackId !== track.id ? closest.trackId : null,
+            targetLaneRect: closest.trackId !== track.id
+              ? { top: closest.rect.top, height: closest.rect.height }
+              : null,
+          });
+        }
       } else if (mode === 'resize-left') {
-        // Dragging left edge: crops from the start of the audio
         let newStart = snapToGrid(origStart + deltaSec, bpm, 1);
         newStart = Math.max(0, newStart);
         const maxStart = origStart + origDuration - MIN_CLIP_DURATION;
         newStart = Math.min(newStart, maxStart);
 
         const shift = newStart - origStart;
-        // Constrain: can't crop past the audio buffer end
         let newAudioOffset = origAudioOffset + shift;
         if (newAudioOffset < 0) {
           newStart = origStart - origAudioOffset;
@@ -115,9 +158,6 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         const newDuration = origDuration + (origStart - newStart);
         updateClip(clip.id, { startTime: newStart, duration: newDuration, audioOffset: newAudioOffset });
       } else {
-        // Dragging right edge: extends or crops the clip duration.
-        // No audio-buffer cap — if the clip exceeds the buffer, Web Audio pads
-        // with silence and the user can regenerate to fill the extra region.
         let newDuration = snapToGrid(origDuration + deltaSec, bpm, 1);
         newDuration = Math.max(MIN_CLIP_DURATION, newDuration);
         newDuration = Math.min(newDuration, totalDuration - origStart);
@@ -125,14 +165,22 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       }
     };
 
-    const onMouseUp = () => {
+    const onMouseUp = (ev: MouseEvent) => {
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
+      setDragGhost(null);
+
+      if (mode === 'move' && dragRef.current) {
+        const closest = findClosestLane(ev.clientY);
+        if (closest && closest.trackId !== track.id) {
+          moveClipToTrack(clip.id, closest.trackId);
+        }
+      }
     };
 
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
-  }, [clip.id, clip.startTime, clip.duration, clip.audioOffset, clip.audioDuration, pixelsPerSecond, project, updateClip, getDragMode]);
+  }, [clip.id, clip.startTime, clip.duration, clip.audioOffset, clip.audioDuration, pixelsPerSecond, project, updateClip, getDragMode, track.id, moveClipToTrack, findClosestLane]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -194,9 +242,11 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   return (
     <>
       <div
+        ref={clipBlockRef}
         className={`absolute top-1 bottom-1 rounded-sm select-none overflow-hidden
           ${statusStyles[clip.generationStatus] ?? ''}
           ${isSelected ? 'ring-2 ring-white ring-offset-1 ring-offset-transparent' : ''}
+          ${dragGhost ? 'opacity-40' : ''}
         `}
         style={{
           left,
@@ -339,6 +389,45 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           clipId={clip.id}
           onClose={() => setEditModalOpen(false)}
         />
+      )}
+
+      {/* Cross-track drag ghost + target lane highlight */}
+      {dragGhost && (
+        <>
+          {/* Ghost preview following the cursor */}
+          <div
+            className="fixed pointer-events-none z-[100] rounded-sm overflow-hidden"
+            style={{
+              left: dragGhost.x,
+              top: dragGhost.y,
+              width: Math.min(dragGhost.width, 400),
+              height: dragGhost.height,
+              backgroundColor: hexToRgba(track.color, 0.5),
+              borderLeft: `2px solid ${track.color}`,
+              boxShadow: `0 4px 20px ${hexToRgba(track.color, 0.3)}, 0 0 0 1px ${hexToRgba(track.color, 0.4)}`,
+            }}
+          >
+            <div className="px-1.5 py-0.5 text-[9px] font-medium text-white truncate drop-shadow-sm">
+              {clip.prompt || track.displayName}
+            </div>
+          </div>
+
+          {/* Target lane highlight */}
+          {dragGhost.targetLaneRect && (
+            <div
+              className="fixed pointer-events-none z-[99]"
+              style={{
+                left: 0,
+                top: dragGhost.targetLaneRect.top,
+                width: '100vw',
+                height: dragGhost.targetLaneRect.height,
+                backgroundColor: hexToRgba(track.color, 0.08),
+                borderTop: `1px solid ${hexToRgba(track.color, 0.4)}`,
+                borderBottom: `1px solid ${hexToRgba(track.color, 0.4)}`,
+              }}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -7,6 +7,7 @@ import { Playhead } from './Playhead';
 import { GridOverlay } from './GridOverlay';
 import { snapToGrid } from '../../utils/time';
 import { MultiTrackGenerateModal } from '../generation/MultiTrackGenerateModal';
+import { useAudioImport } from '../../hooks/useAudioImport';
 
 export const TRACK_INSPECTOR_HEIGHT = 220; // px — must match TrackInspector height
 
@@ -64,6 +65,42 @@ export function Timeline() {
 
   const [ctxDrag, setCtxDrag] = useState<DragRect | null>(null);
   const [selDrag, setSelDrag] = useState<DragRect | null>(null);
+  const [fileDragOver, setFileDragOver] = useState(false);
+  const dragCounterRef = useRef(0);
+  const { importMultipleFiles } = useAudioImport();
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes('Files')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+    }
+  }, []);
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes('Files')) {
+      e.preventDefault();
+      dragCounterRef.current++;
+      setFileDragOver(true);
+    }
+  }, []);
+
+  const handleDragLeave = useCallback(() => {
+    dragCounterRef.current--;
+    if (dragCounterRef.current <= 0) {
+      dragCounterRef.current = 0;
+      setFileDragOver(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(async (e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounterRef.current = 0;
+    setFileDragOver(false);
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      await importMultipleFiles(files);
+    }
+  }, [importMultipleFiles]);
 
   const sortedTracks = project
     ? [...project.tracks].sort((a, b) => a.order - b.order)
@@ -218,11 +255,23 @@ export function Timeline() {
     <>
       <div
         ref={scrollRef}
-        className="flex-1 overflow-auto bg-daw-bg"
+        className="flex-1 overflow-auto bg-daw-bg relative"
         onWheel={handleWheel}
         onMouseDownCapture={handleMouseDownCapture}
+        onDragOver={handleDragOver}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
         style={{ cursor: 'default' }}
       >
+        {fileDragOver && (
+          <div className="absolute inset-0 z-50 flex items-center justify-center bg-blue-900/30 border-2 border-dashed border-blue-400/60 pointer-events-none">
+            <div className="bg-blue-950/80 border border-blue-500/50 rounded-lg px-6 py-4 text-center">
+              <p className="text-sm font-medium text-blue-200">Drop audio files here</p>
+              <p className="text-[10px] text-blue-400 mt-1">WAV, MP3, OGG, FLAC, AAC</p>
+            </div>
+          </div>
+        )}
         <div className="relative" style={{ width: totalWidth, minWidth: '100%' }}>
           <TimeRuler />
 

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -1,19 +1,17 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef } from 'react';
 import type { Track } from '../../types/project';
 import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
 import { ClipBlock } from './ClipBlock';
 import { AddLayerModal } from '../generation/AddLayerModal';
 import { snapToGrid } from '../../utils/time';
+import { useAudioImport } from '../../hooks/useAudioImport';
 
 interface TrackLaneProps {
   track: Track;
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
 // Lane context menu (right-click / double-click on empty area)
-// ─────────────────────────────────────────────────────────────────────────────
-
 interface LaneContextMenuProps {
   x: number;
   y: number;
@@ -39,37 +37,61 @@ function LaneContextMenu({ x, y, onAddLayer, onClose }: LaneContextMenuProps) {
           onClick={() => { onClose(); onAddLayer(); }}
           className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors"
         >
-          Add Layer…
+          Add Layer...
         </button>
       </div>
     </>
   );
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// TrackLane
-// ─────────────────────────────────────────────────────────────────────────────
+const MIN_LANE_HEIGHT = 40;
+const MAX_LANE_HEIGHT = 200;
 
 export function TrackLane({ track }: TrackLaneProps) {
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const contextWindow = useUIStore((s) => s.contextWindow);
   const project = useProjectStore((s) => s.project);
+  const updateTrack = useProjectStore((s) => s.updateTrack);
 
-  // ── Context menu ──────────────────────────────────────────────────────────
   const [ctxMenu, setCtxMenu] = useState<{
     x: number; y: number; startTime: number; duration: number;
   } | null>(null);
 
-  // ── AddLayerModal state (opened via right-click / double-click context menu) ──
   const [addLayerTarget, setAddLayerTarget] = useState<{
     startTime: number; duration: number;
   } | null>(null);
+
+  const { importAudioToTrack } = useAudioImport();
+  const [fileDragOver, setFileDragOver] = useState(false);
+
+  // Lane height resize
+  const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
+  const laneHeight = track.laneHeight ?? 64;
+
+  const onResizeMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizeRef.current = { startY: e.clientY, startH: laneHeight };
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!resizeRef.current) return;
+      const delta = ev.clientY - resizeRef.current.startY;
+      const newH = Math.min(MAX_LANE_HEIGHT, Math.max(MIN_LANE_HEIGHT, resizeRef.current.startH + delta));
+      updateTrack(track.id, { laneHeight: newH });
+    };
+    const onMouseUp = () => {
+      resizeRef.current = null;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+  }, [laneHeight, track.id, updateTrack]);
 
   if (!project) return null;
 
   const totalWidth = project.totalDuration * pixelsPerSecond;
 
-  // Check if a time position is on or near an existing clip
   const hitsClip = useCallback((clickTime: number): boolean => {
     const GUARD = 8 / pixelsPerSecond;
     return track.clips.some(
@@ -77,7 +99,6 @@ export function TrackLane({ track }: TrackLaneProps) {
     );
   }, [track.clips, pixelsPerSecond]);
 
-  // ── Right-click → context menu ────────────────────────────────────────────
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) return;
     e.preventDefault();
@@ -92,7 +113,6 @@ export function TrackLane({ track }: TrackLaneProps) {
     setAddLayerTarget(null);
   }, [pixelsPerSecond, project.bpm, project.totalDuration]);
 
-  // ── Double-click → context menu (Mac alternative) ────────────────────────
   const handleDoubleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) return;
     e.stopPropagation();
@@ -112,21 +132,58 @@ export function TrackLane({ track }: TrackLaneProps) {
     setAddLayerTarget(null);
   }, []);
 
+  const handleFileDragOver = useCallback((e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes('Files')) {
+      e.preventDefault();
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = 'copy';
+      setFileDragOver(true);
+    }
+  }, []);
+
+  const handleFileDragLeave = useCallback(() => {
+    setFileDragOver(false);
+  }, []);
+
+  const handleFileDrop = useCallback(async (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setFileDragOver(false);
+    const files = e.dataTransfer.files;
+    if (!files.length || !project) return;
+
+    const rect = e.currentTarget.getBoundingClientRect();
+    const laneX = e.clientX - rect.left;
+    const rawTime = laneX / pixelsPerSecond;
+    const startTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1));
+
+    for (const file of Array.from(files)) {
+      if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
+        await importAudioToTrack(file, track.id, startTime);
+      }
+    }
+  }, [project, pixelsPerSecond, track.id, importAudioToTrack]);
+
   return (
     <>
       <div
         data-track-id={track.id}
-        className="relative h-16 border-b border-daw-border"
-        style={{ width: totalWidth }}
-        onContextMenu={handleContextMenu}
-        onDoubleClick={handleDoubleClick}
+        className={`relative border-b border-daw-border ${fileDragOver ? 'bg-blue-900/20' : ''}`}
+        style={{ width: totalWidth, height: laneHeight }}
+        onDragOver={handleFileDragOver}
+        onDragLeave={handleFileDragLeave}
+        onDrop={handleFileDrop}
       >
-        {/* Clips */}
+        {fileDragOver && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-30 border border-dashed border-blue-400/60 rounded-sm">
+            <span className="text-[10px] text-blue-300 bg-blue-950/80 px-2 py-0.5 rounded">Drop audio here</span>
+          </div>
+        )}
+
         {track.clips.map((clip) => (
           <ClipBlock key={clip.id} clip={clip} track={track} />
         ))}
 
-        {/* Lane context menu */}
         {ctxMenu && (
           <LaneContextMenu
             x={ctxMenu.x}
@@ -135,9 +192,14 @@ export function TrackLane({ track }: TrackLaneProps) {
             onClose={() => setCtxMenu(null)}
           />
         )}
+
+        {/* Bottom-edge resize handle */}
+        <div
+          className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize bg-transparent hover:bg-indigo-500/40 transition-colors z-20"
+          onMouseDown={onResizeMouseDown}
+        />
       </div>
 
-      {/* AddLayerModal — rendered outside the lane div to avoid clipping */}
       {addLayerTarget && (
         <AddLayerModal
           trackId={track.id}

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -1,7 +1,11 @@
+import { useCallback, useRef } from 'react';
 import type { Track } from '../../types/project';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { TRACK_CATALOG } from '../../constants/tracks';
+
+const MIN_LANE_HEIGHT = 40;
+const MAX_LANE_HEIGHT = 200;
 
 interface TrackHeaderProps {
   track: Track;
@@ -26,15 +30,38 @@ export function TrackHeader({
   const setExpandedTrackId = useUIStore((s) => s.setExpandedTrackId);
   const info = TRACK_CATALOG[track.trackName];
 
+  const laneHeight = track.laneHeight ?? 64;
+  const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
+
+  const onHeightResizeDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizeRef.current = { startY: e.clientY, startH: laneHeight };
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!resizeRef.current) return;
+      const delta = ev.clientY - resizeRef.current.startY;
+      const newH = Math.min(MAX_LANE_HEIGHT, Math.max(MIN_LANE_HEIGHT, resizeRef.current.startH + delta));
+      updateTrack(track.id, { laneHeight: newH });
+    };
+    const onMouseUp = () => {
+      resizeRef.current = null;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+  }, [laneHeight, track.id, updateTrack]);
+
   const isExpanded = expandedTrackId === track.id;
   const toggleExpand = () => setExpandedTrackId(isExpanded ? null : track.id);
 
   return (
     <div
-      className={`relative flex flex-col justify-center gap-1 h-16 px-2 border-b border-daw-border group select-none ${
+      className={`relative flex flex-col justify-center gap-1 px-2 border-b border-daw-border group select-none ${
         isDragOver ? 'bg-daw-surface-2' : ''
       }`}
       style={{
+        height: track.laneHeight ?? 64,
         borderLeft: `3px solid ${track.color}`,
         borderTop: isDragOver && dragOverPosition === 'before' ? '2px solid #6366f1' : undefined,
         borderBottom: isDragOver && dragOverPosition === 'after' ? '2px solid #6366f1' : undefined,
@@ -113,6 +140,12 @@ export function TrackHeader({
           </button>
         </div>
       </div>
+
+      {/* Bottom-edge height resize handle */}
+      <div
+        className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize bg-transparent hover:bg-indigo-500/40 transition-colors z-10"
+        onMouseDown={onHeightResizeDown}
+      />
     </div>
   );
 }

--- a/src/components/tracks/TrackList.tsx
+++ b/src/components/tracks/TrackList.tsx
@@ -9,6 +9,8 @@ export function TrackList() {
   const project = useProjectStore((s) => s.project);
   const reorderTrack = useProjectStore((s) => s.reorderTrack);
   const expandedTrackId = useUIStore((s) => s.expandedTrackId);
+  const trackListWidth = useUIStore((s) => s.trackListWidth);
+  const setTrackListWidth = useUIStore((s) => s.setTrackListWidth);
 
   const draggedIdRef = useRef<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
@@ -21,7 +23,6 @@ export function TrackList() {
   const handleDragOver = useCallback((e: React.DragEvent, id: string) => {
     e.preventDefault();
     if (!draggedIdRef.current || draggedIdRef.current === id) return;
-    // Determine whether to insert before or after based on pointer position
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
     const midY = rect.top + rect.height / 2;
     setDragOverId(id);
@@ -46,23 +47,42 @@ export function TrackList() {
     setDragOverId(null);
   }, []);
 
+  // Width resize handle
+  const resizeDragRef = useRef<{ startX: number; startW: number } | null>(null);
+
+  const onResizeMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    resizeDragRef.current = { startX: e.clientX, startW: trackListWidth };
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!resizeDragRef.current) return;
+      const delta = ev.clientX - resizeDragRef.current.startX;
+      setTrackListWidth(resizeDragRef.current.startW + delta);
+    };
+    const onMouseUp = () => {
+      resizeDragRef.current = null;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+  }, [trackListWidth, setTrackListWidth]);
+
   if (!project) return null;
 
-  // Display tracks in visual order: lowest order at top
   const sortedTracks = [...project.tracks].sort((a, b) => a.order - b.order);
 
   return (
     <div
-      className="flex flex-col w-[220px] min-w-[220px] bg-daw-surface border-r border-daw-border"
+      className="flex flex-col bg-daw-surface border-r border-daw-border relative shrink-0"
+      style={{ width: trackListWidth }}
       onDragLeave={(e) => {
-        // Clear highlight when pointer leaves the list container entirely
         if (!e.currentTarget.contains(e.relatedTarget as Node)) {
           setDragOverId(null);
         }
       }}
     >
       {/* Header spacer aligned with TimeRuler */}
-      <div className="h-6 border-b border-daw-border" />
+      <div className="h-6 border-b border-daw-border shrink-0" />
 
       <div className="flex-1 overflow-y-auto">
         {sortedTracks.map((track) => (
@@ -83,6 +103,12 @@ export function TrackList() {
       </div>
 
       <AddTrackButton />
+
+      {/* Right-edge resize handle */}
+      <div
+        className="absolute top-0 right-0 w-1.5 h-full cursor-col-resize bg-transparent hover:bg-indigo-500/40 transition-colors z-10"
+        onMouseDown={onResizeMouseDown}
+      />
     </div>
   );
 }

--- a/src/components/transport/TransportBar.tsx
+++ b/src/components/transport/TransportBar.tsx
@@ -11,7 +11,7 @@ export function TransportBar() {
   const toggleMetronome = useTransportStore((s) => s.toggleMetronome);
 
   return (
-    <div className="flex items-center h-10 px-3 gap-3 bg-daw-surface border-b border-daw-border">
+    <div className="flex items-center gap-3">
       <div className="flex items-center gap-1">
         <button
           onClick={stop}

--- a/src/hooks/useAudioImport.ts
+++ b/src/hooks/useAudioImport.ts
@@ -65,27 +65,87 @@ export function useAudioImport() {
     // Compute waveform peaks
     const peaks = computeWaveformPeaks(trimmedBuffer, 200);
 
-    // Mark clip as ready
+    // Mark clip as ready with uploaded source
     updateClipStatus(clip.id, 'ready', {
       isolatedAudioKey: isolatedKey,
       waveformPeaks: peaks,
       audioDuration: clipDuration,
       audioOffset: 0,
+      source: 'uploaded',
     });
   }, [addTrack, addClip, updateClipStatus]);
+
+  const importAudioToTrack = useCallback(async (file: File, trackId: string, startTime: number) => {
+    const project = useProjectStore.getState().project;
+    if (!project) return;
+
+    const engine = getAudioEngine();
+    await engine.resume();
+
+    const arrayBuffer = await file.arrayBuffer();
+    const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
+    const duration = audioBuffer.duration;
+    const clipDuration = Math.min(duration, project.totalDuration - startTime);
+    if (clipDuration <= 0) return;
+
+    const clip = addClip(trackId, {
+      startTime,
+      duration: clipDuration,
+      prompt: `Imported: ${file.name}`,
+      lyrics: '',
+    });
+
+    const sampleRate = audioBuffer.sampleRate;
+    const trimmedLength = Math.min(
+      Math.floor(clipDuration * sampleRate),
+      audioBuffer.length,
+    );
+    const trimmedBuffer = engine.ctx.createBuffer(
+      audioBuffer.numberOfChannels,
+      trimmedLength,
+      sampleRate,
+    );
+    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+      const src = audioBuffer.getChannelData(ch);
+      const dst = trimmedBuffer.getChannelData(ch);
+      for (let i = 0; i < trimmedLength; i++) {
+        dst[i] = src[i];
+      }
+    }
+
+    const wavBlob = audioBufferToWavBlob(trimmedBuffer);
+    const isolatedKey = await saveAudioBlob(project.id, clip.id, 'isolated', wavBlob);
+    const peaks = computeWaveformPeaks(trimmedBuffer, 200);
+
+    updateClipStatus(clip.id, 'ready', {
+      isolatedAudioKey: isolatedKey,
+      waveformPeaks: peaks,
+      audioDuration: clipDuration,
+      audioOffset: 0,
+      source: 'uploaded',
+    });
+  }, [addClip, updateClipStatus]);
+
+  const importMultipleFiles = useCallback(async (files: FileList | File[]) => {
+    for (const file of Array.from(files)) {
+      if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
+        await importAudioFile(file);
+      }
+    }
+  }, [importAudioFile]);
 
   const openFilePicker = useCallback(() => {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = 'audio/*';
+    input.multiple = true;
     input.onchange = async () => {
-      const file = input.files?.[0];
-      if (file) {
-        await importAudioFile(file);
+      if (input.files && input.files.length > 0) {
+        await importMultipleFiles(input.files);
       }
     };
     input.click();
-  }, [importAudioFile]);
+  }, [importMultipleFiles]);
 
-  return { importAudioFile, openFilePicker };
+  return { importAudioFile, importAudioToTrack, importMultipleFiles, openFilePicker };
 }

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -52,7 +52,7 @@ interface ProjectState {
 
   addTrack: (trackName: TrackName) => Track;
   removeTrack: (trackId: string) => void;
-  updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed'>>) => void;
+  updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'laneHeight'>>) => void;
   reorderTrack: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
 
   addClip: (trackId: string, clip: Omit<Clip, 'id' | 'trackId' | 'generationStatus' | 'generationJobId' | 'cumulativeMixKey' | 'isolatedAudioKey' | 'waveformPeaks'>) => Clip;
@@ -64,6 +64,9 @@ interface ProjectState {
   saveClipVersion: (clipId: string) => void;
   /** Restore clip audio fields from a version by index. */
   setActiveVersion: (clipId: string, idx: number) => void;
+
+  toggleClipStar: (clipId: string) => void;
+  moveClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => void;
 
   getTrackById: (trackId: string) => Track | undefined;
   getClipById: (clipId: string) => Clip | undefined;
@@ -498,6 +501,58 @@ export const useProjectStore = create<ProjectState>()(
               : c,
           ),
         })),
+      },
+    });
+  },
+
+  toggleClipStar: (clipId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => ({
+          ...t,
+          clips: t.clips.map((c) =>
+            c.id === clipId ? { ...c, starred: !c.starred } : c,
+          ),
+        })),
+      },
+    });
+  },
+
+  moveClipToTrack: (clipId, targetTrackId, startTime) => {
+    const state = get();
+    if (!state.project) return;
+    const srcTrack = state.project.tracks.find((t) => t.clips.some((c) => c.id === clipId));
+    if (!srcTrack) return;
+    if (srcTrack.id === targetTrackId && startTime === undefined) return;
+    const clip = srcTrack.clips.find((c) => c.id === clipId);
+    if (!clip) return;
+    _pushHistory(state.project);
+    const movedClip = {
+      ...clip,
+      trackId: targetTrackId,
+      ...(startTime !== undefined ? { startTime } : {}),
+    };
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id === srcTrack.id && t.id !== targetTrackId) {
+            return { ...t, clips: t.clips.filter((c) => c.id !== clipId) };
+          }
+          if (t.id === targetTrackId && t.id !== srcTrack.id) {
+            return { ...t, clips: [...t.clips, movedClip] };
+          }
+          if (t.id === srcTrack.id && t.id === targetTrackId) {
+            return { ...t, clips: t.clips.map((c) => c.id === clipId ? movedClip : c) };
+          }
+          return t;
+        }),
       },
     });
   },

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -18,6 +18,9 @@ interface UIState {
   showKeyboardShortcutsDialog: boolean;
   showMixer: boolean;
   mixerHeight: number;
+  showAssetsPanel: boolean;
+  assetsPanelWidth: number;
+  trackListWidth: number;
   /** Global context window set by Cmd+drag on the timeline. */
   contextWindow: { startTime: number; endTime: number; trackIds: string[] } | null;
   /** Multi-track select window set by non-Cmd drag on the timeline. */
@@ -43,6 +46,9 @@ interface UIState {
   setShowKeyboardShortcutsDialog: (v: boolean) => void;
   setShowMixer: (v: boolean) => void;
   setMixerHeight: (v: number) => void;
+  setShowAssetsPanel: (v: boolean) => void;
+  setAssetsPanelWidth: (v: number) => void;
+  setTrackListWidth: (v: number) => void;
   setContextWindow: (v: { startTime: number; endTime: number; trackIds: string[] } | null) => void;
   setSelectWindow: (v: { startTime: number; endTime: number; trackIds: string[] } | null) => void;
   setExpandedTrackId: (id: string | null) => void;
@@ -65,7 +71,10 @@ export const useUIStore = create<UIState>((set) => ({
   batchGenerateInitialRange: null,
   showKeyboardShortcutsDialog: false,
   showMixer: false,
-  mixerHeight: 260,
+  mixerHeight: 420,
+  showAssetsPanel: false,
+  assetsPanelWidth: 240,
+  trackListWidth: 220,
   contextWindow: null,
   selectWindow: null,
   expandedTrackId: null,
@@ -114,7 +123,10 @@ export const useUIStore = create<UIState>((set) => ({
   setBatchGenerateInitialRange: (v) => set({ batchGenerateInitialRange: v }),
   setShowKeyboardShortcutsDialog: (v) => set({ showKeyboardShortcutsDialog: v }),
   setShowMixer: (v) => set({ showMixer: v }),
-  setMixerHeight: (v) => set({ mixerHeight: Math.min(450, Math.max(160, v)) }),
+  setMixerHeight: (v) => set({ mixerHeight: Math.min(500, Math.max(160, v)) }),
+  setShowAssetsPanel: (v) => set({ showAssetsPanel: v }),
+  setAssetsPanelWidth: (v) => set({ assetsPanelWidth: Math.min(500, Math.max(160, v)) }),
+  setTrackListWidth: (v) => set({ trackListWidth: Math.min(400, Math.max(120, v)) }),
   setContextWindow: (v) => set({ contextWindow: v }),
   setSelectWindow: (v) => set({ selectWindow: v }),
   setExpandedTrackId: (id) => set({ expandedTrackId: id }),

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -60,6 +60,10 @@ export interface Clip {
   versions?: ClipVersion[];
   /** Currently displayed version index (0 = oldest). When undefined, live fields are used. */
   activeVersionIdx?: number;
+  /** Origin of this clip: AI-generated or user-uploaded audio. */
+  source?: 'generated' | 'uploaded';
+  /** User bookmark flag for quick access in the Assets panel. */
+  starred?: boolean;
 }
 
 export interface Track {
@@ -86,6 +90,8 @@ export interface Track {
   // Track Inspector
   /** Default prompt for clips on this track; falls back to track display name if empty. */
   localCaption?: string;
+  /** Per-track lane height in pixels (default 64, min 40, max 200). */
+  laneHeight?: number;
 }
 
 export interface GenerationDefaults {


### PR DESCRIPTION
## Summary

- Revert from floating panels to a traditional docked DAW layout (ACE Studio 2.0 reference): TrackList left sidebar, Timeline center, Assets right sidebar, Mixer bottom-docked
- Merge transport controls (play/stop/loop/metronome/tempo) into the top toolbar
- Add per-track lane height resize (40-200px) via bottom-edge drag handles on both TrackHeader and TrackLane
- Add resizable width for both TrackList (right-edge drag) and Assets panel (left-edge drag)
- Increase Mixer default height to 420px with adjusted fader formula so volume labels are always visible
- Add `importAudioToTrack` for dropping audio files directly onto existing track lanes
- Add `moveClipToTrack` action with visual cross-track drag: ghost preview, target lane highlight, snap-to-closest-lane
- Delete FloatingPanel component and panelLayoutStore (replaced by docked layout)

## Test plan

- [ ] Verify TrackList left sidebar aligns with timeline track lanes
- [ ] Drag right edge of TrackList to resize width
- [ ] Drag left edge of Assets panel to resize width
- [ ] Drag bottom edge of any track header or lane to resize track height
- [ ] Toggle Mixer visibility, drag top edge to resize height
- [ ] Verify mixer volume labels and faders are fully visible at default height
- [ ] Drag an audio clip from one track lane to another -- verify ghost preview and lane highlight
- [ ] Drop audio files onto an existing track lane -- verify clip is created on that track
- [ ] Transport controls work from the merged toolbar

Made with [Cursor](https://cursor.com)