### PR TITLE
feat: track type system, edit modal, asset management, and UX fixes

### DIFF
--- a/src/components/assets/AssetsPanel.tsx
+++ b/src/components/assets/AssetsPanel.tsx
@@ -1,15 +1,9 @@
 import { useState, useMemo, useCallback, useRef } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
-import type { Clip, Track } from '../../types/project';
-
+import type { AssetClip } from '../../types/project';
 
 type Tab = 'starred' | 'generated' | 'uploaded';
-
-interface AssetEntry {
-  clip: Clip;
-  track: Track;
-}
 
 function MiniWaveform({ peaks, color }: { peaks: number[] | null; color: string }) {
   if (!peaks || peaks.length === 0) return <div className="w-full h-full bg-zinc-800 rounded-sm" />;
@@ -48,7 +42,9 @@ export function AssetsPanel() {
   const setAssetsPanelWidth = useUIStore((s) => s.setAssetsPanelWidth);
   const selectClip = useUIStore((s) => s.selectClip);
   const project = useProjectStore((s) => s.project);
-  const toggleClipStar = useProjectStore((s) => s.toggleClipStar);
+  const removeAsset = useProjectStore((s) => s.removeAsset);
+  const toggleAssetStar = useProjectStore((s) => s.toggleAssetStar);
+  const getClipById = useProjectStore((s) => s.getClipById);
 
   const [activeTab, setActiveTab] = useState<Tab>('starred');
 
@@ -70,42 +66,41 @@ export function AssetsPanel() {
     window.addEventListener('mouseup', onMouseUp);
   }, [assetsPanelWidth, setAssetsPanelWidth]);
 
-  const allEntries = useMemo<AssetEntry[]>(() => {
-    if (!project) return [];
-    const entries: AssetEntry[] = [];
-    for (const track of project.tracks) {
-      for (const clip of track.clips) {
-        if (clip.generationStatus === 'ready') {
-          entries.push({ clip, track });
-        }
-      }
+  const allAssets = useMemo<AssetClip[]>(() => {
+    return project?.assets ?? [];
+  }, [project?.assets]);
+
+  const starredAssets = useMemo(() => allAssets.filter((a) => a.starred), [allAssets]);
+  const generatedAssets = useMemo(() => allAssets.filter((a) => a.source !== 'uploaded'), [allAssets]);
+  const uploadedAssets = useMemo(() => allAssets.filter((a) => a.source === 'uploaded'), [allAssets]);
+
+  const activeAssets = activeTab === 'starred' ? starredAssets
+    : activeTab === 'generated' ? generatedAssets
+    : uploadedAssets;
+
+  const handleClick = useCallback((asset: AssetClip) => {
+    const clip = getClipById(asset.clipId);
+    if (clip) {
+      selectClip(asset.clipId, false);
     }
-    return entries;
-  }, [project]);
+  }, [selectClip, getClipById]);
 
-  const starredEntries = useMemo(() => allEntries.filter((e) => e.clip.starred), [allEntries]);
-  const generatedEntries = useMemo(() => allEntries.filter((e) => e.clip.source !== 'uploaded'), [allEntries]);
-  const uploadedEntries = useMemo(() => allEntries.filter((e) => e.clip.source === 'uploaded'), [allEntries]);
-
-  const activeEntries = activeTab === 'starred' ? starredEntries
-    : activeTab === 'generated' ? generatedEntries
-    : uploadedEntries;
-
-  const handleClick = useCallback((clipId: string) => {
-    selectClip(clipId, false);
-  }, [selectClip]);
-
-  const handleStar = useCallback((e: React.MouseEvent, clipId: string) => {
+  const handleStar = useCallback((e: React.MouseEvent, assetId: string) => {
     e.stopPropagation();
-    toggleClipStar(clipId);
-  }, [toggleClipStar]);
+    toggleAssetStar(assetId);
+  }, [toggleAssetStar]);
+
+  const handleDelete = useCallback((e: React.MouseEvent, assetId: string) => {
+    e.stopPropagation();
+    removeAsset(assetId);
+  }, [removeAsset]);
 
   if (!showAssetsPanel || !project) return null;
 
   const tabs: { id: Tab; label: string; count: number }[] = [
-    { id: 'starred', label: 'Starred', count: starredEntries.length },
-    { id: 'generated', label: 'Generated', count: generatedEntries.length },
-    { id: 'uploaded', label: 'Uploaded', count: uploadedEntries.length },
+    { id: 'starred', label: 'Starred', count: starredAssets.length },
+    { id: 'generated', label: 'Generated', count: generatedAssets.length },
+    { id: 'uploaded', label: 'Uploaded', count: uploadedAssets.length },
   ];
 
   return (
@@ -141,7 +136,7 @@ export function AssetsPanel() {
 
       {/* List */}
       <div className="flex-1 overflow-y-auto min-h-0">
-        {activeEntries.length === 0 ? (
+        {activeAssets.length === 0 ? (
           <div className="flex items-center justify-center h-24 text-[10px] text-zinc-600">
             {activeTab === 'starred' ? 'No starred clips yet' :
              activeTab === 'uploaded' ? 'No uploaded audio yet' :
@@ -149,49 +144,66 @@ export function AssetsPanel() {
           </div>
         ) : (
           <div className="py-1">
-            {activeEntries.map(({ clip, track }) => (
-              <button
-                key={clip.id}
-                onClick={() => handleClick(clip.id)}
-                className="w-full flex items-start gap-2 px-3 py-1.5 hover:bg-zinc-800/60 transition-colors text-left group"
-              >
-                <div className="shrink-0 mt-0.5">
-                  <MiniWaveform peaks={clip.waveformPeaks} color={track.color} />
-                </div>
-
-                <div className="flex-1 min-w-0 overflow-hidden">
-                  <div className="flex items-center gap-1">
-                    <span className={`shrink-0 text-[8px] px-1 py-px rounded ${
-                      clip.source === 'uploaded'
-                        ? 'bg-amber-900/40 text-amber-400'
-                        : 'bg-violet-900/40 text-violet-400'
-                    }`}>
-                      {clip.source === 'uploaded' ? '↑' : 'AI'}
-                    </span>
-                    <span className="text-[10px] text-zinc-300 truncate">
-                      {clip.prompt || track.displayName}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1 mt-0.5">
-                    <span className="text-[9px] text-zinc-600 truncate">{track.displayName}</span>
-                    <span className="text-[9px] text-zinc-700">·</span>
-                    <span className="text-[9px] text-zinc-600">{fmtDuration(clip.duration)}</span>
-                  </div>
-                </div>
-
-                <button
-                  onClick={(e) => handleStar(e, clip.id)}
-                  className={`shrink-0 w-5 h-5 flex items-center justify-center rounded text-[10px] transition-colors ${
-                    clip.starred
-                      ? 'text-yellow-400 hover:text-yellow-300'
-                      : 'text-zinc-700 hover:text-zinc-500 opacity-0 group-hover:opacity-100'
+            {activeAssets.map((asset) => {
+              const clipStillOnTrack = !!getClipById(asset.clipId);
+              return (
+                <div
+                  key={asset.id}
+                  onClick={() => handleClick(asset)}
+                  className={`w-full flex items-start gap-2 px-3 py-1.5 hover:bg-zinc-800/60 transition-colors text-left group cursor-pointer ${
+                    !clipStillOnTrack ? 'opacity-60' : ''
                   }`}
-                  title={clip.starred ? 'Remove star' : 'Star this clip'}
                 >
-                  {clip.starred ? '★' : '☆'}
-                </button>
-              </button>
-            ))}
+                  <div className="shrink-0 mt-0.5">
+                    <MiniWaveform peaks={asset.waveformPeaks} color="#71717a" />
+                  </div>
+
+                  <div className="flex-1 min-w-0 overflow-hidden">
+                    <div className="flex items-center gap-1">
+                      <span className={`shrink-0 text-[8px] px-1 py-px rounded ${
+                        asset.source === 'uploaded'
+                          ? 'bg-amber-900/40 text-amber-400'
+                          : 'bg-violet-900/40 text-violet-400'
+                      }`}>
+                        {asset.source === 'uploaded' ? '↑' : 'AI'}
+                      </span>
+                      <span className="text-[10px] text-zinc-300 truncate">
+                        {asset.prompt || asset.trackDisplayName}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 mt-0.5">
+                      <span className="text-[9px] text-zinc-600 truncate">{asset.trackDisplayName}</span>
+                      <span className="text-[9px] text-zinc-700">·</span>
+                      <span className="text-[9px] text-zinc-600">{fmtDuration(asset.duration)}</span>
+                      {!clipStillOnTrack && (
+                        <span className="text-[8px] text-zinc-700 italic ml-1">removed</span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-0.5 shrink-0">
+                    <button
+                      onClick={(e) => handleStar(e, asset.id)}
+                      className={`w-5 h-5 flex items-center justify-center rounded text-[10px] transition-colors ${
+                        asset.starred
+                          ? 'text-yellow-400 hover:text-yellow-300'
+                          : 'text-zinc-700 hover:text-zinc-500 opacity-0 group-hover:opacity-100'
+                      }`}
+                      title={asset.starred ? 'Remove star' : 'Star this clip'}
+                    >
+                      {asset.starred ? '★' : '☆'}
+                    </button>
+                    <button
+                      onClick={(e) => handleDelete(e, asset.id)}
+                      className="w-5 h-5 flex items-center justify-center rounded text-[10px] text-zinc-700 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
+                      title="Remove from assets"
+                    >
+                      ×
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/components/dialogs/InstrumentPicker.tsx
+++ b/src/components/dialogs/InstrumentPicker.tsx
@@ -1,62 +1,175 @@
+import { useState, useCallback } from 'react';
 import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
-import { TRACK_NAMES, TRACK_CATALOG } from '../../constants/tracks';
-import type { TrackName } from '../../types/project';
+import { TRACK_NAMES, TRACK_CATALOG, TRACK_TYPE_CATALOG } from '../../constants/tracks';
+import type { TrackName, TrackType } from '../../types/project';
+import { useAudioImport } from '../../hooks/useAudioImport';
+
+type PickerStep = 'type' | 'instrument';
 
 export function InstrumentPicker() {
   const show = useUIStore((s) => s.showInstrumentPicker);
   const setShow = useUIStore((s) => s.setShowInstrumentPicker);
   const addTrack = useProjectStore((s) => s.addTrack);
   const project = useProjectStore((s) => s.project);
+  const { openFilePicker } = useAudioImport();
+
+  const [step, setStep] = useState<PickerStep>('type');
+  const [selectedType, setSelectedType] = useState<TrackType>('stems');
+
+  const close = useCallback(() => {
+    setShow(false);
+    setStep('type');
+    setSelectedType('stems');
+  }, [setShow]);
 
   if (!show || !project) return null;
 
-  // Count existing tracks per name so we can show a badge
   const trackCountByName: Partial<Record<TrackName, number>> = {};
   for (const t of project.tracks) {
     trackCountByName[t.trackName] = (trackCountByName[t.trackName] ?? 0) + 1;
   }
 
-  const handleSelect = (name: TrackName) => {
-    addTrack(name);
-    setShow(false);
+  const handleTypeSelect = (type: TrackType) => {
+    setSelectedType(type);
+    setStep('instrument');
   };
 
+  const handleInstrumentSelect = (name: TrackName) => {
+    addTrack(name, selectedType);
+    close();
+  };
+
+  const typeOrder: TrackType[] = ['stems', 'sample', 'sequencer', 'pianoRoll'];
+  const isComingSoon = selectedType === 'sequencer' || selectedType === 'pianoRoll';
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="w-[440px] bg-daw-surface rounded-lg border border-daw-border shadow-2xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={(e) => { if (e.target === e.currentTarget) close(); }}>
+      <div className="w-[480px] bg-daw-surface rounded-lg border border-daw-border shadow-2xl">
         <div className="flex items-center justify-between px-4 py-3 border-b border-daw-border">
-          <h2 className="text-sm font-medium">Add Track</h2>
+          <div className="flex items-center gap-2">
+            {step === 'instrument' && (
+              <button
+                onClick={() => setStep('type')}
+                className="text-zinc-500 hover:text-zinc-300 text-sm"
+              >
+                ←
+              </button>
+            )}
+            <h2 className="text-sm font-medium">
+              {step === 'type' ? 'Add Track' : `Add ${TRACK_TYPE_CATALOG[selectedType].label} Track`}
+            </h2>
+          </div>
           <button
-            onClick={() => setShow(false)}
+            onClick={close}
             className="text-zinc-500 hover:text-zinc-300 text-lg leading-none"
           >
             ×
           </button>
         </div>
 
-        <div className="p-4 grid grid-cols-3 gap-2">
-          {TRACK_NAMES.map((name) => {
-            const info = TRACK_CATALOG[name];
-            const count = trackCountByName[name] ?? 0;
-            return (
-              <button
-                key={name}
-                onClick={() => handleSelect(name)}
-                className="flex items-center gap-2 px-3 py-2.5 rounded text-left bg-daw-surface-2 hover:bg-zinc-600 cursor-pointer transition-colors relative"
-                style={{ borderLeft: `3px solid ${info.color}` }}
-              >
-                <span className="text-lg">{info.emoji}</span>
-                <span className="text-xs font-medium">{info.displayName}</span>
-                {count > 0 && (
-                  <span className="absolute top-1 right-1.5 text-[9px] font-bold text-zinc-400">
-                    ×{count}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
+        {step === 'type' && (
+          <div className="p-4 grid grid-cols-2 gap-3">
+            {typeOrder.map((type) => {
+              const info = TRACK_TYPE_CATALOG[type];
+              const comingSoon = type === 'sequencer' || type === 'pianoRoll';
+              return (
+                <button
+                  key={type}
+                  onClick={() => handleTypeSelect(type)}
+                  className={`flex flex-col gap-1.5 p-3 rounded-lg text-left transition-colors relative ${
+                    comingSoon
+                      ? 'bg-daw-surface-2/60 opacity-70 hover:opacity-90'
+                      : 'bg-daw-surface-2 hover:bg-zinc-600'
+                  }`}
+                  style={{ borderLeft: `3px solid ${info.color}` }}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-xl">{info.emoji}</span>
+                    <span className="text-sm font-medium">{info.label}</span>
+                    <span
+                      className="ml-auto text-[9px] font-bold px-1.5 py-0.5 rounded"
+                      style={{ backgroundColor: info.color + '30', color: info.color }}
+                    >
+                      {info.abbr}
+                    </span>
+                  </div>
+                  <span className="text-[11px] text-zinc-400 leading-tight">{info.description}</span>
+                  {comingSoon && (
+                    <span className="absolute top-2 right-2 text-[9px] font-bold text-amber-400 bg-amber-400/10 px-1.5 py-0.5 rounded">
+                      SOON
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {step === 'instrument' && selectedType === 'stems' && (
+          <div className="p-4 grid grid-cols-3 gap-2">
+            {TRACK_NAMES.map((name) => {
+              const info = TRACK_CATALOG[name];
+              const count = trackCountByName[name] ?? 0;
+              return (
+                <button
+                  key={name}
+                  onClick={() => handleInstrumentSelect(name)}
+                  className="flex items-center gap-2 px-3 py-2.5 rounded text-left bg-daw-surface-2 hover:bg-zinc-600 cursor-pointer transition-colors relative"
+                  style={{ borderLeft: `3px solid ${info.color}` }}
+                >
+                  <span className="text-lg">{info.emoji}</span>
+                  <span className="text-xs font-medium">{info.displayName}</span>
+                  {count > 0 && (
+                    <span className="absolute top-1 right-1.5 text-[9px] font-bold text-zinc-400">
+                      ×{count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {step === 'instrument' && selectedType === 'sample' && (
+          <div className="p-5 flex flex-col gap-3">
+            <button
+              onClick={() => { addTrack('custom', 'sample'); close(); }}
+              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-zinc-600 transition-colors text-left"
+              style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.sample.color}` }}
+            >
+              <span className="text-xl">📂</span>
+              <div>
+                <div className="text-sm font-medium">Empty Track</div>
+                <div className="text-[11px] text-zinc-400">Create a blank sample track — drag audio onto it later</div>
+              </div>
+            </button>
+            <button
+              onClick={() => { close(); openFilePicker(); }}
+              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-zinc-600 transition-colors text-left"
+              style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.sample.color}` }}
+            >
+              <span className="text-xl">📁</span>
+              <div>
+                <div className="text-sm font-medium">Import Audio File</div>
+                <div className="text-[11px] text-zinc-400">Pick a file from your computer to create a track with audio</div>
+              </div>
+            </button>
+          </div>
+        )}
+
+        {step === 'instrument' && isComingSoon && (
+          <div className="p-8 flex flex-col items-center gap-4 text-center">
+            <span className="text-4xl">{TRACK_TYPE_CATALOG[selectedType].emoji}</span>
+            <h3 className="text-base font-medium">{TRACK_TYPE_CATALOG[selectedType].label}</h3>
+            <p className="text-sm text-zinc-400 max-w-xs">
+              {TRACK_TYPE_CATALOG[selectedType].description}
+            </p>
+            <span className="text-xs font-bold text-amber-400 bg-amber-400/10 px-3 py-1.5 rounded-full">
+              Coming Soon
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -25,6 +25,8 @@ interface DragGhostInfo {
   height: number;
   targetTrackId: string | null;
   targetLaneRect: { top: number; height: number } | null;
+  /** Original lane rect for showing source placeholder */
+  sourceLaneRect: { top: number; height: number } | null;
 }
 
 export function ClipBlock({ clip, track }: ClipBlockProps) {
@@ -128,14 +130,19 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
         const closest = findClosestLane(ev.clientY);
         if (closest) {
+          const ghostLeft = newStart * pixelsPerSecond;
+          const sourceLane = findClosestLane(startY);
           setDragGhost({
-            x: ev.clientX - clipW / 2,
-            y: ev.clientY - clipH / 2,
+            x: ghostLeft,
+            y: closest.rect.top + 4,
             width: clipW,
             height: clipH,
             targetTrackId: closest.trackId !== track.id ? closest.trackId : null,
             targetLaneRect: closest.trackId !== track.id
               ? { top: closest.rect.top, height: closest.rect.height }
+              : null,
+            sourceLaneRect: closest.trackId !== track.id && sourceLane
+              ? { top: sourceLane.rect.top, height: sourceLane.rect.height }
               : null,
           });
         }
@@ -246,7 +253,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         className={`absolute top-1 bottom-1 rounded-sm select-none overflow-hidden
           ${statusStyles[clip.generationStatus] ?? ''}
           ${isSelected ? 'ring-2 ring-white ring-offset-1 ring-offset-transparent' : ''}
-          ${dragGhost ? 'opacity-40' : ''}
+          ${dragGhost && dragGhost.targetTrackId ? 'opacity-0' : dragGhost ? '' : ''}
         `}
         style={{
           left,
@@ -392,22 +399,67 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       )}
 
       {/* Cross-track drag ghost + target lane highlight */}
-      {dragGhost && (
+      {dragGhost && dragGhost.targetTrackId && (
         <>
-          {/* Ghost preview following the cursor */}
+          {/* Source lane placeholder (dashed outline showing where clip came from) */}
+          {dragGhost.sourceLaneRect && (
+            <div
+              className="fixed pointer-events-none z-[98]"
+              style={{
+                left: clipBlockRef.current?.getBoundingClientRect().left ?? left,
+                top: dragGhost.sourceLaneRect.top + 4,
+                width,
+                height: dragGhost.sourceLaneRect.height - 8,
+                border: `1.5px dashed ${hexToRgba(track.color, 0.4)}`,
+                borderRadius: 2,
+                backgroundColor: hexToRgba(track.color, 0.04),
+              }}
+            />
+          )}
+
+          {/* Lane-aligned ghost — visually mirrors the original clip at full size */}
           <div
             className="fixed pointer-events-none z-[100] rounded-sm overflow-hidden"
             style={{
-              left: dragGhost.x,
+              left: clipBlockRef.current?.getBoundingClientRect().left ?? left,
               top: dragGhost.y,
-              width: Math.min(dragGhost.width, 400),
+              width: dragGhost.width,
               height: dragGhost.height,
-              backgroundColor: hexToRgba(track.color, 0.5),
+              backgroundColor: hexToRgba(track.color, 0.45),
               borderLeft: `2px solid ${track.color}`,
-              boxShadow: `0 4px 20px ${hexToRgba(track.color, 0.3)}, 0 0 0 1px ${hexToRgba(track.color, 0.4)}`,
+              boxShadow: `0 4px 20px ${hexToRgba(track.color, 0.3)}, 0 0 0 1px ${hexToRgba(track.color, 0.5)}`,
+              transition: 'top 80ms ease-out',
             }}
           >
-            <div className="px-1.5 py-0.5 text-[9px] font-medium text-white truncate drop-shadow-sm">
+            {/* Mini waveform inside ghost */}
+            {peaks && numBars > 0 && (
+              <div className="absolute inset-0 flex items-center overflow-hidden">
+                <svg
+                  width={peakWidthPx}
+                  height="100%"
+                  viewBox={`0 0 ${peakWidthPx} 100`}
+                  preserveAspectRatio="none"
+                  className="opacity-50 ml-0.5"
+                >
+                  {Array.from({ length: numBars }, (_, i) => {
+                    const peakIdx = startPeakIdx + Math.floor((i / numBars) * visiblePeakCount);
+                    const peak = peaks[Math.min(peakIdx, peaks.length - 1)];
+                    const h = peak * 80;
+                    return (
+                      <rect
+                        key={i}
+                        x={i * barSpacing}
+                        y={50 - h / 2}
+                        width={Math.max(barSpacing * 0.7, 0.5)}
+                        height={Math.max(h, 1)}
+                        fill={track.color}
+                      />
+                    );
+                  })}
+                </svg>
+              </div>
+            )}
+            <div className="absolute top-0 left-1.5 right-1.5 text-[9px] font-medium text-white truncate leading-4 z-10 drop-shadow-sm">
               {clip.prompt || track.displayName}
             </div>
           </div>
@@ -421,9 +473,10 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
                 top: dragGhost.targetLaneRect.top,
                 width: '100vw',
                 height: dragGhost.targetLaneRect.height,
-                backgroundColor: hexToRgba(track.color, 0.08),
-                borderTop: `1px solid ${hexToRgba(track.color, 0.4)}`,
-                borderBottom: `1px solid ${hexToRgba(track.color, 0.4)}`,
+                backgroundColor: hexToRgba(track.color, 0.06),
+                borderTop: `1px solid ${hexToRgba(track.color, 0.35)}`,
+                borderBottom: `1px solid ${hexToRgba(track.color, 0.35)}`,
+                transition: 'top 80ms ease-out',
               }}
             />
           )}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useState } from 'react';
+import { useRef, useCallback, useState, useEffect } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { TimeRuler } from './TimeRuler';
@@ -9,7 +9,8 @@ import { snapToGrid } from '../../utils/time';
 import { MultiTrackGenerateModal } from '../generation/MultiTrackGenerateModal';
 import { useAudioImport } from '../../hooks/useAudioImport';
 
-export const TRACK_INSPECTOR_HEIGHT = 220; // px — must match TrackInspector height
+/** @deprecated Inspector is now a modal; kept for potential future use */
+export const TRACK_INSPECTOR_HEIGHT = 220;
 
 const DRAG_THRESHOLD_PX = 4;
 
@@ -59,7 +60,6 @@ export function Timeline() {
   const setContextWindow = useUIStore((s) => s.setContextWindow);
   const selectWindow = useUIStore((s) => s.selectWindow);
   const setSelectWindow = useUIStore((s) => s.setSelectWindow);
-  const expandedTrackId = useUIStore((s) => s.expandedTrackId);
   const scrollRef = useRef<HTMLDivElement>(null);
   const trackAreaRef = useRef<HTMLDivElement>(null);
 
@@ -101,6 +101,21 @@ export function Timeline() {
       await importMultipleFiles(files);
     }
   }, [importMultipleFiles]);
+
+  // Safety net: if a child (e.g. TrackLane) stops propagation on drop,
+  // the Timeline's own handleDrop never fires. Listen globally to clear the overlay.
+  useEffect(() => {
+    const clearOverlay = () => {
+      dragCounterRef.current = 0;
+      setFileDragOver(false);
+    };
+    window.addEventListener('drop', clearOverlay);
+    window.addEventListener('dragend', clearOverlay);
+    return () => {
+      window.removeEventListener('drop', clearOverlay);
+      window.removeEventListener('dragend', clearOverlay);
+    };
+  }, []);
 
   const sortedTracks = project
     ? [...project.tracks].sort((a, b) => a.order - b.order)
@@ -366,15 +381,7 @@ export function Timeline() {
             )}
 
             {sortedTracks.map((track) => (
-              <div key={track.id}>
-                <TrackLane track={track} />
-                {expandedTrackId === track.id && (
-                  <div
-                    className="border-b border-daw-border bg-zinc-950/60"
-                    style={{ height: TRACK_INSPECTOR_HEIGHT }}
-                  />
-                )}
-              </div>
+              <TrackLane key={track.id} track={track} />
             ))}
 
             {sortedTracks.length === 0 && (

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -6,6 +6,7 @@ import { ClipBlock } from './ClipBlock';
 import { AddLayerModal } from '../generation/AddLayerModal';
 import { snapToGrid } from '../../utils/time';
 import { useAudioImport } from '../../hooks/useAudioImport';
+import { TRACK_TYPE_CATALOG } from '../../constants/tracks';
 
 interface TrackLaneProps {
   track: Track;
@@ -90,6 +91,8 @@ export function TrackLane({ track }: TrackLaneProps) {
 
   if (!project) return null;
 
+  const trackType = track.trackType ?? 'stems';
+  const isComingSoon = trackType === 'sequencer' || trackType === 'pianoRoll';
   const totalWidth = project.totalDuration * pixelsPerSecond;
 
   const hitsClip = useCallback((clickTime: number): boolean => {
@@ -101,6 +104,7 @@ export function TrackLane({ track }: TrackLaneProps) {
 
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) return;
+    if (isComingSoon) return;
     e.preventDefault();
     e.stopPropagation();
     const rect = e.currentTarget.getBoundingClientRect();
@@ -111,10 +115,11 @@ export function TrackLane({ track }: TrackLaneProps) {
     const duration = Math.max(10, Math.min(30, remaining));
     setCtxMenu({ x: e.clientX, y: e.clientY, startTime, duration });
     setAddLayerTarget(null);
-  }, [pixelsPerSecond, project.bpm, project.totalDuration]);
+  }, [isComingSoon, pixelsPerSecond, project.bpm, project.totalDuration]);
 
   const handleDoubleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) return;
+    if (isComingSoon) return;
     e.stopPropagation();
     const rect = e.currentTarget.getBoundingClientRect();
     const laneX = e.clientX - rect.left;
@@ -126,7 +131,7 @@ export function TrackLane({ track }: TrackLaneProps) {
     const duration = Math.max(10, Math.min(30, remaining));
     setCtxMenu({ x: e.clientX, y: e.clientY, startTime, duration });
     setAddLayerTarget(null);
-  }, [pixelsPerSecond, project.bpm, project.totalDuration, hitsClip]);
+  }, [isComingSoon, pixelsPerSecond, project.bpm, project.totalDuration, hitsClip]);
 
   const clearSel = useCallback(() => {
     setAddLayerTarget(null);
@@ -180,9 +185,19 @@ export function TrackLane({ track }: TrackLaneProps) {
           </div>
         )}
 
-        {track.clips.map((clip) => (
-          <ClipBlock key={clip.id} clip={clip} track={track} />
-        ))}
+        {isComingSoon ? (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
+            <div className="flex items-center gap-2 bg-daw-surface/80 backdrop-blur-sm px-4 py-2 rounded-lg border border-daw-border">
+              <span className="text-lg">{TRACK_TYPE_CATALOG[trackType].emoji}</span>
+              <span className="text-xs font-medium text-zinc-400">{TRACK_TYPE_CATALOG[trackType].label}</span>
+              <span className="text-[9px] font-bold text-amber-400 bg-amber-400/10 px-1.5 py-0.5 rounded">Coming Soon</span>
+            </div>
+          </div>
+        ) : (
+          track.clips.map((clip) => (
+            <ClipBlock key={clip.id} clip={clip} track={track} />
+          ))
+        )}
 
         {ctxMenu && (
           <LaneContextMenu

--- a/src/components/tracks/TrackEditModal.tsx
+++ b/src/components/tracks/TrackEditModal.tsx
@@ -1,0 +1,274 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { Track, TrackType } from '../../types/project';
+import { useProjectStore } from '../../store/projectStore';
+import { TRACK_CATALOG, TRACK_TYPE_CATALOG } from '../../constants/tracks';
+import { Knob } from '../ui/Knob';
+
+interface TrackEditModalProps {
+  track: Track;
+  onClose: () => void;
+}
+
+export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
+  const updateTrack = useProjectStore((s) => s.updateTrack);
+  const renameTrack = useProjectStore((s) => s.renameTrack);
+  const removeTrack = useProjectStore((s) => s.removeTrack);
+  const updateTrackMixer = useProjectStore((s) => s.updateTrackMixer);
+  const setTrackLocalCaption = useProjectStore((s) => s.setTrackLocalCaption);
+  const setTrackReverb = useProjectStore((s) => s.setTrackReverb);
+
+  const [name, setName] = useState(track.displayName);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const commitName = useCallback(() => {
+    const trimmed = name.trim();
+    if (trimmed && trimmed !== track.displayName) {
+      renameTrack(track.id, trimmed);
+    }
+  }, [name, track.displayName, track.id, renameTrack]);
+
+  const handleDelete = useCallback(() => {
+    removeTrack(track.id);
+    onClose();
+  }, [track.id, removeTrack, onClose]);
+
+  const info = TRACK_CATALOG[track.trackName];
+  const typeInfo = TRACK_TYPE_CATALOG[track.trackType ?? 'stems'];
+
+  const eqLow = track.eqLowGain ?? 0;
+  const eqMid = track.eqMidGain ?? 0;
+  const eqHigh = track.eqHighGain ?? 0;
+  const compEnabled = track.compressorEnabled ?? false;
+  const compThreshold = track.compressorThreshold ?? -24;
+  const compRatio = track.compressorRatio ?? 4;
+  const reverbMix = track.reverbMix ?? 0;
+  const reverbRoom = track.reverbRoomSize ?? 0.5;
+  const pan = track.pan ?? 0;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="w-[420px] max-h-[85vh] bg-daw-surface rounded-lg border border-daw-border shadow-2xl flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-daw-border shrink-0">
+          <div className="flex items-center gap-2">
+            <span className="text-lg">{info.emoji}</span>
+            <span
+              className="text-[9px] font-bold px-1.5 py-0.5 rounded"
+              style={{ backgroundColor: typeInfo.color + '25', color: typeInfo.color }}
+            >
+              {typeInfo.label}
+            </span>
+            <h2 className="text-sm font-medium text-zinc-200">Edit Track</h2>
+          </div>
+          <button onClick={onClose} className="text-zinc-500 hover:text-zinc-300 text-lg leading-none">×</button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+          {/* Track Name */}
+          <div>
+            <label className="block text-[10px] font-medium uppercase tracking-wide text-zinc-500 mb-1">Track Name</label>
+            <input
+              ref={nameInputRef}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onBlur={commitName}
+              onKeyDown={(e) => { if (e.key === 'Enter') { commitName(); (e.target as HTMLInputElement).blur(); } }}
+              className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus:border-indigo-500/60"
+            />
+          </div>
+
+          {/* Track Type */}
+          <div>
+            <label className="block text-[10px] font-medium uppercase tracking-wide text-zinc-500 mb-1">Track Type</label>
+            <div className="flex gap-1.5">
+              {(['stems', 'sample', 'sequencer', 'pianoRoll'] as TrackType[]).map((tt) => {
+                const tti = TRACK_TYPE_CATALOG[tt];
+                const isActive = (track.trackType ?? 'stems') === tt;
+                const comingSoon = tt === 'sequencer' || tt === 'pianoRoll';
+                return (
+                  <button
+                    key={tt}
+                    onClick={() => {
+                      if (!comingSoon) updateTrack(track.id, { trackType: tt });
+                    }}
+                    className={`flex items-center gap-1 px-2 py-1 rounded text-[10px] font-medium transition-colors ${
+                      isActive
+                        ? 'ring-1 ring-offset-1 ring-offset-transparent'
+                        : comingSoon
+                          ? 'opacity-40 cursor-not-allowed'
+                          : 'hover:bg-zinc-700'
+                    }`}
+                    style={{
+                      backgroundColor: isActive ? tti.color + '25' : undefined,
+                      color: isActive ? tti.color : undefined,
+                      ...(isActive ? { '--tw-ring-color': tti.color } as React.CSSProperties : {}),
+                    }}
+                    title={comingSoon ? 'Coming soon' : tti.label}
+                  >
+                    <span>{tti.emoji}</span>
+                    <span>{tti.abbr}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Volume + Pan + Mute/Solo */}
+          <div>
+            <label className="block text-[10px] font-medium uppercase tracking-wide text-zinc-500 mb-1">Volume & Pan</label>
+            <div className="flex items-center gap-3">
+              <div className="flex-1">
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={Math.round(track.volume * 100)}
+                  onChange={(e) => updateTrack(track.id, { volume: parseInt(e.target.value) / 100 })}
+                  className="w-full h-1.5"
+                  title={`Volume: ${Math.round(track.volume * 100)}%`}
+                />
+                <div className="text-[9px] text-zinc-500 mt-0.5">Vol: {Math.round(track.volume * 100)}%</div>
+              </div>
+              <div className="flex flex-col items-center gap-0.5">
+                <Knob
+                  value={pan}
+                  min={-1}
+                  max={1}
+                  defaultValue={0}
+                  step={0.01}
+                  size={30}
+                  onChange={(v) => updateTrackMixer(track.id, { pan: v })}
+                />
+                <span className="text-[9px] text-zinc-500">
+                  {pan === 0 ? 'C' : pan < 0 ? `L${Math.round(Math.abs(pan) * 100)}` : `R${Math.round(pan * 100)}`}
+                </span>
+              </div>
+              <div className="flex gap-1">
+                <button
+                  onClick={() => updateTrack(track.id, { muted: !track.muted })}
+                  className={`w-7 h-6 text-[10px] font-bold rounded transition-colors ${
+                    track.muted ? 'bg-amber-600 text-white' : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300'
+                  }`}
+                >
+                  M
+                </button>
+                <button
+                  onClick={() => updateTrack(track.id, { soloed: !track.soloed })}
+                  className={`w-7 h-6 text-[10px] font-bold rounded transition-colors ${
+                    track.soloed ? 'bg-emerald-600 text-white' : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300'
+                  }`}
+                >
+                  S
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Local Caption */}
+          <div>
+            <label className="block text-[10px] font-medium uppercase tracking-wide text-zinc-500 mb-1">Local Caption</label>
+            <input
+              type="text"
+              value={track.localCaption ?? ''}
+              onChange={(e) => setTrackLocalCaption(track.id, e.target.value)}
+              placeholder={track.displayName}
+              className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-indigo-500/60"
+            />
+            <p className="text-[9px] text-zinc-600 mt-0.5">Defaults to track name if empty</p>
+          </div>
+
+          {/* EQ */}
+          <div>
+            <label className="block text-[10px] font-medium uppercase tracking-wide text-zinc-500 mb-2">EQ</label>
+            <div className="flex items-end gap-5 justify-center">
+              <div className="flex flex-col items-center gap-1">
+                <Knob value={eqLow} min={-15} max={15} defaultValue={0} step={0.5} size={32} onChange={(v) => updateTrackMixer(track.id, { eqLowGain: v })} />
+                <span className="text-[9px] text-zinc-400">{eqLow > 0 ? '+' : ''}{eqLow.toFixed(0)} dB</span>
+                <span className="text-[9px] text-zinc-600">Low</span>
+              </div>
+              <div className="flex flex-col items-center gap-1">
+                <Knob value={eqMid} min={-15} max={15} defaultValue={0} step={0.5} size={32} onChange={(v) => updateTrackMixer(track.id, { eqMidGain: v })} />
+                <span className="text-[9px] text-zinc-400">{eqMid > 0 ? '+' : ''}{eqMid.toFixed(0)} dB</span>
+                <span className="text-[9px] text-zinc-600">Mid</span>
+              </div>
+              <div className="flex flex-col items-center gap-1">
+                <Knob value={eqHigh} min={-15} max={15} defaultValue={0} step={0.5} size={32} onChange={(v) => updateTrackMixer(track.id, { eqHighGain: v })} />
+                <span className="text-[9px] text-zinc-400">{eqHigh > 0 ? '+' : ''}{eqHigh.toFixed(0)} dB</span>
+                <span className="text-[9px] text-zinc-600">High</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Compressor */}
+          <div>
+            <div className="flex items-center gap-2 mb-2">
+              <label className="text-[10px] font-medium uppercase tracking-wide text-zinc-500">Compressor</label>
+              <button
+                onClick={() => updateTrackMixer(track.id, { compressorEnabled: !compEnabled })}
+                className={`px-2 py-0.5 rounded text-[9px] font-bold transition-colors ${
+                  compEnabled ? 'bg-orange-600 text-white' : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300'
+                }`}
+              >
+                {compEnabled ? 'ON' : 'OFF'}
+              </button>
+            </div>
+            <div className={`flex items-end gap-5 justify-center transition-opacity ${compEnabled ? '' : 'opacity-40'}`}>
+              <div className="flex flex-col items-center gap-1">
+                <Knob value={compThreshold} min={-60} max={0} defaultValue={-24} step={1} size={32} onChange={(v) => updateTrackMixer(track.id, { compressorThreshold: v })} disabled={!compEnabled} />
+                <span className="text-[9px] text-zinc-400">{compThreshold} dB</span>
+                <span className="text-[9px] text-zinc-600">Threshold</span>
+              </div>
+              <div className="flex flex-col items-center gap-1">
+                <Knob value={compRatio} min={1} max={20} defaultValue={4} step={0.5} size={32} onChange={(v) => updateTrackMixer(track.id, { compressorRatio: v })} disabled={!compEnabled} />
+                <span className="text-[9px] text-zinc-400">{compRatio.toFixed(1)}:1</span>
+                <span className="text-[9px] text-zinc-600">Ratio</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Reverb */}
+          <div>
+            <label className="block text-[10px] font-medium uppercase tracking-wide text-zinc-500 mb-2">Reverb</label>
+            <div className="flex items-end gap-5 justify-center">
+              <div className="flex flex-col items-center gap-1">
+                <Knob value={reverbMix} min={0} max={1} defaultValue={0} step={0.01} size={32} onChange={(v) => setTrackReverb(track.id, v, reverbRoom)} />
+                <span className="text-[9px] text-zinc-400">{Math.round(reverbMix * 100)}%</span>
+                <span className="text-[9px] text-zinc-600">Mix</span>
+              </div>
+              <div className="flex flex-col items-center gap-1">
+                <Knob value={reverbRoom} min={0} max={1} defaultValue={0.5} step={0.01} size={32} onChange={(v) => setTrackReverb(track.id, reverbMix, v)} />
+                <span className="text-[9px] text-zinc-400">{Math.round(reverbRoom * 100)}%</span>
+                <span className="text-[9px] text-zinc-600">Room</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-4 py-3 border-t border-daw-border shrink-0">
+          <button
+            onClick={handleDelete}
+            className="px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/30 rounded transition-colors"
+          >
+            Delete Track
+          </button>
+          <button
+            onClick={onClose}
+            className="px-4 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded transition-colors"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { Track } from '../../types/project';
 import { useProjectStore } from '../../store/projectStore';
-import { useUIStore } from '../../store/uiStore';
-import { TRACK_CATALOG } from '../../constants/tracks';
+import { TRACK_CATALOG, TRACK_TYPE_CATALOG } from '../../constants/tracks';
+import { TrackEditModal } from './TrackEditModal';
 
 const MIN_LANE_HEIGHT = 40;
 const MAX_LANE_HEIGHT = 200;
@@ -25,10 +25,36 @@ export function TrackHeader({
   dragOverPosition,
 }: TrackHeaderProps) {
   const updateTrack = useProjectStore((s) => s.updateTrack);
+  const renameTrack = useProjectStore((s) => s.renameTrack);
   const removeTrack = useProjectStore((s) => s.removeTrack);
-  const expandedTrackId = useUIStore((s) => s.expandedTrackId);
-  const setExpandedTrackId = useUIStore((s) => s.setExpandedTrackId);
   const info = TRACK_CATALOG[track.trackName];
+  const typeInfo = TRACK_TYPE_CATALOG[track.trackType ?? 'stems'];
+
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(track.displayName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const startEditing = useCallback(() => {
+    setEditValue(track.displayName);
+    setIsEditing(true);
+    setTimeout(() => inputRef.current?.select(), 0);
+  }, [track.displayName]);
+
+  const commitRename = useCallback(() => {
+    const trimmed = editValue.trim();
+    if (trimmed && trimmed !== track.displayName) {
+      renameTrack(track.id, trimmed);
+    }
+    setIsEditing(false);
+  }, [editValue, track.displayName, track.id, renameTrack]);
+
+  const cancelEditing = useCallback(() => {
+    setIsEditing(false);
+    setEditValue(track.displayName);
+  }, [track.displayName]);
 
   const laneHeight = track.laneHeight ?? 64;
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
@@ -52,10 +78,20 @@ export function TrackHeader({
     window.addEventListener('mouseup', onMouseUp);
   }, [laneHeight, track.id, updateTrack]);
 
-  const isExpanded = expandedTrackId === track.id;
-  const toggleExpand = () => setExpandedTrackId(isExpanded ? null : track.id);
+  const handleHeaderDoubleClick = useCallback((e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).tagName === 'INPUT') return;
+    e.stopPropagation();
+    setEditModalOpen(true);
+  }, []);
+
+  const handleHeaderContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setCtxMenu({ x: e.clientX, y: e.clientY });
+  }, []);
 
   return (
+    <>
     <div
       className={`relative flex flex-col justify-center gap-1 px-2 border-b border-daw-border group select-none ${
         isDragOver ? 'bg-daw-surface-2' : ''
@@ -71,19 +107,47 @@ export function TrackHeader({
       onDragOver={(e) => onDragOver(e, track.id)}
       onDrop={(e) => onDrop(e, track.id)}
       onDragEnd={(e) => e.currentTarget.style.opacity = '1'}
+      onDoubleClick={handleHeaderDoubleClick}
+      onContextMenu={handleHeaderContextMenu}
     >
-      {/* Top row: drag handle + emoji + name */}
-      <div className="flex items-center gap-1.5 min-w-0">
+      {/* Top row: drag handle + type badge + emoji + name */}
+      <div className="flex items-center gap-1 min-w-0">
         <div
           className="flex-shrink-0 text-zinc-600 hover:text-zinc-400 cursor-grab active:cursor-grabbing text-sm leading-none select-none"
           title="Drag to reorder"
         >
           ⠿
         </div>
-        <span className="text-base flex-shrink-0" title={info.displayName}>{info.emoji}</span>
-        <span className="text-xs font-medium text-zinc-200 truncate" title={track.displayName}>
-          {track.displayName}
+        <span
+          className="flex-shrink-0 text-[8px] font-bold px-1 py-px rounded leading-tight"
+          style={{ backgroundColor: typeInfo.color + '25', color: typeInfo.color }}
+          title={typeInfo.label}
+        >
+          {typeInfo.abbr}
         </span>
+        <span className="text-sm flex-shrink-0" title={info.displayName}>{info.emoji}</span>
+        {isEditing ? (
+          <input
+            ref={inputRef}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitRename();
+              if (e.key === 'Escape') cancelEditing();
+            }}
+            className="text-xs font-medium text-zinc-200 bg-zinc-700 rounded px-1 py-0.5 min-w-0 outline-none border border-indigo-500/60"
+            autoFocus
+          />
+        ) : (
+          <span
+            className="text-xs font-medium text-zinc-200 truncate cursor-text"
+            title={`${track.displayName} (double-click to rename)`}
+            onDoubleClick={startEditing}
+          >
+            {track.displayName}
+          </span>
+        )}
       </div>
 
       {/* Bottom row: volume + buttons */}
@@ -121,15 +185,11 @@ export function TrackHeader({
             S
           </button>
           <button
-            onClick={toggleExpand}
-            className={`w-6 h-5 text-[10px] font-bold rounded transition-colors ${
-              isExpanded
-                ? 'bg-zinc-600 text-white'
-                : 'bg-daw-surface-2 text-zinc-600 hover:text-zinc-300'
-            }`}
-            title="Inspector"
+            onClick={() => setEditModalOpen(true)}
+            className="w-6 h-5 text-[10px] font-bold rounded transition-colors bg-daw-surface-2 text-zinc-600 hover:text-zinc-300"
+            title="Edit track"
           >
-            {isExpanded ? '▲' : '▼'}
+            ⚙
           </button>
           <button
             onClick={() => removeTrack(track.id)}
@@ -147,5 +207,36 @@ export function TrackHeader({
         onMouseDown={onHeightResizeDown}
       />
     </div>
+
+    {/* Context menu */}
+    {ctxMenu && (
+      <>
+        <div className="fixed inset-0 z-40" onClick={() => setCtxMenu(null)} onContextMenu={(e) => { e.preventDefault(); setCtxMenu(null); }} />
+        <div
+          className="fixed z-50 bg-daw-surface border border-daw-border rounded shadow-xl py-1 min-w-[160px]"
+          style={{ left: Math.min(ctxMenu.x, window.innerWidth - 180), top: Math.min(ctxMenu.y, window.innerHeight - 100) }}
+        >
+          <button
+            onClick={() => { setCtxMenu(null); setEditModalOpen(true); }}
+            className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors"
+          >
+            Edit Track...
+          </button>
+          <div className="my-1 border-t border-daw-border" />
+          <button
+            onClick={() => { setCtxMenu(null); removeTrack(track.id); }}
+            className="w-full text-left px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/30 transition-colors"
+          >
+            Delete Track
+          </button>
+        </div>
+      </>
+    )}
+
+    {/* Edit modal */}
+    {editModalOpen && (
+      <TrackEditModal track={track} onClose={() => setEditModalOpen(false)} />
+    )}
+    </>
   );
 }

--- a/src/components/tracks/TrackList.tsx
+++ b/src/components/tracks/TrackList.tsx
@@ -2,13 +2,11 @@ import { useState, useCallback, useRef } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { TrackHeader } from './TrackHeader';
-import { TrackInspector } from './TrackInspector';
 import { AddTrackButton } from './AddTrackButton';
 
 export function TrackList() {
   const project = useProjectStore((s) => s.project);
   const reorderTrack = useProjectStore((s) => s.reorderTrack);
-  const expandedTrackId = useUIStore((s) => s.expandedTrackId);
   const trackListWidth = useUIStore((s) => s.trackListWidth);
   const setTrackListWidth = useUIStore((s) => s.setTrackListWidth);
 
@@ -86,19 +84,15 @@ export function TrackList() {
 
       <div className="flex-1 overflow-y-auto">
         {sortedTracks.map((track) => (
-          <div key={track.id}>
-            <TrackHeader
-              track={track}
-              onDragStart={handleDragStart}
-              onDragOver={handleDragOver}
-              onDrop={handleDrop}
-              isDragOver={dragOverId === track.id}
-              dragOverPosition={dragOverId === track.id ? dragOverPosition : null}
-            />
-            {expandedTrackId === track.id && (
-              <TrackInspector track={track} />
-            )}
-          </div>
+          <TrackHeader
+            key={track.id}
+            track={track}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            isDragOver={dragOverId === track.id}
+            dragOverPosition={dragOverId === track.id ? dragOverPosition : null}
+          />
         ))}
       </div>
 

--- a/src/constants/tracks.ts
+++ b/src/constants/tracks.ts
@@ -1,4 +1,4 @@
-import type { TrackName } from '../types/project';
+import type { TrackName, TrackType } from '../types/project';
 
 export interface TrackInfo {
   name: TrackName;
@@ -29,6 +29,22 @@ export const TRACK_NAMES: TrackName[] = [
   'strings', 'synth', 'fx', 'brass', 'woodwinds',
   'backing_vocals', 'vocals',
 ];
+
+export interface TrackTypeInfo {
+  type: TrackType;
+  label: string;
+  abbr: string;
+  emoji: string;
+  color: string;
+  description: string;
+}
+
+export const TRACK_TYPE_CATALOG: Record<TrackType, TrackTypeInfo> = {
+  stems:     { type: 'stems',     label: 'Stems',      abbr: 'STM', emoji: '🎛️', color: '#3b82f6', description: 'AI-generated isolated instrument tracks' },
+  sample:    { type: 'sample',    label: 'Sample',     abbr: 'SMP', emoji: '📁', color: '#f97316', description: 'User-imported audio clips' },
+  sequencer: { type: 'sequencer', label: 'Sequencer',  abbr: 'SEQ', emoji: '🎹', color: '#22c55e', description: 'Step-based pattern editor (coming soon)' },
+  pianoRoll: { type: 'pianoRoll', label: 'Piano Roll', abbr: 'PNO', emoji: '🎵', color: '#a855f7', description: 'MIDI note editor with virtual instruments (coming soon)' },
+};
 
 export const KEY_SCALES = [
   'C major', 'C minor', 'C# major', 'C# minor',

--- a/src/hooks/useAudioImport.ts
+++ b/src/hooks/useAudioImport.ts
@@ -23,8 +23,7 @@ export function useAudioImport() {
     const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
     const duration = audioBuffer.duration;
 
-    // Create a custom track
-    const track = addTrack('custom');
+    const track = addTrack('custom', 'sample');
     // Rename to the file name
     useProjectStore.getState().updateTrack(track.id, {
       displayName: file.name.replace(/\.[^.]+$/, ''),

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -22,10 +22,11 @@ export async function generateAllTracks(): Promise<void> {
   genStore.setIsGenerating(true);
 
   try {
-    const tracks = getTracksInGenerationOrder();
+    const allTracks = getTracksInGenerationOrder();
+    const tracks = allTracks.filter(t => (t.trackType ?? 'stems') === 'stems');
     let previousCumulativeBlob: Blob | null = null;
 
-    console.log(`[GenerationPipeline] generateAllTracks: ${tracks.length} tracks in order:`,
+    console.log(`[GenerationPipeline] generateAllTracks: ${tracks.length} stems tracks (of ${allTracks.length} total) in order:`,
       tracks.map(t => t.trackName));
 
     for (const track of tracks) {
@@ -187,6 +188,12 @@ async function generateClipInternal(
   const clip = store.getClipById(clipId);
   const track = store.getTrackForClip(clipId);
   if (!clip || !track) return null;
+
+  const trackType = track.trackType ?? 'stems';
+  if (trackType !== 'stems') {
+    console.warn(`[GenerationPipeline] Skipping generation for non-stems track (type=${trackType}, track=${track.displayName})`);
+    return null;
+  }
 
   // Create generation job
   const jobId = uuidv4();

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
-import type { Project, Track, Clip, ClipVersion, TrackName, ClipGenerationStatus } from '../types/project';
+import type { Project, Track, Clip, ClipVersion, TrackName, TrackType, ClipGenerationStatus, AssetClip } from '../types/project';
 import { TRACK_CATALOG } from '../constants/tracks';
 import {
   DEFAULT_BPM,
@@ -50,9 +50,10 @@ interface ProjectState {
   setTrackLocalCaption: (trackId: string, caption: string) => void;
   setTrackReverb: (trackId: string, mix: number, roomSize: number) => void;
 
-  addTrack: (trackName: TrackName) => Track;
+  addTrack: (trackName: TrackName, trackType?: TrackType) => Track;
   removeTrack: (trackId: string) => void;
-  updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'laneHeight'>>) => void;
+  updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'laneHeight' | 'trackType'>>) => void;
+  renameTrack: (trackId: string, newName: string) => void;
   reorderTrack: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
 
   addClip: (trackId: string, clip: Omit<Clip, 'id' | 'trackId' | 'generationStatus' | 'generationJobId' | 'cumulativeMixKey' | 'isolatedAudioKey' | 'waveformPeaks'>) => Clip;
@@ -67,6 +68,9 @@ interface ProjectState {
 
   toggleClipStar: (clipId: string) => void;
   moveClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => void;
+
+  removeAsset: (assetId: string) => void;
+  toggleAssetStar: (assetId: string) => void;
 
   getTrackById: (trackId: string) => Track | undefined;
   getClipById: (clipId: string) => Clip | undefined;
@@ -104,7 +108,21 @@ export const useProjectStore = create<ProjectState>()(
   setProject: (project) => {
     _history.length = 0;
     _future.length = 0;
-    set({ project });
+    // Migration: backfill trackType for projects created before the field existed
+    const migrated: Project = {
+      ...project,
+      tracks: project.tracks.map((t) => {
+        if (t.trackType) return t;
+        const inferred: TrackType =
+          t.trackName === 'custom' && t.clips.some((c) => c.source === 'uploaded')
+            ? 'sample'
+            : t.trackName === 'custom'
+              ? 'sample'
+              : 'stems';
+        return { ...t, trackType: inferred };
+      }),
+    };
+    set({ project: migrated });
   },
 
   undo: () => {
@@ -206,21 +224,22 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
-  addTrack: (trackName) => {
+  addTrack: (trackName, trackType) => {
     const state = get();
     if (!state.project) throw new Error('No project');
     _pushHistory(state.project);
 
+    const resolvedType: TrackType = trackType ?? (trackName === 'custom' ? 'sample' : 'stems');
     const info = TRACK_CATALOG[trackName];
     const existingOrders = state.project.tracks.map((t) => t.order);
     const maxOrder = existingOrders.length > 0 ? Math.max(...existingOrders) : 0;
 
-    // When duplicate track names exist, append an incrementing suffix: "Drums 2", "Drums 3", …
     const sameNameCount = state.project.tracks.filter((t) => t.trackName === trackName).length;
     const displayName = sameNameCount === 0 ? info.displayName : `${info.displayName} ${sameNameCount + 1}`;
 
     const track: Track = {
       id: uuidv4(),
+      trackType: resolvedType,
       trackName,
       displayName,
       color: info.color,
@@ -269,6 +288,21 @@ export const useProjectStore = create<ProjectState>()(
         updatedAt: Date.now(),
         tracks: state.project.tracks.map((t) =>
           t.id === trackId ? { ...t, ...updates } : t,
+        ),
+      },
+    });
+  },
+
+  renameTrack: (trackId, newName) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, displayName: newName } : t,
         ),
       },
     });
@@ -424,16 +458,49 @@ export const useProjectStore = create<ProjectState>()(
   updateClipStatus: (clipId, status, extra) => {
     const state = get();
     if (!state.project) return;
+
+    const updatedTracks = state.project.tracks.map((t) => ({
+      ...t,
+      clips: t.clips.map((c) =>
+        c.id === clipId ? { ...c, generationStatus: status, ...extra } : c,
+      ),
+    }));
+
+    let assets = [...(state.project.assets ?? [])];
+
+    // Auto-archive: when clip becomes 'ready', upsert into assets
+    if (status === 'ready') {
+      const track = updatedTracks.find((t) => t.clips.some((c) => c.id === clipId));
+      const clip = track?.clips.find((c) => c.id === clipId);
+      if (track && clip) {
+        const existingIdx = assets.findIndex((a) => a.clipId === clipId);
+        const asset: AssetClip = {
+          id: existingIdx >= 0 ? assets[existingIdx].id : uuidv4(),
+          clipId,
+          trackDisplayName: track.displayName,
+          prompt: clip.prompt,
+          source: clip.source ?? 'generated',
+          isolatedAudioKey: clip.isolatedAudioKey ?? (extra?.isolatedAudioKey as string | null) ?? null,
+          cumulativeMixKey: clip.cumulativeMixKey ?? (extra?.cumulativeMixKey as string | null) ?? null,
+          waveformPeaks: clip.waveformPeaks ?? (extra?.waveformPeaks as number[] | null) ?? null,
+          starred: existingIdx >= 0 ? assets[existingIdx].starred : false,
+          createdAt: Date.now(),
+          duration: clip.duration,
+        };
+        if (existingIdx >= 0) {
+          assets[existingIdx] = asset;
+        } else {
+          assets.push(asset);
+        }
+      }
+    }
+
     set({
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        tracks: state.project.tracks.map((t) => ({
-          ...t,
-          clips: t.clips.map((c) =>
-            c.id === clipId ? { ...c, generationStatus: status, ...extra } : c,
-          ),
-        })),
+        tracks: updatedTracks,
+        assets,
       },
     });
   },
@@ -509,6 +576,8 @@ export const useProjectStore = create<ProjectState>()(
     const state = get();
     if (!state.project) return;
     _pushHistory(state.project);
+    const clip = state.project.tracks.flatMap((t) => t.clips).find((c) => c.id === clipId);
+    const newStarred = clip ? !clip.starred : true;
     set({
       project: {
         ...state.project,
@@ -516,9 +585,12 @@ export const useProjectStore = create<ProjectState>()(
         tracks: state.project.tracks.map((t) => ({
           ...t,
           clips: t.clips.map((c) =>
-            c.id === clipId ? { ...c, starred: !c.starred } : c,
+            c.id === clipId ? { ...c, starred: newStarred } : c,
           ),
         })),
+        assets: (state.project.assets ?? []).map((a) =>
+          a.clipId === clipId ? { ...a, starred: newStarred } : a,
+        ),
       },
     });
   },
@@ -553,6 +625,43 @@ export const useProjectStore = create<ProjectState>()(
           }
           return t;
         }),
+      },
+    });
+  },
+
+  removeAsset: (assetId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        assets: (state.project.assets ?? []).filter((a) => a.id !== assetId),
+      },
+    });
+  },
+
+  toggleAssetStar: (assetId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const asset = (state.project.assets ?? []).find((a) => a.id === assetId);
+    if (!asset) return;
+    const newStarred = !asset.starred;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        assets: (state.project.assets ?? []).map((a) =>
+          a.id === assetId ? { ...a, starred: newStarred } : a,
+        ),
+        tracks: state.project.tracks.map((t) => ({
+          ...t,
+          clips: t.clips.map((c) =>
+            c.id === asset.clipId ? { ...c, starred: newStarred } : c,
+          ),
+        })),
       },
     });
   },

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -4,6 +4,8 @@ export type TrackName =
   | 'backing_vocals' | 'vocals'
   | 'custom';
 
+export type TrackType = 'stems' | 'sample' | 'sequencer' | 'pianoRoll';
+
 export type ClipGenerationStatus =
   | 'empty' | 'queued' | 'generating' | 'processing' | 'ready' | 'error' | 'stale';
 
@@ -68,6 +70,7 @@ export interface Clip {
 
 export interface Track {
   id: string;
+  trackType?: TrackType;
   trackName: TrackName;
   displayName: string;
   color: string;
@@ -92,6 +95,21 @@ export interface Track {
   localCaption?: string;
   /** Per-track lane height in pixels (default 64, min 40, max 200). */
   laneHeight?: number;
+}
+
+/** Persistent asset entry — survives clip/track removal. Only deleted explicitly from the Assets panel. */
+export interface AssetClip {
+  id: string;
+  clipId: string;
+  trackDisplayName: string;
+  prompt: string;
+  source: 'generated' | 'uploaded';
+  isolatedAudioKey: string | null;
+  cumulativeMixKey: string | null;
+  waveformPeaks: number[] | null;
+  starred: boolean;
+  createdAt: number;
+  duration: number;
 }
 
 export interface GenerationDefaults {
@@ -119,4 +137,6 @@ export interface Project {
   globalCaption?: string;
   /** Master output fader level (0–1), default 1.0 */
   masterVolume?: number;
+  /** Persistent asset clips — survives clip/track removal. */
+  assets?: AssetClip[];
 }


### PR DESCRIPTION
## Summary
- **Track Type System**: Introduce `TrackType` enum (`stems`, `sample`, `sequencer`, `pianoRoll`) with catalog metadata (label, emoji, color, description). Tracks now carry an explicit `trackType` field with migration for old projects.
- **TrackEditModal**: New modal (double-click / right-click / gear icon on track header) consolidates renaming, type switching, volume/pan, mute/solo, local caption, EQ, compressor, and reverb — replacing the old inline `TrackInspector`.
- **Asset Management**: Clips auto-archive to `project.assets` on generation complete; `AssetsPanel` reads from persistent assets with star/delete and "removed" tagging.
- **InstrumentPicker**: Sample tracks can now be created as empty (drag audio later) or with immediate file import.
- **Cross-track Drag Fix**: Remove 400px width cap on drag ghost so long clips maintain full visual size during drag — true WYSIWYG.
- **Drop Overlay Fix**: Global `drop`/`dragend` listeners ensure file-upload overlay always clears.
- **Generation Guard**: Pipeline skips non-`stems` tracks; `TrackLane` shows "Coming Soon" for sequencer/pianoRoll.

## Test plan
- [ ] Create stems, sample tracks; verify type badge and color
- [ ] Double-click track header → edit name, switch type, adjust EQ/reverb/compression
- [ ] Generate a clip → verify it appears in Assets panel
- [ ] Star/unstar assets, delete assets
- [ ] Add empty sample track, then drag audio onto it
- [ ] Drag a long audio clip across tracks — ghost should maintain full width
- [ ] Drop an audio file onto timeline — overlay should clear immediately


Made with [Cursor](https://cursor.com)