### PR TITLE
feat: FL Studio-style step sequencer UI overhaul

### DIFF
--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"/>

--- a/src/components/sequencer/MiniKnob.tsx
+++ b/src/components/sequencer/MiniKnob.tsx
@@ -1,0 +1,125 @@
+import { useRef, useCallback } from 'react';
+
+interface MiniKnobProps {
+  value: number;
+  min?: number;
+  max?: number;
+  size?: number;
+  color?: string;
+  label?: string;
+  onChange: (value: number) => void;
+  bipolar?: boolean;
+}
+
+const ARC_START = (3 * Math.PI) / 4;
+const ARC_END = (1 * Math.PI) / 4 + 2 * Math.PI;
+const ARC_RANGE = ARC_END - ARC_START;
+
+export function MiniKnob({
+  value,
+  min = 0,
+  max = 1,
+  size = 18,
+  color = '#22c55e',
+  label,
+  onChange,
+  bipolar = false,
+}: MiniKnobProps) {
+  const dragRef = useRef<{ startY: number; startVal: number } | null>(null);
+
+  const norm = (value - min) / (max - min);
+  const r = size / 2;
+  const strokeW = 2.5;
+  const arcR = r - strokeW;
+  const cx = r;
+  const cy = r;
+
+  const polarToXY = (angle: number) => ({
+    x: cx + arcR * Math.cos(angle),
+    y: cy + arcR * Math.sin(angle),
+  });
+
+  const bgStart = polarToXY(ARC_START);
+  const bgEnd = polarToXY(ARC_END);
+  const bgPath = `M ${bgStart.x} ${bgStart.y} A ${arcR} ${arcR} 0 1 1 ${bgEnd.x} ${bgEnd.y}`;
+
+  let fillPath = '';
+  if (bipolar) {
+    const midAngle = ARC_START + ARC_RANGE * 0.5;
+    const valAngle = ARC_START + ARC_RANGE * norm;
+    const fromAngle = Math.min(midAngle, valAngle);
+    const toAngle = Math.max(midAngle, valAngle);
+    const sweep = toAngle - fromAngle;
+    const largeArc = sweep > Math.PI ? 1 : 0;
+    const from = polarToXY(fromAngle);
+    const to = polarToXY(toAngle);
+    fillPath = `M ${from.x} ${from.y} A ${arcR} ${arcR} 0 ${largeArc} 1 ${to.x} ${to.y}`;
+  } else {
+    const valAngle = ARC_START + ARC_RANGE * norm;
+    const sweep = valAngle - ARC_START;
+    const largeArc = sweep > Math.PI ? 1 : 0;
+    const start = polarToXY(ARC_START);
+    const end = polarToXY(valAngle);
+    fillPath = `M ${start.x} ${start.y} A ${arcR} ${arcR} 0 ${largeArc} 1 ${end.x} ${end.y}`;
+  }
+
+  const indicatorAngle = ARC_START + ARC_RANGE * norm;
+  const indInner = polarToXY(indicatorAngle);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dragRef.current = { startY: e.clientY, startVal: value };
+      const onMove = (ev: MouseEvent) => {
+        if (!dragRef.current) return;
+        const dy = dragRef.current.startY - ev.clientY;
+        const range = max - min;
+        const sensitivity = ev.shiftKey ? 0.001 : 0.005;
+        const newVal = Math.max(min, Math.min(max, dragRef.current.startVal + dy * range * sensitivity));
+        onChange(newVal);
+      };
+      const onUp = () => {
+        dragRef.current = null;
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    },
+    [value, min, max, onChange],
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onChange(bipolar ? (min + max) / 2 : min);
+    },
+    [bipolar, min, max, onChange],
+  );
+
+  const displayVal = bipolar
+    ? `${value > 0 ? '+' : ''}${Math.round(value * 100)}`
+    : `${Math.round(norm * 100)}`;
+
+  return (
+    <div
+      className="flex flex-col items-center gap-0 cursor-ns-resize"
+      title={label ? `${label}: ${displayVal}%` : `${displayVal}%`}
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+    >
+      <svg width={size} height={size} className="shrink-0">
+        <path d={bgPath} fill="none" stroke="#404040" strokeWidth={strokeW} strokeLinecap="round" />
+        {norm > 0.003 || bipolar ? (
+          <path d={fillPath} fill="none" stroke={color} strokeWidth={strokeW} strokeLinecap="round" />
+        ) : null}
+        <circle cx={indInner.x} cy={indInner.y} r={1.5} fill="#e0e0e0" />
+      </svg>
+      {label && (
+        <span className="text-[7px] text-[#808080] leading-none mt-0.5 select-none">{label}</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/sequencer/SequencerEditor.tsx
+++ b/src/components/sequencer/SequencerEditor.tsx
@@ -1,16 +1,51 @@
 import { useRef, useState, useEffect, useMemo, useCallback } from 'react';
-import type { Track } from '../../types/project';
+import type { SequencerRow } from '../../types/project';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
 import { getSample, cacheUserSample } from '../../services/sampleManager';
 import { ALL_DRUM_SAMPLES } from '../../constants/tracks';
 import { bounceSequencerToAudio } from '../../services/sequencerBounce';
+import { MiniKnob } from './MiniKnob';
 
-const STEP_W = 36;
-const STEP_H = 40;
-const ROW_LABEL_W = 200;
-const VELOCITY_LANE_H = 56;
+/* ── FL Studio-inspired palette ─────────────────────────────────────── */
+const FL = {
+  bg: '#2a2a2a',
+  bgAlt: '#2d2d2d',
+  rowBg: '#303030',
+  rowBgAlt: '#2d2d2d',
+  headerBg: '#1e1e1e',
+  stepOff: '#3c3c3c',
+  stepOffHover: '#454545',
+  beatBg: '#353535',
+  border: '#222222',
+  borderLight: '#444444',
+  barBorder: '#555555',
+  text: '#c0c0c0',
+  textDim: '#808080',
+  textBright: '#e0e0e0',
+  accent: '#5a9a3c',
+  accentBright: '#7ec55a',
+  muteLed: '#2a2a2a',
+  muteActive: '#5a9a3c',
+  graphBg: '#252525',
+  graphGrid: '#333333',
+};
+
+type RowSize = 'compact' | 'normal' | 'expanded';
+const ROW_SIZES: Record<RowSize, { stepH: number; stepW: number }> = {
+  compact: { stepH: 20, stepW: 22 },
+  normal: { stepH: 28, stepW: 28 },
+  expanded: { stepH: 36, stepW: 34 },
+};
+
+const ROW_LABEL_W = 160;
+const GRAPH_H = 64;
+
+const ROW_COLORS = [
+  '#ef4444', '#f97316', '#eab308', '#84cc16', '#22c55e',
+  '#06b6d4', '#3b82f6', '#8b5cf6', '#ec4899', '#f43f5e',
+];
 
 export function SequencerEditor() {
   const trackId = useUIStore((s) => s.openSequencerTrackId);
@@ -29,6 +64,7 @@ export function SequencerEditor() {
   const batchSetSteps = useProjectStore((s) => s.batchSetSequencerSteps);
   const toggleRowMute = useProjectStore((s) => s.toggleSequencerRowMute);
   const setRowVolume = useProjectStore((s) => s.setSequencerRowVolume);
+  const setRowPan = useProjectStore((s) => s.setSequencerRowPan);
   const removeRow = useProjectStore((s) => s.removeSequencerRow);
   const clearRow = useProjectStore((s) => s.clearSequencerRow);
   const updateSwing = useProjectStore((s) => s.updateSequencerSwing);
@@ -37,11 +73,20 @@ export function SequencerEditor() {
   const addRow = useProjectStore((s) => s.addSequencerRow);
   const setRowSample = useProjectStore((s) => s.setSequencerRowSample);
   const initPattern = useProjectStore((s) => s.initSequencerPattern);
+  const reorderRows = useProjectStore((s) => s.reorderSequencerRows);
+  const cloneRow = useProjectStore((s) => s.cloneSequencerRow);
+  const renameRow = useProjectStore((s) => s.renameSequencerRow);
+  const setRowColor = useProjectStore((s) => s.setSequencerRowColor);
+  const fillRow = useProjectStore((s) => s.fillSequencerRow);
 
+  const [rowSize, setRowSize] = useState<RowSize>('normal');
   const [selectedRow, setSelectedRow] = useState<string | null>(null);
   const [samplePickerRow, setSamplePickerRow] = useState<string | null>(null);
   const [showAddInstrument, setShowAddInstrument] = useState(false);
-  const [rowCtxMenu, setRowCtxMenu] = useState<{ rowId: string; x: number; y: number } | null>(null);
+  const [rowCtxMenu, setRowCtxMenu] = useState<{
+    rowId: string; x: number; y: number;
+    showColorPicker?: boolean; renamingName?: string;
+  } | null>(null);
   const [isBouncing, setIsBouncing] = useState(false);
   const [soloRowId, setSoloRowId] = useState<string | null>(null);
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
@@ -55,20 +100,27 @@ export function SequencerEditor() {
   const togglePreviewRef = useRef<() => void>(() => {});
   const paintStateRef = useRef<{ rowId: string; paintActive: boolean } | null>(null);
 
-  // Marquee selection state
   const [selection, setSelection] = useState<{
     rowStart: number; rowEnd: number; stepStart: number; stepEnd: number;
   } | null>(null);
   const marqueeRef = useRef<{
     anchorRowIdx: number; anchorStepIdx: number; active: boolean;
   } | null>(null);
-  // Shift-drag copy state
   const shiftDragRef = useRef<{
     origSelection: { rowStart: number; rowEnd: number; stepStart: number; stepEnd: number };
     anchorStepIdx: number;
     lastOffset: number;
   } | null>(null);
   const [copyGhostOffset, setCopyGhostOffset] = useState<number | null>(null);
+
+  // Row drag-reorder state
+  const [dragRowIdx, setDragRowIdx] = useState<number | null>(null);
+  const [dragOverIdx, setDragOverIdx] = useState<number | null>(null);
+
+  // Inline rename state
+  const [inlineRenameRowId, setInlineRenameRowId] = useState<string | null>(null);
+  const [inlineRenameValue, setInlineRenameValue] = useState('');
+  const inlineRenameInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (track && !track.sequencerPattern) {
@@ -110,7 +162,6 @@ export function SequencerEditor() {
     [selection],
   );
 
-  // Keyboard shortcuts: Space = play/stop, Escape = close or clear selection
   useEffect(() => {
     if (!trackId) return;
     const handler = (e: KeyboardEvent) => {
@@ -163,17 +214,26 @@ export function SequencerEditor() {
     return () => window.removeEventListener('keydown', handler, true);
   }, [trackId, closeEditor, stopPreview]);
 
+  useEffect(() => {
+    if (inlineRenameRowId && inlineRenameInputRef.current) {
+      inlineRenameInputRef.current.focus();
+      inlineRenameInputRef.current.select();
+    }
+  }, [inlineRenameRowId]);
+
   if (!trackId || !track || !project) return null;
 
   const pattern = track.sequencerPattern;
   if (!pattern) return null;
 
+  const { stepH, stepW } = ROW_SIZES[rowSize];
   const bpm = project.bpm;
   const totalSteps = pattern.stepsPerBar * pattern.bars;
   const stepDuration = (60 / bpm) / (pattern.stepsPerBar / 4);
   const patternDuration = stepDuration * totalSteps;
   const currentStep = isPreviewPlaying ? previewStep : -1;
-  const gridWidth = totalSteps * STEP_W;
+  const gridWidth = totalSteps * stepW;
+  const stepsPerBeat = pattern.stepsPerBar / 4;
 
   function isRowAudible(rowId: string, muted: boolean): boolean {
     if (soloRowId) return rowId === soloRowId;
@@ -216,8 +276,11 @@ export function SequencerEditor() {
           source.buffer = buffer;
           const gain = ctx.createGain();
           gain.gain.value = step.velocity * row.volume;
+          const pan = ctx.createStereoPanner();
+          pan.pan.value = row.pan ?? 0;
           source.connect(gain);
-          gain.connect(ctx.destination);
+          gain.connect(pan);
+          pan.connect(ctx.destination);
           source.start(time);
           sources.push(source);
         }
@@ -248,7 +311,6 @@ export function SequencerEditor() {
     if (isPreviewPlaying) stopPreview();
     else startPreview();
   };
-
   togglePreviewRef.current = togglePreview;
 
   const previewSample = async (sampleKey: string, velocity: number) => {
@@ -267,6 +329,8 @@ export function SequencerEditor() {
 
   const getRowIdx = (rowId: string): number => pattern.rows.findIndex((r) => r.id === rowId);
 
+  /* ── Grid interaction handlers ──────────────────────────────────────── */
+
   const handleGridMouseDown = (rowId: string, stepIdx: number, e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
@@ -275,7 +339,6 @@ export function SequencerEditor() {
     if (rowIdx < 0) return;
 
     if (e.shiftKey && selection) {
-      // Shift+drag on existing selection: start copy-drag
       const rMin = Math.min(selection.rowStart, selection.rowEnd);
       const rMax = Math.max(selection.rowStart, selection.rowEnd);
       const sMin = Math.min(selection.stepStart, selection.stepEnd);
@@ -339,7 +402,6 @@ export function SequencerEditor() {
       }
     }
 
-    // Not shift-drag-copy: prepare for marquee or single-click toggle
     marqueeRef.current = { anchorRowIdx: rowIdx, anchorStepIdx: stepIdx, active: false };
 
     const onMove = (ev: MouseEvent) => {
@@ -383,7 +445,6 @@ export function SequencerEditor() {
     e.preventDefault();
 
     if (e.shiftKey) {
-      // Shift+click: start paint mode — toggle this step and drag to paint same state
       const row = pattern.rows.find((r) => r.id === rowId);
       if (!row) return;
       const wasActive = row.steps[stepIdx]?.active ?? false;
@@ -416,7 +477,6 @@ export function SequencerEditor() {
       window.addEventListener('mousemove', onMove);
       window.addEventListener('mouseup', onUp);
     } else {
-      // Normal click: toggle single step
       toggleStep(track.id, rowId, stepIdx);
       const row = pattern.rows.find((r) => r.id === rowId);
       if (row) {
@@ -485,119 +545,231 @@ export function SequencerEditor() {
     window.addEventListener('mouseup', onUp);
   };
 
-  const stepsPerBeat = pattern.stepsPerBar / 4;
+  const commitInlineRename = () => {
+    if (inlineRenameRowId && inlineRenameValue.trim()) {
+      renameRow(track.id, inlineRenameRowId, inlineRenameValue.trim());
+    }
+    setInlineRenameRowId(null);
+    setInlineRenameValue('');
+  };
+
+  /* ── Row drag-reorder ───────────────────────────────────────────────── */
+
+  const handleRowDragStart = (idx: number, e: React.DragEvent) => {
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', String(idx));
+    setDragRowIdx(idx);
+  };
+
+  const handleRowDragOver = (idx: number, e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverIdx(idx);
+  };
+
+  const handleRowDrop = (idx: number) => {
+    if (dragRowIdx !== null && dragRowIdx !== idx) {
+      reorderRows(track.id, dragRowIdx, idx);
+    }
+    setDragRowIdx(null);
+    setDragOverIdx(null);
+  };
+
+  /* ── Render ─────────────────────────────────────────────────────────── */
 
   return (
     <div
-      className="border-t border-zinc-700 bg-zinc-900 flex flex-col select-none"
-      style={{ height: editorHeight }}
+      className="flex flex-col select-none"
+      style={{ height: editorHeight, background: FL.bg }}
       tabIndex={-1}
     >
       {/* Resize handle */}
       <div
-        className="h-1 cursor-ns-resize bg-zinc-800 hover:bg-indigo-500/40 transition-colors shrink-0"
+        className="h-1 cursor-ns-resize shrink-0"
+        style={{ background: FL.headerBg }}
         onMouseDown={onResizeStart}
-      />
-
-      {/* Header bar */}
-      <div className="flex items-center gap-3 px-3 py-1.5 bg-zinc-900 border-b border-zinc-800 shrink-0">
-        <span className="text-emerald-400 font-bold text-xs">STEP SEQUENCER</span>
-        <span className="text-zinc-500 text-[10px]">{track.displayName}</span>
-
-        <div className="flex items-center gap-2 ml-4">
-          <label className="flex items-center gap-1 text-[10px] text-zinc-400">
-            Steps/Bar:
-            <select
-              value={pattern.stepsPerBar}
-              onChange={(e) => setStepsPerBar(track.id, Number(e.target.value))}
-              className="bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-200 text-[10px]"
-            >
-              <option value={8}>8</option>
-              <option value={16}>16</option>
-              <option value={32}>32</option>
-            </select>
-          </label>
-          <div className="flex items-center gap-1 text-[10px] text-zinc-400">
-            Bars:
-            <button
-              onClick={() => { if (pattern.bars > 1) setBars(track.id, pattern.bars - 1); }}
-              disabled={pattern.bars <= 1}
-              className="w-5 h-5 flex items-center justify-center bg-zinc-800 border border-zinc-700 rounded text-zinc-300 hover:bg-zinc-700 disabled:opacity-30 disabled:cursor-not-allowed text-[10px] font-bold"
-            >
-              -
-            </button>
-            <span className="text-zinc-200 w-5 text-center font-medium">{pattern.bars}</span>
-            <button
-              onClick={() => setBars(track.id, pattern.bars + 1)}
-              className="w-5 h-5 flex items-center justify-center bg-zinc-800 border border-zinc-700 rounded text-zinc-300 hover:bg-zinc-700 text-[10px] font-bold"
-            >
-              +
-            </button>
-          </div>
-          <label className="flex items-center gap-1 text-[10px] text-zinc-400">
-            Swing:
-            <input
-              type="range" min={0} max={100}
-              value={Math.round(pattern.swing * 100)}
-              onChange={(e) => updateSwing(track.id, Number(e.target.value) / 100)}
-              className="w-16 h-1"
-            />
-            <span className="text-zinc-300 w-8 text-right">{Math.round(pattern.swing * 100)}%</span>
-          </label>
-        </div>
-
-        <div className="flex items-center gap-1.5 ml-auto">
-          <button
-            onClick={togglePreview}
-            className={`px-3 py-1 rounded text-[10px] font-medium transition-colors ${
-              isPreviewPlaying
-                ? 'bg-amber-600/80 hover:bg-amber-600 text-white'
-                : 'bg-zinc-700/80 hover:bg-zinc-600 text-zinc-200'
-            }`}
-            title="Space to toggle"
-          >
-            {isPreviewPlaying ? '■ Stop' : '▶ Play'}
-          </button>
-          <button
-            onClick={handleBounce}
-            disabled={isBouncing}
-            className="px-3 py-1 bg-indigo-600/80 hover:bg-indigo-600 text-white rounded text-[10px] font-medium transition-colors disabled:opacity-50 disabled:cursor-wait"
-          >
-            {isBouncing ? 'Bouncing...' : 'Bounce to Audio'}
-          </button>
-          <button
-            onClick={() => { stopPreview(); closeEditor(null); }}
-            className="px-2 py-1 bg-zinc-800 hover:bg-zinc-700 text-zinc-400 hover:text-zinc-200 rounded text-[10px] transition-colors"
-            title="Esc"
-          >
-            Close
-          </button>
-        </div>
+      >
+        <div className="mx-auto mt-px" style={{ width: 40, height: 2, borderRadius: 1, background: FL.borderLight }} />
       </div>
 
-      {/* Grid area */}
+      {/* ── Header toolbar ────────────────────────────────────────────── */}
+      <div
+        className="flex items-center gap-2 px-3 shrink-0"
+        style={{ height: 32, background: FL.headerBg, borderBottom: `1px solid ${FL.border}` }}
+      >
+        {/* Channel rack icon */}
+        <div className="flex items-center gap-1.5">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <rect x="1" y="1" width="5" height="5" rx="1" fill={FL.accent} />
+            <rect x="8" y="1" width="5" height="5" rx="1" fill={FL.accent} opacity="0.5" />
+            <rect x="1" y="8" width="5" height="5" rx="1" fill={FL.accent} opacity="0.5" />
+            <rect x="8" y="8" width="5" height="5" rx="1" fill={FL.accent} opacity="0.3" />
+          </svg>
+          <span style={{ color: FL.accentBright, fontSize: 11, fontWeight: 700, letterSpacing: 0.5 }}>
+            CHANNEL RACK
+          </span>
+        </div>
+
+        <span style={{ color: FL.textDim, fontSize: 10 }}>{track.displayName}</span>
+
+        {/* Steps/bar segmented control */}
+        <div className="flex items-center gap-1 ml-3" style={{ fontSize: 10 }}>
+          <span style={{ color: FL.textDim }}>Steps:</span>
+          <div className="flex" style={{ borderRadius: 3, overflow: 'hidden', border: `1px solid ${FL.borderLight}` }}>
+            {[8, 16, 32].map((v) => (
+              <button
+                key={v}
+                onClick={() => setStepsPerBar(track.id, v)}
+                style={{
+                  padding: '1px 6px',
+                  fontSize: 10,
+                  fontWeight: pattern.stepsPerBar === v ? 700 : 400,
+                  color: pattern.stepsPerBar === v ? FL.textBright : FL.textDim,
+                  background: pattern.stepsPerBar === v ? FL.accent : 'transparent',
+                  border: 'none',
+                  cursor: 'pointer',
+                }}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Bars +/- */}
+        <div className="flex items-center gap-1" style={{ fontSize: 10 }}>
+          <span style={{ color: FL.textDim }}>Bars:</span>
+          <button
+            onClick={() => { if (pattern.bars > 1) setBars(track.id, pattern.bars - 1); }}
+            disabled={pattern.bars <= 1}
+            style={{
+              width: 16, height: 16, display: 'flex', alignItems: 'center', justifyContent: 'center',
+              background: FL.stepOff, border: `1px solid ${FL.borderLight}`, borderRadius: 2,
+              color: pattern.bars <= 1 ? FL.border : FL.text, cursor: pattern.bars <= 1 ? 'not-allowed' : 'pointer',
+              fontSize: 12, fontWeight: 700, lineHeight: 1,
+            }}
+          >
+            -
+          </button>
+          <span style={{ color: FL.textBright, width: 18, textAlign: 'center', fontWeight: 600 }}>{pattern.bars}</span>
+          <button
+            onClick={() => setBars(track.id, pattern.bars + 1)}
+            style={{
+              width: 16, height: 16, display: 'flex', alignItems: 'center', justifyContent: 'center',
+              background: FL.stepOff, border: `1px solid ${FL.borderLight}`, borderRadius: 2,
+              color: FL.text, cursor: 'pointer', fontSize: 12, fontWeight: 700, lineHeight: 1,
+            }}
+          >
+            +
+          </button>
+        </div>
+
+        {/* Swing knob */}
+        <div className="flex items-center gap-1">
+          <MiniKnob
+            value={pattern.swing}
+            min={0}
+            max={1}
+            size={20}
+            color={FL.accentBright}
+            label="Swing"
+            onChange={(v) => updateSwing(track.id, v)}
+          />
+        </div>
+
+        {/* Row size toggle */}
+        <div className="flex items-center gap-0.5 ml-2" style={{ fontSize: 9 }}>
+          {(['compact', 'normal', 'expanded'] as RowSize[]).map((sz) => (
+            <button
+              key={sz}
+              onClick={() => setRowSize(sz)}
+              title={sz}
+              style={{
+                width: sz === 'compact' ? 12 : sz === 'normal' ? 14 : 16,
+                height: sz === 'compact' ? 8 : sz === 'normal' ? 10 : 12,
+                borderRadius: 2,
+                border: `1px solid ${rowSize === sz ? FL.accentBright : FL.borderLight}`,
+                background: rowSize === sz ? FL.accent + '60' : 'transparent',
+                cursor: 'pointer',
+              }}
+            />
+          ))}
+        </div>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Play / Bounce / Close */}
+        <button
+          onClick={togglePreview}
+          style={{
+            padding: '2px 10px', borderRadius: 3, fontSize: 10, fontWeight: 600, border: 'none', cursor: 'pointer',
+            background: isPreviewPlaying ? '#c0392b' : FL.accent,
+            color: '#fff',
+          }}
+          title="Space to toggle"
+        >
+          {isPreviewPlaying ? '■ Stop' : '▶ Play'}
+        </button>
+        <button
+          onClick={handleBounce}
+          disabled={isBouncing}
+          style={{
+            padding: '2px 10px', borderRadius: 3, fontSize: 10, fontWeight: 600, border: 'none', cursor: 'pointer',
+            background: '#2980b9', color: '#fff', opacity: isBouncing ? 0.5 : 1,
+          }}
+        >
+          {isBouncing ? 'Bouncing...' : 'Bounce'}
+        </button>
+        <button
+          onClick={() => { stopPreview(); closeEditor(null); }}
+          style={{
+            padding: '2px 8px', borderRadius: 3, fontSize: 10, border: `1px solid ${FL.borderLight}`,
+            background: 'transparent', color: FL.textDim, cursor: 'pointer',
+          }}
+          title="Esc"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* ── Grid area ─────────────────────────────────────────────────── */}
       <div ref={gridScrollRef} className="flex-1 overflow-auto relative" style={{ minHeight: 0 }}>
         <div className="flex" style={{ minWidth: ROW_LABEL_W + gridWidth }}>
-          {/* Row labels (sticky left, Logic Pro-inspired layout) */}
-          <div className="sticky left-0 z-10 bg-zinc-900 shrink-0 border-r border-zinc-800/60" style={{ width: ROW_LABEL_W }}>
-            {/* Header spacer aligned with beat numbers */}
-            <div className="border-b border-zinc-700/40" style={{ height: 18 }} />
 
-            {pattern.rows.map((row) => {
+          {/* ── Row labels (sticky left) ──────────────────────────────── */}
+          <div
+            className="sticky left-0 z-10 shrink-0"
+            style={{ width: ROW_LABEL_W, background: FL.bg, borderRight: `1px solid ${FL.border}` }}
+          >
+            {/* Beat header spacer */}
+            <div style={{ height: 18, borderBottom: `1px solid ${FL.border}` }} />
+
+            {pattern.rows.map((row, rowIdx) => {
               const isSoloed = soloRowId === row.id;
               const audible = isRowAudible(row.id, row.muted);
+              const isSelected = selectedRow === row.id;
+              const isDragTarget = dragOverIdx === rowIdx && dragRowIdx !== rowIdx;
+
               return (
                 <div
                   key={row.id}
-                  className={`grid items-center border-b border-zinc-800/50 group ${
-                    selectedRow === row.id ? 'bg-zinc-800/60' : 'hover:bg-zinc-800/20'
-                  }`}
+                  draggable
+                  onDragStart={(e) => handleRowDragStart(rowIdx, e)}
+                  onDragOver={(e) => handleRowDragOver(rowIdx, e)}
+                  onDragEnd={() => { setDragRowIdx(null); setDragOverIdx(null); }}
+                  onDrop={() => handleRowDrop(rowIdx)}
+                  className="flex items-center"
                   style={{
-                    height: STEP_H,
-                    gridTemplateColumns: '4px 24px 1fr 24px 24px',
-                    gap: '0 4px',
-                    paddingRight: 6,
-                    opacity: audible ? 1 : 0.4,
+                    height: stepH,
+                    background: isSelected ? '#3a3a3a' : rowIdx % 2 === 0 ? FL.rowBg : FL.rowBgAlt,
+                    borderBottom: `1px solid ${FL.border}`,
+                    borderTop: isDragTarget ? `2px solid ${FL.accentBright}` : '2px solid transparent',
+                    opacity: audible ? 1 : 0.35,
+                    cursor: 'default',
+                    gap: 2,
+                    paddingLeft: 2,
+                    paddingRight: 3,
                   }}
                   onClick={() => setSelectedRow(row.id === selectedRow ? null : row.id)}
                   onContextMenu={(e) => {
@@ -605,63 +777,100 @@ export function SequencerEditor() {
                     e.stopPropagation();
                     setRowCtxMenu({ rowId: row.id, x: e.clientX, y: e.clientY });
                   }}
-                  onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; }}
-                  onDrop={(e) => handleFileDrop(row.id, e)}
+                  onDragOverCapture={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; }}
+                  onDropCapture={(dontUse) => { /* handled by onDrop */ }}
                 >
-                  {/* Color indicator */}
-                  <div className="h-full rounded-r" style={{ backgroundColor: row.color }} />
+                  {/* Drag handle + color bar */}
+                  <div
+                    className="shrink-0 cursor-grab"
+                    style={{ width: 4, height: stepH - 4, borderRadius: 2, background: row.color }}
+                    title="Drag to reorder"
+                  />
 
-                  {/* Play preview button */}
-                  <button
-                    className="w-6 h-6 flex items-center justify-center text-zinc-500 hover:text-white rounded hover:bg-zinc-700/60 transition-colors"
-                    onClick={(e) => { e.stopPropagation(); previewSample(row.sampleKey, 0.8); }}
-                    title="Preview sound"
-                  >
-                    <svg width="10" height="12" viewBox="0 0 10 12" fill="currentColor">
-                      <path d="M0 0 L10 6 L0 12 Z" />
-                    </svg>
-                  </button>
-
-                  {/* Instrument name */}
-                  <button
-                    className="text-left text-xs text-zinc-200 truncate px-1 hover:text-white transition-colors font-medium cursor-pointer"
-                    title={`${row.name} — click to pick sample`}
+                  {/* LED mute indicator */}
+                  <div
+                    className="shrink-0 cursor-pointer"
+                    style={{
+                      width: 8, height: 8, borderRadius: '50%',
+                      background: row.muted ? FL.muteLed : isSoloed ? '#f1c40f' : FL.muteActive,
+                      border: `1px solid ${FL.borderLight}`,
+                      boxShadow: row.muted ? 'none' : isSoloed ? '0 0 4px #f1c40f80' : `0 0 4px ${FL.muteActive}80`,
+                    }}
                     onClick={(e) => {
                       e.stopPropagation();
-                      setSamplePickerRow(samplePickerRow === row.id ? null : row.id);
+                      toggleRowMute(track.id, row.id);
                     }}
-                  >
-                    {row.name}
-                  </button>
-
-                  {/* Mute button */}
-                  <button
-                    className={`w-6 h-6 text-[10px] font-bold rounded flex items-center justify-center transition-colors ${
-                      row.muted
-                        ? 'bg-amber-600 text-white'
-                        : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700'
-                    }`}
-                    onClick={(e) => { e.stopPropagation(); toggleRowMute(track.id, row.id); }}
-                    title={row.muted ? 'Unmute' : 'Mute'}
-                  >
-                    M
-                  </button>
-
-                  {/* Solo button */}
-                  <button
-                    className={`w-6 h-6 text-[10px] font-bold rounded flex items-center justify-center transition-colors ${
-                      isSoloed
-                        ? 'bg-yellow-500 text-zinc-900'
-                        : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700'
-                    }`}
-                    onClick={(e) => {
+                    onContextMenu={(e) => {
+                      e.preventDefault();
                       e.stopPropagation();
                       setSoloRowId(isSoloed ? null : row.id);
                     }}
-                    title={isSoloed ? 'Unsolo' : 'Solo'}
-                  >
-                    S
-                  </button>
+                    title={row.muted ? 'Unmute (click) / Solo (right-click)' : isSoloed ? 'Unsolo (right-click)' : 'Mute (click) / Solo (right-click)'}
+                  />
+
+                  {/* Pan knob */}
+                  <MiniKnob
+                    value={row.pan ?? 0}
+                    min={-1}
+                    max={1}
+                    size={16}
+                    color="#3498db"
+                    onChange={(v) => setRowPan(track.id, row.id, v)}
+                    bipolar
+                  />
+
+                  {/* Volume knob */}
+                  <MiniKnob
+                    value={row.volume}
+                    min={0}
+                    max={1}
+                    size={16}
+                    color={FL.accentBright}
+                    onChange={(v) => setRowVolume(track.id, row.id, v)}
+                  />
+
+                  {/* Channel name button */}
+                  {inlineRenameRowId === row.id ? (
+                    <input
+                      ref={inlineRenameInputRef}
+                      value={inlineRenameValue}
+                      onChange={(e) => setInlineRenameValue(e.target.value)}
+                      onBlur={commitInlineRename}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') commitInlineRename();
+                        if (e.key === 'Escape') { setInlineRenameRowId(null); setInlineRenameValue(''); }
+                      }}
+                      className="flex-1 min-w-0"
+                      style={{
+                        background: FL.stepOff, border: `1px solid ${FL.accent}`, borderRadius: 3,
+                        color: FL.textBright, fontSize: 10, padding: '0 4px', outline: 'none',
+                        height: Math.min(stepH - 6, 20),
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  ) : (
+                    <button
+                      className="flex-1 min-w-0 text-left truncate"
+                      style={{
+                        background: 'transparent', border: 'none', cursor: 'pointer',
+                        color: isSelected ? FL.textBright : FL.text,
+                        fontSize: 10, fontWeight: isSelected ? 600 : 400,
+                        padding: '0 3px', lineHeight: 1.2,
+                      }}
+                      title={`${row.name} — click to select, double-click to rename`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setSamplePickerRow(samplePickerRow === row.id ? null : row.id);
+                      }}
+                      onDoubleClick={(e) => {
+                        e.stopPropagation();
+                        setInlineRenameRowId(row.id);
+                        setInlineRenameValue(row.name);
+                      }}
+                    >
+                      {row.name}
+                    </button>
+                  )}
                 </div>
               );
             })}
@@ -669,13 +878,24 @@ export function SequencerEditor() {
             {/* Add instrument row */}
             <div className="relative">
               <button
-                className="flex items-center gap-2 w-full px-3 border-b border-zinc-800/50 text-zinc-500 hover:text-emerald-400 hover:bg-zinc-800/40 transition-colors"
-                style={{ height: STEP_H }}
+                className="flex items-center gap-2 w-full"
+                style={{
+                  height: stepH,
+                  padding: '0 8px',
+                  background: 'transparent',
+                  border: 'none',
+                  borderBottom: `1px solid ${FL.border}`,
+                  color: FL.textDim,
+                  fontSize: 10,
+                  cursor: 'pointer',
+                }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = FL.accentBright; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = FL.textDim; }}
                 onClick={() => setShowAddInstrument(!showAddInstrument)}
                 title="Add instrument"
               >
-                <span className="text-sm font-bold">+</span>
-                <span className="text-[11px]">Add Instrument...</span>
+                <span style={{ fontSize: 14, fontWeight: 700 }}>+</span>
+                <span>Add Channel...</span>
               </button>
               {showAddInstrument && (
                 <SamplePickerDropdown
@@ -691,7 +911,6 @@ export function SequencerEditor() {
               )}
             </div>
 
-            {/* Sample picker dropdown for existing rows */}
             {samplePickerRow && (
               <SamplePickerDropdown
                 currentKey={pattern.rows.find((r) => r.id === samplePickerRow)?.sampleKey ?? ''}
@@ -723,10 +942,10 @@ export function SequencerEditor() {
             )}
           </div>
 
-          {/* Step grid */}
+          {/* ── Step grid ─────────────────────────────────────────────── */}
           <div className="relative">
             {/* Beat/bar number header */}
-            <div className="flex border-b border-zinc-700/40" style={{ height: 18 }}>
+            <div className="flex" style={{ height: 18, borderBottom: `1px solid ${FL.border}` }}>
               {Array.from({ length: totalSteps }).map((_, idx) => {
                 const isBeatStart = idx % stepsPerBeat === 0;
                 const isBarStart = idx % pattern.stepsPerBar === 0;
@@ -735,25 +954,36 @@ export function SequencerEditor() {
                 return (
                   <div
                     key={idx}
-                    className="shrink-0 flex items-center justify-center text-[8px] font-medium border-l"
+                    className="shrink-0 flex items-center justify-center"
                     style={{
-                      width: STEP_W,
-                      borderColor: isBarStart ? 'rgba(161,161,170,0.4)' : isBeatStart ? 'rgba(113,113,122,0.25)' : 'rgba(63,63,70,0.15)',
-                      color: isBarStart ? '#a1a1aa' : isBeatStart ? '#71717a' : 'transparent',
+                      width: stepW,
+                      fontSize: 8,
+                      fontWeight: isBarStart ? 700 : 500,
+                      color: isBarStart ? FL.text : isBeatStart ? FL.textDim : 'transparent',
+                      borderLeft: isBarStart
+                        ? `1px solid ${FL.barBorder}`
+                        : isBeatStart
+                          ? `1px solid ${FL.borderLight}`
+                          : `1px solid ${FL.border}`,
                     }}
                   >
                     {isBarStart ? `${barNum}` : isBeatStart ? `${beatNum}` : ''}
                   </div>
                 );
               })}
-              {/* Extend button in header row */}
               <button
-                className="shrink-0 flex items-center justify-center text-zinc-600 hover:text-emerald-400 hover:bg-zinc-800/60 transition-colors border-l border-zinc-700/30"
-                style={{ width: STEP_W * 2, height: 18 }}
+                className="shrink-0 flex items-center justify-center"
+                style={{
+                  width: stepW * 2, height: 18,
+                  background: 'transparent', border: 'none', borderLeft: `1px solid ${FL.borderLight}`,
+                  color: FL.textDim, fontSize: 10, fontWeight: 700, cursor: 'pointer',
+                }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = FL.accentBright; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = FL.textDim; }}
                 onClick={() => setBars(track.id, pattern.bars + 1)}
                 title="Add 1 bar"
               >
-                <span className="text-[10px] font-bold">+1</span>
+                +1
               </button>
             </div>
 
@@ -763,14 +993,20 @@ export function SequencerEditor() {
               return (
                 <div
                   key={row.id}
-                  className="flex border-b border-zinc-800/30"
-                  style={{ height: STEP_H, opacity: audible ? 1 : 0.35 }}
+                  className="flex"
+                  style={{
+                    height: stepH,
+                    opacity: audible ? 1 : 0.3,
+                    borderBottom: `1px solid ${FL.border}`,
+                  }}
                 >
                   {row.steps.map((step, idx) => {
                     const isBeatStart = idx % stepsPerBeat === 0;
                     const isBarStart = idx % pattern.stepsPerBar === 0;
                     const isCurrent = idx === currentStep && isPreviewPlaying;
                     const selected = isInSelection(rowIdx, idx);
+                    const beatIdx = Math.floor(idx / stepsPerBeat);
+                    const isOddBeat = beatIdx % 2 === 1;
 
                     let isGhost = false;
                     if (copyGhostOffset !== null && copyGhostOffset !== 0 && selection) {
@@ -789,24 +1025,26 @@ export function SequencerEditor() {
                       }
                     }
 
+                    const cellBg = step.active
+                      ? undefined
+                      : isOddBeat ? FL.beatBg : FL.stepOff;
+
                     return (
                       <div
                         key={idx}
                         data-seq-step={idx}
                         data-seq-row={row.id}
-                        className={`relative shrink-0 cursor-pointer transition-all duration-75 ${
-                          isBarStart
-                            ? 'border-l border-l-zinc-500/40'
-                            : isBeatStart
-                              ? 'border-l border-l-zinc-700/30'
-                              : 'border-l border-l-zinc-800/15'
-                        } ${isCurrent ? 'ring-1 ring-inset ring-white/30' : ''}`}
+                        className="shrink-0 relative"
                         style={{
-                          width: STEP_W,
-                          height: STEP_H,
-                          backgroundColor: step.active
-                            ? `${row.color}${Math.round(step.velocity * 180 + 55).toString(16).padStart(2, '0')}`
-                            : isCurrent ? 'rgba(255,255,255,0.03)' : undefined,
+                          width: stepW,
+                          height: stepH,
+                          borderLeft: isBarStart
+                            ? `1px solid ${FL.barBorder}`
+                            : isBeatStart
+                              ? `1px solid ${FL.borderLight}`
+                              : `1px solid ${FL.border}`,
+                          background: cellBg,
+                          cursor: 'pointer',
                         }}
                         onMouseDown={(e) => handleGridMouseDown(row.id, idx, e)}
                         onContextMenu={(e) => {
@@ -815,56 +1053,106 @@ export function SequencerEditor() {
                           handleVelocityMouseDown(row.id, idx, e);
                         }}
                       >
-                        {step.active && (
+                        {/* Step button (FL-style rounded pill) */}
+                        {step.active ? (
                           <div
-                            className="absolute inset-1 rounded-sm pointer-events-none"
                             style={{
-                              backgroundColor: row.color,
-                              opacity: 0.2 + step.velocity * 0.5,
+                              position: 'absolute',
+                              left: 2, top: 2,
+                              right: 2, bottom: 2,
+                              borderRadius: 3,
+                              background: row.color,
+                              opacity: 0.3 + step.velocity * 0.7,
+                              boxShadow: `inset 0 1px 0 rgba(255,255,255,0.15), 0 1px 2px rgba(0,0,0,0.3)`,
+                            }}
+                          />
+                        ) : (
+                          <div
+                            style={{
+                              position: 'absolute',
+                              left: 2, top: 2,
+                              right: 2, bottom: 2,
+                              borderRadius: 3,
+                              background: isOddBeat ? '#393939' : '#363636',
+                              boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.4), inset 0 -1px 0 rgba(255,255,255,0.03)',
                             }}
                           />
                         )}
-                        {selected && (
+
+                        {/* Playhead highlight */}
+                        {isCurrent && (
                           <div
-                            className="absolute inset-0 pointer-events-none border-2 border-cyan-400/60"
-                            style={{ backgroundColor: 'rgba(34,211,238,0.08)' }}
+                            style={{
+                              position: 'absolute', inset: 0,
+                              border: '1px solid rgba(255,255,255,0.3)',
+                              borderRadius: 3,
+                              pointerEvents: 'none',
+                            }}
                           />
                         )}
+
+                        {/* Selection overlay */}
+                        {selected && (
+                          <div
+                            style={{
+                              position: 'absolute', inset: 0,
+                              border: '2px solid #3498db80',
+                              background: 'rgba(52,152,219,0.1)',
+                              pointerEvents: 'none',
+                            }}
+                          />
+                        )}
+
+                        {/* Copy ghost */}
                         {isGhost && !step.active && (
                           <div
-                            className="absolute inset-1 rounded-sm pointer-events-none"
                             style={{
-                              backgroundColor: row.color,
+                              position: 'absolute',
+                              left: 2, top: 2, right: 2, bottom: 2,
+                              borderRadius: 3,
+                              background: row.color,
                               opacity: 0.35,
-                              border: '1px dashed rgba(34,211,238,0.5)',
+                              border: '1px dashed rgba(52,152,219,0.6)',
                             }}
                           />
                         )}
                       </div>
                     );
                   })}
-                  {/* Extend button per row */}
+
+                  {/* Extend button */}
                   <div
-                    className="shrink-0 flex items-center justify-center text-zinc-700 hover:text-emerald-400 hover:bg-zinc-800/40 cursor-pointer transition-colors border-l border-zinc-700/30"
-                    style={{ width: STEP_W * 2, height: STEP_H }}
+                    className="shrink-0 flex items-center justify-center cursor-pointer"
+                    style={{
+                      width: stepW * 2, height: stepH,
+                      borderLeft: `1px solid ${FL.borderLight}`,
+                      color: FL.textDim, fontSize: 16,
+                    }}
+                    onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = FL.accentBright; }}
+                    onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = FL.textDim; }}
                     onClick={() => setBars(track.id, pattern.bars + 1)}
                     title="Add 1 bar"
                   >
-                    <span className="text-lg font-light">+</span>
+                    +
                   </div>
                 </div>
               );
             })}
 
-            {/* Playhead */}
+            {/* Playhead line */}
             {isPreviewPlaying && currentStep >= 0 && (
               <div
-                className="absolute w-0.5 bg-white/50 pointer-events-none z-20"
                 style={{
-                  left: currentStep * STEP_W + STEP_W / 2,
+                  position: 'absolute',
+                  left: currentStep * stepW + stepW / 2,
                   top: 18,
-                  height: pattern.rows.length * STEP_H,
+                  width: 2,
+                  height: pattern.rows.length * stepH,
+                  background: 'rgba(255,255,255,0.5)',
+                  pointerEvents: 'none',
+                  zIndex: 20,
                   transition: 'left 60ms linear',
+                  borderRadius: 1,
                 }}
               />
             )}
@@ -872,35 +1160,64 @@ export function SequencerEditor() {
         </div>
       </div>
 
-      {/* Velocity lane for selected row */}
+      {/* ── Graph Editor (velocity lane) ──────────────────────────────── */}
       {selectedRow && (() => {
         const row = pattern.rows.find((r) => r.id === selectedRow);
         if (!row) return null;
         return (
-          <div className="flex shrink-0 border-t border-zinc-700/50 bg-zinc-900/80" style={{ height: VELOCITY_LANE_H }}>
+          <div className="shrink-0 flex" style={{ height: GRAPH_H, borderTop: `1px solid ${FL.border}` }}>
+            {/* Label + tabs */}
             <div
-              className="shrink-0 flex items-center px-2 text-[9px] text-zinc-500 font-medium bg-zinc-900"
-              style={{ width: ROW_LABEL_W }}
+              className="shrink-0 flex flex-col justify-center px-2"
+              style={{ width: ROW_LABEL_W, background: FL.graphBg }}
             >
-              VEL — {row.name}
+              <div className="flex items-center gap-1.5">
+                <div style={{ width: 3, height: 12, borderRadius: 1, background: row.color }} />
+                <span style={{ fontSize: 9, color: FL.text, fontWeight: 600 }}>VELOCITY</span>
+              </div>
+              <span style={{ fontSize: 8, color: FL.textDim, marginTop: 2 }}>{row.name}</span>
             </div>
-            <div className="flex items-end overflow-hidden">
+
+            {/* Graph bars */}
+            <div
+              className="flex items-end overflow-hidden relative"
+              style={{ background: FL.graphBg, flex: 1 }}
+            >
+              {/* Horizontal grid lines */}
+              {[0.25, 0.5, 0.75].map((pct) => (
+                <div
+                  key={pct}
+                  style={{
+                    position: 'absolute',
+                    left: 0, right: 0,
+                    bottom: `${pct * 100}%`,
+                    height: 1,
+                    background: FL.graphGrid,
+                    pointerEvents: 'none',
+                  }}
+                />
+              ))}
+
               {row.steps.map((step, idx) => {
                 const isCurrent = idx === currentStep && isPreviewPlaying;
+                const isBeatStart = idx % stepsPerBeat === 0;
                 return (
                   <div
                     key={idx}
-                    className={`shrink-0 flex items-end justify-center cursor-ns-resize ${
-                      isCurrent ? 'bg-white/5' : ''
-                    }`}
-                    style={{ width: STEP_W, height: VELOCITY_LANE_H }}
+                    className="shrink-0 flex items-end justify-center cursor-ns-resize"
+                    style={{
+                      width: stepW,
+                      height: GRAPH_H,
+                      borderLeft: isBeatStart ? `1px solid ${FL.graphGrid}` : undefined,
+                      background: isCurrent ? 'rgba(255,255,255,0.03)' : undefined,
+                    }}
                     onMouseDown={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
                       const rect = e.currentTarget.getBoundingClientRect();
                       const update = (ev: MouseEvent) => {
                         const pct = 1 - Math.max(0, Math.min(1, (ev.clientY - rect.top) / rect.height));
-                        setStepVelocity(track.id, selectedRow, idx, Math.max(0.05, pct));
+                        setStepVelocity(track.id, selectedRow!, idx, Math.max(0.05, pct));
                       };
                       update(e.nativeEvent);
                       const onUp = () => {
@@ -913,12 +1230,13 @@ export function SequencerEditor() {
                   >
                     {step.active && (
                       <div
-                        className="rounded-t-sm"
                         style={{
-                          width: Math.max(6, STEP_W * 0.5),
+                          width: Math.max(4, stepW * 0.6),
                           height: `${step.velocity * 100}%`,
-                          backgroundColor: row.color,
-                          opacity: 0.85,
+                          background: `linear-gradient(to top, ${row.color}, ${row.color}cc)`,
+                          borderRadius: '2px 2px 0 0',
+                          opacity: 0.9,
+                          boxShadow: `0 0 4px ${row.color}40`,
                         }}
                       />
                     )}
@@ -930,43 +1248,127 @@ export function SequencerEditor() {
         );
       })()}
 
-      {/* Row context menu */}
+      {/* ── Context menu ──────────────────────────────────────────────── */}
       {rowCtxMenu && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setRowCtxMenu(null)} onContextMenu={(e) => { e.preventDefault(); setRowCtxMenu(null); }} />
           <div
-            className="fixed z-50 bg-zinc-900 border border-zinc-700 rounded shadow-xl py-1 min-w-[150px]"
-            style={{ left: Math.min(rowCtxMenu.x, window.innerWidth - 170), top: Math.min(rowCtxMenu.y, window.innerHeight - 120) }}
+            className="fixed z-50 py-1"
+            style={{
+              left: Math.min(rowCtxMenu.x, window.innerWidth - 180),
+              top: Math.min(rowCtxMenu.y, window.innerHeight - 260),
+              background: FL.headerBg,
+              border: `1px solid ${FL.borderLight}`,
+              borderRadius: 4,
+              boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
+              minWidth: 160,
+            }}
           >
-            <button
+            <CtxMenuItem
+              label="Rename / Color..."
+              onClick={() => {
+                setInlineRenameRowId(rowCtxMenu.rowId);
+                const r = pattern.rows.find((r) => r.id === rowCtxMenu.rowId);
+                setInlineRenameValue(r?.name ?? '');
+                setRowCtxMenu(null);
+              }}
+            />
+            <CtxMenuSep />
+
+            {/* Color swatches */}
+            <div style={{ padding: '4px 8px', display: 'flex', gap: 3, flexWrap: 'wrap' }}>
+              {ROW_COLORS.map((c) => (
+                <div
+                  key={c}
+                  style={{
+                    width: 14, height: 14, borderRadius: 3, background: c, cursor: 'pointer',
+                    border: pattern.rows.find((r) => r.id === rowCtxMenu.rowId)?.color === c
+                      ? '2px solid #fff' : '1px solid rgba(255,255,255,0.1)',
+                  }}
+                  onClick={() => {
+                    setRowColor(track.id, rowCtxMenu.rowId, c);
+                    setRowCtxMenu(null);
+                  }}
+                />
+              ))}
+            </div>
+            <CtxMenuSep />
+
+            <CtxMenuItem
+              label="Clone Channel"
+              onClick={() => { cloneRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); }}
+            />
+            <CtxMenuSep />
+
+            <CtxMenuItem
+              label="Fill every 2 steps"
+              onClick={() => { fillRow(track.id, rowCtxMenu.rowId, 2); setRowCtxMenu(null); }}
+            />
+            <CtxMenuItem
+              label="Fill every 4 steps"
+              onClick={() => { fillRow(track.id, rowCtxMenu.rowId, 4); setRowCtxMenu(null); }}
+            />
+            <CtxMenuItem
+              label="Fill every 8 steps"
+              onClick={() => { fillRow(track.id, rowCtxMenu.rowId, 8); setRowCtxMenu(null); }}
+            />
+            <CtxMenuSep />
+
+            <CtxMenuItem
+              label="Clear Steps"
               onClick={() => { clearRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); }}
-              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-300 hover:bg-zinc-800 transition-colors"
-            >
-              Clear Steps
-            </button>
-            <button
-              onClick={() => { previewSample(pattern.rows.find(r => r.id === rowCtxMenu.rowId)?.sampleKey ?? '', 0.8); }}
-              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-300 hover:bg-zinc-800 transition-colors"
-            >
-              Preview Sound
-            </button>
-            <div className="my-0.5 border-t border-zinc-800" />
-            <button
+            />
+            <CtxMenuItem
+              label="Preview Sound"
+              onClick={() => {
+                previewSample(pattern.rows.find((r) => r.id === rowCtxMenu.rowId)?.sampleKey ?? '', 0.8);
+              }}
+            />
+            <CtxMenuSep />
+
+            <CtxMenuItem
+              label="Delete Channel"
+              danger
               onClick={() => {
                 if (soloRowId === rowCtxMenu.rowId) setSoloRowId(null);
                 removeRow(track.id, rowCtxMenu.rowId);
                 setRowCtxMenu(null);
                 if (selectedRow === rowCtxMenu.rowId) setSelectedRow(null);
               }}
-              className="w-full text-left px-3 py-1.5 text-[11px] text-red-400 hover:bg-red-900/30 transition-colors"
-            >
-              Delete Row
-            </button>
+            />
           </div>
         </>
       )}
     </div>
   );
+}
+
+/* ── Context Menu Item ────────────────────────────────────────────── */
+
+function CtxMenuItem({ label, onClick, danger }: { label: string; onClick: () => void; danger?: boolean }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: 'block', width: '100%', textAlign: 'left',
+        padding: '4px 12px', fontSize: 11, border: 'none', cursor: 'pointer',
+        background: 'transparent',
+        color: danger ? '#e74c3c' : FL.text,
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLElement).style.background = danger ? 'rgba(231,76,60,0.15)' : FL.stepOff;
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLElement).style.background = 'transparent';
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function CtxMenuSep() {
+  return <div style={{ margin: '2px 8px', height: 1, background: FL.border }} />;
 }
 
 /* ── Sample Picker Dropdown ─────────────────────────────────────────── */
@@ -976,10 +1378,9 @@ interface SamplePickerDropdownProps {
   onSelect: (key: string, name: string) => void;
   onClose: () => void;
   onPreview: (key: string) => void;
-  onImportFile?: () => void;
 }
 
-function SamplePickerDropdown({ currentKey, onSelect, onClose, onPreview, onImportFile }: SamplePickerDropdownProps) {
+function SamplePickerDropdown({ currentKey, onSelect, onClose, onPreview }: SamplePickerDropdownProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -998,28 +1399,50 @@ function SamplePickerDropdown({ currentKey, onSelect, onClose, onPreview, onImpo
   return (
     <>
       <div className="fixed inset-0 z-40" onClick={onClose} />
-      <div className="absolute left-0 z-50 mt-1 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl py-1 w-48">
-        <div className="px-2 py-1 text-[9px] text-zinc-500 font-medium uppercase">Built-in Samples</div>
+      <div
+        className="absolute left-0 z-50 mt-1 py-1"
+        style={{
+          background: FL.headerBg,
+          border: `1px solid ${FL.borderLight}`,
+          borderRadius: 4,
+          boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
+          width: 180,
+        }}
+      >
+        <div style={{ padding: '4px 8px', fontSize: 9, color: FL.textDim, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+          Built-in Samples
+        </div>
         {ALL_DRUM_SAMPLES.map((kit) => (
           <button
             key={kit.id}
-            className={`w-full flex items-center gap-2 px-2 py-1.5 text-[11px] hover:bg-zinc-800 transition-colors text-left ${
-              currentKey === kit.id ? 'text-emerald-400' : 'text-zinc-300'
-            }`}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6, width: '100%',
+              padding: '4px 8px', fontSize: 11, border: 'none', cursor: 'pointer',
+              background: 'transparent', textAlign: 'left',
+              color: currentKey === kit.id ? FL.accentBright : FL.text,
+            }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = FL.stepOff; }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
             onClick={() => onSelect(kit.id, kit.name)}
-            onMouseEnter={() => onPreview(kit.id)}
+            onMouseDown={() => onPreview(kit.id)}
           >
-            <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: kit.color }} />
-            <span>{kit.name}</span>
-            {currentKey === kit.id && <span className="ml-auto text-emerald-400">✓</span>}
+            <div style={{ width: 8, height: 8, borderRadius: '50%', background: kit.color }} />
+            <span style={{ flex: 1 }}>{kit.name}</span>
+            {currentKey === kit.id && <span style={{ color: FL.accentBright }}>✓</span>}
           </button>
         ))}
-        <div className="my-0.5 border-t border-zinc-800" />
+        <div style={{ margin: '2px 8px', height: 1, background: FL.border }} />
         <button
-          className="w-full flex items-center gap-2 px-2 py-1.5 text-[11px] text-amber-400 hover:bg-zinc-800 transition-colors text-left"
+          style={{
+            display: 'flex', alignItems: 'center', gap: 6, width: '100%',
+            padding: '4px 8px', fontSize: 11, border: 'none', cursor: 'pointer',
+            background: 'transparent', textAlign: 'left', color: '#f39c12',
+          }}
+          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = FL.stepOff; }}
+          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
           onClick={() => fileInputRef.current?.click()}
         >
-          <span className="text-sm">📂</span>
+          <span style={{ fontSize: 12 }}>📂</span>
           <span>Import Audio...</span>
         </button>
         <input

--- a/src/components/sequencer/SequencerGrid.tsx
+++ b/src/components/sequencer/SequencerGrid.tsx
@@ -7,6 +7,20 @@ import { getAudioEngine } from '../../hooks/useAudioEngine';
 import { getSample, cacheUserSample } from '../../services/sampleManager';
 import { DEFAULT_DRUM_KIT } from '../../constants/tracks';
 
+const FL = {
+  bg: '#2a2a2a',
+  rowBg: '#303030',
+  rowBgAlt: '#2d2d2d',
+  stepOff: '#3c3c3c',
+  beatBg: '#353535',
+  border: '#222222',
+  borderLight: '#444444',
+  barBorder: '#555555',
+  text: '#c0c0c0',
+  textDim: '#808080',
+  accent: '#5a9a3c',
+};
+
 const STEP_H = 24;
 const ROW_LABEL_W = 90;
 const VELOCITY_LANE_H = 44;
@@ -52,18 +66,15 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
   const totalSteps = pattern.stepsPerBar * pattern.bars;
   const stepDuration = (60 / bpm) / (pattern.stepsPerBar / 4);
   const patternDuration = stepDuration * totalSteps;
-
-  // Compute step width from BPM and zoom so it aligns with the timeline grid
   const stepW = Math.max(MIN_STEP_W, stepDuration * pixelsPerSecond);
   const patternWidthPx = totalSteps * stepW;
   const totalTimelineWidth = project.totalDuration * pixelsPerSecond;
+  const stepsPerBeat = pattern.stepsPerBar / 4;
 
-  // How many times the pattern tiles across the timeline
   const tileCount = patternDuration > 0
     ? Math.ceil(totalTimelineWidth / patternWidthPx)
     : 1;
 
-  // Current step highlight during playback
   const currentStep = isPlaying && patternDuration > 0
     ? Math.floor((currentTime % patternDuration) / stepDuration)
     : -1;
@@ -144,86 +155,95 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
     <div
       className="flex flex-col select-none"
       data-sequencer-grid
-      style={{ width: totalTimelineWidth, height, minHeight: height }}
+      style={{ width: totalTimelineWidth, height, minHeight: height, background: FL.bg }}
       onMouseDownCapture={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
       onDoubleClick={(e) => e.stopPropagation()}
       onContextMenu={(e) => e.stopPropagation()}
     >
-      {/* Toolbar — sticky to the left edge via position:sticky */}
+      {/* Toolbar */}
       <div
-        className="flex items-center gap-2 px-2 bg-zinc-900/90 border-b border-zinc-700/50 text-[10px] shrink-0 sticky left-0 z-20 backdrop-blur-sm"
-        style={{ height: TOOLBAR_H }}
+        className="flex items-center gap-2 px-2 shrink-0 sticky left-0 z-20"
+        style={{ height: TOOLBAR_H, background: FL.bg, borderBottom: `1px solid ${FL.border}` }}
       >
-        <span className="text-emerald-400 font-bold text-[11px]">SEQ</span>
-        <div className="flex items-center gap-1">
-          <span className="text-zinc-500">Steps:</span>
+        <span style={{ color: FL.accent, fontWeight: 700, fontSize: 11 }}>SEQ</span>
+        <div className="flex items-center gap-1" style={{ fontSize: 10 }}>
+          <span style={{ color: FL.textDim }}>Steps:</span>
           <select
             value={pattern.stepsPerBar}
             onChange={(e) => setStepsPerBar(track.id, Number(e.target.value))}
-            className="bg-zinc-800 border border-zinc-700 rounded px-1 py-0.5 text-zinc-300 text-[10px]"
+            style={{ background: FL.stepOff, border: `1px solid ${FL.borderLight}`, borderRadius: 2, padding: '0 4px', color: FL.text, fontSize: 10 }}
           >
             <option value={8}>8</option>
             <option value={16}>16</option>
             <option value={32}>32</option>
           </select>
         </div>
-        <div className="flex items-center gap-1">
-          <span className="text-zinc-500">Bars:</span>
+        <div className="flex items-center gap-1" style={{ fontSize: 10 }}>
+          <span style={{ color: FL.textDim }}>Bars:</span>
           <select
             value={pattern.bars}
             onChange={(e) => setBars(track.id, Number(e.target.value))}
-            className="bg-zinc-800 border border-zinc-700 rounded px-1 py-0.5 text-zinc-300 text-[10px]"
+            style={{ background: FL.stepOff, border: `1px solid ${FL.borderLight}`, borderRadius: 2, padding: '0 4px', color: FL.text, fontSize: 10 }}
           >
             {[1, 2, 4, 8].map((b) => (
               <option key={b} value={b}>{b}</option>
             ))}
           </select>
         </div>
-        <div className="flex items-center gap-1">
-          <span className="text-zinc-500">Swing:</span>
+        <div className="flex items-center gap-1" style={{ fontSize: 10 }}>
+          <span style={{ color: FL.textDim }}>Swing:</span>
           <input
-            type="range"
-            min={0}
-            max={100}
+            type="range" min={0} max={100}
             value={Math.round(pattern.swing * 100)}
             onChange={(e) => updateSwing(track.id, Number(e.target.value) / 100)}
             className="w-14 h-1"
           />
-          <span className="text-zinc-400 w-6 text-right">{Math.round(pattern.swing * 100)}%</span>
+          <span style={{ color: FL.text, width: 24, textAlign: 'right' }}>{Math.round(pattern.swing * 100)}%</span>
         </div>
         <button
           onClick={() => {
             const next = availableSamples[pattern.rows.length % availableSamples.length];
             addRow(track.id, next.id, next.name, next.color);
           }}
-          className="ml-auto px-2 py-0.5 bg-emerald-700/40 hover:bg-emerald-700/60 text-emerald-300 rounded text-[10px] transition-colors"
+          style={{
+            marginLeft: 'auto', padding: '1px 8px', borderRadius: 3,
+            background: FL.accent + '60', border: 'none', color: FL.accent, fontSize: 10,
+            cursor: 'pointer', fontWeight: 600,
+          }}
         >
           + Row
         </button>
       </div>
 
-      {/* Grid body — scrolls with the timeline horizontally */}
+      {/* Grid body */}
       <div className="flex-1 overflow-hidden relative" style={{ minHeight: 0 }}>
         <div className="flex" style={{ width: totalTimelineWidth }}>
-          {/* Row labels — sticky to left */}
-          <div className="sticky left-0 z-10 bg-zinc-900/95 shrink-0" style={{ width: ROW_LABEL_W }}>
-            {pattern.rows.map((row) => (
+          {/* Row labels */}
+          <div className="sticky left-0 z-10 shrink-0" style={{ width: ROW_LABEL_W, background: FL.bg }}>
+            {pattern.rows.map((row, rowIdx) => (
               <div
                 key={row.id}
-                className={`flex items-center border-b border-zinc-800/50 cursor-pointer ${
-                  selectedRow === row.id ? 'bg-zinc-800/50' : 'hover:bg-zinc-800/20'
-                }`}
-                style={{ height: STEP_H }}
+                className="flex items-center"
+                style={{
+                  height: STEP_H,
+                  background: selectedRow === row.id ? '#3a3a3a' : rowIdx % 2 === 0 ? FL.rowBg : FL.rowBgAlt,
+                  borderBottom: `1px solid ${FL.border}`,
+                  cursor: 'pointer',
+                }}
                 onClick={() => setSelectedRow(row.id === selectedRow ? null : row.id)}
                 onContextMenu={(e) => handleRowContextMenu(row.id, e)}
                 onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; }}
                 onDrop={(e) => handleFileDrop(row.id, e)}
               >
-                <div className="w-1 h-full shrink-0" style={{ backgroundColor: row.color }} />
+                <div style={{ width: 2, height: '100%', background: row.color }} className="shrink-0" />
                 <button
-                  className="flex-1 text-left text-[10px] text-zinc-300 truncate px-1.5 hover:text-white transition-colors"
-                  title={`${row.name} — click to change, drag audio to replace`}
+                  className="flex-1 text-left truncate"
+                  style={{
+                    background: 'transparent', border: 'none', cursor: 'pointer',
+                    fontSize: 10, color: FL.text, padding: '0 4px',
+                  }}
+                  title={`${row.name} — click to change`}
                   onClick={(e) => {
                     e.stopPropagation();
                     setSamplePickerRow(samplePickerRow === row.id ? null : row.id);
@@ -232,16 +252,22 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
                   {row.name}
                 </button>
                 <button
-                  className={`w-5 h-4 text-[8px] font-bold rounded mr-0.5 transition-colors ${
-                    row.muted ? 'bg-amber-600 text-white' : 'bg-zinc-800 text-zinc-600 hover:text-zinc-400'
-                  }`}
+                  style={{
+                    width: 16, height: 14, fontSize: 8, fontWeight: 700, borderRadius: 2,
+                    marginRight: 2, border: 'none', cursor: 'pointer',
+                    background: row.muted ? '#c0392b' : FL.stepOff,
+                    color: row.muted ? '#fff' : FL.textDim,
+                  }}
                   onClick={(e) => { e.stopPropagation(); toggleRowMute(track.id, row.id); }}
                   title={row.muted ? 'Unmute' : 'Mute'}
                 >
                   M
                 </button>
                 <div
-                  className="w-6 h-3 bg-zinc-800 rounded-sm mr-1 cursor-ew-resize overflow-hidden"
+                  style={{
+                    width: 20, height: 10, background: FL.stepOff, borderRadius: 2,
+                    marginRight: 2, cursor: 'ew-resize', overflow: 'hidden',
+                  }}
                   title={`Vol: ${Math.round(row.volume * 100)}%`}
                   onMouseDown={(e) => {
                     e.stopPropagation();
@@ -260,8 +286,7 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
                   }}
                 >
                   <div
-                    className="h-full rounded-sm"
-                    style={{ width: `${row.volume * 100}%`, backgroundColor: row.color + '80' }}
+                    style={{ height: '100%', borderRadius: 2, width: `${row.volume * 100}%`, background: row.color + '80' }}
                   />
                 </div>
               </div>
@@ -298,32 +323,32 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
             )}
           </div>
 
-          {/* Step grid — tiled across the full timeline width */}
+          {/* Step grid */}
           <div className="relative" style={{ width: totalTimelineWidth - ROW_LABEL_W }}>
-            {pattern.rows.map((row) => (
-              <div key={row.id} className="flex border-b border-zinc-800/30" style={{ height: STEP_H }}>
+            {pattern.rows.map((row, rowIdx) => (
+              <div key={row.id} className="flex" style={{ height: STEP_H, borderBottom: `1px solid ${FL.border}` }}>
                 {Array.from({ length: tileCount }).map((_, tileIdx) => (
                   <div key={tileIdx} className="flex shrink-0" style={{ width: patternWidthPx }}>
                     {row.steps.map((step, idx) => {
-                      const isBeatStart = idx % (pattern.stepsPerBar / 4) === 0;
+                      const isBeatStart = idx % stepsPerBeat === 0;
                       const isBarStart = idx % pattern.stepsPerBar === 0 && idx > 0;
                       const isCurrent = idx === currentStep && isPlaying;
+                      const beatIdx = Math.floor(idx / stepsPerBeat);
+                      const isOddBeat = beatIdx % 2 === 1;
                       return (
                         <div
                           key={idx}
-                          className={`relative shrink-0 cursor-pointer ${
-                            isBarStart
-                              ? 'border-l border-l-zinc-500/50'
-                              : isBeatStart
-                                ? 'border-l border-l-zinc-700/40'
-                                : 'border-l border-l-zinc-800/20'
-                          } ${isCurrent ? 'ring-1 ring-inset ring-white/25' : ''}`}
+                          className="relative shrink-0"
                           style={{
                             width: stepW,
                             height: STEP_H,
-                            backgroundColor: step.active
-                              ? `${row.color}${Math.round(step.velocity * 180 + 55).toString(16).padStart(2, '0')}`
-                              : isCurrent ? 'rgba(255,255,255,0.04)' : undefined,
+                            borderLeft: isBarStart
+                              ? `1px solid ${FL.barBorder}`
+                              : isBeatStart
+                                ? `1px solid ${FL.borderLight}`
+                                : `1px solid ${FL.border}`,
+                            background: step.active ? undefined : (isOddBeat ? FL.beatBg : FL.stepOff),
+                            cursor: 'pointer',
                           }}
                           onClick={(e) => handleStepClick(row.id, idx, e)}
                           onContextMenu={(e) => {
@@ -334,11 +359,21 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
                         >
                           {step.active && (
                             <div
-                              className="absolute bottom-0 left-0 right-0 pointer-events-none"
                               style={{
-                                height: `${step.velocity * 100}%`,
-                                backgroundColor: row.color,
-                                opacity: 0.25,
+                                position: 'absolute', left: 1, top: 1, right: 1, bottom: 1,
+                                borderRadius: 2,
+                                background: row.color,
+                                opacity: 0.3 + step.velocity * 0.7,
+                                boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.15)',
+                              }}
+                            />
+                          )}
+                          {isCurrent && (
+                            <div
+                              style={{
+                                position: 'absolute', inset: 0,
+                                border: '1px solid rgba(255,255,255,0.25)',
+                                pointerEvents: 'none',
                               }}
                             />
                           )}
@@ -348,27 +383,25 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
                   </div>
                 ))}
 
-                {/* Pattern tile separator lines */}
                 {tileCount > 1 && Array.from({ length: tileCount - 1 }).map((_, i) => (
                   <div
                     key={`sep-${i}`}
-                    className="absolute top-0 bottom-0 w-px bg-emerald-500/30 pointer-events-none"
-                    style={{ left: (i + 1) * patternWidthPx }}
+                    className="absolute top-0 bottom-0 pointer-events-none"
+                    style={{ left: (i + 1) * patternWidthPx, width: 1, background: `${FL.accent}40` }}
                   />
                 ))}
               </div>
             ))}
 
-            {/* Playhead overlay */}
             {isPlaying && currentStep >= 0 && (() => {
               const playheadX = currentTime * pixelsPerSecond - ROW_LABEL_W;
               if (playheadX < 0) return null;
               return (
                 <div
-                  className="absolute top-0 w-0.5 bg-white/40 pointer-events-none z-20"
+                  className="absolute top-0 pointer-events-none z-20"
                   style={{
-                    left: playheadX,
-                    height: gridRowsHeight,
+                    left: playheadX, width: 2, height: gridRowsHeight,
+                    background: 'rgba(255,255,255,0.4)', borderRadius: 1,
                   }}
                 />
               );
@@ -377,7 +410,7 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
         </div>
       </div>
 
-      {/* Velocity lane for selected row */}
+      {/* Velocity lane */}
       {showVelocity && selectedRow && (
         <VelocityLane
           track={track}
@@ -398,25 +431,33 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
         <>
           <div className="fixed inset-0 z-40" onClick={() => setRowCtxMenu(null)} onContextMenu={(e) => { e.preventDefault(); setRowCtxMenu(null); }} />
           <div
-            className="fixed z-50 bg-zinc-900 border border-zinc-700 rounded shadow-xl py-1 min-w-[140px]"
-            style={{ left: Math.min(rowCtxMenu.x, window.innerWidth - 160), top: Math.min(rowCtxMenu.y, window.innerHeight - 100) }}
+            className="fixed z-50 py-1"
+            style={{
+              left: Math.min(rowCtxMenu.x, window.innerWidth - 160),
+              top: Math.min(rowCtxMenu.y, window.innerHeight - 100),
+              background: FL.bg,
+              border: `1px solid ${FL.borderLight}`,
+              borderRadius: 4,
+              boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
+              minWidth: 140,
+            }}
           >
             <button
               onClick={() => { clearRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); }}
-              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-300 hover:bg-zinc-800 transition-colors"
+              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '4px 12px', fontSize: 11, border: 'none', cursor: 'pointer', background: 'transparent', color: FL.text }}
             >
               Clear Steps
             </button>
             <button
               onClick={() => { previewSample(pattern.rows.find(r => r.id === rowCtxMenu.rowId)?.sampleKey ?? '', 0.8); }}
-              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-300 hover:bg-zinc-800 transition-colors"
+              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '4px 12px', fontSize: 11, border: 'none', cursor: 'pointer', background: 'transparent', color: FL.text }}
             >
               Preview Sound
             </button>
-            <div className="my-0.5 border-t border-zinc-800" />
+            <div style={{ margin: '2px 8px', height: 1, background: FL.border }} />
             <button
               onClick={() => { removeRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); if (selectedRow === rowCtxMenu.rowId) setSelectedRow(null); }}
-              className="w-full text-left px-3 py-1.5 text-[11px] text-red-400 hover:bg-red-900/30 transition-colors"
+              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '4px 12px', fontSize: 11, border: 'none', cursor: 'pointer', background: 'transparent', color: '#e74c3c' }}
             >
               Delete Row
             </button>
@@ -448,12 +489,15 @@ function VelocityLane({
 }: VelocityLaneProps) {
   const row = pattern.rows.find((r) => r.id === rowId);
   if (!row) return null;
+  const stepsPerBeat = pattern.stepsPerBar / 4;
+  const VELOCITY_LANE_H = 44;
+  const ROW_LABEL_W = 90;
 
   return (
-    <div className="flex shrink-0 border-t border-zinc-700/50 bg-zinc-900/60" style={{ height: VELOCITY_LANE_H }}>
+    <div className="flex shrink-0" style={{ height: VELOCITY_LANE_H, borderTop: `1px solid ${FL.border}`, background: '#252525' }}>
       <div
-        className="shrink-0 flex items-center px-2 text-[9px] text-zinc-500 font-medium sticky left-0 z-10 bg-zinc-900/95"
-        style={{ width: ROW_LABEL_W }}
+        className="shrink-0 flex items-center px-2 sticky left-0 z-10"
+        style={{ width: ROW_LABEL_W, fontSize: 9, color: FL.textDim, fontWeight: 500, background: '#252525' }}
       >
         VEL — {row.name}
       </div>
@@ -462,13 +506,16 @@ function VelocityLane({
           <div key={tileIdx} className="flex items-end shrink-0" style={{ width: patternWidthPx }}>
             {row.steps.map((step, idx) => {
               const isCurrent = idx === currentStep && isPlaying;
+              const isBeatStart = idx % stepsPerBeat === 0;
               return (
                 <div
                   key={idx}
-                  className={`shrink-0 flex items-end justify-center cursor-ns-resize ${
-                    isCurrent ? 'bg-white/5' : ''
-                  }`}
-                  style={{ width: stepW, height: VELOCITY_LANE_H }}
+                  className="shrink-0 flex items-end justify-center cursor-ns-resize"
+                  style={{
+                    width: stepW, height: VELOCITY_LANE_H,
+                    borderLeft: isBeatStart ? `1px solid #333` : undefined,
+                    background: isCurrent ? 'rgba(255,255,255,0.03)' : undefined,
+                  }}
                   onMouseDown={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
@@ -488,12 +535,12 @@ function VelocityLane({
                 >
                   {step.active && (
                     <div
-                      className="rounded-t-sm"
                       style={{
                         width: Math.max(4, stepW * 0.5),
                         height: `${step.velocity * 100}%`,
-                        backgroundColor: row.color,
-                        opacity: 0.8,
+                        background: `linear-gradient(to top, ${row.color}, ${row.color}cc)`,
+                        borderRadius: '2px 2px 0 0',
+                        opacity: 0.85,
                       }}
                     />
                   )}
@@ -520,20 +567,34 @@ function SamplePickerDropdown({ currentKey, onSelect, onClose, onPreview }: Samp
   return (
     <>
       <div className="fixed inset-0 z-40" onClick={onClose} />
-      <div className="absolute left-0 z-50 mt-1 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl py-1 w-44">
-        <div className="px-2 py-1 text-[9px] text-zinc-500 font-medium uppercase">Built-in Samples</div>
+      <div
+        className="absolute left-0 z-50 mt-1 py-1"
+        style={{
+          background: FL.bg,
+          border: `1px solid ${FL.borderLight}`,
+          borderRadius: 4,
+          boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
+          width: 170,
+        }}
+      >
+        <div style={{ padding: '4px 8px', fontSize: 9, color: FL.textDim, fontWeight: 600, textTransform: 'uppercase' }}>
+          Built-in Samples
+        </div>
         {DEFAULT_DRUM_KIT.map((kit) => (
           <button
             key={kit.id}
-            className={`w-full flex items-center gap-2 px-2 py-1.5 text-[10px] hover:bg-zinc-800 transition-colors text-left ${
-              currentKey === kit.id ? 'text-emerald-400' : 'text-zinc-300'
-            }`}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6, width: '100%',
+              padding: '3px 8px', fontSize: 10, border: 'none', cursor: 'pointer',
+              background: 'transparent', textAlign: 'left',
+              color: currentKey === kit.id ? FL.accent : FL.text,
+            }}
             onClick={() => onSelect(kit.id, kit.name)}
             onMouseEnter={() => onPreview(kit.id)}
           >
-            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: kit.color }} />
+            <div style={{ width: 6, height: 6, borderRadius: '50%', background: kit.color }} />
             <span>{kit.name}</span>
-            {currentKey === kit.id && <span className="ml-auto text-emerald-400">✓</span>}
+            {currentKey === kit.id && <span style={{ marginLeft: 'auto', color: FL.accent }}>✓</span>}
           </button>
         ))}
       </div>

--- a/src/services/sequencerBounce.ts
+++ b/src/services/sequencerBounce.ts
@@ -42,7 +42,8 @@ export async function bounceSequencerToAudio(
   const renderDuration = patternDuration + maxSampleDuration;
   const renderLength = Math.ceil(renderDuration * sampleRate);
 
-  const offCtx = new OfflineAudioContext(1, renderLength, sampleRate);
+  const numChannels = pattern.rows.some((r) => (r.pan ?? 0) !== 0) ? 2 : 1;
+  const offCtx = new OfflineAudioContext(numChannels, renderLength, sampleRate);
 
   for (const row of pattern.rows) {
     if (row.muted) continue;
@@ -65,7 +66,14 @@ export async function bounceSequencerToAudio(
       const gain = offCtx.createGain();
       gain.gain.value = step.velocity * row.volume;
       source.connect(gain);
-      gain.connect(offCtx.destination);
+      if (numChannels === 2 && (row.pan ?? 0) !== 0) {
+        const panner = offCtx.createStereoPanner();
+        panner.pan.value = row.pan ?? 0;
+        gain.connect(panner);
+        panner.connect(offCtx.destination);
+      } else {
+        gain.connect(offCtx.destination);
+      }
       source.start(time);
     }
   }
@@ -76,13 +84,15 @@ export async function bounceSequencerToAudio(
   const trimLength = Math.ceil(patternDuration * sampleRate);
   const trimmed = new AudioBuffer({
     length: trimLength,
-    numberOfChannels: 1,
+    numberOfChannels: numChannels,
     sampleRate,
   });
-  const srcData = rendered.getChannelData(0);
-  const dstData = trimmed.getChannelData(0);
-  for (let i = 0; i < trimLength && i < srcData.length; i++) {
-    dstData[i] = srcData[i];
+  for (let ch = 0; ch < numChannels; ch++) {
+    const srcData = rendered.getChannelData(ch);
+    const dstData = trimmed.getChannelData(ch);
+    for (let i = 0; i < trimLength && i < srcData.length; i++) {
+      dstData[i] = srcData[i];
+    }
   }
 
   const wavBlob = audioBufferToWavBlob(trimmed);

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -85,9 +85,15 @@ interface ProjectState {
   setSequencerStepsPerBar: (trackId: string, stepsPerBar: number) => void;
   setSequencerBars: (trackId: string, bars: number) => void;
   setSequencerRowVolume: (trackId: string, rowId: string, volume: number) => void;
+  setSequencerRowPan: (trackId: string, rowId: string, pan: number) => void;
   toggleSequencerRowMute: (trackId: string, rowId: string) => void;
   setSequencerRowSample: (trackId: string, rowId: string, sampleKey: string) => void;
   clearSequencerRow: (trackId: string, rowId: string) => void;
+  reorderSequencerRows: (trackId: string, fromIndex: number, toIndex: number) => void;
+  cloneSequencerRow: (trackId: string, rowId: string) => void;
+  renameSequencerRow: (trackId: string, rowId: string, name: string) => void;
+  setSequencerRowColor: (trackId: string, rowId: string, color: string) => void;
+  fillSequencerRow: (trackId: string, rowId: string, every: number) => void;
   batchSetSequencerSteps: (trackId: string, ops: { rowId: string; stepIndex: number; active: boolean; velocity: number }[]) => void;
 
   getTrackById: (trackId: string) => Track | undefined;
@@ -283,6 +289,7 @@ export const useProjectStore = create<ProjectState>()(
           sampleKey: kit.id,
           steps: Array.from({ length: totalSteps }, () => ({ active: false, velocity: 0.8 })),
           volume: 0.8,
+          pan: 0,
           muted: false,
           color: kit.color,
         })),
@@ -867,6 +874,7 @@ export const useProjectStore = create<ProjectState>()(
       sampleKey: kit.id,
       steps: Array.from({ length: totalSteps }, emptyStep),
       volume: 0.8,
+      pan: 0,
       muted: false,
       color: kit.color,
     }));
@@ -962,6 +970,7 @@ export const useProjectStore = create<ProjectState>()(
             sampleKey: sampleId,
             steps: Array.from({ length: totalSteps }, () => ({ active: false, velocity: 0.8 })),
             volume: 0.8,
+            pan: 0,
             muted: false,
             color,
           };
@@ -1099,6 +1108,29 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
+  setSequencerRowPan: (trackId, rowId, pan) => {
+    const state = get();
+    if (!state.project) return;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) =>
+                r.id === rowId ? { ...r, pan: Math.max(-1, Math.min(1, pan)) } : r,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
   toggleSequencerRowMute: (trackId, rowId) => {
     const state = get();
     if (!state.project) return;
@@ -1165,6 +1197,129 @@ export const useProjectStore = create<ProjectState>()(
                   ? { ...r, steps: r.steps.map((s) => ({ ...s, active: false })) }
                   : r,
               ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  reorderSequencerRows: (trackId, fromIndex, toIndex) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          const rows = [...t.sequencerPattern.rows];
+          const [moved] = rows.splice(fromIndex, 1);
+          if (!moved) return t;
+          rows.splice(toIndex, 0, moved);
+          return { ...t, sequencerPattern: { ...t.sequencerPattern, rows } };
+        }),
+      },
+    });
+  },
+
+  cloneSequencerRow: (trackId, rowId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          const idx = t.sequencerPattern.rows.findIndex((r) => r.id === rowId);
+          if (idx < 0) return t;
+          const orig = t.sequencerPattern.rows[idx];
+          const clone: SequencerRow = {
+            ...orig,
+            id: uuidv4(),
+            name: `${orig.name} copy`,
+            steps: orig.steps.map((s) => ({ ...s })),
+          };
+          const rows = [...t.sequencerPattern.rows];
+          rows.splice(idx + 1, 0, clone);
+          return { ...t, sequencerPattern: { ...t.sequencerPattern, rows } };
+        }),
+      },
+    });
+  },
+
+  renameSequencerRow: (trackId, rowId, name) => {
+    const state = get();
+    if (!state.project) return;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) =>
+                r.id === rowId ? { ...r, name } : r,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  setSequencerRowColor: (trackId, rowId, color) => {
+    const state = get();
+    if (!state.project) return;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) =>
+                r.id === rowId ? { ...r, color } : r,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  fillSequencerRow: (trackId, rowId, every) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r) => {
+                if (r.id !== rowId) return r;
+                return {
+                  ...r,
+                  steps: r.steps.map((s, i) =>
+                    i % every === 0 ? { ...s, active: true } : s,
+                  ),
+                };
+              }),
             },
           };
         }),

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -79,6 +79,7 @@ export interface SequencerRow {
   sampleKey: string;      // built-in sample id or IndexedDB key for user sample
   steps: SequencerStep[];
   volume: number;         // 0–1
+  pan: number;            // -1 (full left) to +1 (full right), default 0
   muted: boolean;
   color: string;
 }


### PR DESCRIPTION
## Summary
- Completely redesigned the Step Sequencer UI to match FL Studio's Channel Rack aesthetic and interaction patterns
- Added new `MiniKnob` SVG component for compact inline pan/volume controls with drag-to-adjust
- Implemented FL-inspired dark color palette, compact channel rows with LED mute indicators, rounded pill-style step buttons with velocity-modulated opacity
- Added row drag-reorder, inline channel rename, color picker, clone/fill/clear context menu actions
- Stereo pan support in sequencer bounce service via `StereoPannerNode` and `OfflineAudioContext`
- Added `pan` field to `SequencerRow` data model and 6 new store actions
- Fixed Vite CSS analysis ENOENT error by adding placeholder `vite.svg`

## Test plan
- [ ] Open the step sequencer and verify FL Studio-style visual appearance
- [ ] Test inline pan/volume knobs on each channel row
- [ ] Test drag-to-reorder rows
- [ ] Test right-click context menu (rename, color, clone, fill, clear, delete)
- [ ] Test bounce to audio with stereo pan applied
- [ ] Verify no white screen on page load (vite.svg fix)

Made with [Cursor](https://cursor.com)