### PR TITLE
feat: step sequencer, toolbar editing tools, clip trim/split, and drag fixes

### DIFF
--- a/src/components/dialogs/InstrumentPicker.tsx
+++ b/src/components/dialogs/InstrumentPicker.tsx
@@ -41,7 +41,7 @@ export function InstrumentPicker() {
   };
 
   const typeOrder: TrackType[] = ['stems', 'sample', 'sequencer', 'pianoRoll'];
-  const isComingSoon = selectedType === 'sequencer' || selectedType === 'pianoRoll';
+  const isComingSoon = selectedType === 'pianoRoll';
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={(e) => { if (e.target === e.currentTarget) close(); }}>
@@ -72,7 +72,7 @@ export function InstrumentPicker() {
           <div className="p-4 grid grid-cols-2 gap-3">
             {typeOrder.map((type) => {
               const info = TRACK_TYPE_CATALOG[type];
-              const comingSoon = type === 'sequencer' || type === 'pianoRoll';
+              const comingSoon = type === 'pianoRoll';
               return (
                 <button
                   key={type}
@@ -153,6 +153,43 @@ export function InstrumentPicker() {
               <div>
                 <div className="text-sm font-medium">Import Audio File</div>
                 <div className="text-[11px] text-zinc-400">Pick a file from your computer to create a track with audio</div>
+              </div>
+            </button>
+          </div>
+        )}
+
+        {step === 'instrument' && selectedType === 'sequencer' && (
+          <div className="p-5 flex flex-col gap-3">
+            <div className="text-center mb-2">
+              <span className="text-3xl">🎹</span>
+              <p className="text-xs text-zinc-400 mt-2">Creates a step sequencer track with a default 808-style drum kit (8 sounds). You can customize samples after creation.</p>
+            </div>
+            <button
+              onClick={() => {
+                addTrack('percussion', 'sequencer');
+                close();
+              }}
+              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-zinc-600 transition-colors text-left"
+              style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.sequencer.color}` }}
+            >
+              <span className="text-xl">🥁</span>
+              <div>
+                <div className="text-sm font-medium">Drum Kit Sequencer</div>
+                <div className="text-[11px] text-zinc-400">16-step pattern with Kick, Snare, Hi-Hat, Clap, Tom, Rim</div>
+              </div>
+            </button>
+            <button
+              onClick={() => {
+                addTrack('synth', 'sequencer');
+                close();
+              }}
+              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-zinc-600 transition-colors text-left"
+              style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.sequencer.color}` }}
+            >
+              <span className="text-xl">🎛️</span>
+              <div>
+                <div className="text-sm font-medium">Synth Sequencer</div>
+                <div className="text-[11px] text-zinc-400">Same drum kit — rename and swap samples for any sound</div>
               </div>
             </button>
           </div>

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -28,6 +28,7 @@ const SECTIONS: Section[] = [
     rows: [
       { keys: ['Delete', 'Backspace'],  description: 'Delete selected clips' },
       { keys: [`${mod}`, 'D'],          description: 'Duplicate selected clip' },
+      { keys: ['S'],                    description: 'Split clip at playhead' },
       { keys: [`${mod}`, 'A'],          description: 'Select all clips' },
       { keys: ['E'],                    description: 'Edit selected clip' },
       { keys: [`${mod}`, 'Enter'],      description: 'Generate selected clip' },

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -12,6 +12,7 @@ import { ProjectListDialog } from '../dialogs/ProjectListDialog';
 import { KeyboardShortcutsDialog } from '../dialogs/KeyboardShortcutsDialog';
 import { MixerPanel } from '../mixer/MixerPanel';
 import { AssetsPanel } from '../assets/AssetsPanel';
+import { SequencerEditor } from '../sequencer/SequencerEditor';
 import { useAudioEngine } from '../../hooks/useAudioEngine';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
@@ -44,6 +45,7 @@ export function AppShell() {
         {project && <AssetsPanel />}
       </div>
 
+      {project && <SequencerEditor />}
       {project && <MixerPanel />}
       {project && <GenerationPanel />}
       <StatusBar />

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -1,10 +1,17 @@
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
+import { useTransportStore } from '../../store/transportStore';
 import { useAudioImport } from '../../hooks/useAudioImport';
 import { TransportBar } from '../transport/TransportBar';
 
 export function Toolbar() {
   const project = useProjectStore((s) => s.project);
+  const splitClip = useProjectStore((s) => s.splitClip);
+  const removeClip = useProjectStore((s) => s.removeClip);
+  const duplicateClip = useProjectStore((s) => s.duplicateClip);
+  const selectedClipIds = useUIStore((s) => s.selectedClipIds);
+  const deselectAll = useUIStore((s) => s.deselectAll);
+  const currentTime = useTransportStore((s) => s.currentTime);
   const setShowNewProjectDialog = useUIStore((s) => s.setShowNewProjectDialog);
   const setShowSettingsDialog = useUIStore((s) => s.setShowSettingsDialog);
   const setShowExportDialog = useUIStore((s) => s.setShowExportDialog);
@@ -15,6 +22,9 @@ export function Toolbar() {
   const showAssetsPanel = useUIStore((s) => s.showAssetsPanel);
   const setShowAssetsPanel = useUIStore((s) => s.setShowAssetsPanel);
   const { openFilePicker } = useAudioImport();
+
+  const hasSelection = selectedClipIds.size > 0;
+  const singleSelected = selectedClipIds.size === 1 ? [...selectedClipIds][0] : null;
 
   return (
     <div className="flex items-center h-10 px-3 gap-2 bg-daw-surface border-b border-daw-border shrink-0">
@@ -48,6 +58,50 @@ export function Toolbar() {
         title="Import audio file"
       >
         Import
+      </button>
+
+      <div className="w-px h-5 bg-daw-border" />
+
+      {/* Editing tools */}
+      <button
+        onClick={() => singleSelected && splitClip(singleSelected, currentTime)}
+        disabled={!singleSelected}
+        className="px-2.5 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-30"
+        title="Split clip at playhead (S)"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="inline -mt-px mr-1">
+          <path d="M7 1v12M3 4l4 3-4 3M11 4l-4 3 4 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+        Split
+      </button>
+      <button
+        onClick={() => {
+          if (hasSelection) {
+            const ids = [...selectedClipIds];
+            deselectAll();
+            ids.forEach((id) => removeClip(id));
+          }
+        }}
+        disabled={!hasSelection}
+        className="px-2.5 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-30"
+        title="Delete selected clips (Del)"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="inline -mt-px mr-1">
+          <path d="M2.5 4h9M5 4V2.5h4V4M3.5 4v7.5a1 1 0 001 1h5a1 1 0 001-1V4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+        Delete
+      </button>
+      <button
+        onClick={() => singleSelected && duplicateClip(singleSelected)}
+        disabled={!singleSelected}
+        className="px-2.5 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-30"
+        title="Duplicate clip (Cmd+D)"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="inline -mt-px mr-1">
+          <rect x="1.5" y="3.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.3"/>
+          <path d="M5.5 3.5V2.5a1 1 0 011-1h5a1 1 0 011 1v5a1 1 0 01-1 1h-1" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+        </svg>
+        Duplicate
       </button>
 
       {/* Center section: Transport controls */}

--- a/src/components/sequencer/SequencerEditor.tsx
+++ b/src/components/sequencer/SequencerEditor.tsx
@@ -1,0 +1,938 @@
+import { useRef, useState, useEffect, useMemo, useCallback } from 'react';
+import type { Track } from '../../types/project';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getSample, cacheUserSample } from '../../services/sampleManager';
+import { ALL_DRUM_SAMPLES } from '../../constants/tracks';
+import { bounceSequencerToAudio } from '../../services/sequencerBounce';
+
+const STEP_W = 36;
+const STEP_H = 40;
+const ROW_LABEL_W = 200;
+const VELOCITY_LANE_H = 56;
+
+export function SequencerEditor() {
+  const trackId = useUIStore((s) => s.openSequencerTrackId);
+  const editorHeight = useUIStore((s) => s.sequencerEditorHeight);
+  const setEditorHeight = useUIStore((s) => s.setSequencerEditorHeight);
+  const closeEditor = useUIStore((s) => s.setOpenSequencerTrackId);
+
+  const project = useProjectStore((s) => s.project);
+  const track = useMemo(
+    () => project?.tracks.find((t) => t.id === trackId) ?? null,
+    [project, trackId],
+  );
+
+  const toggleStep = useProjectStore((s) => s.toggleSequencerStep);
+  const setStepVelocity = useProjectStore((s) => s.setSequencerStepVelocity);
+  const batchSetSteps = useProjectStore((s) => s.batchSetSequencerSteps);
+  const toggleRowMute = useProjectStore((s) => s.toggleSequencerRowMute);
+  const setRowVolume = useProjectStore((s) => s.setSequencerRowVolume);
+  const removeRow = useProjectStore((s) => s.removeSequencerRow);
+  const clearRow = useProjectStore((s) => s.clearSequencerRow);
+  const updateSwing = useProjectStore((s) => s.updateSequencerSwing);
+  const setStepsPerBar = useProjectStore((s) => s.setSequencerStepsPerBar);
+  const setBars = useProjectStore((s) => s.setSequencerBars);
+  const addRow = useProjectStore((s) => s.addSequencerRow);
+  const setRowSample = useProjectStore((s) => s.setSequencerRowSample);
+  const initPattern = useProjectStore((s) => s.initSequencerPattern);
+
+  const [selectedRow, setSelectedRow] = useState<string | null>(null);
+  const [samplePickerRow, setSamplePickerRow] = useState<string | null>(null);
+  const [rowCtxMenu, setRowCtxMenu] = useState<{ rowId: string; x: number; y: number } | null>(null);
+  const [isBouncing, setIsBouncing] = useState(false);
+  const [soloRowId, setSoloRowId] = useState<string | null>(null);
+  const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
+  const gridScrollRef = useRef<HTMLDivElement>(null);
+
+  const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
+  const [previewStep, setPreviewStep] = useState(-1);
+  const previewSourcesRef = useRef<AudioBufferSourceNode[]>([]);
+  const previewRafRef = useRef<number | null>(null);
+  const previewStartRef = useRef<{ ctxTime: number; loopDuration: number } | null>(null);
+  const togglePreviewRef = useRef<() => void>(() => {});
+  const paintStateRef = useRef<{ rowId: string; paintActive: boolean } | null>(null);
+
+  // Marquee selection state
+  const [selection, setSelection] = useState<{
+    rowStart: number; rowEnd: number; stepStart: number; stepEnd: number;
+  } | null>(null);
+  const marqueeRef = useRef<{
+    anchorRowIdx: number; anchorStepIdx: number; active: boolean;
+  } | null>(null);
+  // Shift-drag copy state
+  const shiftDragRef = useRef<{
+    origSelection: { rowStart: number; rowEnd: number; stepStart: number; stepEnd: number };
+    anchorStepIdx: number;
+    lastOffset: number;
+  } | null>(null);
+  const [copyGhostOffset, setCopyGhostOffset] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (track && !track.sequencerPattern) {
+      initPattern(track.id);
+    }
+  }, [track, initPattern]);
+
+  const stopPreview = useCallback(() => {
+    for (const s of previewSourcesRef.current) {
+      try { s.stop(); } catch { /* already stopped */ }
+      s.disconnect();
+    }
+    previewSourcesRef.current = [];
+    if (previewRafRef.current !== null) {
+      cancelAnimationFrame(previewRafRef.current);
+      previewRafRef.current = null;
+    }
+    previewStartRef.current = null;
+    setIsPreviewPlaying(false);
+    setPreviewStep(-1);
+  }, []);
+
+  useEffect(() => {
+    return () => stopPreview();
+  }, [trackId, stopPreview]);
+
+  const selectionRef = useRef(selection);
+  selectionRef.current = selection;
+
+  const isInSelection = useCallback(
+    (rowIdx: number, stepIdx: number) => {
+      if (!selection) return false;
+      const rMin = Math.min(selection.rowStart, selection.rowEnd);
+      const rMax = Math.max(selection.rowStart, selection.rowEnd);
+      const sMin = Math.min(selection.stepStart, selection.stepEnd);
+      const sMax = Math.max(selection.stepStart, selection.stepEnd);
+      return rowIdx >= rMin && rowIdx <= rMax && stepIdx >= sMin && stepIdx <= sMax;
+    },
+    [selection],
+  );
+
+  // Keyboard shortcuts: Space = play/stop, Escape = close or clear selection
+  useEffect(() => {
+    if (!trackId) return;
+    const handler = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+
+      if (e.code === 'Space') {
+        e.preventDefault();
+        e.stopPropagation();
+        togglePreviewRef.current();
+      } else if (e.code === 'Escape') {
+        e.preventDefault();
+        if (selectionRef.current) {
+          setSelection(null);
+        } else {
+          stopPreview();
+          closeEditor(null);
+        }
+      }
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [trackId, closeEditor, stopPreview]);
+
+  if (!trackId || !track || !project) return null;
+
+  const pattern = track.sequencerPattern;
+  if (!pattern) return null;
+
+  const bpm = project.bpm;
+  const totalSteps = pattern.stepsPerBar * pattern.bars;
+  const stepDuration = (60 / bpm) / (pattern.stepsPerBar / 4);
+  const patternDuration = stepDuration * totalSteps;
+  const currentStep = isPreviewPlaying ? previewStep : -1;
+  const gridWidth = totalSteps * STEP_W;
+
+  function isRowAudible(rowId: string, muted: boolean): boolean {
+    if (soloRowId) return rowId === soloRowId;
+    return !muted;
+  }
+
+  async function startPreview() {
+    if (!pattern || patternDuration <= 0) return;
+    stopPreview();
+
+    const engine = getAudioEngine();
+    await engine.resume();
+    const ctx = engine.ctx;
+
+    const sampleBuffers = new Map<string, AudioBuffer>();
+    for (const row of pattern.rows) {
+      if (!isRowAudible(row.id, row.muted)) continue;
+      const buf = await getSample(ctx, row.sampleKey);
+      if (buf) sampleBuffers.set(row.sampleKey, buf);
+    }
+
+    const now = ctx.currentTime;
+    const sources: AudioBufferSourceNode[] = [];
+
+    for (let loop = 0; loop < 2; loop++) {
+      const loopOffset = loop * patternDuration;
+      for (const row of pattern.rows) {
+        if (!isRowAudible(row.id, row.muted)) continue;
+        const buffer = sampleBuffers.get(row.sampleKey);
+        if (!buffer) continue;
+        for (let stepIdx = 0; stepIdx < row.steps.length; stepIdx++) {
+          const step = row.steps[stepIdx];
+          if (!step.active) continue;
+          let swingOffset = 0;
+          if (pattern.swing > 0 && stepIdx % 2 === 1) {
+            swingOffset = stepDuration * pattern.swing * 0.5;
+          }
+          const time = now + loopOffset + stepIdx * stepDuration + swingOffset;
+          const source = ctx.createBufferSource();
+          source.buffer = buffer;
+          const gain = ctx.createGain();
+          gain.gain.value = step.velocity * row.volume;
+          source.connect(gain);
+          gain.connect(ctx.destination);
+          source.start(time);
+          sources.push(source);
+        }
+      }
+    }
+
+    previewSourcesRef.current = sources;
+    previewStartRef.current = { ctxTime: now, loopDuration: patternDuration };
+    setIsPreviewPlaying(true);
+
+    const animate = () => {
+      if (!previewStartRef.current) return;
+      const eng = getAudioEngine();
+      const elapsed = eng.ctx.currentTime - previewStartRef.current.ctxTime;
+      const pos = elapsed % previewStartRef.current.loopDuration;
+      const s = Math.floor(pos / stepDuration);
+      setPreviewStep(s);
+      if (elapsed >= previewStartRef.current.loopDuration * 2) {
+        stopPreview();
+        return;
+      }
+      previewRafRef.current = requestAnimationFrame(animate);
+    };
+    previewRafRef.current = requestAnimationFrame(animate);
+  }
+
+  const togglePreview = () => {
+    if (isPreviewPlaying) stopPreview();
+    else startPreview();
+  };
+
+  togglePreviewRef.current = togglePreview;
+
+  const previewSample = async (sampleKey: string, velocity: number) => {
+    const engine = getAudioEngine();
+    await engine.resume();
+    const buf = await getSample(engine.ctx, sampleKey);
+    if (!buf) return;
+    const source = engine.ctx.createBufferSource();
+    source.buffer = buf;
+    const gain = engine.ctx.createGain();
+    gain.gain.value = velocity;
+    source.connect(gain);
+    gain.connect(engine.ctx.destination);
+    source.start();
+  };
+
+  const getRowIdx = (rowId: string): number => pattern.rows.findIndex((r) => r.id === rowId);
+
+  const handleGridMouseDown = (rowId: string, stepIdx: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    const rowIdx = getRowIdx(rowId);
+    if (rowIdx < 0) return;
+
+    if (e.shiftKey && selection) {
+      // Shift+drag on existing selection: start copy-drag
+      const rMin = Math.min(selection.rowStart, selection.rowEnd);
+      const rMax = Math.max(selection.rowStart, selection.rowEnd);
+      const sMin = Math.min(selection.stepStart, selection.stepEnd);
+      const sMax = Math.max(selection.stepStart, selection.stepEnd);
+
+      if (rowIdx >= rMin && rowIdx <= rMax && stepIdx >= sMin && stepIdx <= sMax) {
+        shiftDragRef.current = {
+          origSelection: { rowStart: rMin, rowEnd: rMax, stepStart: sMin, stepEnd: sMax },
+          anchorStepIdx: stepIdx,
+          lastOffset: 0,
+        };
+        setCopyGhostOffset(0);
+
+        const onMove = (ev: MouseEvent) => {
+          if (!shiftDragRef.current) return;
+          const target = document.elementFromPoint(ev.clientX, ev.clientY);
+          if (!target) return;
+          const stepEl = (target as HTMLElement).closest('[data-seq-step]') as HTMLElement | null;
+          if (!stepEl) return;
+          const hoverStep = Number(stepEl.dataset.seqStep);
+          if (isNaN(hoverStep)) return;
+          const offset = hoverStep - shiftDragRef.current.anchorStepIdx;
+          shiftDragRef.current.lastOffset = offset;
+          setCopyGhostOffset(offset);
+        };
+        const onUp = () => {
+          window.removeEventListener('mousemove', onMove);
+          window.removeEventListener('mouseup', onUp);
+          if (!shiftDragRef.current || !pattern) return;
+          const { origSelection, lastOffset } = shiftDragRef.current;
+          shiftDragRef.current = null;
+          setCopyGhostOffset(null);
+
+          if (lastOffset === 0) return;
+
+          const ops: { rowId: string; stepIndex: number; active: boolean; velocity: number }[] = [];
+          for (let ri = origSelection.rowStart; ri <= origSelection.rowEnd; ri++) {
+            const row = pattern.rows[ri];
+            if (!row) continue;
+            for (let si = origSelection.stepStart; si <= origSelection.stepEnd; si++) {
+              const step = row.steps[si];
+              if (!step || !step.active) continue;
+              const destStep = si + lastOffset;
+              if (destStep < 0 || destStep >= row.steps.length) continue;
+              ops.push({ rowId: row.id, stepIndex: destStep, active: true, velocity: step.velocity });
+            }
+          }
+          if (ops.length > 0) {
+            batchSetSteps(track.id, ops);
+            setSelection({
+              rowStart: origSelection.rowStart,
+              rowEnd: origSelection.rowEnd,
+              stepStart: origSelection.stepStart + lastOffset,
+              stepEnd: origSelection.stepEnd + lastOffset,
+            });
+          }
+        };
+        window.addEventListener('mousemove', onMove);
+        window.addEventListener('mouseup', onUp);
+        return;
+      }
+    }
+
+    // Not shift-drag-copy: start marquee selection
+    marqueeRef.current = { anchorRowIdx: rowIdx, anchorStepIdx: stepIdx, active: false };
+    setSelection({ rowStart: rowIdx, rowEnd: rowIdx, stepStart: stepIdx, stepEnd: stepIdx });
+
+    const onMove = (ev: MouseEvent) => {
+      if (!marqueeRef.current) return;
+      marqueeRef.current.active = true;
+      const target = document.elementFromPoint(ev.clientX, ev.clientY);
+      if (!target) return;
+      const stepEl = (target as HTMLElement).closest('[data-seq-step]') as HTMLElement | null;
+      if (!stepEl) return;
+      const hoverRow = stepEl.dataset.seqRow;
+      const hoverStep = Number(stepEl.dataset.seqStep);
+      if (!hoverRow || isNaN(hoverStep)) return;
+      const hoverRowIdx = pattern.rows.findIndex((r) => r.id === hoverRow);
+      if (hoverRowIdx < 0) return;
+      setSelection({
+        rowStart: marqueeRef.current.anchorRowIdx,
+        rowEnd: hoverRowIdx,
+        stepStart: marqueeRef.current.anchorStepIdx,
+        stepEnd: hoverStep,
+      });
+    };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      if (marqueeRef.current && !marqueeRef.current.active) {
+        // Was just a click without drag: clear selection, do normal toggle
+        setSelection(null);
+        handleStepMouseDown(rowId, stepIdx, e);
+      }
+      marqueeRef.current = null;
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
+  const handleStepMouseDown = (rowId: string, stepIdx: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (e.shiftKey) {
+      // Shift+click: start paint mode — toggle this step and drag to paint same state
+      const row = pattern.rows.find((r) => r.id === rowId);
+      if (!row) return;
+      const wasActive = row.steps[stepIdx]?.active ?? false;
+      const paintActive = !wasActive;
+      toggleStep(track.id, rowId, stepIdx);
+      if (paintActive) previewSample(row.sampleKey, row.steps[stepIdx]?.velocity ?? 0.8);
+      paintStateRef.current = { rowId, paintActive };
+
+      const onMove = (ev: MouseEvent) => {
+        if (!paintStateRef.current) return;
+        const target = document.elementFromPoint(ev.clientX, ev.clientY);
+        if (!target) return;
+        const stepEl = target.closest('[data-seq-step]') as HTMLElement | null;
+        if (!stepEl) return;
+        const stepRow = stepEl.dataset.seqRow;
+        const stepIndex = Number(stepEl.dataset.seqStep);
+        if (stepRow !== paintStateRef.current.rowId || isNaN(stepIndex)) return;
+        const currentRow = pattern.rows.find((r) => r.id === stepRow);
+        if (!currentRow) return;
+        const isActive = currentRow.steps[stepIndex]?.active ?? false;
+        if (isActive !== paintStateRef.current.paintActive) {
+          toggleStep(track.id, stepRow, stepIndex);
+        }
+      };
+      const onUp = () => {
+        paintStateRef.current = null;
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    } else {
+      // Normal click: toggle single step
+      toggleStep(track.id, rowId, stepIdx);
+      const row = pattern.rows.find((r) => r.id === rowId);
+      if (row) {
+        const step = row.steps[stepIdx];
+        if (!step?.active) previewSample(row.sampleKey, step?.velocity ?? 0.8);
+      }
+    }
+  };
+
+  const handleVelocityMouseDown = (rowId: string, stepIdx: number, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const startY = e.clientY;
+    const row = pattern.rows.find((r) => r.id === rowId);
+    const startVel = row?.steps[stepIdx]?.velocity ?? 0.8;
+    const onMove = (ev: MouseEvent) => {
+      const dy = startY - ev.clientY;
+      const newVel = Math.max(0.05, Math.min(1, startVel + dy * 0.005));
+      setStepVelocity(track.id, rowId, stepIdx, newVel);
+    };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
+  const handleFileDrop = async (rowId: string, e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const file = e.dataTransfer.files[0];
+    if (!file || !file.type.startsWith('audio/')) return;
+    const engine = getAudioEngine();
+    await engine.resume();
+    const arrayBuffer = await file.arrayBuffer();
+    const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
+    const key = `user-sample-${Date.now()}-${file.name}`;
+    cacheUserSample(key, audioBuffer);
+    setRowSample(track.id, rowId, key);
+  };
+
+  const handleBounce = async () => {
+    setIsBouncing(true);
+    try {
+      await bounceSequencerToAudio(track.id, pattern, bpm);
+    } finally {
+      setIsBouncing(false);
+    }
+  };
+
+  const onResizeStart = (e: React.MouseEvent) => {
+    e.preventDefault();
+    resizeRef.current = { startY: e.clientY, startH: editorHeight };
+    const onMove = (ev: MouseEvent) => {
+      if (!resizeRef.current) return;
+      const delta = resizeRef.current.startY - ev.clientY;
+      setEditorHeight(resizeRef.current.startH + delta);
+    };
+    const onUp = () => {
+      resizeRef.current = null;
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
+  const stepsPerBeat = pattern.stepsPerBar / 4;
+
+  return (
+    <div
+      className="border-t border-zinc-700 bg-zinc-900 flex flex-col select-none"
+      style={{ height: editorHeight }}
+      tabIndex={-1}
+    >
+      {/* Resize handle */}
+      <div
+        className="h-1 cursor-ns-resize bg-zinc-800 hover:bg-indigo-500/40 transition-colors shrink-0"
+        onMouseDown={onResizeStart}
+      />
+
+      {/* Header bar */}
+      <div className="flex items-center gap-3 px-3 py-1.5 bg-zinc-900 border-b border-zinc-800 shrink-0">
+        <span className="text-emerald-400 font-bold text-xs">STEP SEQUENCER</span>
+        <span className="text-zinc-500 text-[10px]">{track.displayName}</span>
+
+        <div className="flex items-center gap-2 ml-4">
+          <label className="flex items-center gap-1 text-[10px] text-zinc-400">
+            Steps/Bar:
+            <select
+              value={pattern.stepsPerBar}
+              onChange={(e) => setStepsPerBar(track.id, Number(e.target.value))}
+              className="bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-200 text-[10px]"
+            >
+              <option value={8}>8</option>
+              <option value={16}>16</option>
+              <option value={32}>32</option>
+            </select>
+          </label>
+          <label className="flex items-center gap-1 text-[10px] text-zinc-400">
+            Bars:
+            <select
+              value={pattern.bars}
+              onChange={(e) => setBars(track.id, Number(e.target.value))}
+              className="bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-200 text-[10px]"
+            >
+              {[1, 2, 4, 8].map((b) => (
+                <option key={b} value={b}>{b}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-1 text-[10px] text-zinc-400">
+            Swing:
+            <input
+              type="range" min={0} max={100}
+              value={Math.round(pattern.swing * 100)}
+              onChange={(e) => updateSwing(track.id, Number(e.target.value) / 100)}
+              className="w-16 h-1"
+            />
+            <span className="text-zinc-300 w-8 text-right">{Math.round(pattern.swing * 100)}%</span>
+          </label>
+        </div>
+
+        <div className="flex items-center gap-1.5 ml-auto">
+          <button
+            onClick={() => {
+              const allSamples = ALL_DRUM_SAMPLES;
+              const next = allSamples[pattern.rows.length % allSamples.length];
+              addRow(track.id, next.id, next.name, next.color);
+            }}
+            className="px-2 py-1 bg-emerald-700/30 hover:bg-emerald-700/50 text-emerald-300 rounded text-[10px] font-medium transition-colors"
+          >
+            + Row
+          </button>
+          <button
+            onClick={togglePreview}
+            className={`px-3 py-1 rounded text-[10px] font-medium transition-colors ${
+              isPreviewPlaying
+                ? 'bg-amber-600/80 hover:bg-amber-600 text-white'
+                : 'bg-zinc-700/80 hover:bg-zinc-600 text-zinc-200'
+            }`}
+            title="Space to toggle"
+          >
+            {isPreviewPlaying ? '■ Stop' : '▶ Play'}
+          </button>
+          <button
+            onClick={handleBounce}
+            disabled={isBouncing}
+            className="px-3 py-1 bg-indigo-600/80 hover:bg-indigo-600 text-white rounded text-[10px] font-medium transition-colors disabled:opacity-50 disabled:cursor-wait"
+          >
+            {isBouncing ? 'Bouncing...' : 'Bounce to Audio'}
+          </button>
+          <button
+            onClick={() => { stopPreview(); closeEditor(null); }}
+            className="px-2 py-1 bg-zinc-800 hover:bg-zinc-700 text-zinc-400 hover:text-zinc-200 rounded text-[10px] transition-colors"
+            title="Esc"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      {/* Grid area */}
+      <div ref={gridScrollRef} className="flex-1 overflow-auto relative" style={{ minHeight: 0 }}>
+        <div className="flex" style={{ minWidth: ROW_LABEL_W + gridWidth }}>
+          {/* Row labels (sticky left, Logic Pro-inspired layout) */}
+          <div className="sticky left-0 z-10 bg-zinc-900 shrink-0 border-r border-zinc-800/60" style={{ width: ROW_LABEL_W }}>
+            {/* Header spacer aligned with beat numbers */}
+            <div className="border-b border-zinc-700/40" style={{ height: 18 }} />
+
+            {pattern.rows.map((row) => {
+              const isSoloed = soloRowId === row.id;
+              const audible = isRowAudible(row.id, row.muted);
+              return (
+                <div
+                  key={row.id}
+                  className={`grid items-center border-b border-zinc-800/50 group ${
+                    selectedRow === row.id ? 'bg-zinc-800/60' : 'hover:bg-zinc-800/20'
+                  }`}
+                  style={{
+                    height: STEP_H,
+                    gridTemplateColumns: '4px 24px 1fr 24px 24px',
+                    gap: '0 4px',
+                    paddingRight: 6,
+                    opacity: audible ? 1 : 0.4,
+                  }}
+                  onClick={() => setSelectedRow(row.id === selectedRow ? null : row.id)}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setRowCtxMenu({ rowId: row.id, x: e.clientX, y: e.clientY });
+                  }}
+                  onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; }}
+                  onDrop={(e) => handleFileDrop(row.id, e)}
+                >
+                  {/* Color indicator */}
+                  <div className="h-full rounded-r" style={{ backgroundColor: row.color }} />
+
+                  {/* Play preview button */}
+                  <button
+                    className="w-6 h-6 flex items-center justify-center text-zinc-500 hover:text-white rounded hover:bg-zinc-700/60 transition-colors"
+                    onClick={(e) => { e.stopPropagation(); previewSample(row.sampleKey, 0.8); }}
+                    title="Preview sound"
+                  >
+                    <svg width="10" height="12" viewBox="0 0 10 12" fill="currentColor">
+                      <path d="M0 0 L10 6 L0 12 Z" />
+                    </svg>
+                  </button>
+
+                  {/* Instrument name */}
+                  <button
+                    className="text-left text-xs text-zinc-200 truncate px-1 hover:text-white transition-colors font-medium cursor-pointer"
+                    title={`${row.name} — click to pick sample`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setSamplePickerRow(samplePickerRow === row.id ? null : row.id);
+                    }}
+                  >
+                    {row.name}
+                  </button>
+
+                  {/* Mute button */}
+                  <button
+                    className={`w-6 h-6 text-[10px] font-bold rounded flex items-center justify-center transition-colors ${
+                      row.muted
+                        ? 'bg-amber-600 text-white'
+                        : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700'
+                    }`}
+                    onClick={(e) => { e.stopPropagation(); toggleRowMute(track.id, row.id); }}
+                    title={row.muted ? 'Unmute' : 'Mute'}
+                  >
+                    M
+                  </button>
+
+                  {/* Solo button */}
+                  <button
+                    className={`w-6 h-6 text-[10px] font-bold rounded flex items-center justify-center transition-colors ${
+                      isSoloed
+                        ? 'bg-yellow-500 text-zinc-900'
+                        : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700'
+                    }`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setSoloRowId(isSoloed ? null : row.id);
+                    }}
+                    title={isSoloed ? 'Unsolo' : 'Solo'}
+                  >
+                    S
+                  </button>
+                </div>
+              );
+            })}
+
+            {/* Sample picker dropdown */}
+            {samplePickerRow && (
+              <SamplePickerDropdown
+                currentKey={pattern.rows.find((r) => r.id === samplePickerRow)?.sampleKey ?? ''}
+                onSelect={(key, name) => {
+                  setRowSample(track.id, samplePickerRow, key);
+                  const state = useProjectStore.getState();
+                  if (state.project) {
+                    const updatedTracks = state.project.tracks.map((t) => {
+                      if (t.id !== track.id || !t.sequencerPattern) return t;
+                      return {
+                        ...t,
+                        sequencerPattern: {
+                          ...t.sequencerPattern,
+                          rows: t.sequencerPattern.rows.map((r) =>
+                            r.id === samplePickerRow ? { ...r, name } : r,
+                          ),
+                        },
+                      };
+                    });
+                    useProjectStore.setState({
+                      project: { ...state.project, tracks: updatedTracks, updatedAt: Date.now() },
+                    });
+                  }
+                  setSamplePickerRow(null);
+                }}
+                onClose={() => setSamplePickerRow(null)}
+                onPreview={(key) => previewSample(key, 0.8)}
+              />
+            )}
+          </div>
+
+          {/* Step grid */}
+          <div className="relative">
+            {/* Beat/bar number header */}
+            <div className="flex border-b border-zinc-700/40" style={{ height: 18 }}>
+              {Array.from({ length: totalSteps }).map((_, idx) => {
+                const isBeatStart = idx % stepsPerBeat === 0;
+                const isBarStart = idx % pattern.stepsPerBar === 0;
+                const beatNum = Math.floor(idx / stepsPerBeat) + 1;
+                const barNum = Math.floor(idx / pattern.stepsPerBar) + 1;
+                return (
+                  <div
+                    key={idx}
+                    className="shrink-0 flex items-center justify-center text-[8px] font-medium border-l"
+                    style={{
+                      width: STEP_W,
+                      borderColor: isBarStart ? 'rgba(161,161,170,0.4)' : isBeatStart ? 'rgba(113,113,122,0.25)' : 'rgba(63,63,70,0.15)',
+                      color: isBarStart ? '#a1a1aa' : isBeatStart ? '#71717a' : 'transparent',
+                    }}
+                  >
+                    {isBarStart ? `${barNum}` : isBeatStart ? `${beatNum}` : ''}
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Step cells */}
+            {pattern.rows.map((row, rowIdx) => {
+              const audible = isRowAudible(row.id, row.muted);
+              return (
+                <div
+                  key={row.id}
+                  className="flex border-b border-zinc-800/30"
+                  style={{ height: STEP_H, opacity: audible ? 1 : 0.35 }}
+                >
+                  {row.steps.map((step, idx) => {
+                    const isBeatStart = idx % stepsPerBeat === 0;
+                    const isBarStart = idx % pattern.stepsPerBar === 0;
+                    const isCurrent = idx === currentStep && isPreviewPlaying;
+                    const selected = isInSelection(rowIdx, idx);
+
+                    // Copy-ghost: show preview of where steps will be pasted
+                    let isGhost = false;
+                    if (copyGhostOffset !== null && copyGhostOffset !== 0 && selection) {
+                      const rMin = Math.min(selection.rowStart, selection.rowEnd);
+                      const rMax = Math.max(selection.rowStart, selection.rowEnd);
+                      const sMin = Math.min(selection.stepStart, selection.stepEnd);
+                      const sMax = Math.max(selection.stepStart, selection.stepEnd);
+                      if (rowIdx >= rMin && rowIdx <= rMax) {
+                        const srcStep = idx - copyGhostOffset;
+                        if (srcStep >= sMin && srcStep <= sMax) {
+                          const srcRow = pattern.rows[rowIdx];
+                          if (srcRow?.steps[srcStep]?.active) {
+                            isGhost = true;
+                          }
+                        }
+                      }
+                    }
+
+                    return (
+                      <div
+                        key={idx}
+                        data-seq-step={idx}
+                        data-seq-row={row.id}
+                        className={`relative shrink-0 cursor-pointer transition-all duration-75 ${
+                          isBarStart
+                            ? 'border-l border-l-zinc-500/40'
+                            : isBeatStart
+                              ? 'border-l border-l-zinc-700/30'
+                              : 'border-l border-l-zinc-800/15'
+                        } ${isCurrent ? 'ring-1 ring-inset ring-white/30' : ''}`}
+                        style={{
+                          width: STEP_W,
+                          height: STEP_H,
+                          backgroundColor: step.active
+                            ? `${row.color}${Math.round(step.velocity * 180 + 55).toString(16).padStart(2, '0')}`
+                            : isCurrent ? 'rgba(255,255,255,0.03)' : undefined,
+                        }}
+                        onMouseDown={(e) => handleGridMouseDown(row.id, idx, e)}
+                        onContextMenu={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          handleVelocityMouseDown(row.id, idx, e);
+                        }}
+                      >
+                        {step.active && (
+                          <div
+                            className="absolute inset-1 rounded-sm pointer-events-none"
+                            style={{
+                              backgroundColor: row.color,
+                              opacity: 0.2 + step.velocity * 0.5,
+                            }}
+                          />
+                        )}
+                        {/* Selection highlight */}
+                        {selected && (
+                          <div
+                            className="absolute inset-0 pointer-events-none border-2 border-cyan-400/60"
+                            style={{ backgroundColor: 'rgba(34,211,238,0.08)' }}
+                          />
+                        )}
+                        {/* Copy ghost overlay */}
+                        {isGhost && !step.active && (
+                          <div
+                            className="absolute inset-1 rounded-sm pointer-events-none"
+                            style={{
+                              backgroundColor: row.color,
+                              opacity: 0.35,
+                              border: '1px dashed rgba(34,211,238,0.5)',
+                            }}
+                          />
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+
+            {/* Playhead */}
+            {isPreviewPlaying && currentStep >= 0 && (
+              <div
+                className="absolute w-0.5 bg-white/50 pointer-events-none z-20"
+                style={{
+                  left: currentStep * STEP_W + STEP_W / 2,
+                  top: 18,
+                  height: pattern.rows.length * STEP_H,
+                  transition: 'left 60ms linear',
+                }}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Velocity lane for selected row */}
+      {selectedRow && (() => {
+        const row = pattern.rows.find((r) => r.id === selectedRow);
+        if (!row) return null;
+        return (
+          <div className="flex shrink-0 border-t border-zinc-700/50 bg-zinc-900/80" style={{ height: VELOCITY_LANE_H }}>
+            <div
+              className="shrink-0 flex items-center px-2 text-[9px] text-zinc-500 font-medium bg-zinc-900"
+              style={{ width: ROW_LABEL_W }}
+            >
+              VEL — {row.name}
+            </div>
+            <div className="flex items-end overflow-hidden">
+              {row.steps.map((step, idx) => {
+                const isCurrent = idx === currentStep && isPreviewPlaying;
+                return (
+                  <div
+                    key={idx}
+                    className={`shrink-0 flex items-end justify-center cursor-ns-resize ${
+                      isCurrent ? 'bg-white/5' : ''
+                    }`}
+                    style={{ width: STEP_W, height: VELOCITY_LANE_H }}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      const rect = e.currentTarget.getBoundingClientRect();
+                      const update = (ev: MouseEvent) => {
+                        const pct = 1 - Math.max(0, Math.min(1, (ev.clientY - rect.top) / rect.height));
+                        setStepVelocity(track.id, selectedRow, idx, Math.max(0.05, pct));
+                      };
+                      update(e.nativeEvent);
+                      const onUp = () => {
+                        window.removeEventListener('mousemove', update);
+                        window.removeEventListener('mouseup', onUp);
+                      };
+                      window.addEventListener('mousemove', update);
+                      window.addEventListener('mouseup', onUp);
+                    }}
+                  >
+                    {step.active && (
+                      <div
+                        className="rounded-t-sm"
+                        style={{
+                          width: Math.max(6, STEP_W * 0.5),
+                          height: `${step.velocity * 100}%`,
+                          backgroundColor: row.color,
+                          opacity: 0.85,
+                        }}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })()}
+
+      {/* Row context menu */}
+      {rowCtxMenu && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setRowCtxMenu(null)} onContextMenu={(e) => { e.preventDefault(); setRowCtxMenu(null); }} />
+          <div
+            className="fixed z-50 bg-zinc-900 border border-zinc-700 rounded shadow-xl py-1 min-w-[150px]"
+            style={{ left: Math.min(rowCtxMenu.x, window.innerWidth - 170), top: Math.min(rowCtxMenu.y, window.innerHeight - 120) }}
+          >
+            <button
+              onClick={() => { clearRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); }}
+              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-300 hover:bg-zinc-800 transition-colors"
+            >
+              Clear Steps
+            </button>
+            <button
+              onClick={() => { previewSample(pattern.rows.find(r => r.id === rowCtxMenu.rowId)?.sampleKey ?? '', 0.8); }}
+              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-300 hover:bg-zinc-800 transition-colors"
+            >
+              Preview Sound
+            </button>
+            <div className="my-0.5 border-t border-zinc-800" />
+            <button
+              onClick={() => {
+                if (soloRowId === rowCtxMenu.rowId) setSoloRowId(null);
+                removeRow(track.id, rowCtxMenu.rowId);
+                setRowCtxMenu(null);
+                if (selectedRow === rowCtxMenu.rowId) setSelectedRow(null);
+              }}
+              className="w-full text-left px-3 py-1.5 text-[11px] text-red-400 hover:bg-red-900/30 transition-colors"
+            >
+              Delete Row
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ── Sample Picker Dropdown ─────────────────────────────────────────── */
+
+interface SamplePickerDropdownProps {
+  currentKey: string;
+  onSelect: (key: string, name: string) => void;
+  onClose: () => void;
+  onPreview: (key: string) => void;
+}
+
+function SamplePickerDropdown({ currentKey, onSelect, onClose, onPreview }: SamplePickerDropdownProps) {
+  return (
+    <>
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+      <div className="absolute left-0 z-50 mt-1 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl py-1 w-48">
+        <div className="px-2 py-1 text-[9px] text-zinc-500 font-medium uppercase">Built-in Samples</div>
+        {ALL_DRUM_SAMPLES.map((kit) => (
+          <button
+            key={kit.id}
+            className={`w-full flex items-center gap-2 px-2 py-1.5 text-[11px] hover:bg-zinc-800 transition-colors text-left ${
+              currentKey === kit.id ? 'text-emerald-400' : 'text-zinc-300'
+            }`}
+            onClick={() => onSelect(kit.id, kit.name)}
+            onMouseEnter={() => onPreview(kit.id)}
+          >
+            <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: kit.color }} />
+            <span>{kit.name}</span>
+            {currentKey === kit.id && <span className="ml-auto text-emerald-400">✓</span>}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/sequencer/SequencerGrid.tsx
+++ b/src/components/sequencer/SequencerGrid.tsx
@@ -1,0 +1,542 @@
+import { useCallback, useRef, useState, useEffect, useMemo } from 'react';
+import type { Track } from '../../types/project';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import { useTransportStore } from '../../store/transportStore';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getSample, cacheUserSample } from '../../services/sampleManager';
+import { DEFAULT_DRUM_KIT } from '../../constants/tracks';
+
+const STEP_H = 24;
+const ROW_LABEL_W = 90;
+const VELOCITY_LANE_H = 44;
+const TOOLBAR_H = 28;
+const MIN_STEP_W = 14;
+
+interface SequencerGridProps {
+  track: Track;
+  height: number;
+}
+
+export function SequencerGrid({ track, height }: SequencerGridProps) {
+  const pattern = track.sequencerPattern;
+  const project = useProjectStore((s) => s.project);
+  const toggleStep = useProjectStore((s) => s.toggleSequencerStep);
+  const setStepVelocity = useProjectStore((s) => s.setSequencerStepVelocity);
+  const toggleRowMute = useProjectStore((s) => s.toggleSequencerRowMute);
+  const setRowVolume = useProjectStore((s) => s.setSequencerRowVolume);
+  const removeRow = useProjectStore((s) => s.removeSequencerRow);
+  const clearRow = useProjectStore((s) => s.clearSequencerRow);
+  const updateSwing = useProjectStore((s) => s.updateSequencerSwing);
+  const setStepsPerBar = useProjectStore((s) => s.setSequencerStepsPerBar);
+  const setBars = useProjectStore((s) => s.setSequencerBars);
+  const addRow = useProjectStore((s) => s.addSequencerRow);
+  const setRowSample = useProjectStore((s) => s.setSequencerRowSample);
+  const initPattern = useProjectStore((s) => s.initSequencerPattern);
+
+  const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
+  const isPlaying = useTransportStore((s) => s.isPlaying);
+  const currentTime = useTransportStore((s) => s.currentTime);
+
+  const [selectedRow, setSelectedRow] = useState<string | null>(null);
+  const [samplePickerRow, setSamplePickerRow] = useState<string | null>(null);
+  const [rowCtxMenu, setRowCtxMenu] = useState<{ rowId: string; x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    if (!pattern) initPattern(track.id);
+  }, [pattern, track.id, initPattern]);
+
+  if (!pattern || !project) return null;
+
+  const bpm = project.bpm;
+  const totalSteps = pattern.stepsPerBar * pattern.bars;
+  const stepDuration = (60 / bpm) / (pattern.stepsPerBar / 4);
+  const patternDuration = stepDuration * totalSteps;
+
+  // Compute step width from BPM and zoom so it aligns with the timeline grid
+  const stepW = Math.max(MIN_STEP_W, stepDuration * pixelsPerSecond);
+  const patternWidthPx = totalSteps * stepW;
+  const totalTimelineWidth = project.totalDuration * pixelsPerSecond;
+
+  // How many times the pattern tiles across the timeline
+  const tileCount = patternDuration > 0
+    ? Math.ceil(totalTimelineWidth / patternWidthPx)
+    : 1;
+
+  // Current step highlight during playback
+  const currentStep = isPlaying && patternDuration > 0
+    ? Math.floor((currentTime % patternDuration) / stepDuration)
+    : -1;
+
+  const previewSample = useCallback(async (sampleKey: string, velocity: number) => {
+    const engine = getAudioEngine();
+    await engine.resume();
+    const buf = await getSample(engine.ctx, sampleKey);
+    if (!buf) return;
+    const source = engine.ctx.createBufferSource();
+    source.buffer = buf;
+    const gain = engine.ctx.createGain();
+    gain.gain.value = velocity;
+    source.connect(gain);
+    gain.connect(engine.ctx.destination);
+    source.start();
+  }, []);
+
+  const handleStepClick = useCallback((rowId: string, stepIdx: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    toggleStep(track.id, rowId, stepIdx);
+
+    const row = pattern?.rows.find((r) => r.id === rowId);
+    if (row) {
+      const step = row.steps[stepIdx];
+      if (!step?.active) {
+        previewSample(row.sampleKey, step?.velocity ?? 0.8);
+      }
+    }
+  }, [track.id, toggleStep, pattern, previewSample]);
+
+  const handleVelocityMouseDown = useCallback((rowId: string, stepIdx: number, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const startY = e.clientY;
+    const row = pattern?.rows.find((r) => r.id === rowId);
+    const startVel = row?.steps[stepIdx]?.velocity ?? 0.8;
+    const onMove = (ev: MouseEvent) => {
+      const dy = startY - ev.clientY;
+      const newVel = Math.max(0.05, Math.min(1, startVel + dy * 0.005));
+      setStepVelocity(track.id, rowId, stepIdx, newVel);
+    };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }, [track.id, setStepVelocity, pattern]);
+
+  const handleFileDrop = useCallback(async (rowId: string, e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const file = e.dataTransfer.files[0];
+    if (!file || !file.type.startsWith('audio/')) return;
+    const engine = getAudioEngine();
+    await engine.resume();
+    const arrayBuffer = await file.arrayBuffer();
+    const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
+    const key = `user-sample-${Date.now()}-${file.name}`;
+    cacheUserSample(key, audioBuffer);
+    setRowSample(track.id, rowId, key);
+  }, [track.id, setRowSample]);
+
+  const handleRowContextMenu = useCallback((rowId: string, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setRowCtxMenu({ rowId, x: e.clientX, y: e.clientY });
+  }, []);
+
+  const availableSamples = useMemo(() => DEFAULT_DRUM_KIT, []);
+
+  const gridRowsHeight = pattern.rows.length * STEP_H;
+  const showVelocity = selectedRow !== null;
+
+  return (
+    <div
+      className="flex flex-col select-none"
+      data-sequencer-grid
+      style={{ width: totalTimelineWidth, height, minHeight: height }}
+      onMouseDownCapture={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => e.stopPropagation()}
+      onContextMenu={(e) => e.stopPropagation()}
+    >
+      {/* Toolbar — sticky to the left edge via position:sticky */}
+      <div
+        className="flex items-center gap-2 px-2 bg-zinc-900/90 border-b border-zinc-700/50 text-[10px] shrink-0 sticky left-0 z-20 backdrop-blur-sm"
+        style={{ height: TOOLBAR_H }}
+      >
+        <span className="text-emerald-400 font-bold text-[11px]">SEQ</span>
+        <div className="flex items-center gap-1">
+          <span className="text-zinc-500">Steps:</span>
+          <select
+            value={pattern.stepsPerBar}
+            onChange={(e) => setStepsPerBar(track.id, Number(e.target.value))}
+            className="bg-zinc-800 border border-zinc-700 rounded px-1 py-0.5 text-zinc-300 text-[10px]"
+          >
+            <option value={8}>8</option>
+            <option value={16}>16</option>
+            <option value={32}>32</option>
+          </select>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-zinc-500">Bars:</span>
+          <select
+            value={pattern.bars}
+            onChange={(e) => setBars(track.id, Number(e.target.value))}
+            className="bg-zinc-800 border border-zinc-700 rounded px-1 py-0.5 text-zinc-300 text-[10px]"
+          >
+            {[1, 2, 4, 8].map((b) => (
+              <option key={b} value={b}>{b}</option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-zinc-500">Swing:</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={Math.round(pattern.swing * 100)}
+            onChange={(e) => updateSwing(track.id, Number(e.target.value) / 100)}
+            className="w-14 h-1"
+          />
+          <span className="text-zinc-400 w-6 text-right">{Math.round(pattern.swing * 100)}%</span>
+        </div>
+        <button
+          onClick={() => {
+            const next = availableSamples[pattern.rows.length % availableSamples.length];
+            addRow(track.id, next.id, next.name, next.color);
+          }}
+          className="ml-auto px-2 py-0.5 bg-emerald-700/40 hover:bg-emerald-700/60 text-emerald-300 rounded text-[10px] transition-colors"
+        >
+          + Row
+        </button>
+      </div>
+
+      {/* Grid body — scrolls with the timeline horizontally */}
+      <div className="flex-1 overflow-hidden relative" style={{ minHeight: 0 }}>
+        <div className="flex" style={{ width: totalTimelineWidth }}>
+          {/* Row labels — sticky to left */}
+          <div className="sticky left-0 z-10 bg-zinc-900/95 shrink-0" style={{ width: ROW_LABEL_W }}>
+            {pattern.rows.map((row) => (
+              <div
+                key={row.id}
+                className={`flex items-center border-b border-zinc-800/50 cursor-pointer ${
+                  selectedRow === row.id ? 'bg-zinc-800/50' : 'hover:bg-zinc-800/20'
+                }`}
+                style={{ height: STEP_H }}
+                onClick={() => setSelectedRow(row.id === selectedRow ? null : row.id)}
+                onContextMenu={(e) => handleRowContextMenu(row.id, e)}
+                onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; }}
+                onDrop={(e) => handleFileDrop(row.id, e)}
+              >
+                <div className="w-1 h-full shrink-0" style={{ backgroundColor: row.color }} />
+                <button
+                  className="flex-1 text-left text-[10px] text-zinc-300 truncate px-1.5 hover:text-white transition-colors"
+                  title={`${row.name} — click to change, drag audio to replace`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSamplePickerRow(samplePickerRow === row.id ? null : row.id);
+                  }}
+                >
+                  {row.name}
+                </button>
+                <button
+                  className={`w-5 h-4 text-[8px] font-bold rounded mr-0.5 transition-colors ${
+                    row.muted ? 'bg-amber-600 text-white' : 'bg-zinc-800 text-zinc-600 hover:text-zinc-400'
+                  }`}
+                  onClick={(e) => { e.stopPropagation(); toggleRowMute(track.id, row.id); }}
+                  title={row.muted ? 'Unmute' : 'Mute'}
+                >
+                  M
+                </button>
+                <div
+                  className="w-6 h-3 bg-zinc-800 rounded-sm mr-1 cursor-ew-resize overflow-hidden"
+                  title={`Vol: ${Math.round(row.volume * 100)}%`}
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                    const rect = e.currentTarget.getBoundingClientRect();
+                    const update = (ev: MouseEvent) => {
+                      const pct = Math.max(0, Math.min(1, (ev.clientX - rect.left) / rect.width));
+                      setRowVolume(track.id, row.id, pct);
+                    };
+                    update(e.nativeEvent);
+                    const onUp = () => {
+                      window.removeEventListener('mousemove', update);
+                      window.removeEventListener('mouseup', onUp);
+                    };
+                    window.addEventListener('mousemove', update);
+                    window.addEventListener('mouseup', onUp);
+                  }}
+                >
+                  <div
+                    className="h-full rounded-sm"
+                    style={{ width: `${row.volume * 100}%`, backgroundColor: row.color + '80' }}
+                  />
+                </div>
+              </div>
+            ))}
+
+            {samplePickerRow && (
+              <SamplePickerDropdown
+                currentKey={pattern.rows.find((r) => r.id === samplePickerRow)?.sampleKey ?? ''}
+                onSelect={(key, name) => {
+                  setRowSample(track.id, samplePickerRow, key);
+                  const state = useProjectStore.getState();
+                  if (state.project) {
+                    const updatedTracks = state.project.tracks.map((t) => {
+                      if (t.id !== track.id || !t.sequencerPattern) return t;
+                      return {
+                        ...t,
+                        sequencerPattern: {
+                          ...t.sequencerPattern,
+                          rows: t.sequencerPattern.rows.map((r) =>
+                            r.id === samplePickerRow ? { ...r, name } : r,
+                          ),
+                        },
+                      };
+                    });
+                    useProjectStore.setState({
+                      project: { ...state.project, tracks: updatedTracks, updatedAt: Date.now() },
+                    });
+                  }
+                  setSamplePickerRow(null);
+                }}
+                onClose={() => setSamplePickerRow(null)}
+                onPreview={(key) => previewSample(key, 0.8)}
+              />
+            )}
+          </div>
+
+          {/* Step grid — tiled across the full timeline width */}
+          <div className="relative" style={{ width: totalTimelineWidth - ROW_LABEL_W }}>
+            {pattern.rows.map((row) => (
+              <div key={row.id} className="flex border-b border-zinc-800/30" style={{ height: STEP_H }}>
+                {Array.from({ length: tileCount }).map((_, tileIdx) => (
+                  <div key={tileIdx} className="flex shrink-0" style={{ width: patternWidthPx }}>
+                    {row.steps.map((step, idx) => {
+                      const isBeatStart = idx % (pattern.stepsPerBar / 4) === 0;
+                      const isBarStart = idx % pattern.stepsPerBar === 0 && idx > 0;
+                      const isCurrent = idx === currentStep && isPlaying;
+                      return (
+                        <div
+                          key={idx}
+                          className={`relative shrink-0 cursor-pointer ${
+                            isBarStart
+                              ? 'border-l border-l-zinc-500/50'
+                              : isBeatStart
+                                ? 'border-l border-l-zinc-700/40'
+                                : 'border-l border-l-zinc-800/20'
+                          } ${isCurrent ? 'ring-1 ring-inset ring-white/25' : ''}`}
+                          style={{
+                            width: stepW,
+                            height: STEP_H,
+                            backgroundColor: step.active
+                              ? `${row.color}${Math.round(step.velocity * 180 + 55).toString(16).padStart(2, '0')}`
+                              : isCurrent ? 'rgba(255,255,255,0.04)' : undefined,
+                          }}
+                          onClick={(e) => handleStepClick(row.id, idx, e)}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            handleVelocityMouseDown(row.id, idx, e);
+                          }}
+                        >
+                          {step.active && (
+                            <div
+                              className="absolute bottom-0 left-0 right-0 pointer-events-none"
+                              style={{
+                                height: `${step.velocity * 100}%`,
+                                backgroundColor: row.color,
+                                opacity: 0.25,
+                              }}
+                            />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+
+                {/* Pattern tile separator lines */}
+                {tileCount > 1 && Array.from({ length: tileCount - 1 }).map((_, i) => (
+                  <div
+                    key={`sep-${i}`}
+                    className="absolute top-0 bottom-0 w-px bg-emerald-500/30 pointer-events-none"
+                    style={{ left: (i + 1) * patternWidthPx }}
+                  />
+                ))}
+              </div>
+            ))}
+
+            {/* Playhead overlay */}
+            {isPlaying && currentStep >= 0 && (() => {
+              const playheadX = currentTime * pixelsPerSecond - ROW_LABEL_W;
+              if (playheadX < 0) return null;
+              return (
+                <div
+                  className="absolute top-0 w-0.5 bg-white/40 pointer-events-none z-20"
+                  style={{
+                    left: playheadX,
+                    height: gridRowsHeight,
+                  }}
+                />
+              );
+            })()}
+          </div>
+        </div>
+      </div>
+
+      {/* Velocity lane for selected row */}
+      {showVelocity && selectedRow && (
+        <VelocityLane
+          track={track}
+          rowId={selectedRow}
+          pattern={pattern}
+          stepW={stepW}
+          patternWidthPx={patternWidthPx}
+          tileCount={tileCount}
+          totalTimelineWidth={totalTimelineWidth}
+          currentStep={currentStep}
+          isPlaying={isPlaying}
+          onVelocityChange={(stepIdx, vel) => setStepVelocity(track.id, selectedRow, stepIdx, vel)}
+        />
+      )}
+
+      {/* Row context menu */}
+      {rowCtxMenu && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setRowCtxMenu(null)} onContextMenu={(e) => { e.preventDefault(); setRowCtxMenu(null); }} />
+          <div
+            className="fixed z-50 bg-zinc-900 border border-zinc-700 rounded shadow-xl py-1 min-w-[140px]"
+            style={{ left: Math.min(rowCtxMenu.x, window.innerWidth - 160), top: Math.min(rowCtxMenu.y, window.innerHeight - 100) }}
+          >
+            <button
+              onClick={() => { clearRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); }}
+              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-300 hover:bg-zinc-800 transition-colors"
+            >
+              Clear Steps
+            </button>
+            <button
+              onClick={() => { previewSample(pattern.rows.find(r => r.id === rowCtxMenu.rowId)?.sampleKey ?? '', 0.8); }}
+              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-300 hover:bg-zinc-800 transition-colors"
+            >
+              Preview Sound
+            </button>
+            <div className="my-0.5 border-t border-zinc-800" />
+            <button
+              onClick={() => { removeRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); if (selectedRow === rowCtxMenu.rowId) setSelectedRow(null); }}
+              className="w-full text-left px-3 py-1.5 text-[11px] text-red-400 hover:bg-red-900/30 transition-colors"
+            >
+              Delete Row
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ── Velocity Lane ──────────────────────────────────────────────────── */
+
+interface VelocityLaneProps {
+  track: Track;
+  rowId: string;
+  pattern: NonNullable<Track['sequencerPattern']>;
+  stepW: number;
+  patternWidthPx: number;
+  tileCount: number;
+  totalTimelineWidth: number;
+  currentStep: number;
+  isPlaying: boolean;
+  onVelocityChange: (stepIdx: number, velocity: number) => void;
+}
+
+function VelocityLane({
+  rowId, pattern, stepW, patternWidthPx, tileCount, totalTimelineWidth,
+  currentStep, isPlaying, onVelocityChange,
+}: VelocityLaneProps) {
+  const row = pattern.rows.find((r) => r.id === rowId);
+  if (!row) return null;
+
+  return (
+    <div className="flex shrink-0 border-t border-zinc-700/50 bg-zinc-900/60" style={{ height: VELOCITY_LANE_H }}>
+      <div
+        className="shrink-0 flex items-center px-2 text-[9px] text-zinc-500 font-medium sticky left-0 z-10 bg-zinc-900/95"
+        style={{ width: ROW_LABEL_W }}
+      >
+        VEL — {row.name}
+      </div>
+      <div className="flex items-end" style={{ width: totalTimelineWidth - ROW_LABEL_W }}>
+        {Array.from({ length: tileCount }).map((_, tileIdx) => (
+          <div key={tileIdx} className="flex items-end shrink-0" style={{ width: patternWidthPx }}>
+            {row.steps.map((step, idx) => {
+              const isCurrent = idx === currentStep && isPlaying;
+              return (
+                <div
+                  key={idx}
+                  className={`shrink-0 flex items-end justify-center cursor-ns-resize ${
+                    isCurrent ? 'bg-white/5' : ''
+                  }`}
+                  style={{ width: stepW, height: VELOCITY_LANE_H }}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const rect = e.currentTarget.getBoundingClientRect();
+                    const update = (ev: MouseEvent) => {
+                      const pct = 1 - Math.max(0, Math.min(1, (ev.clientY - rect.top) / rect.height));
+                      onVelocityChange(idx, Math.max(0.05, pct));
+                    };
+                    update(e.nativeEvent);
+                    const onUp = () => {
+                      window.removeEventListener('mousemove', update);
+                      window.removeEventListener('mouseup', onUp);
+                    };
+                    window.addEventListener('mousemove', update);
+                    window.addEventListener('mouseup', onUp);
+                  }}
+                >
+                  {step.active && (
+                    <div
+                      className="rounded-t-sm"
+                      style={{
+                        width: Math.max(4, stepW * 0.5),
+                        height: `${step.velocity * 100}%`,
+                        backgroundColor: row.color,
+                        opacity: 0.8,
+                      }}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── Sample Picker Dropdown ─────────────────────────────────────────── */
+
+interface SamplePickerDropdownProps {
+  currentKey: string;
+  onSelect: (key: string, name: string) => void;
+  onClose: () => void;
+  onPreview: (key: string) => void;
+}
+
+function SamplePickerDropdown({ currentKey, onSelect, onClose, onPreview }: SamplePickerDropdownProps) {
+  return (
+    <>
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+      <div className="absolute left-0 z-50 mt-1 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl py-1 w-44">
+        <div className="px-2 py-1 text-[9px] text-zinc-500 font-medium uppercase">Built-in Samples</div>
+        {DEFAULT_DRUM_KIT.map((kit) => (
+          <button
+            key={kit.id}
+            className={`w-full flex items-center gap-2 px-2 py-1.5 text-[10px] hover:bg-zinc-800 transition-colors text-left ${
+              currentKey === kit.id ? 'text-emerald-400' : 'text-zinc-300'
+            }`}
+            onClick={() => onSelect(kit.id, kit.name)}
+            onMouseEnter={() => onPreview(kit.id)}
+          >
+            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: kit.color }} />
+            <span>{kit.name}</span>
+            {currentKey === kit.id && <span className="ml-auto text-emerald-400">✓</span>}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -25,8 +25,8 @@ interface DragGhostInfo {
   height: number;
   targetTrackId: string | null;
   targetLaneRect: { top: number; height: number } | null;
-  /** Original lane rect for showing source placeholder */
   sourceLaneRect: { top: number; height: number } | null;
+  isShiftCopy?: boolean;
 }
 
 export function ClipBlock({ clip, track }: ClipBlockProps) {
@@ -80,6 +80,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   }, []);
 
   const moveClipToTrack = useProjectStore((s) => s.moveClipToTrack);
+  const duplicateClipToTrack = useProjectStore((s) => s.duplicateClipToTrack);
   const clipBlockRef = useRef<HTMLDivElement>(null);
 
   const findClosestLane = useCallback((clientY: number): { trackId: string; rect: DOMRect } | null => {
@@ -111,39 +112,49 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     const bpm = project?.bpm ?? 120;
     const totalDuration = project?.totalDuration ?? 600;
     dragRef.current = false;
+    let isShiftCopy = e.shiftKey;
 
     const clipW = clip.duration * pixelsPerSecond;
     const clipH = clipBlockRef.current?.offsetHeight ?? 48;
+    const clipRect = clipBlockRef.current?.getBoundingClientRect();
+    const clickOffsetPx = clipRect ? startX - clipRect.left : 0;
 
     const onMouseMove = (ev: MouseEvent) => {
       const dx = ev.clientX - startX;
       const dy = ev.clientY - startY;
       if (Math.abs(dx) < 3 && Math.abs(dy) < 3 && !dragRef.current) return;
       dragRef.current = true;
+      isShiftCopy = ev.shiftKey;
 
       const deltaSec = dx / pixelsPerSecond;
 
       if (mode === 'move') {
-        let newStart = snapToGrid(origStart + deltaSec, bpm, 1);
-        newStart = Math.max(0, Math.min(newStart, totalDuration - origDuration));
-        updateClip(clip.id, { startTime: newStart });
+        if (isShiftCopy) {
+          updateClip(clip.id, { startTime: origStart });
+        } else {
+          let newStart = snapToGrid(origStart + deltaSec, bpm, 1);
+          newStart = Math.max(0, Math.min(newStart, totalDuration - origDuration));
+          updateClip(clip.id, { startTime: newStart });
+        }
 
         const closest = findClosestLane(ev.clientY);
         if (closest) {
-          const ghostLeft = newStart * pixelsPerSecond;
+          const ghostLeftVp = ev.clientX - clickOffsetPx;
           const sourceLane = findClosestLane(startY);
+          const isCrossingTrack = closest.trackId !== track.id;
           setDragGhost({
-            x: ghostLeft,
+            x: ghostLeftVp,
             y: closest.rect.top + 4,
             width: clipW,
             height: clipH,
-            targetTrackId: closest.trackId !== track.id ? closest.trackId : null,
-            targetLaneRect: closest.trackId !== track.id
+            targetTrackId: (isCrossingTrack || isShiftCopy) ? closest.trackId : null,
+            targetLaneRect: (isCrossingTrack || isShiftCopy)
               ? { top: closest.rect.top, height: closest.rect.height }
               : null,
-            sourceLaneRect: closest.trackId !== track.id && sourceLane
+            sourceLaneRect: (isCrossingTrack || isShiftCopy) && sourceLane
               ? { top: sourceLane.rect.top, height: sourceLane.rect.height }
               : null,
+            isShiftCopy,
           });
         }
       } else if (mode === 'resize-left') {
@@ -154,14 +165,18 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
         const shift = newStart - origStart;
         let newAudioOffset = origAudioOffset + shift;
+
+        // Can't reveal past start of audio buffer — clamp
         if (newAudioOffset < 0) {
-          newStart = origStart - origAudioOffset;
           newAudioOffset = 0;
+          newStart = origStart - origAudioOffset;
         }
+        // Can't trim past end of audio buffer
         if (newAudioOffset > origAudioDuration - MIN_CLIP_DURATION) {
           newAudioOffset = origAudioDuration - MIN_CLIP_DURATION;
           newStart = origStart + (newAudioOffset - origAudioOffset);
         }
+
         const newDuration = origDuration + (origStart - newStart);
         updateClip(clip.id, { startTime: newStart, duration: newDuration, audioOffset: newAudioOffset });
       } else {
@@ -179,7 +194,14 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
       if (mode === 'move' && dragRef.current) {
         const closest = findClosestLane(ev.clientY);
-        if (closest && closest.trackId !== track.id) {
+        const deltaSec = (ev.clientX - startX) / pixelsPerSecond;
+        const dropStart = Math.max(0, snapToGrid(origStart + deltaSec, bpm, 1));
+
+        if (ev.shiftKey && closest) {
+          // Shift+drag = copy: restore original position, duplicate to target
+          updateClip(clip.id, { startTime: origStart });
+          duplicateClipToTrack(clip.id, closest.trackId, dropStart);
+        } else if (closest && closest.trackId !== track.id) {
           moveClipToTrack(clip.id, closest.trackId);
         }
       }
@@ -187,7 +209,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
-  }, [clip.id, clip.startTime, clip.duration, clip.audioOffset, clip.audioDuration, pixelsPerSecond, project, updateClip, getDragMode, track.id, moveClipToTrack, findClosestLane]);
+  }, [clip.id, clip.startTime, clip.duration, clip.audioOffset, clip.audioDuration, pixelsPerSecond, project, updateClip, getDragMode, track.id, moveClipToTrack, duplicateClipToTrack, findClosestLane]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -231,20 +253,29 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     stale: 'opacity-50',
   };
 
-  // Crop waveform peaks to the visible region
+  // Waveform: render at fixed density so trimming/extending never stretches the waveform
   const audioDuration = clip.audioDuration ?? clip.duration;
   const audioOffset = clip.audioOffset ?? 0;
-  const peakWidthPx = width - 4; // padding
+  const peakWidthPx = width - 4;
 
-  // Determine visible portion of peaks array
+  // Fixed pixels-per-peak: each peak sample always maps to the same width
+  const pxPerPeak = peaks && peaks.length > 0 && audioDuration > 0
+    ? (audioDuration * pixelsPerSecond) / peaks.length
+    : 2;
+  // Minimum bar width of 2px
+  const barWidth = Math.max(pxPerPeak * 0.7, 0.5);
+  const barSpacing = Math.max(pxPerPeak, 1);
+
+  // Which peak indices are visible in this clip window
   const startPeakIdx = peaks ? Math.floor((audioOffset / audioDuration) * peaks.length) : 0;
+  const visibleAudioSec = Math.min(clip.duration, Math.max(0, audioDuration - audioOffset));
   const endPeakIdx = peaks ? Math.min(
-    Math.ceil(((audioOffset + clip.duration) / audioDuration) * peaks.length),
+    Math.ceil(((audioOffset + visibleAudioSec) / audioDuration) * peaks.length),
     peaks.length,
   ) : 0;
   const visiblePeakCount = endPeakIdx - startPeakIdx;
-  const numBars = peaks ? Math.min(visiblePeakCount, Math.floor(peakWidthPx / 2)) : 0;
-  const barSpacing = numBars > 0 ? peakWidthPx / numBars : 0;
+  const numBars = Math.max(0, visiblePeakCount);
+  const audioWidthPx = numBars * barSpacing;
 
   return (
     <>
@@ -253,7 +284,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         className={`absolute top-1 bottom-1 rounded-sm select-none overflow-hidden
           ${statusStyles[clip.generationStatus] ?? ''}
           ${isSelected ? 'ring-2 ring-white ring-offset-1 ring-offset-transparent' : ''}
-          ${dragGhost && dragGhost.targetTrackId ? 'opacity-0' : dragGhost ? '' : ''}
+          ${dragGhost && dragGhost.targetTrackId && !dragGhost.isShiftCopy ? 'opacity-0' : ''}
         `}
         style={{
           left,
@@ -272,26 +303,26 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         <div className="absolute top-0 bottom-0 left-0 w-[6px] cursor-col-resize z-10" />
         <div className="absolute top-0 bottom-0 right-0 w-[6px] cursor-col-resize z-10" />
 
-        {/* Waveform — peaks rendered at fixed density, not stretched */}
-        {peaks && numBars > 0 && (
+        {/* Waveform — fixed density, only in audio-backed region */}
+        {peaks && numBars > 0 && audioWidthPx > 0 && (
           <div className="absolute inset-0 flex items-center overflow-hidden">
             <svg
-              width={peakWidthPx}
+              width={audioWidthPx}
               height="100%"
-              viewBox={`0 0 ${peakWidthPx} 100`}
+              viewBox={`0 0 ${audioWidthPx} 100`}
               preserveAspectRatio="none"
               className="opacity-60 ml-0.5"
             >
               {Array.from({ length: numBars }, (_, i) => {
-                const peakIdx = startPeakIdx + Math.floor((i / numBars) * visiblePeakCount);
-                const peak = peaks[Math.min(peakIdx, peaks.length - 1)];
+                const peakIdx = Math.min(startPeakIdx + i, peaks.length - 1);
+                const peak = peaks[peakIdx];
                 const h = peak * 80;
                 return (
                   <rect
                     key={i}
                     x={i * barSpacing}
                     y={50 - h / 2}
-                    width={Math.max(barSpacing * 0.7, 0.5)}
+                    width={barWidth}
                     height={Math.max(h, 1)}
                     fill={track.color}
                   />
@@ -406,25 +437,27 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
             <div
               className="fixed pointer-events-none z-[98]"
               style={{
-                left: clipBlockRef.current?.getBoundingClientRect().left ?? left,
+                left: left,
                 top: dragGhost.sourceLaneRect.top + 4,
                 width,
                 height: dragGhost.sourceLaneRect.height - 8,
                 border: `1.5px dashed ${hexToRgba(track.color, 0.4)}`,
                 borderRadius: 2,
-                backgroundColor: hexToRgba(track.color, 0.04),
+                backgroundColor: hexToRgba(track.color, dragGhost.isShiftCopy ? 0.15 : 0.04),
               }}
             />
           )}
 
-          {/* Lane-aligned ghost — visually mirrors the original clip at full size */}
+          {/* Lane-aligned ghost — visually mirrors the original clip at target lane size */}
           <div
             className="fixed pointer-events-none z-[100] rounded-sm overflow-hidden"
             style={{
-              left: clipBlockRef.current?.getBoundingClientRect().left ?? left,
+              left: dragGhost.x,
               top: dragGhost.y,
               width: dragGhost.width,
-              height: dragGhost.height,
+              height: dragGhost.targetLaneRect
+                ? dragGhost.targetLaneRect.height - 8
+                : dragGhost.height,
               backgroundColor: hexToRgba(track.color, 0.45),
               borderLeft: `2px solid ${track.color}`,
               boxShadow: `0 4px 20px ${hexToRgba(track.color, 0.3)}, 0 0 0 1px ${hexToRgba(track.color, 0.5)}`,
@@ -432,25 +465,25 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
             }}
           >
             {/* Mini waveform inside ghost */}
-            {peaks && numBars > 0 && (
+            {peaks && numBars > 0 && audioWidthPx > 0 && (
               <div className="absolute inset-0 flex items-center overflow-hidden">
                 <svg
-                  width={peakWidthPx}
+                  width={audioWidthPx}
                   height="100%"
-                  viewBox={`0 0 ${peakWidthPx} 100`}
+                  viewBox={`0 0 ${audioWidthPx} 100`}
                   preserveAspectRatio="none"
                   className="opacity-50 ml-0.5"
                 >
                   {Array.from({ length: numBars }, (_, i) => {
-                    const peakIdx = startPeakIdx + Math.floor((i / numBars) * visiblePeakCount);
-                    const peak = peaks[Math.min(peakIdx, peaks.length - 1)];
+                    const peakIdx = Math.min(startPeakIdx + i, peaks.length - 1);
+                    const peak = peaks[peakIdx];
                     const h = peak * 80;
                     return (
                       <rect
                         key={i}
                         x={i * barSpacing}
                         y={50 - h / 2}
-                        width={Math.max(barSpacing * 0.7, 0.5)}
+                        width={barWidth}
                         height={Math.max(h, 1)}
                         fill={track.color}
                       />
@@ -462,6 +495,12 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
             <div className="absolute top-0 left-1.5 right-1.5 text-[9px] font-medium text-white truncate leading-4 z-10 drop-shadow-sm">
               {clip.prompt || track.displayName}
             </div>
+            {/* Copy badge when Shift is held */}
+            {dragGhost.isShiftCopy && (
+              <div className="absolute -top-1 -right-1 w-4 h-4 bg-emerald-500 rounded-full flex items-center justify-center text-[9px] font-bold text-white shadow z-20">
+                +
+              </div>
+            )}
           </div>
 
           {/* Target lane highlight */}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -146,6 +146,7 @@ export function Timeline() {
       const target = e.target as HTMLElement;
       if (target.closest?.('[data-clip-block]')) return;
       if (target.closest?.('.fixed')) return;
+      if (target.closest?.('[data-sequencer-grid]')) return;
 
       const isCtx = e.metaKey || e.ctrlKey;
 

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -12,15 +12,15 @@ interface TrackLaneProps {
   track: Track;
 }
 
-// Lane context menu (right-click / double-click on empty area)
 interface LaneContextMenuProps {
   x: number;
   y: number;
   onAddLayer: () => void;
+  onOpenSequencer?: () => void;
   onClose: () => void;
 }
 
-function LaneContextMenu({ x, y, onAddLayer, onClose }: LaneContextMenuProps) {
+function LaneContextMenu({ x, y, onAddLayer, onOpenSequencer, onClose }: LaneContextMenuProps) {
   const clampedX = Math.min(x, window.innerWidth - 180);
   const clampedY = Math.min(y, window.innerHeight - 80);
   return (
@@ -34,6 +34,14 @@ function LaneContextMenu({ x, y, onAddLayer, onClose }: LaneContextMenuProps) {
         className="fixed z-50 bg-daw-surface border border-daw-border rounded shadow-xl py-1 min-w-[160px]"
         style={{ left: clampedX, top: clampedY }}
       >
+        {onOpenSequencer && (
+          <button
+            onClick={() => { onClose(); onOpenSequencer(); }}
+            className="w-full text-left px-3 py-1.5 text-xs text-emerald-300 hover:bg-daw-surface-2 transition-colors"
+          >
+            Open Sequencer Editor...
+          </button>
+        )}
         <button
           onClick={() => { onClose(); onAddLayer(); }}
           className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors"
@@ -46,11 +54,12 @@ function LaneContextMenu({ x, y, onAddLayer, onClose }: LaneContextMenuProps) {
 }
 
 const MIN_LANE_HEIGHT = 40;
-const MAX_LANE_HEIGHT = 200;
+const MAX_LANE_HEIGHT = 400;
 
 export function TrackLane({ track }: TrackLaneProps) {
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const contextWindow = useUIStore((s) => s.contextWindow);
+  const setOpenSequencerTrackId = useUIStore((s) => s.setOpenSequencerTrackId);
   const project = useProjectStore((s) => s.project);
   const updateTrack = useProjectStore((s) => s.updateTrack);
 
@@ -65,7 +74,6 @@ export function TrackLane({ track }: TrackLaneProps) {
   const { importAudioToTrack } = useAudioImport();
   const [fileDragOver, setFileDragOver] = useState(false);
 
-  // Lane height resize
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
   const laneHeight = track.laneHeight ?? 64;
 
@@ -92,7 +100,8 @@ export function TrackLane({ track }: TrackLaneProps) {
   if (!project) return null;
 
   const trackType = track.trackType ?? 'stems';
-  const isComingSoon = trackType === 'sequencer' || trackType === 'pianoRoll';
+  const isSequencer = trackType === 'sequencer';
+  const isComingSoon = trackType === 'pianoRoll';
   const totalWidth = project.totalDuration * pixelsPerSecond;
 
   const hitsClip = useCallback((clickTime: number): boolean => {
@@ -120,6 +129,14 @@ export function TrackLane({ track }: TrackLaneProps) {
   const handleDoubleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) return;
     if (isComingSoon) return;
+
+    // For sequencer tracks, double-click opens the editor
+    if (isSequencer) {
+      e.stopPropagation();
+      setOpenSequencerTrackId(track.id);
+      return;
+    }
+
     e.stopPropagation();
     const rect = e.currentTarget.getBoundingClientRect();
     const laneX = e.clientX - rect.left;
@@ -131,7 +148,7 @@ export function TrackLane({ track }: TrackLaneProps) {
     const duration = Math.max(10, Math.min(30, remaining));
     setCtxMenu({ x: e.clientX, y: e.clientY, startTime, duration });
     setAddLayerTarget(null);
-  }, [isComingSoon, pixelsPerSecond, project.bpm, project.totalDuration, hitsClip]);
+  }, [isComingSoon, isSequencer, pixelsPerSecond, project.bpm, project.totalDuration, hitsClip, track.id, setOpenSequencerTrackId]);
 
   const clearSel = useCallback(() => {
     setAddLayerTarget(null);
@@ -169,12 +186,16 @@ export function TrackLane({ track }: TrackLaneProps) {
     }
   }, [project, pixelsPerSecond, track.id, importAudioToTrack]);
 
+  const hasClips = track.clips.length > 0;
+
   return (
     <>
       <div
         data-track-id={track.id}
         className={`relative border-b border-daw-border ${fileDragOver ? 'bg-blue-900/20' : ''}`}
         style={{ width: totalWidth, height: laneHeight }}
+        onContextMenu={handleContextMenu}
+        onDoubleClick={handleDoubleClick}
         onDragOver={handleFileDragOver}
         onDragLeave={handleFileDragLeave}
         onDrop={handleFileDrop}
@@ -194,9 +215,25 @@ export function TrackLane({ track }: TrackLaneProps) {
             </div>
           </div>
         ) : (
-          track.clips.map((clip) => (
-            <ClipBlock key={clip.id} clip={clip} track={track} />
-          ))
+          <>
+            {/* Render clips (works for all track types including sequencer after bounce) */}
+            {track.clips.map((clip) => (
+              <ClipBlock key={clip.id} clip={clip} track={track} />
+            ))}
+
+            {/* Sequencer track hint when no bounced clips */}
+            {isSequencer && !hasClips && (
+              <div
+                className="absolute inset-0 flex items-center justify-center cursor-pointer"
+                onClick={() => setOpenSequencerTrackId(track.id)}
+              >
+                <div className="flex items-center gap-2 bg-daw-surface/60 backdrop-blur-sm px-4 py-2 rounded-lg border border-daw-border border-dashed">
+                  <span className="text-emerald-400 text-sm">SEQ</span>
+                  <span className="text-xs text-zinc-400">Double-click to open sequencer editor</span>
+                </div>
+              </div>
+            )}
+          </>
         )}
 
         {ctxMenu && (
@@ -204,6 +241,7 @@ export function TrackLane({ track }: TrackLaneProps) {
             x={ctxMenu.x}
             y={ctxMenu.y}
             onAddLayer={() => setAddLayerTarget({ startTime: ctxMenu.startTime, duration: ctxMenu.duration })}
+            onOpenSequencer={isSequencer ? () => setOpenSequencerTrackId(track.id) : undefined}
             onClose={() => setCtxMenu(null)}
           />
         )}
@@ -227,3 +265,4 @@ export function TrackLane({ track }: TrackLaneProps) {
     </>
   );
 }
+

--- a/src/components/tracks/TrackEditModal.tsx
+++ b/src/components/tracks/TrackEditModal.tsx
@@ -93,7 +93,7 @@ export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
               {(['stems', 'sample', 'sequencer', 'pianoRoll'] as TrackType[]).map((tt) => {
                 const tti = TRACK_TYPE_CATALOG[tt];
                 const isActive = (track.trackType ?? 'stems') === tt;
-                const comingSoon = tt === 'sequencer' || tt === 'pianoRoll';
+                const comingSoon = tt === 'pianoRoll';
                 return (
                   <button
                     key={tt}

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -5,7 +5,7 @@ import { TRACK_CATALOG, TRACK_TYPE_CATALOG } from '../../constants/tracks';
 import { TrackEditModal } from './TrackEditModal';
 
 const MIN_LANE_HEIGHT = 40;
-const MAX_LANE_HEIGHT = 200;
+const MAX_LANE_HEIGHT = 400;
 
 interface TrackHeaderProps {
   track: Track;

--- a/src/constants/tracks.ts
+++ b/src/constants/tracks.ts
@@ -42,9 +42,33 @@ export interface TrackTypeInfo {
 export const TRACK_TYPE_CATALOG: Record<TrackType, TrackTypeInfo> = {
   stems:     { type: 'stems',     label: 'Stems',      abbr: 'STM', emoji: '🎛️', color: '#3b82f6', description: 'AI-generated isolated instrument tracks' },
   sample:    { type: 'sample',    label: 'Sample',     abbr: 'SMP', emoji: '📁', color: '#f97316', description: 'User-imported audio clips' },
-  sequencer: { type: 'sequencer', label: 'Sequencer',  abbr: 'SEQ', emoji: '🎹', color: '#22c55e', description: 'Step-based pattern editor (coming soon)' },
+  sequencer: { type: 'sequencer', label: 'Sequencer',  abbr: 'SEQ', emoji: '🎹', color: '#22c55e', description: 'Step-based drum pattern editor' },
   pianoRoll: { type: 'pianoRoll', label: 'Piano Roll', abbr: 'PNO', emoji: '🎵', color: '#a855f7', description: 'MIDI note editor with virtual instruments (coming soon)' },
 };
+
+export interface DrumKitSample {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export const DEFAULT_DRUM_KIT: DrumKitSample[] = [
+  { id: 'kick',       name: 'Kick',       color: '#ef4444' },
+  { id: 'snare',      name: 'Snare',      color: '#f97316' },
+  { id: 'closed_hh',  name: 'Closed HH',  color: '#eab308' },
+  { id: 'open_hh',    name: 'Open HH',    color: '#84cc16' },
+];
+
+export const ALL_DRUM_SAMPLES: DrumKitSample[] = [
+  { id: 'kick',       name: 'Kick',       color: '#ef4444' },
+  { id: 'snare',      name: 'Snare',      color: '#f97316' },
+  { id: 'closed_hh',  name: 'Closed HH',  color: '#eab308' },
+  { id: 'open_hh',    name: 'Open HH',    color: '#84cc16' },
+  { id: 'clap',       name: 'Clap',       color: '#22c55e' },
+  { id: 'rim',        name: 'Rim',        color: '#06b6d4' },
+  { id: 'low_tom',    name: 'Low Tom',    color: '#3b82f6' },
+  { id: 'high_tom',   name: 'High Tom',   color: '#8b5cf6' },
+];
 
 export const KEY_SCALES = [
   'C major', 'C minor', 'C# major', 'C# minor',

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -1,10 +1,18 @@
 import { TrackNode } from './TrackNode';
+import type { SequencerPattern } from '../types/project';
 
 export interface ScheduledSource {
   source: AudioBufferSourceNode;
   clipId: string;
   trackId: string;
   startTime: number;
+}
+
+export interface SequencerScheduleInfo {
+  trackId: string;
+  pattern: SequencerPattern;
+  sampleBuffers: Map<string, AudioBuffer>;
+  bpm: number;
 }
 
 export interface ClipScheduleInfo {
@@ -134,6 +142,81 @@ export class AudioEngine {
     this._startedAt = this.ctx.currentTime;
     this._offset = fromTime;
     this._startTimeUpdate(totalDuration);
+  }
+
+  /**
+   * Schedule sequencer pattern playback for a track.
+   * The pattern loops from time 0 and tiles across the timeline.
+   */
+  scheduleSequencer(
+    info: SequencerScheduleInfo,
+    fromTime: number,
+    totalDuration: number,
+  ) {
+    const { trackId, pattern, sampleBuffers, bpm } = info;
+    const trackNode = this.getOrCreateTrackNode(trackId);
+    const contextNow = this.ctx.currentTime;
+
+    const stepDuration = (60 / bpm) / (pattern.stepsPerBar / 4);
+    const patternDuration = stepDuration * pattern.stepsPerBar * pattern.bars;
+    if (patternDuration <= 0) return;
+
+    // Tile the pattern across the timeline
+    const startLoop = Math.floor(fromTime / patternDuration);
+    const endLoop = Math.ceil(totalDuration / patternDuration);
+
+    for (let loopIdx = startLoop; loopIdx < endLoop; loopIdx++) {
+      const loopStartTime = loopIdx * patternDuration;
+
+      for (const row of pattern.rows) {
+        if (row.muted) continue;
+        const buffer = sampleBuffers.get(row.sampleKey);
+        if (!buffer) continue;
+
+        for (let stepIdx = 0; stepIdx < row.steps.length; stepIdx++) {
+          const step = row.steps[stepIdx];
+          if (!step.active) continue;
+
+          // Apply swing: offset even-indexed steps (1, 3, 5, ...)
+          let swingOffset = 0;
+          if (pattern.swing > 0 && stepIdx % 2 === 1) {
+            swingOffset = stepDuration * pattern.swing * 0.5;
+          }
+
+          const stepTime = loopStartTime + stepIdx * stepDuration + swingOffset;
+          if (stepTime + buffer.duration <= fromTime) continue;
+          if (stepTime >= totalDuration) break;
+
+          const source = this.ctx.createBufferSource();
+          source.buffer = buffer;
+
+          // Per-step velocity gain
+          const velocityGain = this.ctx.createGain();
+          velocityGain.gain.value = step.velocity * row.volume;
+          source.connect(velocityGain);
+          velocityGain.connect(trackNode.inputGain);
+
+          const delay = stepTime - fromTime;
+          if (delay >= 0) {
+            source.start(contextNow + delay);
+          } else {
+            const seekInto = -delay;
+            if (seekInto < buffer.duration) {
+              source.start(contextNow, seekInto);
+            } else {
+              continue;
+            }
+          }
+
+          this.scheduledSources.push({
+            source,
+            clipId: `seq-${row.id}-${stepIdx}-${loopIdx}`,
+            trackId,
+            startTime: stepTime,
+          });
+        }
+      }
+    }
   }
 
   private _startTimeUpdate(totalDuration: number) {

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -251,6 +251,16 @@ export function useKeyboardShortcuts() {
           break;
         }
 
+        // Split clip at playhead
+        case 'KeyS': {
+          const selected = [...ui.selectedClipIds];
+          if (selected.length === 1) {
+            e.preventDefault();
+            project.splitClip(selected[0], transport.currentTime);
+          }
+          break;
+        }
+
         // Mixer toggle
         case 'KeyM':
           e.preventDefault();

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -3,6 +3,7 @@ import { useTransportStore } from '../store/transportStore';
 import { useProjectStore } from '../store/projectStore';
 import { getAudioEngine } from './useAudioEngine';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
+import { getSample } from '../services/sampleManager';
 
 /**
  * Trim an AudioBuffer to a specific project-time region.
@@ -100,10 +101,49 @@ export function useTransport() {
           trackId: track.id,
           startTime: clip.startTime,
           buffer,
-          audioOffset: 0,
+          audioOffset: clip.audioOffset ?? 0,
           clipDuration: clip.duration,
         });
       }
+    }
+
+    // Schedule sequencer patterns
+    for (const track of proj.tracks) {
+      if ((track.trackType ?? 'stems') !== 'sequencer') continue;
+      if (!track.sequencerPattern || track.sequencerPattern.rows.length === 0) continue;
+
+      const sampleBuffers = new Map<string, AudioBuffer>();
+      for (const row of track.sequencerPattern.rows) {
+        if (row.muted) continue;
+        const buf = await getSample(engine.ctx, row.sampleKey);
+        if (buf) sampleBuffers.set(row.sampleKey, buf);
+      }
+
+      if (sampleBuffers.size > 0) {
+        const trackNode = engine.getOrCreateTrackNode(track.id);
+        trackNode.volume = track.volume;
+        trackNode.muted = track.muted;
+        trackNode.soloed = track.soloed;
+        trackNode.pan = track.pan ?? 0;
+        trackNode.eqLowGain = track.eqLowGain ?? 0;
+        trackNode.eqMidGain = track.eqMidGain ?? 0;
+        trackNode.eqHighGain = track.eqHighGain ?? 0;
+        trackNode.applyCompressor(
+          track.compressorEnabled ?? false,
+          track.compressorThreshold ?? -24,
+          track.compressorRatio ?? 4,
+        );
+        trackNode.setReverb(track.reverbMix ?? 0, track.reverbRoomSize ?? 0.5);
+      }
+
+      // Defer actual scheduling after we know startFrom and effectiveEnd (below)
+      (engine as any).__pendingSequencers = (engine as any).__pendingSequencers || [];
+      (engine as any).__pendingSequencers.push({
+        trackId: track.id,
+        pattern: track.sequencerPattern,
+        sampleBuffers,
+        bpm: proj.bpm,
+      });
     }
 
     engine.updateSoloState();
@@ -121,6 +161,15 @@ export function useTransport() {
     }
 
     engine.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
+
+    // Schedule any pending sequencer patterns
+    const pendingSeqs = (engine as any).__pendingSequencers as any[] | undefined;
+    if (pendingSeqs) {
+      for (const seqInfo of pendingSeqs) {
+        engine.scheduleSequencer(seqInfo, startFrom, effectiveEnd);
+      }
+      delete (engine as any).__pendingSequencers;
+    }
 
     const { metronomeEnabled } = useTransportStore.getState();
     if (metronomeEnabled) {

--- a/src/services/sampleManager.ts
+++ b/src/services/sampleManager.ts
@@ -1,0 +1,249 @@
+/**
+ * Procedural drum synthesis and sample caching for the step sequencer.
+ * Each drum sound is synthesized from scratch using Web Audio API oscillators,
+ * noise bursts, and envelopes — no external audio files required.
+ */
+
+const _cache = new Map<string, AudioBuffer>();
+
+function createNoiseBuffer(ctx: BaseAudioContext, duration: number, sampleRate: number): AudioBuffer {
+  const length = Math.floor(duration * sampleRate);
+  const buf = ctx.createBuffer(1, length, sampleRate);
+  const data = buf.getChannelData(0);
+  for (let i = 0; i < length; i++) {
+    data[i] = Math.random() * 2 - 1;
+  }
+  return buf;
+}
+
+async function renderOffline(
+  duration: number,
+  sampleRate: number,
+  build: (ctx: OfflineAudioContext) => void,
+): Promise<AudioBuffer> {
+  const length = Math.ceil(duration * sampleRate);
+  const offCtx = new OfflineAudioContext(1, length, sampleRate);
+  build(offCtx);
+  return offCtx.startRendering();
+}
+
+function synthKick(sr: number): Promise<AudioBuffer> {
+  return renderOffline(0.5, sr, (ctx) => {
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(160, 0);
+    osc.frequency.exponentialRampToValueAtTime(40, 0.12);
+
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(1, 0);
+    gain.gain.exponentialRampToValueAtTime(0.001, 0.45);
+
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start(0);
+    osc.stop(0.5);
+  });
+}
+
+function synthSnare(sr: number): Promise<AudioBuffer> {
+  return renderOffline(0.3, sr, (ctx) => {
+    // Tone body
+    const osc = ctx.createOscillator();
+    osc.type = 'triangle';
+    osc.frequency.setValueAtTime(200, 0);
+    osc.frequency.exponentialRampToValueAtTime(100, 0.05);
+    const oscGain = ctx.createGain();
+    oscGain.gain.setValueAtTime(0.7, 0);
+    oscGain.gain.exponentialRampToValueAtTime(0.001, 0.15);
+    osc.connect(oscGain);
+    oscGain.connect(ctx.destination);
+    osc.start(0);
+    osc.stop(0.3);
+
+    // Noise
+    const noiseBuf = createNoiseBuffer(ctx, 0.3, sr);
+    const noise = ctx.createBufferSource();
+    noise.buffer = noiseBuf;
+    const filter = ctx.createBiquadFilter();
+    filter.type = 'highpass';
+    filter.frequency.value = 1500;
+    const noiseGain = ctx.createGain();
+    noiseGain.gain.setValueAtTime(0.8, 0);
+    noiseGain.gain.exponentialRampToValueAtTime(0.001, 0.2);
+    noise.connect(filter);
+    filter.connect(noiseGain);
+    noiseGain.connect(ctx.destination);
+    noise.start(0);
+  });
+}
+
+function synthClosedHH(sr: number): Promise<AudioBuffer> {
+  return renderOffline(0.12, sr, (ctx) => {
+    const noiseBuf = createNoiseBuffer(ctx, 0.12, sr);
+    const noise = ctx.createBufferSource();
+    noise.buffer = noiseBuf;
+
+    const hp = ctx.createBiquadFilter();
+    hp.type = 'highpass';
+    hp.frequency.value = 5000;
+    const bp = ctx.createBiquadFilter();
+    bp.type = 'bandpass';
+    bp.frequency.value = 10000;
+    bp.Q.value = 1;
+
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(0.6, 0);
+    gain.gain.exponentialRampToValueAtTime(0.001, 0.08);
+
+    noise.connect(hp);
+    hp.connect(bp);
+    bp.connect(gain);
+    gain.connect(ctx.destination);
+    noise.start(0);
+  });
+}
+
+function synthOpenHH(sr: number): Promise<AudioBuffer> {
+  return renderOffline(0.4, sr, (ctx) => {
+    const noiseBuf = createNoiseBuffer(ctx, 0.4, sr);
+    const noise = ctx.createBufferSource();
+    noise.buffer = noiseBuf;
+
+    const hp = ctx.createBiquadFilter();
+    hp.type = 'highpass';
+    hp.frequency.value = 5000;
+    const bp = ctx.createBiquadFilter();
+    bp.type = 'bandpass';
+    bp.frequency.value = 10000;
+    bp.Q.value = 1;
+
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(0.6, 0);
+    gain.gain.exponentialRampToValueAtTime(0.001, 0.35);
+
+    noise.connect(hp);
+    hp.connect(bp);
+    bp.connect(gain);
+    gain.connect(ctx.destination);
+    noise.start(0);
+  });
+}
+
+function synthClap(sr: number): Promise<AudioBuffer> {
+  return renderOffline(0.3, sr, (ctx) => {
+    const noiseBuf = createNoiseBuffer(ctx, 0.3, sr);
+    const noise = ctx.createBufferSource();
+    noise.buffer = noiseBuf;
+
+    const bp = ctx.createBiquadFilter();
+    bp.type = 'bandpass';
+    bp.frequency.value = 2500;
+    bp.Q.value = 2;
+
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(0, 0);
+    gain.gain.linearRampToValueAtTime(0.8, 0.005);
+    gain.gain.setValueAtTime(0.3, 0.01);
+    gain.gain.linearRampToValueAtTime(0.8, 0.015);
+    gain.gain.exponentialRampToValueAtTime(0.001, 0.25);
+
+    noise.connect(bp);
+    bp.connect(gain);
+    gain.connect(ctx.destination);
+    noise.start(0);
+  });
+}
+
+function synthRim(sr: number): Promise<AudioBuffer> {
+  return renderOffline(0.1, sr, (ctx) => {
+    const osc = ctx.createOscillator();
+    osc.type = 'square';
+    osc.frequency.value = 400;
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(0.6, 0);
+    gain.gain.exponentialRampToValueAtTime(0.001, 0.06);
+    const hp = ctx.createBiquadFilter();
+    hp.type = 'highpass';
+    hp.frequency.value = 600;
+    osc.connect(hp);
+    hp.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start(0);
+    osc.stop(0.1);
+  });
+}
+
+function synthLowTom(sr: number): Promise<AudioBuffer> {
+  return renderOffline(0.4, sr, (ctx) => {
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(120, 0);
+    osc.frequency.exponentialRampToValueAtTime(60, 0.15);
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(0.9, 0);
+    gain.gain.exponentialRampToValueAtTime(0.001, 0.35);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start(0);
+    osc.stop(0.4);
+  });
+}
+
+function synthHighTom(sr: number): Promise<AudioBuffer> {
+  return renderOffline(0.3, sr, (ctx) => {
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(200, 0);
+    osc.frequency.exponentialRampToValueAtTime(100, 0.1);
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(0.9, 0);
+    gain.gain.exponentialRampToValueAtTime(0.001, 0.25);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start(0);
+    osc.stop(0.3);
+  });
+}
+
+const SYNTH_MAP: Record<string, (sr: number) => Promise<AudioBuffer>> = {
+  kick: synthKick,
+  snare: synthSnare,
+  closed_hh: synthClosedHH,
+  open_hh: synthOpenHH,
+  clap: synthClap,
+  rim: synthRim,
+  low_tom: synthLowTom,
+  high_tom: synthHighTom,
+};
+
+export async function getSample(
+  ctx: AudioContext,
+  sampleKey: string,
+): Promise<AudioBuffer | null> {
+  const cached = _cache.get(sampleKey);
+  if (cached) return cached;
+
+  const synth = SYNTH_MAP[sampleKey];
+  if (synth) {
+    const buf = await synth(ctx.sampleRate);
+    _cache.set(sampleKey, buf);
+    return buf;
+  }
+
+  return null;
+}
+
+/**
+ * Store a user-provided AudioBuffer in the sample cache.
+ */
+export function cacheUserSample(key: string, buffer: AudioBuffer) {
+  _cache.set(key, buffer);
+}
+
+export function getBuiltInSampleIds(): string[] {
+  return Object.keys(SYNTH_MAP);
+}
+
+export function clearSampleCache() {
+  _cache.clear();
+}

--- a/src/services/sequencerBounce.ts
+++ b/src/services/sequencerBounce.ts
@@ -1,0 +1,111 @@
+import type { SequencerPattern } from '../types/project';
+import { getSample } from './sampleManager';
+import { audioBufferToWavBlob } from '../utils/wav';
+import { computeWaveformPeaks } from '../utils/waveformPeaks';
+import { saveAudioBlob } from './audioFileManager';
+import { useProjectStore } from '../store/projectStore';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+
+/**
+ * Renders a SequencerPattern to an AudioBuffer using OfflineAudioContext,
+ * then stores it as a Clip on the given track.
+ */
+export async function bounceSequencerToAudio(
+  trackId: string,
+  pattern: SequencerPattern,
+  bpm: number,
+  startTime: number = 0,
+): Promise<void> {
+  const engine = getAudioEngine();
+  await engine.resume();
+
+  const sampleRate = engine.ctx.sampleRate;
+  const stepDuration = (60 / bpm) / (pattern.stepsPerBar / 4);
+  const totalSteps = pattern.stepsPerBar * pattern.bars;
+  const patternDuration = stepDuration * totalSteps;
+
+  if (patternDuration <= 0) return;
+
+  // Load all samples
+  const sampleBuffers = new Map<string, AudioBuffer>();
+  for (const row of pattern.rows) {
+    if (row.muted) continue;
+    const buf = await getSample(engine.ctx, row.sampleKey);
+    if (buf) sampleBuffers.set(row.sampleKey, buf);
+  }
+
+  // Find the longest sample tail so we don't clip the last hit
+  let maxSampleDuration = 0;
+  for (const buf of sampleBuffers.values()) {
+    if (buf.duration > maxSampleDuration) maxSampleDuration = buf.duration;
+  }
+  const renderDuration = patternDuration + maxSampleDuration;
+  const renderLength = Math.ceil(renderDuration * sampleRate);
+
+  const offCtx = new OfflineAudioContext(1, renderLength, sampleRate);
+
+  for (const row of pattern.rows) {
+    if (row.muted) continue;
+    const buffer = sampleBuffers.get(row.sampleKey);
+    if (!buffer) continue;
+
+    for (let stepIdx = 0; stepIdx < row.steps.length; stepIdx++) {
+      const step = row.steps[stepIdx];
+      if (!step.active) continue;
+
+      let swingOffset = 0;
+      if (pattern.swing > 0 && stepIdx % 2 === 1) {
+        swingOffset = stepDuration * pattern.swing * 0.5;
+      }
+
+      const time = stepIdx * stepDuration + swingOffset;
+
+      const source = offCtx.createBufferSource();
+      source.buffer = buffer;
+      const gain = offCtx.createGain();
+      gain.gain.value = step.velocity * row.volume;
+      source.connect(gain);
+      gain.connect(offCtx.destination);
+      source.start(time);
+    }
+  }
+
+  const rendered = await offCtx.startRendering();
+
+  // Trim to pattern duration (cut off the tail padding)
+  const trimLength = Math.ceil(patternDuration * sampleRate);
+  const trimmed = new AudioBuffer({
+    length: trimLength,
+    numberOfChannels: 1,
+    sampleRate,
+  });
+  const srcData = rendered.getChannelData(0);
+  const dstData = trimmed.getChannelData(0);
+  for (let i = 0; i < trimLength && i < srcData.length; i++) {
+    dstData[i] = srcData[i];
+  }
+
+  const wavBlob = audioBufferToWavBlob(trimmed);
+  const peaks = computeWaveformPeaks(trimmed, 200);
+
+  const store = useProjectStore.getState();
+  const project = store.project;
+  if (!project) return;
+
+  const clip = store.addClip(trackId, {
+    startTime,
+    duration: patternDuration,
+    prompt: `Sequencer: ${pattern.name} — ${totalSteps} steps, ${pattern.bars} bar(s)`,
+    lyrics: '',
+  });
+
+  const isolatedKey = await saveAudioBlob(project.id, clip.id, 'isolated', wavBlob);
+
+  store.updateClipStatus(clip.id, 'ready', {
+    isolatedAudioKey: isolatedKey,
+    waveformPeaks: peaks,
+    audioDuration: patternDuration,
+    audioOffset: 0,
+    source: 'generated',
+  });
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
-import type { Project, Track, Clip, ClipVersion, TrackName, TrackType, ClipGenerationStatus, AssetClip } from '../types/project';
-import { TRACK_CATALOG } from '../constants/tracks';
+import type { Project, Track, Clip, ClipVersion, TrackName, TrackType, ClipGenerationStatus, AssetClip, SequencerPattern, SequencerRow, SequencerStep } from '../types/project';
+import { TRACK_CATALOG, DEFAULT_DRUM_KIT } from '../constants/tracks';
 import {
   DEFAULT_BPM,
   DEFAULT_KEY_SCALE,
@@ -66,11 +66,28 @@ interface ProjectState {
   /** Restore clip audio fields from a version by index. */
   setActiveVersion: (clipId: string, idx: number) => void;
 
+  splitClip: (clipId: string, splitTime: number) => void;
   toggleClipStar: (clipId: string) => void;
   moveClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => void;
+  duplicateClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => Clip | undefined;
 
   removeAsset: (assetId: string) => void;
   toggleAssetStar: (assetId: string) => void;
+
+  // Sequencer actions
+  initSequencerPattern: (trackId: string) => void;
+  toggleSequencerStep: (trackId: string, rowId: string, stepIndex: number) => void;
+  setSequencerStepVelocity: (trackId: string, rowId: string, stepIndex: number, velocity: number) => void;
+  addSequencerRow: (trackId: string, sampleId: string, name: string, color: string) => void;
+  removeSequencerRow: (trackId: string, rowId: string) => void;
+  updateSequencerSwing: (trackId: string, swing: number) => void;
+  setSequencerStepsPerBar: (trackId: string, stepsPerBar: number) => void;
+  setSequencerBars: (trackId: string, bars: number) => void;
+  setSequencerRowVolume: (trackId: string, rowId: string, volume: number) => void;
+  toggleSequencerRowMute: (trackId: string, rowId: string) => void;
+  setSequencerRowSample: (trackId: string, rowId: string, sampleKey: string) => void;
+  clearSequencerRow: (trackId: string, rowId: string) => void;
+  batchSetSequencerSteps: (trackId: string, ops: { rowId: string; stepIndex: number; active: boolean; velocity: number }[]) => void;
 
   getTrackById: (trackId: string) => Track | undefined;
   getClipById: (clipId: string) => Clip | undefined;
@@ -248,7 +265,31 @@ export const useProjectStore = create<ProjectState>()(
       muted: false,
       soloed: false,
       clips: [],
+      laneHeight: resolvedType === 'sequencer' ? 80 : undefined,
     };
+
+    // Auto-initialize sequencer pattern for sequencer tracks
+    if (resolvedType === 'sequencer') {
+      const stepsPerBar = 16;
+      const bars = 1;
+      const totalSteps = stepsPerBar * bars;
+      track.sequencerPattern = {
+        id: uuidv4(),
+        name: 'Pattern 1',
+        rows: DEFAULT_DRUM_KIT.map((kit) => ({
+          id: uuidv4(),
+          name: kit.name,
+          sampleKey: kit.id,
+          steps: Array.from({ length: totalSteps }, () => ({ active: false, velocity: 0.8 })),
+          volume: 0.8,
+          muted: false,
+          color: kit.color,
+        })),
+        stepsPerBar,
+        bars,
+        swing: 0,
+      };
+    }
 
     const newTracks = [...state.project.tracks, track];
     set({
@@ -455,6 +496,66 @@ export const useProjectStore = create<ProjectState>()(
     return newClip;
   },
 
+  splitClip: (clipId, splitTime) => {
+    const state = get();
+    if (!state.project) return;
+
+    let sourceClip: Clip | undefined;
+    let trackId: string | undefined;
+    for (const t of state.project.tracks) {
+      const c = t.clips.find((c) => c.id === clipId);
+      if (c) { sourceClip = c; trackId = t.id; break; }
+    }
+    if (!sourceClip || !trackId) return;
+
+    const origStart = sourceClip.startTime;
+    const origEnd = origStart + sourceClip.duration;
+    if (splitTime <= origStart || splitTime >= origEnd) return;
+
+    _pushHistory(state.project);
+    const origAudioOffset = sourceClip.audioOffset ?? 0;
+    const isReady = sourceClip.generationStatus === 'ready' && !!sourceClip.isolatedAudioKey;
+
+    const leftDuration = splitTime - origStart;
+    const rightDuration = origEnd - splitTime;
+
+    const leftClip: Clip = {
+      ...sourceClip,
+      duration: leftDuration,
+    };
+
+    const rightClip: Clip = {
+      ...sourceClip,
+      id: uuidv4(),
+      startTime: splitTime,
+      duration: rightDuration,
+      audioOffset: origAudioOffset + leftDuration,
+      generationStatus: isReady ? 'ready' : 'empty',
+      generationJobId: null,
+      cumulativeMixKey: sourceClip.cumulativeMixKey,
+      isolatedAudioKey: isReady ? sourceClip.isolatedAudioKey : null,
+      waveformPeaks: isReady && sourceClip.waveformPeaks ? [...sourceClip.waveformPeaks] : null,
+      audioDuration: sourceClip.audioDuration,
+    };
+
+    const newTracks = state.project.tracks.map((t) => {
+      if (t.id !== trackId) return t;
+      return {
+        ...t,
+        clips: t.clips.map((c) => (c.id === clipId ? leftClip : c)).concat(rightClip),
+      };
+    });
+
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        tracks: newTracks,
+      },
+    });
+  },
+
   updateClipStatus: (clipId, status, extra) => {
     const state = get();
     if (!state.project) return;
@@ -629,6 +730,42 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
+  duplicateClipToTrack: (clipId, targetTrackId, startTime) => {
+    const state = get();
+    if (!state.project) return undefined;
+    let sourceClip: Clip | undefined;
+    for (const t of state.project.tracks) {
+      const c = t.clips.find((c) => c.id === clipId);
+      if (c) { sourceClip = c; break; }
+    }
+    if (!sourceClip) return undefined;
+    _pushHistory(state.project);
+    const isReady = sourceClip.generationStatus === 'ready' && !!sourceClip.isolatedAudioKey;
+    const newClip: Clip = {
+      ...sourceClip,
+      id: uuidv4(),
+      trackId: targetTrackId,
+      startTime: startTime ?? sourceClip.startTime,
+      generationStatus: isReady ? 'ready' : 'empty',
+      generationJobId: null,
+      cumulativeMixKey: sourceClip.cumulativeMixKey,
+      isolatedAudioKey: isReady ? sourceClip.isolatedAudioKey : null,
+      waveformPeaks: isReady && sourceClip.waveformPeaks ? [...sourceClip.waveformPeaks] : null,
+    };
+    const newTracks = state.project.tracks.map((t) =>
+      t.id === targetTrackId ? { ...t, clips: [...t.clips, newClip] } : t,
+    );
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        tracks: newTracks,
+      },
+    });
+    return newClip;
+  },
+
   removeAsset: (assetId) => {
     const state = get();
     if (!state.project) return;
@@ -662,6 +799,369 @@ export const useProjectStore = create<ProjectState>()(
             c.id === asset.clipId ? { ...c, starred: newStarred } : c,
           ),
         })),
+      },
+    });
+  },
+
+  // ── Sequencer actions ───────────────────────────────────────────────────
+
+  initSequencerPattern: (trackId) => {
+    const state = get();
+    if (!state.project) return;
+    const track = state.project.tracks.find((t) => t.id === trackId);
+    if (!track || track.sequencerPattern) return;
+    _pushHistory(state.project);
+
+    const stepsPerBar = 16;
+    const bars = 1;
+    const totalSteps = stepsPerBar * bars;
+    const emptyStep = (): SequencerStep => ({ active: false, velocity: 0.8 });
+
+    const rows: SequencerRow[] = DEFAULT_DRUM_KIT.map((kit) => ({
+      id: uuidv4(),
+      name: kit.name,
+      sampleKey: kit.id,
+      steps: Array.from({ length: totalSteps }, emptyStep),
+      volume: 0.8,
+      muted: false,
+      color: kit.color,
+    }));
+
+    const pattern: SequencerPattern = {
+      id: uuidv4(),
+      name: 'Pattern 1',
+      rows,
+      stepsPerBar,
+      bars,
+      swing: 0,
+    };
+
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, sequencerPattern: pattern } : t,
+        ),
+      },
+    });
+  },
+
+  toggleSequencerStep: (trackId, rowId, stepIndex) => {
+    const state = get();
+    if (!state.project) return;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) => {
+                if (r.id !== rowId) return r;
+                const newSteps = [...r.steps];
+                const s = newSteps[stepIndex];
+                if (s) newSteps[stepIndex] = { ...s, active: !s.active };
+                return { ...r, steps: newSteps };
+              }),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  setSequencerStepVelocity: (trackId, rowId, stepIndex, velocity) => {
+    const state = get();
+    if (!state.project) return;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) => {
+                if (r.id !== rowId) return r;
+                const newSteps = [...r.steps];
+                const s = newSteps[stepIndex];
+                if (s) newSteps[stepIndex] = { ...s, velocity: Math.max(0, Math.min(1, velocity)) };
+                return { ...r, steps: newSteps };
+              }),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  addSequencerRow: (trackId, sampleId, name, color) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          const totalSteps = t.sequencerPattern.stepsPerBar * t.sequencerPattern.bars;
+          const newRow: SequencerRow = {
+            id: uuidv4(),
+            name,
+            sampleKey: sampleId,
+            steps: Array.from({ length: totalSteps }, () => ({ active: false, velocity: 0.8 })),
+            volume: 0.8,
+            muted: false,
+            color,
+          };
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: [...t.sequencerPattern.rows, newRow],
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  removeSequencerRow: (trackId, rowId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.filter((r) => r.id !== rowId),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  updateSequencerSwing: (trackId, swing) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: { ...t.sequencerPattern, swing: Math.max(0, Math.min(1, swing)) },
+          };
+        }),
+      },
+    });
+  },
+
+  setSequencerStepsPerBar: (trackId, stepsPerBar) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          const p = t.sequencerPattern;
+          const newTotal = stepsPerBar * p.bars;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...p,
+              stepsPerBar,
+              rows: p.rows.map((r) => {
+                const steps = [...r.steps];
+                while (steps.length < newTotal) steps.push({ active: false, velocity: 0.8 });
+                return { ...r, steps: steps.slice(0, newTotal) };
+              }),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  setSequencerBars: (trackId, bars) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          const p = t.sequencerPattern;
+          const newTotal = p.stepsPerBar * bars;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...p,
+              bars,
+              rows: p.rows.map((r) => {
+                const steps = [...r.steps];
+                while (steps.length < newTotal) steps.push({ active: false, velocity: 0.8 });
+                return { ...r, steps: steps.slice(0, newTotal) };
+              }),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  setSequencerRowVolume: (trackId, rowId, volume) => {
+    const state = get();
+    if (!state.project) return;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) =>
+                r.id === rowId ? { ...r, volume: Math.max(0, Math.min(1, volume)) } : r,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  toggleSequencerRowMute: (trackId, rowId) => {
+    const state = get();
+    if (!state.project) return;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) =>
+                r.id === rowId ? { ...r, muted: !r.muted } : r,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  setSequencerRowSample: (trackId, rowId, sampleKey) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) =>
+                r.id === rowId ? { ...r, sampleKey } : r,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  clearSequencerRow: (trackId, rowId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) =>
+                r.id === rowId
+                  ? { ...r, steps: r.steps.map((s) => ({ ...s, active: false })) }
+                  : r,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  batchSetSequencerSteps: (trackId, ops) => {
+    const state = get();
+    if (!state.project || ops.length === 0) return;
+    _pushHistory(state.project);
+    const lookup = new Map<string, Map<number, { active: boolean; velocity: number }>>();
+    for (const op of ops) {
+      let m = lookup.get(op.rowId);
+      if (!m) { m = new Map(); lookup.set(op.rowId, m); }
+      m.set(op.stepIndex, { active: op.active, velocity: op.velocity });
+    }
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) => {
+                const stepMap = lookup.get(r.id);
+                if (!stepMap) return r;
+                return {
+                  ...r,
+                  steps: r.steps.map((s, idx) => {
+                    const patch = stepMap.get(idx);
+                    return patch ? { ...s, active: patch.active, velocity: patch.velocity } : s;
+                  }),
+                };
+              }),
+            },
+          };
+        }),
       },
     });
   },

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -27,6 +27,9 @@ interface UIState {
   selectWindow: { startTime: number; endTime: number; trackIds: string[] } | null;
   /** Track whose inspector panel is currently expanded. */
   expandedTrackId: string | null;
+  /** Track whose sequencer editor is currently open (bottom panel). */
+  openSequencerTrackId: string | null;
+  sequencerEditorHeight: number;
 
   setPixelsPerSecond: (pps: number) => void;
   zoomIn: () => void;
@@ -52,6 +55,8 @@ interface UIState {
   setContextWindow: (v: { startTime: number; endTime: number; trackIds: string[] } | null) => void;
   setSelectWindow: (v: { startTime: number; endTime: number; trackIds: string[] } | null) => void;
   setExpandedTrackId: (id: string | null) => void;
+  setOpenSequencerTrackId: (id: string | null) => void;
+  setSequencerEditorHeight: (v: number) => void;
 }
 
 const ZOOM_LEVELS = [10, 25, 50, 100, 200, 500];
@@ -78,6 +83,8 @@ export const useUIStore = create<UIState>((set) => ({
   contextWindow: null,
   selectWindow: null,
   expandedTrackId: null,
+  openSequencerTrackId: null,
+  sequencerEditorHeight: 320,
 
   setPixelsPerSecond: (pps) => set({ pixelsPerSecond: pps }),
 
@@ -130,4 +137,6 @@ export const useUIStore = create<UIState>((set) => ({
   setContextWindow: (v) => set({ contextWindow: v }),
   setSelectWindow: (v) => set({ selectWindow: v }),
   setExpandedTrackId: (id) => set({ expandedTrackId: id }),
+  setOpenSequencerTrackId: (id) => set({ openSequencerTrackId: id }),
+  setSequencerEditorHeight: (v) => set({ sequencerEditorHeight: Math.min(600, Math.max(200, v)) }),
 }));

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -68,6 +68,30 @@ export interface Clip {
   starred?: boolean;
 }
 
+export interface SequencerStep {
+  active: boolean;
+  velocity: number;      // 0–1, default 0.8
+}
+
+export interface SequencerRow {
+  id: string;
+  name: string;           // e.g. "Kick", "Snare", "Hi-Hat"
+  sampleKey: string;      // built-in sample id or IndexedDB key for user sample
+  steps: SequencerStep[];
+  volume: number;         // 0–1
+  muted: boolean;
+  color: string;
+}
+
+export interface SequencerPattern {
+  id: string;
+  name: string;
+  rows: SequencerRow[];
+  stepsPerBar: number;    // default 16 (16th notes)
+  bars: number;           // default 1
+  swing: number;          // 0–1, 0 = straight, 0.67 = heavy swing
+}
+
 export interface Track {
   id: string;
   trackType?: TrackType;
@@ -79,6 +103,7 @@ export interface Track {
   muted: boolean;
   soloed: boolean;
   clips: Clip[];
+  sequencerPattern?: SequencerPattern;
   // Mixer / channel-strip settings
   pan?: number;               // -1 (full left) to +1 (full right), default 0
   eqLowGain?: number;         // dB ±15, low shelf at 250 Hz, default 0


### PR DESCRIPTION
## Summary
- Full step sequencer editor (Logic Pro-inspired) with drum kit synthesis, pattern editing, mute/solo, Shift+paint, marquee selection with Shift+drag copy, keyboard shortcuts, and Bounce to Audio
- Toolbar with Split (S), Delete, Duplicate buttons for clip editing
- splitClip store action that splits a clip at the playhead position into two independent clips
- Clip edge-resize now uses DAW-standard non-destructive trim: fixed-density waveform rendering, right-extend with silence, left-trim without stretching
- Playback respects clip.audioOffset (previously hardcoded to 0)
- Cross-track drag ghost height matches target lane size
- Shift+drag copy ghost position now tracks mouse correctly
- Fixed sequencer close crash (React hooks violation)

## Test plan
- [ ] Open sequencer track, edit pattern, Bounce to Audio
- [ ] Close sequencer editor, verify no crash
- [ ] Select clip, press S to split at playhead
- [ ] Toolbar Split/Delete/Duplicate buttons work
- [ ] Drag clip to another track, ghost height matches target
- [ ] Shift+drag clip to copy, ghost follows mouse correctly
- [ ] Trim clip left/right edges, waveform does not stretch

Made with [Cursor](https://cursor.com)