### PR TITLE
feat: GarageBand-style UI refactor

### DIFF
--- a/src/components/assets/AssetsPanel.tsx
+++ b/src/components/assets/AssetsPanel.tsx
@@ -3,15 +3,15 @@ import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import type { AssetClip } from '../../types/project';
 
-type Tab = 'starred' | 'generated' | 'uploaded';
+type Filter = 'all' | 'starred' | 'generated' | 'uploaded';
 
 function MiniWaveform({ peaks, color }: { peaks: number[] | null; color: string }) {
-  if (!peaks || peaks.length === 0) return <div className="w-full h-full bg-zinc-800 rounded-sm" />;
+  if (!peaks || peaks.length === 0) return <div className="w-full h-full bg-[#333] rounded" />;
   const w = 60;
   const h = 20;
   const step = w / peaks.length;
   return (
-    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" className="rounded-sm bg-zinc-800/60">
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" className="rounded bg-[#252525]">
       {peaks.map((p, i) => {
         const barH = Math.max(p * (h - 2), 0.5);
         return (
@@ -46,7 +46,8 @@ export function AssetsPanel() {
   const toggleAssetStar = useProjectStore((s) => s.toggleAssetStar);
   const getClipById = useProjectStore((s) => s.getClipById);
 
-  const [activeTab, setActiveTab] = useState<Tab>('starred');
+  const [activeFilter, setActiveFilter] = useState<Filter>('all');
+  const [searchText, setSearchText] = useState('');
 
   const resizeDragRef = useRef<{ startX: number; startW: number } | null>(null);
   const onResizeMouseDown = useCallback((e: React.MouseEvent) => {
@@ -66,23 +67,27 @@ export function AssetsPanel() {
     window.addEventListener('mouseup', onMouseUp);
   }, [assetsPanelWidth, setAssetsPanelWidth]);
 
-  const allAssets = useMemo<AssetClip[]>(() => {
-    return project?.assets ?? [];
-  }, [project?.assets]);
+  const allAssets = useMemo<AssetClip[]>(() => project?.assets ?? [], [project?.assets]);
 
-  const starredAssets = useMemo(() => allAssets.filter((a) => a.starred), [allAssets]);
-  const generatedAssets = useMemo(() => allAssets.filter((a) => a.source !== 'uploaded'), [allAssets]);
-  const uploadedAssets = useMemo(() => allAssets.filter((a) => a.source === 'uploaded'), [allAssets]);
+  const filteredAssets = useMemo(() => {
+    let list = allAssets;
+    if (activeFilter === 'starred') list = list.filter((a) => a.starred);
+    else if (activeFilter === 'generated') list = list.filter((a) => a.source !== 'uploaded');
+    else if (activeFilter === 'uploaded') list = list.filter((a) => a.source === 'uploaded');
 
-  const activeAssets = activeTab === 'starred' ? starredAssets
-    : activeTab === 'generated' ? generatedAssets
-    : uploadedAssets;
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      list = list.filter((a) =>
+        (a.prompt ?? '').toLowerCase().includes(q) ||
+        (a.trackDisplayName ?? '').toLowerCase().includes(q)
+      );
+    }
+    return list;
+  }, [allAssets, activeFilter, searchText]);
 
   const handleClick = useCallback((asset: AssetClip) => {
     const clip = getClipById(asset.clipId);
-    if (clip) {
-      selectClip(asset.clipId, false);
-    }
+    if (clip) selectClip(asset.clipId, false);
   }, [selectClip, getClipById]);
 
   const handleStar = useCallback((e: React.MouseEvent, assetId: string) => {
@@ -97,73 +102,87 @@ export function AssetsPanel() {
 
   if (!showAssetsPanel || !project) return null;
 
-  const tabs: { id: Tab; label: string; count: number }[] = [
-    { id: 'starred', label: 'Starred', count: starredAssets.length },
-    { id: 'generated', label: 'Generated', count: generatedAssets.length },
-    { id: 'uploaded', label: 'Uploaded', count: uploadedAssets.length },
+  const filters: { id: Filter; label: string }[] = [
+    { id: 'all', label: 'All' },
+    { id: 'starred', label: '★' },
+    { id: 'generated', label: 'AI' },
+    { id: 'uploaded', label: 'Imported' },
   ];
 
   return (
-    <div className="bg-daw-surface border-l border-daw-border flex flex-col shrink-0 relative" style={{ width: assetsPanelWidth }}>
+    <div className="bg-[#2a2a2a] border-l border-[#1a1a1a] flex flex-col shrink-0 relative" style={{ width: assetsPanelWidth }}>
       {/* Left-edge resize handle */}
       <div
-        className="absolute top-0 left-0 w-1.5 h-full cursor-col-resize bg-transparent hover:bg-indigo-500/40 transition-colors z-10"
+        className="absolute top-0 left-0 w-1.5 h-full cursor-col-resize bg-transparent hover:bg-daw-accent/30 transition-colors z-10"
         onMouseDown={onResizeMouseDown}
       />
+
       {/* Header */}
-      <div className="flex items-center justify-between h-6 px-3 border-b border-daw-border shrink-0">
-        <span className="text-[10px] font-medium text-zinc-400 uppercase tracking-wider">Assets</span>
-      </div>
-      {/* Tabs */}
-      <div className="flex border-b border-daw-border shrink-0">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`flex-1 px-1 py-1.5 text-[10px] font-medium transition-colors ${
-              activeTab === tab.id
-                ? 'text-white border-b-2 border-indigo-500'
-                : 'text-zinc-500 hover:text-zinc-300'
-            }`}
-          >
-            {tab.label}
-            {tab.count > 0 && (
-              <span className="ml-1 text-[9px] text-zinc-600">{tab.count}</span>
-            )}
-          </button>
-        ))}
+      <div className="flex items-center h-6 px-3 border-b border-[#3a3a3a] bg-[#333] shrink-0">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" className="text-zinc-500 mr-1.5">
+          <circle cx="5" cy="5" r="3.5" />
+          <path d="M8 8l2.5 2.5" strokeLinecap="round" />
+        </svg>
+        <span className="text-[10px] text-zinc-500 uppercase tracking-wider font-medium">Loop Browser</span>
       </div>
 
-      {/* List */}
+      {/* Search */}
+      <div className="px-2 py-1.5 border-b border-[#3a3a3a]">
+        <input
+          type="text"
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          placeholder="Search loops..."
+          className="w-full text-[11px] text-zinc-300 bg-[#222] border border-[#444] rounded px-2 py-1 outline-none placeholder:text-zinc-600 focus:border-daw-accent/50"
+        />
+      </div>
+
+      {/* Filter keyword buttons */}
+      <div className="flex gap-1 px-2 py-1.5 border-b border-[#3a3a3a] flex-wrap">
+        {filters.map((f) => (
+          <button
+            key={f.id}
+            onClick={() => setActiveFilter(f.id)}
+            className={`px-2 py-0.5 text-[10px] rounded transition-colors ${
+              activeFilter === f.id
+                ? 'bg-daw-accent text-white'
+                : 'bg-[#3a3a3a] text-zinc-400 hover:bg-[#444] hover:text-zinc-200'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+        <span className="text-[9px] text-zinc-600 self-center ml-auto">{filteredAssets.length} items</span>
+      </div>
+
+      {/* Results list */}
       <div className="flex-1 overflow-y-auto min-h-0">
-        {activeAssets.length === 0 ? (
+        {filteredAssets.length === 0 ? (
           <div className="flex items-center justify-center h-24 text-[10px] text-zinc-600">
-            {activeTab === 'starred' ? 'No starred clips yet' :
-             activeTab === 'uploaded' ? 'No uploaded audio yet' :
-             'No generated clips yet'}
+            No matching loops
           </div>
         ) : (
-          <div className="py-1">
-            {activeAssets.map((asset) => {
+          <div className="py-0.5">
+            {filteredAssets.map((asset) => {
               const clipStillOnTrack = !!getClipById(asset.clipId);
               return (
                 <div
                   key={asset.id}
                   onClick={() => handleClick(asset)}
-                  className={`w-full flex items-start gap-2 px-3 py-1.5 hover:bg-zinc-800/60 transition-colors text-left group cursor-pointer ${
-                    !clipStillOnTrack ? 'opacity-60' : ''
+                  className={`w-full flex items-start gap-2 px-3 py-1.5 hover:bg-[#363636] transition-colors text-left group cursor-pointer border-b border-[#333] ${
+                    !clipStillOnTrack ? 'opacity-50' : ''
                   }`}
                 >
                   <div className="shrink-0 mt-0.5">
-                    <MiniWaveform peaks={asset.waveformPeaks} color="#71717a" />
+                    <MiniWaveform peaks={asset.waveformPeaks} color="#6b7280" />
                   </div>
 
                   <div className="flex-1 min-w-0 overflow-hidden">
                     <div className="flex items-center gap-1">
-                      <span className={`shrink-0 text-[8px] px-1 py-px rounded ${
+                      <span className={`shrink-0 text-[8px] px-1 py-px rounded font-medium ${
                         asset.source === 'uploaded'
-                          ? 'bg-amber-900/40 text-amber-400'
-                          : 'bg-violet-900/40 text-violet-400'
+                          ? 'bg-amber-900/30 text-amber-400'
+                          : 'bg-daw-accent/20 text-daw-accent'
                       }`}>
                         {asset.source === 'uploaded' ? '↑' : 'AI'}
                       </span>
@@ -172,12 +191,9 @@ export function AssetsPanel() {
                       </span>
                     </div>
                     <div className="flex items-center gap-1 mt-0.5">
-                      <span className="text-[9px] text-zinc-600 truncate">{asset.trackDisplayName}</span>
-                      <span className="text-[9px] text-zinc-700">·</span>
-                      <span className="text-[9px] text-zinc-600">{fmtDuration(asset.duration)}</span>
-                      {!clipStillOnTrack && (
-                        <span className="text-[8px] text-zinc-700 italic ml-1">removed</span>
-                      )}
+                      <span className="text-[9px] text-zinc-500 truncate">{asset.trackDisplayName}</span>
+                      <span className="text-[9px] text-zinc-600">·</span>
+                      <span className="text-[9px] text-zinc-500">{fmtDuration(asset.duration)}</span>
                     </div>
                   </div>
 
@@ -187,16 +203,16 @@ export function AssetsPanel() {
                       className={`w-5 h-5 flex items-center justify-center rounded text-[10px] transition-colors ${
                         asset.starred
                           ? 'text-yellow-400 hover:text-yellow-300'
-                          : 'text-zinc-700 hover:text-zinc-500 opacity-0 group-hover:opacity-100'
+                          : 'text-zinc-600 hover:text-zinc-400 opacity-0 group-hover:opacity-100'
                       }`}
-                      title={asset.starred ? 'Remove star' : 'Star this clip'}
+                      title={asset.starred ? 'Remove star' : 'Star'}
                     >
                       {asset.starred ? '★' : '☆'}
                     </button>
                     <button
                       onClick={(e) => handleDelete(e, asset.id)}
-                      className="w-5 h-5 flex items-center justify-center rounded text-[10px] text-zinc-700 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
-                      title="Remove from assets"
+                      className="w-5 h-5 flex items-center justify-center rounded text-[10px] text-zinc-600 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
+                      title="Remove"
                     >
                       ×
                     </button>

--- a/src/components/controls/SmartControlsPanel.tsx
+++ b/src/components/controls/SmartControlsPanel.tsx
@@ -1,0 +1,166 @@
+import { useRef, useCallback } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import { Knob } from '../ui/Knob';
+import type { Track } from '../../types/project';
+import { TRACK_CATALOG } from '../../constants/tracks';
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-[9px] text-zinc-500 uppercase tracking-widest font-medium mb-1">{children}</div>
+  );
+}
+
+function SmartKnobGroup({ children, label }: { children: React.ReactNode; label: string }) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="flex gap-2">{children}</div>
+      <span className="text-[9px] text-zinc-500 uppercase tracking-wider">{label}</span>
+    </div>
+  );
+}
+
+function TrackSmartControls({ track }: { track: Track }) {
+  const updateTrack = useProjectStore((s) => s.updateTrack);
+  const updateTrackMixer = useProjectStore((s) => s.updateTrackMixer);
+  const info = TRACK_CATALOG[track.trackName];
+
+  const vol = track.volume;
+  const pan = track.pan ?? 0;
+  const eqLow = track.eqLowGain ?? 0;
+  const eqMid = track.eqMidGain ?? 0;
+  const eqHigh = track.eqHighGain ?? 0;
+  const compEnabled = track.compressorEnabled ?? false;
+  const compThresh = track.compressorThreshold ?? -24;
+  const compRatio = track.compressorRatio ?? 4;
+
+  return (
+    <div className="flex items-start gap-6 px-4">
+      {/* Track info */}
+      <div className="flex flex-col items-center gap-1 min-w-[80px]">
+        <div
+          className="w-10 h-10 rounded-lg flex items-center justify-center text-xl"
+          style={{ backgroundColor: track.color + '30', border: `2px solid ${track.color}40` }}
+        >
+          {info.emoji}
+        </div>
+        <span className="text-[11px] text-zinc-300 font-medium truncate max-w-[80px]">{track.displayName}</span>
+        <span className="text-[9px] text-zinc-500">{track.trackType ?? 'stems'}</span>
+      </div>
+
+      <div className="w-px h-16 bg-[#444] self-center" />
+
+      {/* Volume & Pan */}
+      <div className="flex flex-col items-center gap-1">
+        <SectionLabel>Level</SectionLabel>
+        <div className="flex gap-3">
+          <Knob value={vol} min={0} max={1.5} defaultValue={1} onChange={(v) => updateTrack(track.id, { volume: v })} label="Volume" size={38} step={0.01} />
+          <Knob value={pan} min={-1} max={1} defaultValue={0} onChange={(v) => updateTrackMixer(track.id, { pan: v })} label="Pan" size={38} step={0.01} />
+        </div>
+      </div>
+
+      <div className="w-px h-16 bg-[#444] self-center" />
+
+      {/* EQ */}
+      <div className="flex flex-col items-center gap-1">
+        <SectionLabel>Tone</SectionLabel>
+        <div className="flex gap-2">
+          <Knob value={eqLow} min={-15} max={15} defaultValue={0} onChange={(v) => updateTrackMixer(track.id, { eqLowGain: v })} label="Bass" unit="dB" size={36} step={0.5} />
+          <Knob value={eqMid} min={-15} max={15} defaultValue={0} onChange={(v) => updateTrackMixer(track.id, { eqMidGain: v })} label="Mid" unit="dB" size={36} step={0.5} />
+          <Knob value={eqHigh} min={-15} max={15} defaultValue={0} onChange={(v) => updateTrackMixer(track.id, { eqHighGain: v })} label="Treble" unit="dB" size={36} step={0.5} />
+        </div>
+      </div>
+
+      <div className="w-px h-16 bg-[#444] self-center" />
+
+      {/* Compressor */}
+      <div className="flex flex-col items-center gap-1">
+        <SectionLabel>Compressor</SectionLabel>
+        <button
+          onClick={() => updateTrackMixer(track.id, { compressorEnabled: !compEnabled })}
+          className={`text-[10px] font-semibold px-3 py-1 rounded mb-1 transition-colors ${
+            compEnabled ? 'bg-daw-accent text-white' : 'bg-[#444] text-zinc-400 hover:bg-[#555]'
+          }`}
+        >
+          {compEnabled ? 'ON' : 'OFF'}
+        </button>
+        <div className="flex gap-2">
+          <Knob value={compThresh} min={-60} max={0} defaultValue={-24} onChange={(v) => updateTrackMixer(track.id, { compressorThreshold: v })} label="Thresh" unit="dB" size={34} step={1} disabled={!compEnabled} />
+          <Knob value={compRatio} min={1} max={20} defaultValue={4} onChange={(v) => updateTrackMixer(track.id, { compressorRatio: v })} label="Ratio" size={34} step={0.5} disabled={!compEnabled} />
+        </div>
+      </div>
+
+      {/* Local caption for stems */}
+      {(track.trackType === 'stems' || !track.trackType) && (
+        <>
+          <div className="w-px h-16 bg-[#444] self-center" />
+          <div className="flex flex-col gap-1 min-w-[160px] max-w-[240px]">
+            <SectionLabel>Local Caption</SectionLabel>
+            <textarea
+              value={track.localCaption ?? ''}
+              onChange={(e) => {
+                const store = useProjectStore.getState();
+                store.setTrackLocalCaption(track.id, e.target.value);
+              }}
+              placeholder={track.trackName}
+              rows={3}
+              className="text-[11px] text-zinc-300 bg-[#222] border border-[#444] rounded px-2 py-1 resize-none outline-none focus:border-daw-accent/60 placeholder:text-zinc-600"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function SmartControlsPanel() {
+  const showSmartControls = useUIStore((s) => s.showSmartControls);
+  const project = useProjectStore((s) => s.project);
+  const selectedClipIds = useUIStore((s) => s.selectedClipIds);
+
+  const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
+  const smartControlsHeight = 140;
+
+  if (!showSmartControls || !project) return null;
+
+  const selectedClipId = selectedClipIds.size === 1 ? [...selectedClipIds][0] : null;
+  let selectedTrack: Track | null = null;
+
+  if (selectedClipId) {
+    for (const t of project.tracks) {
+      if (t.clips.some(c => c.id === selectedClipId)) {
+        selectedTrack = t;
+        break;
+      }
+    }
+  }
+
+  if (!selectedTrack && project.tracks.length > 0) {
+    selectedTrack = project.tracks[0];
+  }
+
+  return (
+    <div
+      className="border-t border-[#1a1a1a] bg-gradient-to-b from-[#2d2d2d] to-[#262626] shrink-0"
+      style={{ height: smartControlsHeight }}
+    >
+      {/* Header bar */}
+      <div className="flex items-center h-6 px-3 border-b border-[#3a3a3a] bg-[#333]">
+        <span className="text-[10px] text-zinc-400 uppercase tracking-wider font-medium">Smart Controls</span>
+        <span className="flex-1" />
+        {selectedTrack && (
+          <span className="text-[10px] text-zinc-500">{selectedTrack.displayName}</span>
+        )}
+      </div>
+
+      {/* Controls area */}
+      <div className="flex items-center justify-center h-[calc(100%-24px)] overflow-x-auto">
+        {selectedTrack ? (
+          <TrackSmartControls track={selectedTrack} />
+        ) : (
+          <span className="text-[11px] text-zinc-600">Select a track to view controls</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -79,7 +79,7 @@ export function ExportDialog() {
         <div className="flex justify-end px-4 py-3 border-t border-daw-border gap-2">
           <button
             onClick={() => setShow(false)}
-            className="px-4 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
+            className="px-4 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
           >
             Cancel
           </button>

--- a/src/components/dialogs/InstrumentPicker.tsx
+++ b/src/components/dialogs/InstrumentPicker.tsx
@@ -80,7 +80,7 @@ export function InstrumentPicker() {
                   className={`flex flex-col gap-1.5 p-3 rounded-lg text-left transition-colors relative ${
                     comingSoon
                       ? 'bg-daw-surface-2/60 opacity-70 hover:opacity-90'
-                      : 'bg-daw-surface-2 hover:bg-zinc-600'
+                      : 'bg-daw-surface-2 hover:bg-[#484848]'
                   }`}
                   style={{ borderLeft: `3px solid ${info.color}` }}
                 >
@@ -115,7 +115,7 @@ export function InstrumentPicker() {
                 <button
                   key={name}
                   onClick={() => handleInstrumentSelect(name)}
-                  className="flex items-center gap-2 px-3 py-2.5 rounded text-left bg-daw-surface-2 hover:bg-zinc-600 cursor-pointer transition-colors relative"
+                  className="flex items-center gap-2 px-3 py-2.5 rounded text-left bg-daw-surface-2 hover:bg-[#484848] cursor-pointer transition-colors relative"
                   style={{ borderLeft: `3px solid ${info.color}` }}
                 >
                   <span className="text-lg">{info.emoji}</span>
@@ -135,7 +135,7 @@ export function InstrumentPicker() {
           <div className="p-5 flex flex-col gap-3">
             <button
               onClick={() => { addTrack('custom', 'sample'); close(); }}
-              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-zinc-600 transition-colors text-left"
+              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-[#484848] transition-colors text-left"
               style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.sample.color}` }}
             >
               <span className="text-xl">📂</span>
@@ -146,7 +146,7 @@ export function InstrumentPicker() {
             </button>
             <button
               onClick={() => { close(); openFilePicker(); }}
-              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-zinc-600 transition-colors text-left"
+              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-[#484848] transition-colors text-left"
               style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.sample.color}` }}
             >
               <span className="text-xl">📁</span>
@@ -169,7 +169,7 @@ export function InstrumentPicker() {
                 addTrack('percussion', 'sequencer');
                 close();
               }}
-              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-zinc-600 transition-colors text-left"
+              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-[#484848] transition-colors text-left"
               style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.sequencer.color}` }}
             >
               <span className="text-xl">🎹</span>

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -63,6 +63,14 @@ const SECTIONS: Section[] = [
     ],
   },
   {
+    title: 'Panels',
+    rows: [
+      { keys: ['X'],                    description: 'Toggle Mixer' },
+      { keys: ['B'],                    description: 'Toggle Smart Controls' },
+      { keys: ['O'],                    description: 'Toggle Loop Browser' },
+    ],
+  },
+  {
     title: 'Project',
     rows: [
       { keys: [`${mod}`, 'N'],         description: 'New project' },
@@ -70,7 +78,6 @@ const SECTIONS: Section[] = [
       { keys: [`${mod}`, ','],         description: 'Settings' },
       { keys: [`${mod}`, '⇧', 'E'],    description: 'Export' },
       { keys: [`${mod}`, '⇧', 'I'],    description: 'Add Track' },
-      { keys: ['M'],                    description: 'Toggle Mixer panel' },
       { keys: ['?'],                    description: 'This help overlay' },
     ],
   },
@@ -78,7 +85,7 @@ const SECTIONS: Section[] = [
 
 function Key({ label }: { label: string }) {
   return (
-    <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded text-[10px] font-mono font-semibold bg-zinc-700 border border-zinc-600 text-zinc-200 shadow-sm">
+    <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded text-[10px] font-mono font-semibold bg-[#444] border border-zinc-600 text-zinc-200 shadow-sm">
       {label}
     </kbd>
   );

--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -109,7 +109,7 @@ export function NewProjectDialog() {
         <div className="flex justify-end px-4 py-3 border-t border-daw-border gap-2">
           <button
             onClick={() => setShow(false)}
-            className="px-4 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
+            className="px-4 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
           >
             Cancel
           </button>

--- a/src/components/dialogs/ProjectListDialog.tsx
+++ b/src/components/dialogs/ProjectListDialog.tsx
@@ -133,7 +133,7 @@ export function ProjectListDialog() {
                     ) : (
                       <button
                         onClick={() => handleOpen(p.id)}
-                        className="px-2 py-1 text-[10px] font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
+                        className="px-2 py-1 text-[10px] font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
                       >
                         Open
                       </button>
@@ -155,21 +155,21 @@ export function ProjectListDialog() {
           <div className="flex gap-2">
             <button
               onClick={handleImport}
-              className="px-3 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
+              className="px-3 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
             >
               Import .acedaw
             </button>
             <button
               onClick={handleExport}
               disabled={!currentProject || exporting}
-              className="px-3 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-50"
+              className="px-3 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors disabled:opacity-50"
             >
               {exporting ? 'Packing...' : 'Export .acedaw'}
             </button>
           </div>
           <button
             onClick={() => setShow(false)}
-            className="px-3 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
+            className="px-3 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
           >
             Close
           </button>

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -342,7 +342,7 @@ export function SettingsDialog() {
                 type="button"
                 onClick={handleInitSelectedModel}
                 disabled={initLoading || !model}
-                className="px-2.5 py-1 text-[10px] font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-2.5 py-1 text-[10px] font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {initLoading ? 'Initializing...' : (selectedModelEntry?.is_loaded ? 'Reinitialize' : 'Initialize')}
               </button>
@@ -372,7 +372,7 @@ export function SettingsDialog() {
                   type="button"
                   onClick={handleInitSelectedLm}
                   disabled={initLoading || !selectedLmModel}
-                  className="px-2.5 py-1 text-[10px] font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-2.5 py-1 text-[10px] font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {initLoading ? 'Initializing...' : (selectedLmEntry?.is_loaded ? 'Reinitialize LLM' : 'Initialize LLM')}
                 </button>
@@ -403,7 +403,7 @@ export function SettingsDialog() {
         <div className="flex justify-end px-4 py-3 border-t border-daw-border gap-2">
           <button
             onClick={() => setShow(false)}
-            className="px-4 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
+            className="px-4 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
           >
             Cancel
           </button>

--- a/src/components/generation/AddLayerModal.tsx
+++ b/src/components/generation/AddLayerModal.tsx
@@ -250,7 +250,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
         {/* Body */}
         <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0">
           {/* Timeline diagram */}
-          <div className="bg-zinc-900/60 rounded px-3 pt-2 pb-4 border border-zinc-800">
+          <div className="bg-[#222]/60 rounded px-3 pt-2 pb-4 border border-[#3a3a3a]">
             <p className="text-[10px] text-zinc-400 mb-2">
               {hasContext
                 ? 'The model generates audio for the Select Window, conditioned on the Context Window.'
@@ -266,7 +266,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                 Select
               </span>
               <div className="absolute right-0" style={{ left: '44px', top: '0', bottom: '12px' }}>
-                <div className="absolute inset-x-0 bg-zinc-700 rounded" style={{ top: '50%', height: '2px', transform: 'translateY(-50%)' }} />
+                <div className="absolute inset-x-0 bg-[#444] rounded" style={{ top: '50%', height: '2px', transform: 'translateY(-50%)' }} />
                 {hasContext && (
                   <div
                     className="absolute rounded bg-blue-600/50 border border-blue-500/70"
@@ -333,7 +333,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
           )}
 
           {/* Select window — adjustable range slider */}
-          <div className="bg-zinc-900/60 rounded px-3 pt-2 pb-3 border border-zinc-800">
+          <div className="bg-[#222]/60 rounded px-3 pt-2 pb-3 border border-[#3a3a3a]">
             <div className="flex items-center gap-2 mb-1">
               <span className="text-[10px] font-medium text-zinc-300">{track.displayName}</span>
               <span className="text-[10px] text-zinc-600">Select window</span>
@@ -361,7 +361,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                 onChange={(e) => setLocalCaption(e.target.value)}
                 placeholder={`Describe the ${track.displayName} sound…`}
                 rows={3}
-                className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent"
+                className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent"
               />
             </div>
           )}
@@ -376,7 +376,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                 onChange={(e) => setLocalCaption(e.target.value)}
                 placeholder="Describe the sample you want…"
                 rows={3}
-                className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent"
+                className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent"
               />
             </div>
           )}
@@ -393,7 +393,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                 onChange={(e) => setGlobalCaption(e.target.value)}
                 placeholder="e.g. upbeat pop song with energetic drums…"
                 rows={2}
-                className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent"
+                className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent"
               />
             </div>
           )}
@@ -409,7 +409,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                 onChange={(e) => setLyrics(e.target.value)}
                 placeholder="Song lyrics…"
                 rows={4}
-                className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent font-mono"
+                className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent font-mono"
               />
             </div>
           )}
@@ -422,7 +422,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
               className={`px-2 py-0.5 rounded text-[10px] border transition-colors ${
                 chunkMaskMode === 'auto'
                   ? 'bg-teal-900/50 border-teal-700/50 text-teal-300'
-                  : 'bg-zinc-800 border-zinc-700 text-zinc-400'
+                  : 'bg-[#333] border-[#444] text-zinc-400'
               }`}
             >
               {chunkMaskMode === 'auto' ? 'Auto (model decides)' : 'Explicit (select window only)'}
@@ -430,7 +430,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
           </div>
 
           {/* Advanced options (collapsed) */}
-          <div className="border-t border-zinc-800 pt-2">
+          <div className="border-t border-[#3a3a3a] pt-2">
             <button
               type="button"
               onClick={() => setShowAdvanced((v) => !v)}
@@ -446,7 +446,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                       type="checkbox"
                       checked={sampleMode}
                       onChange={(e) => setSampleMode(e.target.checked)}
-                      className="w-3.5 h-3.5 rounded border-zinc-700 bg-zinc-900 accent-daw-accent"
+                      className="w-3.5 h-3.5 rounded border-[#444] bg-[#222] accent-daw-accent"
                     />
                     <span className="text-[10px] text-zinc-400">Sample Mode</span>
                   </label>
@@ -455,7 +455,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                       type="checkbox"
                       checked={autoExpandPrompt}
                       onChange={(e) => setAutoExpandPrompt(e.target.checked)}
-                      className="w-3.5 h-3.5 rounded border-zinc-700 bg-zinc-900 accent-daw-accent"
+                      className="w-3.5 h-3.5 rounded border-[#444] bg-[#222] accent-daw-accent"
                     />
                     <span className="text-[10px] text-zinc-400">Auto-expand prompt</span>
                   </label>
@@ -467,7 +467,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                     value={seedValue}
                     onChange={(e) => setSeedValue(e.target.value)}
                     placeholder="Leave empty for random"
-                    className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-1.5 text-xs text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-daw-accent"
+                    className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-1.5 text-xs text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-daw-accent"
                   />
                   <p className="mt-1 text-[9px] text-zinc-600">
                     Project: {project.bpm} BPM · {project.keyScale} · {project.timeSignature}/4
@@ -479,7 +479,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
 
           {/* Inferred metadata (edit mode only, when clip has been generated) */}
           {isEditMode && existingClip?.generationStatus === 'ready' && existingClip.inferredMetas && (
-            <div className="border-t border-zinc-800 pt-2">
+            <div className="border-t border-[#3a3a3a] pt-2">
               <p className="text-[9px] text-zinc-500 mb-1.5">Inferred by ACE-Step</p>
               <div className="grid grid-cols-3 gap-x-3 gap-y-1">
                 {existingClip.inferredMetas.bpm != null && (
@@ -530,7 +530,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
               <div className="flex items-center gap-2">
                 <button
                   onClick={handleSave}
-                  className="px-4 py-1.5 text-xs font-medium bg-zinc-800 hover:bg-zinc-700 text-zinc-300 rounded transition-colors"
+                  className="px-4 py-1.5 text-xs font-medium bg-[#333] hover:bg-[#444] text-zinc-300 rounded transition-colors"
                 >
                   Save
                 </button>
@@ -539,7 +539,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                   disabled={isGenerating}
                   className={`px-4 py-1.5 rounded text-xs font-medium transition-colors ${
                     isGenerating
-                      ? 'bg-zinc-700 text-zinc-500 cursor-not-allowed'
+                      ? 'bg-[#444] text-zinc-500 cursor-not-allowed'
                       : hasContext
                         ? 'bg-teal-600 hover:bg-teal-500 text-white'
                         : 'bg-violet-600 hover:bg-violet-500 text-white'
@@ -553,7 +553,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
             <>
               <button
                 onClick={() => { stopPreview(); onClose(); }}
-                className="px-3 py-1.5 rounded text-xs font-medium bg-zinc-800 hover:bg-zinc-700 text-zinc-300 transition-colors"
+                className="px-3 py-1.5 rounded text-xs font-medium bg-[#333] hover:bg-[#444] text-zinc-300 transition-colors"
               >
                 Cancel
               </button>
@@ -562,7 +562,7 @@ export function AddLayerModal({ trackId, startTime, duration, contextWindow, onC
                 disabled={isGenerating}
                 className={`px-4 py-1.5 rounded text-xs font-medium transition-colors ${
                   isGenerating
-                    ? 'bg-zinc-700 text-zinc-500 cursor-not-allowed'
+                    ? 'bg-[#444] text-zinc-500 cursor-not-allowed'
                     : hasContext
                       ? 'bg-teal-600 hover:bg-teal-500 text-white'
                       : 'bg-violet-600 hover:bg-violet-500 text-white'

--- a/src/components/generation/BatchGenerateModal.tsx
+++ b/src/components/generation/BatchGenerateModal.tsx
@@ -133,7 +133,7 @@ export function BatchGenerateModal({ mode, onClose }: Props) {
               {isSilence ? 'Parallel' : 'Sequential'}
             </span>
             {initialRange && (
-              <span className="px-1.5 py-0.5 rounded text-[9px] font-mono bg-zinc-700 text-zinc-300">
+              <span className="px-1.5 py-0.5 rounded text-[9px] font-mono bg-[#444] text-zinc-300">
                 {initialRange.startTime.toFixed(1)}s — {(initialRange.startTime + initialRange.duration).toFixed(1)}s
               </span>
             )}
@@ -159,7 +159,7 @@ export function BatchGenerateModal({ mode, onClose }: Props) {
               onChange={(e) => setGlobalCaption(e.target.value)}
               placeholder="e.g. upbeat pop song with energetic drums and warm bass…"
               rows={2}
-              className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent"
+              className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent"
             />
             {!isSilence && (
               <p className="text-zinc-600 text-[10px]">
@@ -189,7 +189,7 @@ export function BatchGenerateModal({ mode, onClose }: Props) {
                     className={`rounded border transition-colors ${
                       row.checked
                         ? 'border-daw-accent/40 bg-daw-accent/5'
-                        : 'border-zinc-800 bg-zinc-900/40'
+                        : 'border-[#3a3a3a] bg-[#222]/40'
                     }`}
                   >
                     {/* Track header row */}
@@ -217,8 +217,8 @@ export function BatchGenerateModal({ mode, onClose }: Props) {
                         onChange={(e) => updateDescription(row.trackId, e.target.value)}
                         placeholder={`${row.displayName} track description (optional)…`}
                         rows={2}
-                        className={`w-full bg-zinc-900 border rounded px-2 py-1.5 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none ${
-                          row.checked ? 'border-zinc-700 focus:border-daw-accent' : 'border-zinc-800 opacity-50'
+                        className={`w-full bg-[#222] border rounded px-2 py-1.5 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none ${
+                          row.checked ? 'border-[#444] focus:border-daw-accent' : 'border-[#3a3a3a] opacity-50'
                         }`}
                       />
                     </div>
@@ -234,8 +234,8 @@ export function BatchGenerateModal({ mode, onClose }: Props) {
                           onChange={(e) => updateLyrics(row.trackId, e.target.value)}
                           placeholder="Song lyrics…"
                           rows={3}
-                          className={`w-full bg-zinc-900 border rounded px-2 py-1.5 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none font-mono ${
-                            row.checked ? 'border-zinc-700 focus:border-daw-accent' : 'border-zinc-800 opacity-50'
+                          className={`w-full bg-[#222] border rounded px-2 py-1.5 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none font-mono ${
+                            row.checked ? 'border-[#444] focus:border-daw-accent' : 'border-[#3a3a3a] opacity-50'
                           }`}
                         />
                       </div>
@@ -255,7 +255,7 @@ export function BatchGenerateModal({ mode, onClose }: Props) {
               <button
                 onClick={() => setSharedSeed(randomSeed())}
                 title="Randomize seed"
-                className="px-2 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 transition-colors text-zinc-300 text-sm leading-none"
+                className="px-2 py-1.5 rounded bg-[#333] hover:bg-[#444] border border-[#444] transition-colors text-zinc-300 text-sm leading-none"
               >
                 🔀
               </button>
@@ -263,7 +263,7 @@ export function BatchGenerateModal({ mode, onClose }: Props) {
                 type="number"
                 value={sharedSeed}
                 onChange={(e) => setSharedSeed(Number(e.target.value))}
-                className="flex-1 bg-zinc-900 border border-zinc-700 rounded px-2.5 py-1.5 text-xs text-zinc-100 focus:outline-none focus:border-daw-accent font-mono"
+                className="flex-1 bg-[#222] border border-[#444] rounded px-2.5 py-1.5 text-xs text-zinc-100 focus:outline-none focus:border-daw-accent font-mono"
                 min={0}
                 max={2147483647}
               />
@@ -278,7 +278,7 @@ export function BatchGenerateModal({ mode, onClose }: Props) {
         <div className="flex items-center justify-between px-4 py-3 border-t border-daw-border">
           <button
             onClick={onClose}
-            className="px-3 py-1.5 rounded text-xs font-medium bg-zinc-800 hover:bg-zinc-700 text-zinc-300 transition-colors"
+            className="px-3 py-1.5 rounded text-xs font-medium bg-[#333] hover:bg-[#444] text-zinc-300 transition-colors"
           >
             Cancel
           </button>
@@ -290,7 +290,7 @@ export function BatchGenerateModal({ mode, onClose }: Props) {
                 ? isSilence
                   ? 'bg-violet-600 hover:bg-violet-500 text-white'
                   : 'bg-teal-600 hover:bg-teal-500 text-white'
-                : 'bg-zinc-700 text-zinc-500 cursor-not-allowed'
+                : 'bg-[#444] text-zinc-500 cursor-not-allowed'
             }`}
           >
             {isSilence ? '⬜' : '🎵'}

--- a/src/components/generation/GenerationPanel.tsx
+++ b/src/components/generation/GenerationPanel.tsx
@@ -19,7 +19,7 @@ export function GenerationPanel() {
         />
       )}
 
-      <div className="border-t border-daw-border bg-daw-surface">
+      <div className="border-t border-[#1a1a1a] bg-[#2a2a2a]">
         <div className="flex items-center h-9 px-3 gap-3">
           {jobs.length > 0 && (
             <>
@@ -34,7 +34,7 @@ export function GenerationPanel() {
                           ? 'bg-red-900/50 text-red-300'
                           : job.status === 'generating'
                             ? 'bg-indigo-900/50 text-indigo-300'
-                            : 'bg-zinc-800 text-zinc-400'
+                            : 'bg-[#333] text-zinc-400'
                     }`}
                   >
                     {job.status === 'generating' && (

--- a/src/components/generation/MultiTrackGenerateModal.tsx
+++ b/src/components/generation/MultiTrackGenerateModal.tsx
@@ -200,11 +200,11 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
       <div
-        className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl flex flex-col"
+        className="bg-[#222] border border-[#444] rounded-lg shadow-xl flex flex-col"
         style={{ width: 580, maxHeight: '90vh' }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-700">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[#444]">
           <div className="flex items-center gap-2">
             <span className="text-sm font-semibold text-zinc-100">Generate Tracks</span>
             <span
@@ -228,7 +228,7 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
         {/* Body */}
         <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 text-xs text-zinc-300">
           {/* Timeline diagram */}
-          <div className="bg-zinc-900/60 rounded px-3 pt-2 pb-4 border border-zinc-800">
+          <div className="bg-[#222]/60 rounded px-3 pt-2 pb-4 border border-[#3a3a3a]">
             <p className="text-[10px] text-zinc-400 mb-2">
               {hasContext
                 ? 'The model generates audio for the Select Window, conditioned on the Context Window.'
@@ -338,7 +338,7 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
               className={`px-2 py-0.5 rounded text-[10px] border transition-colors ${
                 chunkMaskMode === 'auto'
                   ? 'bg-teal-900/50 border-teal-700/50 text-teal-300'
-                  : 'bg-zinc-800 border-zinc-700 text-zinc-400'
+                  : 'bg-[#333] border-[#444] text-zinc-400'
               }`}
             >
               {chunkMaskMode === 'auto' ? 'Auto (model decides)' : 'Explicit (select window only)'}
@@ -357,8 +357,8 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
                 key={row.trackId}
                 className={`rounded border p-2 space-y-1 transition-colors ${
                   row.checked
-                    ? 'bg-zinc-800/60 border-zinc-700'
-                    : 'bg-zinc-900/40 border-zinc-800 opacity-60'
+                    ? 'bg-[#333]/60 border-[#444]'
+                    : 'bg-[#222]/40 border-[#3a3a3a] opacity-60'
                 }`}
               >
                 <label className="flex items-center gap-2 cursor-pointer">
@@ -378,7 +378,7 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
                       onChange={(e) => updateRowField(idx, 'localDescription', e.target.value)}
                       placeholder="Local description for this track…"
                       rows={2}
-                      className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-[11px] text-zinc-200 placeholder-zinc-600 resize-none focus:outline-none focus:ring-1 focus:ring-teal-600"
+                      className="w-full bg-[#222] border border-[#444] rounded px-2 py-1 text-[11px] text-zinc-200 placeholder-zinc-600 resize-none focus:outline-none focus:ring-1 focus:ring-teal-600"
                     />
                     {row.isVocal && (
                       <textarea
@@ -386,7 +386,7 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
                         onChange={(e) => updateRowField(idx, 'lyrics', e.target.value)}
                         placeholder="Lyrics…"
                         rows={2}
-                        className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-[11px] text-zinc-200 placeholder-zinc-600 resize-none focus:outline-none focus:ring-1 focus:ring-teal-600"
+                        className="w-full bg-[#222] border border-[#444] rounded px-2 py-1 text-[11px] text-zinc-200 placeholder-zinc-600 resize-none focus:outline-none focus:ring-1 focus:ring-teal-600"
                       />
                     )}
                   </div>
@@ -405,7 +405,7 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
               onChange={(e) => setGlobalCaption(e.target.value)}
               placeholder="Describe the overall song (genre, mood, tempo…)"
               rows={2}
-              className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1.5 text-[11px] text-zinc-200 placeholder-zinc-600 resize-none focus:outline-none focus:ring-1 focus:ring-teal-600"
+              className="w-full bg-[#222] border border-[#444] rounded px-2 py-1.5 text-[11px] text-zinc-200 placeholder-zinc-600 resize-none focus:outline-none focus:ring-1 focus:ring-teal-600"
             />
           </div>
 
@@ -416,11 +416,11 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
               type="number"
               value={sharedSeed}
               onChange={(e) => setSharedSeed(parseInt(e.target.value) || 0)}
-              className="flex-1 bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-[11px] text-zinc-200 focus:outline-none focus:ring-1 focus:ring-teal-600 w-28"
+              className="flex-1 bg-[#222] border border-[#444] rounded px-2 py-1 text-[11px] text-zinc-200 focus:outline-none focus:ring-1 focus:ring-teal-600 w-28"
             />
             <button
               onClick={() => setSharedSeed(Math.floor(Math.random() * 2 ** 31))}
-              className="text-[10px] px-2 py-1 rounded bg-zinc-800 border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 transition-colors"
+              className="text-[10px] px-2 py-1 rounded bg-[#333] border border-[#444] text-zinc-400 hover:text-zinc-200 hover:bg-[#444] transition-colors"
             >
               🎲
             </button>
@@ -428,10 +428,10 @@ export function MultiTrackGenerateModal({ selectWindow, contextWindow, onClose }
         </div>
 
         {/* Footer */}
-        <div className="flex justify-end gap-2 px-4 py-3 border-t border-zinc-700">
+        <div className="flex justify-end gap-2 px-4 py-3 border-t border-[#444]">
           <button
             onClick={onClose}
-            className="px-3 py-1.5 rounded text-xs text-zinc-400 border border-zinc-700 hover:bg-zinc-800 transition-colors"
+            className="px-3 py-1.5 rounded text-xs text-zinc-400 border border-[#444] hover:bg-[#333] transition-colors"
           >
             Cancel
           </button>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -13,6 +13,7 @@ import { KeyboardShortcutsDialog } from '../dialogs/KeyboardShortcutsDialog';
 import { MixerPanel } from '../mixer/MixerPanel';
 import { AssetsPanel } from '../assets/AssetsPanel';
 import { SequencerEditor } from '../sequencer/SequencerEditor';
+import { SmartControlsPanel } from '../controls/SmartControlsPanel';
 import { useAudioEngine } from '../../hooks/useAudioEngine';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
@@ -36,7 +37,7 @@ export function AppShell() {
   useKeyboardShortcuts();
 
   return (
-    <div className="flex flex-col h-screen" onClick={handleClick}>
+    <div className="flex flex-col h-screen bg-daw-bg text-zinc-300" onClick={handleClick}>
       <Toolbar />
 
       <div className="flex flex-1 min-h-0">
@@ -45,6 +46,7 @@ export function AppShell() {
         {project && <AssetsPanel />}
       </div>
 
+      {project && <SmartControlsPanel />}
       {project && <SequencerEditor />}
       {project && <MixerPanel />}
       {project && <GenerationPanel />}

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -21,26 +21,24 @@ export function StatusBar() {
   }, []);
 
   return (
-    <div className="flex items-center h-6 px-3 gap-4 bg-daw-surface border-t border-daw-border text-[11px] text-zinc-500">
+    <div className="flex items-center h-5 px-3 gap-4 bg-gradient-to-b from-[#2a2a2a] to-[#232323] border-t border-[#1a1a1a] text-[10px] text-zinc-500">
       <div className="flex items-center gap-1.5">
-        <div
-          className={`w-2 h-2 rounded-full ${connected ? 'bg-emerald-500' : 'bg-red-500'}`}
-        />
-        <span>{connected ? 'Connected' : 'Disconnected'}</span>
+        <div className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-emerald-500' : 'bg-red-500'}`} />
+        <span>{connected ? 'Connected' : 'Offline'}</span>
       </div>
-      <span>{model || 'Server Default'}</span>
+      {model && <span className="text-zinc-600">{model}</span>}
       {activeJobs.length > 0 && (
-        <span>Queue: {activeJobs.length}</span>
+        <span className="text-daw-accent">Generating: {activeJobs.length}</span>
       )}
       <span className="flex-1" />
       <a
         href="http://acestudio.ai/"
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 text-zinc-500 hover:text-violet-400 transition-colors"
+        className="flex items-center gap-1 text-zinc-600 hover:text-daw-accent transition-colors"
       >
-        <img src="/logo.png" alt="" width={14} height={14} className="rounded-sm opacity-60" />
-        ACE Studio ↗
+        <img src="/logo.png" alt="" width={12} height={12} className="rounded-sm opacity-50" />
+        ACE Studio
       </a>
     </div>
   );

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -2,16 +2,58 @@ import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { useTransportStore } from '../../store/transportStore';
 import { useAudioImport } from '../../hooks/useAudioImport';
-import { TransportBar } from '../transport/TransportBar';
+import { useTransport } from '../../hooks/useTransport';
+import { formatTime, formatBarsBeats } from '../../utils/time';
+
+function LCDDisplay() {
+  const currentTime = useTransportStore((s) => s.currentTime);
+  const project = useProjectStore((s) => s.project);
+  const barsBeats = project
+    ? formatBarsBeats(currentTime, project.bpm, project.timeSignature)
+    : '1.1.00';
+
+  return (
+    <div className="gb-lcd flex items-center gap-3 px-3 py-1 min-w-[200px] justify-center">
+      <span className="text-[13px] font-mono text-green-400 tracking-wider">{barsBeats}</span>
+      <span className="text-[11px] font-mono text-zinc-400">{formatTime(currentTime)}</span>
+      {project && (
+        <span className="text-[11px] font-mono text-zinc-500">{project.bpm} bpm</span>
+      )}
+    </div>
+  );
+}
+
+function ControlBarButton({
+  active,
+  onClick,
+  title,
+  disabled,
+  children,
+}: {
+  active?: boolean;
+  onClick: () => void;
+  title: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      className={`w-8 h-7 flex items-center justify-center rounded transition-colors ${
+        active
+          ? 'bg-daw-accent text-white shadow-sm'
+          : 'text-zinc-400 hover:text-zinc-200 hover:bg-daw-surface-2 disabled:opacity-30 disabled:hover:bg-transparent'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
 
 export function Toolbar() {
   const project = useProjectStore((s) => s.project);
-  const splitClip = useProjectStore((s) => s.splitClip);
-  const removeClip = useProjectStore((s) => s.removeClip);
-  const duplicateClip = useProjectStore((s) => s.duplicateClip);
-  const selectedClipIds = useUIStore((s) => s.selectedClipIds);
-  const deselectAll = useUIStore((s) => s.deselectAll);
-  const currentTime = useTransportStore((s) => s.currentTime);
   const setShowNewProjectDialog = useUIStore((s) => s.setShowNewProjectDialog);
   const setShowSettingsDialog = useUIStore((s) => s.setShowSettingsDialog);
   const setShowExportDialog = useUIStore((s) => s.setShowExportDialog);
@@ -21,139 +63,200 @@ export function Toolbar() {
   const setShowMixer = useUIStore((s) => s.setShowMixer);
   const showAssetsPanel = useUIStore((s) => s.showAssetsPanel);
   const setShowAssetsPanel = useUIStore((s) => s.setShowAssetsPanel);
+  const showLibrary = useUIStore((s) => s.showLibrary);
+  const setShowLibrary = useUIStore((s) => s.setShowLibrary);
+  const showSmartControls = useUIStore((s) => s.showSmartControls);
+  const setShowSmartControls = useUIStore((s) => s.setShowSmartControls);
   const { openFilePicker } = useAudioImport();
 
-  const hasSelection = selectedClipIds.size > 0;
-  const singleSelected = selectedClipIds.size === 1 ? [...selectedClipIds][0] : null;
+  const { isPlaying, play, pause, stop } = useTransport();
+  const loopEnabled = useTransportStore((s) => s.loopEnabled);
+  const toggleLoop = useTransportStore((s) => s.toggleLoop);
+  const metronomeEnabled = useTransportStore((s) => s.metronomeEnabled);
+  const toggleMetronome = useTransportStore((s) => s.toggleMetronome);
+  const zoomIn = useUIStore((s) => s.zoomIn);
+  const zoomOut = useUIStore((s) => s.zoomOut);
 
   return (
-    <div className="flex items-center h-10 px-3 gap-2 bg-daw-surface border-b border-daw-border shrink-0">
-      {/* App logo */}
-      <img src="/logo.png" alt="ACE-Step" width={22} height={22} className="rounded-sm shrink-0" />
-      <div className="w-px h-5 bg-daw-border" />
-
-      {/* Left section */}
-      <button
-        onClick={() => setShowProjectListDialog(true)}
-        className="px-3 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
-      >
-        Projects
-      </button>
-      <button
-        onClick={() => setShowNewProjectDialog(true)}
-        className="px-3 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
-      >
-        New
-      </button>
-      <button
-        onClick={() => setShowExportDialog(true)}
-        className="px-3 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
-        disabled={!project}
-      >
-        Export
-      </button>
-
-      <div className="w-px h-5 bg-daw-border" />
-
-      <button
-        onClick={openFilePicker}
-        disabled={!project}
-        className="px-3 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-40"
-        title="Import audio file"
-      >
-        Import
-      </button>
-
-      <div className="w-px h-5 bg-daw-border" />
-
-      {/* Editing tools */}
-      <button
-        onClick={() => singleSelected && splitClip(singleSelected, currentTime)}
-        disabled={!singleSelected}
-        className="px-2.5 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-30"
-        title="Split clip at playhead (S)"
-      >
-        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="inline -mt-px mr-1">
-          <path d="M7 1v12M3 4l4 3-4 3M11 4l-4 3 4 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-        </svg>
-        Split
-      </button>
-      <button
-        onClick={() => {
-          if (hasSelection) {
-            const ids = [...selectedClipIds];
-            deselectAll();
-            ids.forEach((id) => removeClip(id));
-          }
-        }}
-        disabled={!hasSelection}
-        className="px-2.5 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-30"
-        title="Delete selected clips (Del)"
-      >
-        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="inline -mt-px mr-1">
-          <path d="M2.5 4h9M5 4V2.5h4V4M3.5 4v7.5a1 1 0 001 1h5a1 1 0 001-1V4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
-        </svg>
-        Delete
-      </button>
-      <button
-        onClick={() => singleSelected && duplicateClip(singleSelected)}
-        disabled={!singleSelected}
-        className="px-2.5 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors disabled:opacity-30"
-        title="Duplicate clip (Cmd+D)"
-      >
-        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="inline -mt-px mr-1">
-          <rect x="1.5" y="3.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.3"/>
-          <path d="M5.5 3.5V2.5a1 1 0 011-1h5a1 1 0 011 1v5a1 1 0 01-1 1h-1" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
-        </svg>
-        Duplicate
-      </button>
-
-      {/* Center section: Transport controls */}
-      <div className="flex-1 flex items-center justify-center">
-        <TransportBar />
+    <div className="flex items-center h-11 px-2 gap-1 bg-gradient-to-b from-[#3a3a3a] to-[#2d2d2d] border-b border-[#1a1a1a] shrink-0 select-none">
+      {/* Left: Panel toggle buttons */}
+      <div className="flex items-center gap-0.5">
+        <ControlBarButton
+          active={showLibrary}
+          onClick={() => setShowLibrary(!showLibrary)}
+          title="Library (Y)"
+          disabled={!project}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4">
+            <rect x="1" y="2" width="12" height="10" rx="1.5" />
+            <line x1="5" y1="2" x2="5" y2="12" />
+          </svg>
+        </ControlBarButton>
+        <ControlBarButton
+          active={showSmartControls}
+          onClick={() => setShowSmartControls(!showSmartControls)}
+          title="Smart Controls (B)"
+          disabled={!project}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4">
+            <circle cx="4" cy="7" r="2.5" />
+            <circle cx="10" cy="7" r="2.5" />
+            <line x1="4" y1="4.5" x2="4" y2="2" />
+            <line x1="10" y1="4.5" x2="10" y2="2" />
+          </svg>
+        </ControlBarButton>
       </div>
 
-      {/* Right section: panel toggles + settings */}
-      <button
-        onClick={() => setShowMixer(!showMixer)}
-        disabled={!project}
-        className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
-          showMixer
-            ? 'bg-indigo-600 text-white hover:bg-indigo-500'
-            : 'bg-daw-surface-2 hover:bg-zinc-600 text-zinc-300 disabled:opacity-40'
-        }`}
-        title="Toggle Mixer (M)"
-      >
-        Mixer
-      </button>
-      <button
-        onClick={() => setShowAssetsPanel(!showAssetsPanel)}
-        disabled={!project}
-        className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
-          showAssetsPanel
-            ? 'bg-indigo-600 text-white hover:bg-indigo-500'
-            : 'bg-daw-surface-2 hover:bg-zinc-600 text-zinc-300 disabled:opacity-40'
-        }`}
-        title="Toggle Assets Panel"
-      >
-        Assets
-      </button>
+      <div className="w-px h-6 bg-[#555]" />
 
-      <div className="w-px h-5 bg-daw-border" />
+      {/* Left-center: Project actions */}
+      <div className="flex items-center gap-0.5">
+        <button onClick={() => setShowProjectListDialog(true)} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors" title="Projects">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" className="inline -mt-px mr-1">
+            <path d="M1.5 4.5L7 1.5l5.5 3M1.5 7l5.5 3 5.5-3M1.5 9.5l5.5 3 5.5-3" />
+          </svg>
+          Projects
+        </button>
+        <button onClick={() => setShowNewProjectDialog(true)} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors" title="New Project">
+          New
+        </button>
+        <button onClick={() => setShowExportDialog(true)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Export">
+          Export
+        </button>
+        <button onClick={openFilePicker} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Import Audio">
+          Import
+        </button>
+      </div>
 
-      <button
-        onClick={() => setShowSettingsDialog(true)}
-        className="px-3 py-1 text-xs font-medium bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
-      >
-        Settings
-      </button>
-      <button
-        onClick={() => setShowKeyboardShortcutsDialog(true)}
-        title="Keyboard shortcuts (?)"
-        className="w-6 h-6 text-xs font-bold bg-daw-surface-2 hover:bg-zinc-600 text-zinc-400 hover:text-zinc-200 rounded transition-colors flex items-center justify-center"
-      >
-        ?
-      </button>
+      <div className="flex-1" />
+
+      {/* Center: Transport controls */}
+      <div className="flex items-center gap-0.5">
+        {/* Rewind */}
+        <ControlBarButton onClick={stop} title="Go to Beginning (Enter)">
+          <svg width="14" height="12" viewBox="0 0 14 12" fill="currentColor">
+            <rect x="0" y="1" width="2" height="10" rx="0.5" />
+            <path d="M13 1L5 6l8 5V1z" />
+          </svg>
+        </ControlBarButton>
+        {/* Play/Pause */}
+        <button
+          onClick={() => (isPlaying ? pause() : play())}
+          className={`w-9 h-8 flex items-center justify-center rounded transition-colors ${
+            isPlaying
+              ? 'bg-daw-accent text-white'
+              : 'text-zinc-300 hover:text-white hover:bg-daw-surface-2'
+          }`}
+          title={isPlaying ? 'Pause (Space)' : 'Play (Space)'}
+        >
+          {isPlaying ? (
+            <svg width="12" height="14" viewBox="0 0 12 14" fill="currentColor">
+              <rect width="4" height="14" rx="1" />
+              <rect x="8" width="4" height="14" rx="1" />
+            </svg>
+          ) : (
+            <svg width="12" height="14" viewBox="0 0 12 14" fill="currentColor">
+              <path d="M0 0L12 7L0 14V0Z" />
+            </svg>
+          )}
+        </button>
+        {/* Record placeholder */}
+        <ControlBarButton onClick={() => {}} title="Record (R)" disabled>
+          <div className="w-3.5 h-3.5 rounded-full bg-red-500 opacity-60" />
+        </ControlBarButton>
+      </div>
+
+      <div className="w-px h-6 bg-[#555] mx-1" />
+
+      {/* LCD Display */}
+      <LCDDisplay />
+
+      <div className="w-px h-6 bg-[#555] mx-1" />
+
+      {/* Cycle + Metronome */}
+      <div className="flex items-center gap-0.5">
+        <ControlBarButton active={loopEnabled} onClick={toggleLoop} title="Cycle (C)">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M10 1l2 2-2 2" />
+            <path d="M4 13l-2-2 2-2" />
+            <path d="M12 3H5a3 3 0 0 0 0 6" />
+            <path d="M2 11h7a3 3 0 0 0 0-6" />
+          </svg>
+        </ControlBarButton>
+        <ControlBarButton active={metronomeEnabled} onClick={toggleMetronome} title="Metronome (K)">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 13L7 1l3 12" />
+            <path d="M3 13h8" />
+            <path d="M7 5l4-2" />
+          </svg>
+        </ControlBarButton>
+      </div>
+
+      <div className="flex-1" />
+
+      {/* Right: Panel toggles */}
+      <div className="flex items-center gap-0.5">
+        <ControlBarButton
+          active={showMixer}
+          onClick={() => setShowMixer(!showMixer)}
+          title="Mixer (X)"
+          disabled={!project}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4">
+            <line x1="3" y1="2" x2="3" y2="12" />
+            <line x1="7" y1="2" x2="7" y2="12" />
+            <line x1="11" y1="2" x2="11" y2="12" />
+            <circle cx="3" cy="8" r="1.5" fill="currentColor" />
+            <circle cx="7" cy="5" r="1.5" fill="currentColor" />
+            <circle cx="11" cy="9" r="1.5" fill="currentColor" />
+          </svg>
+        </ControlBarButton>
+        <ControlBarButton
+          active={showAssetsPanel}
+          onClick={() => setShowAssetsPanel(!showAssetsPanel)}
+          title="Loop Browser (O)"
+          disabled={!project}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4">
+            <circle cx="6" cy="6" r="4" />
+            <path d="M9 9l3.5 3.5" strokeLinecap="round" />
+          </svg>
+        </ControlBarButton>
+      </div>
+
+      <div className="w-px h-6 bg-[#555]" />
+
+      {/* Settings + Shortcuts */}
+      <div className="flex items-center gap-0.5">
+        <button
+          onClick={() => setShowSettingsDialog(true)}
+          className="px-2 py-1 text-[11px] text-zinc-400 hover:text-white hover:bg-daw-surface-2 rounded transition-colors"
+          title="Settings"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3">
+            <circle cx="7" cy="7" r="2" />
+            <path d="M7 1v1.5M7 11.5V13M1 7h1.5M11.5 7H13M2.8 2.8l1 1M10.2 10.2l1 1M11.2 2.8l-1 1M3.8 10.2l-1 1" />
+          </svg>
+        </button>
+        <button
+          onClick={() => setShowKeyboardShortcutsDialog(true)}
+          title="Keyboard Shortcuts (?)"
+          className="w-6 h-6 text-[11px] font-bold text-zinc-500 hover:text-white hover:bg-daw-surface-2 rounded transition-colors flex items-center justify-center"
+        >
+          ?
+        </button>
+      </div>
+
+      {/* Zoom controls */}
+      <div className="w-px h-6 bg-[#555] ml-1" />
+      <div className="flex items-center gap-0.5">
+        <button onClick={zoomOut} className="w-6 h-6 text-zinc-400 hover:text-white flex items-center justify-center rounded hover:bg-daw-surface-2 transition-colors text-sm" title="Zoom Out">
+          −
+        </button>
+        <button onClick={zoomIn} className="w-6 h-6 text-zinc-400 hover:text-white flex items-center justify-center rounded hover:bg-daw-surface-2 transition-colors text-sm" title="Zoom In">
+          +
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -30,7 +30,7 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
   const compRatio = track.compressorRatio ?? 4;
 
   return (
-    <div className="flex flex-col items-center gap-1.5 px-3 py-2 bg-daw-surface border-r border-daw-border min-w-[120px]">
+    <div className="flex flex-col items-center gap-1.5 px-3 py-2 bg-[#2a2a2a] border-r border-[#3a3a3a] min-w-[120px]">
       <div className="w-full h-1.5 rounded-full mb-0.5" style={{ backgroundColor: track.color }} />
       <span className="text-xs text-zinc-300 font-medium leading-none truncate w-full text-center uppercase tracking-wide" title={track.displayName}>
         {track.displayName}
@@ -40,7 +40,7 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
         <button
           onClick={() => updateTrack(track.id, { muted: !track.muted })}
           className={`text-xs font-bold px-2.5 py-1 rounded transition-colors ${
-            track.muted ? 'bg-amber-500 text-black' : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600'
+            track.muted ? 'bg-amber-500 text-black' : 'bg-[#444] text-zinc-400 hover:bg-[#484848]'
           }`}
         >
           M
@@ -48,7 +48,7 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
         <button
           onClick={() => updateTrack(track.id, { soloed: !track.soloed })}
           className={`text-xs font-bold px-2.5 py-1 rounded transition-colors ${
-            track.soloed ? 'bg-emerald-500 text-black' : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600'
+            track.soloed ? 'bg-emerald-500 text-black' : 'bg-[#444] text-zinc-400 hover:bg-[#484848]'
           }`}
         >
           S
@@ -68,7 +68,7 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
       <button
         onClick={() => updateTrackMixer(track.id, { compressorEnabled: !compEnabled })}
         className={`text-xs font-semibold px-2 py-1 rounded w-full transition-colors ${
-          compEnabled ? 'bg-indigo-600 text-white' : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600'
+          compEnabled ? 'bg-daw-accent text-white' : 'bg-[#444] text-zinc-400 hover:bg-[#555]'
         }`}
       >
         {compEnabled ? 'ON' : 'OFF'}
@@ -103,7 +103,7 @@ function MasterStrip({ faderHeight }: MasterStripProps) {
   const handleChange = (v: number) => { updateProject({ masterVolume: v }); getAudioEngine().masterVolume = v; };
 
   return (
-    <div className="flex flex-col items-center gap-1.5 px-4 py-2 bg-zinc-900 border-l-2 border-zinc-600 min-w-[120px]">
+    <div className="flex flex-col items-center gap-1.5 px-4 py-2 bg-[#252525] border-l-2 border-[#555] min-w-[120px]">
       <span className="text-xs font-bold text-zinc-300 uppercase tracking-widest">Master</span>
       <div className="flex-1 flex flex-col items-center justify-end gap-1 w-full">
         <div className="relative flex justify-center" style={{ height: faderHeight }}>
@@ -111,7 +111,7 @@ function MasterStrip({ faderHeight }: MasterStripProps) {
             type="range" min={0} max={1.5} step={0.01} value={masterVol}
             onChange={(e) => handleChange(parseFloat(e.target.value))}
             className="appearance-none bg-transparent cursor-pointer"
-            style={{ writingMode: 'vertical-lr', direction: 'rtl', width: 32, height: faderHeight, accentColor: '#6366f1' }}
+            style={{ writingMode: 'vertical-lr', direction: 'rtl', width: 32, height: faderHeight, accentColor: '#4a90d9' }}
           />
         </div>
         <span className="text-xs font-mono text-zinc-400">{volumeToDb(masterVol)}</span>
@@ -153,9 +153,9 @@ export function MixerPanel() {
   const faderHeight = Math.max(60, mixerHeight - 300);
 
   return (
-    <div className="border-t border-daw-border bg-daw-surface flex flex-col select-none shrink-0" style={{ height: mixerHeight }}>
+    <div className="border-t border-[#1a1a1a] bg-[#2a2a2a] flex flex-col select-none shrink-0" style={{ height: mixerHeight }}>
       <div
-        className="h-1.5 w-full cursor-ns-resize bg-zinc-700 hover:bg-indigo-500 transition-colors flex-shrink-0"
+        className="h-1.5 w-full cursor-ns-resize bg-[#444] hover:bg-daw-accent transition-colors flex-shrink-0"
         onMouseDown={onResizeMouseDown}
         title="Drag to resize mixer"
       />

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -292,16 +292,17 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     <>
       <div
         ref={clipBlockRef}
-        className={`absolute top-1 bottom-1 rounded-sm select-none overflow-hidden
+        className={`absolute top-1 bottom-1 rounded-md select-none overflow-hidden
           ${statusStyles[clip.generationStatus] ?? ''}
-          ${isSelected ? 'ring-2 ring-white ring-offset-1 ring-offset-transparent' : ''}
+          ${isSelected ? 'ring-2 ring-white/80 ring-offset-1 ring-offset-transparent' : ''}
           ${dragGhost && dragGhost.targetTrackId && !dragGhost.isShiftCopy ? 'opacity-0' : ''}
         `}
         style={{
           left,
           width: Math.max(width, 4),
-          backgroundColor: hexToRgba(track.color, 0.3),
-          borderLeft: `2px solid ${track.color}`,
+          background: `linear-gradient(180deg, ${hexToRgba(track.color, 0.45)} 0%, ${hexToRgba(track.color, 0.28)} 100%)`,
+          borderLeft: `3px solid ${track.color}`,
+          boxShadow: isSelected ? `0 0 8px ${hexToRgba(track.color, 0.3)}` : 'none',
         }}
         data-clip-block
         onMouseDown={handleMouseDown}
@@ -558,50 +559,30 @@ function ClipContextMenu({
     <>
       <div className="fixed inset-0 z-40" onClick={onClose} onContextMenu={(e) => { e.preventDefault(); onClose(); }} />
       <div
-        className="fixed z-50 bg-daw-surface border border-daw-border rounded shadow-xl py-1 min-w-[180px]"
+        className="fixed z-50 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[180px] backdrop-blur-sm"
         style={{ left: clampedX, top: clampedY }}
       >
-        <button
-          onClick={onEdit}
-          className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors"
-        >
+        <button onClick={onEdit} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors">
           Edit Clip
         </button>
         {isReady ? (
-          <button
-            onClick={onRegenerate}
-            disabled={!hasPrompt}
-            className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors disabled:text-zinc-600 disabled:cursor-not-allowed"
-          >
+          <button onClick={onRegenerate} disabled={!hasPrompt} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors disabled:text-zinc-600 disabled:cursor-not-allowed">
             Re-generate
           </button>
         ) : (
-          <button
-            onClick={onGenerate}
-            disabled={!hasPrompt}
-            className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors disabled:text-zinc-600 disabled:cursor-not-allowed"
-          >
+          <button onClick={onGenerate} disabled={!hasPrompt} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors disabled:text-zinc-600 disabled:cursor-not-allowed">
             Generate
           </button>
         )}
-        <button
-          onClick={onDuplicate}
-          className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors"
-        >
+        <button onClick={onDuplicate} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors">
           Duplicate
         </button>
-        <div className="my-1 border-t border-daw-border" />
-        <button
-          onClick={onAddLayer}
-          className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors"
-        >
-          Add Layer here…
+        <div className="my-1 border-t border-[#555]" />
+        <button onClick={onAddLayer} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors">
+          Add Layer here...
         </button>
-        <div className="my-1 border-t border-daw-border" />
-        <button
-          onClick={onDelete}
-          className="w-full text-left px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/30 transition-colors"
-        >
+        <div className="my-1 border-t border-[#555]" />
+        <button onClick={onDelete} className="w-full text-left px-3 py-1.5 text-[11px] text-red-400 hover:bg-red-600 hover:text-white transition-colors">
           Delete
         </button>
       </div>

--- a/src/components/timeline/GridOverlay.tsx
+++ b/src/components/timeline/GridOverlay.tsx
@@ -23,10 +23,11 @@ export function GridOverlay() {
       {lines.map((line, i) => (
         <div
           key={i}
-          className={`absolute top-0 bottom-0 w-px ${
-            line.isBar ? 'bg-daw-grid-bar' : 'bg-daw-grid-beat'
-          }`}
-          style={{ left: line.x }}
+          className="absolute top-0 bottom-0 w-px"
+          style={{
+            left: line.x,
+            backgroundColor: line.isBar ? '#4a4a4a' : '#333333',
+          }}
         />
       ))}
     </div>

--- a/src/components/timeline/TimeRuler.tsx
+++ b/src/components/timeline/TimeRuler.tsx
@@ -1,12 +1,16 @@
 import { useCallback } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
+import { useTransportStore } from '../../store/transportStore';
 import { useTransport } from '../../hooks/useTransport';
 import { getBarDuration } from '../../utils/time';
 
 export function TimeRuler() {
   const project = useProjectStore((s) => s.project);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
+  const loopEnabled = useTransportStore((s) => s.loopEnabled);
+  const loopStart = useTransportStore((s) => s.loopStart);
+  const loopEnd = useTransportStore((s) => s.loopEnd);
   const { seek } = useTransport();
 
   const handleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -17,7 +21,7 @@ export function TimeRuler() {
     seek(time);
   }, [project, pixelsPerSecond, seek]);
 
-  if (!project) return <div className="h-6 bg-daw-surface border-b border-daw-border" />;
+  if (!project) return <div className="h-6 bg-[#333] border-b border-[#2a2a2a]" />;
 
   const barDuration = getBarDuration(project.bpm, project.timeSignature);
   const totalBars = Math.ceil(project.totalDuration / barDuration);
@@ -31,18 +35,33 @@ export function TimeRuler() {
 
   return (
     <div
-      className="relative h-6 bg-daw-surface border-b border-daw-border overflow-hidden select-none cursor-pointer"
+      className="relative h-6 bg-[#353535] border-b border-[#2a2a2a] overflow-hidden select-none cursor-pointer"
       style={{ width: totalWidth }}
       onClick={handleClick}
     >
+      {/* Cycle/loop region (yellow strip, GarageBand style) */}
+      {loopEnabled && loopEnd > loopStart && (
+        <div
+          className="absolute top-0 h-full"
+          style={{
+            left: loopStart * pixelsPerSecond,
+            width: (loopEnd - loopStart) * pixelsPerSecond,
+            background: 'linear-gradient(180deg, rgba(234,179,8,0.35) 0%, rgba(234,179,8,0.15) 100%)',
+            borderLeft: '1px solid rgba(234,179,8,0.5)',
+            borderRight: '1px solid rgba(234,179,8,0.5)',
+          }}
+        />
+      )}
+
+      {/* Bar markers */}
       {markers.map(({ bar, x }) => (
         <div
           key={bar}
-          className="absolute top-0 h-full flex items-end pb-0.5 text-[10px] text-zinc-500 pointer-events-none"
+          className="absolute top-0 h-full flex items-end pb-0.5 pointer-events-none"
           style={{ left: x }}
         >
-          <div className="w-px h-2 bg-daw-grid-bar mr-1" />
-          <span>{bar}</span>
+          <div className="w-px h-3 bg-[#666] mr-1" />
+          <span className="text-[10px] text-zinc-400 font-medium">{bar}</span>
         </div>
       ))}
     </div>

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -299,7 +299,7 @@ export function Timeline() {
     <>
       <div
         ref={scrollRef}
-        className="flex-1 overflow-auto bg-daw-bg relative"
+        className="flex-1 overflow-auto bg-[#242424] relative"
         onWheel={handleWheel}
         onMouseDownCapture={handleMouseDownCapture}
         onDragOver={handleDragOver}

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -31,20 +31,20 @@ function LaneContextMenu({ x, y, onAddLayer, onOpenSequencer, onClose }: LaneCon
         onContextMenu={(e) => { e.preventDefault(); onClose(); }}
       />
       <div
-        className="fixed z-50 bg-daw-surface border border-daw-border rounded shadow-xl py-1 min-w-[160px]"
+        className="fixed z-50 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[160px]"
         style={{ left: clampedX, top: clampedY }}
       >
         {onOpenSequencer && (
           <button
             onClick={() => { onClose(); onOpenSequencer(); }}
-            className="w-full text-left px-3 py-1.5 text-xs text-emerald-300 hover:bg-daw-surface-2 transition-colors"
+            className="w-full text-left px-3 py-1.5 text-[11px] text-emerald-300 hover:bg-daw-accent hover:text-white transition-colors"
           >
             Open Sequencer Editor...
           </button>
         )}
         <button
           onClick={() => { onClose(); onAddLayer(); }}
-          className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors"
+          className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
         >
           Add Layer...
         </button>
@@ -192,7 +192,7 @@ export function TrackLane({ track }: TrackLaneProps) {
     <>
       <div
         data-track-id={track.id}
-        className={`relative border-b border-daw-border ${fileDragOver ? 'bg-blue-900/20' : ''}`}
+        className={`relative border-b border-[#333] ${fileDragOver ? 'bg-blue-900/20' : ''}`}
         style={{ width: totalWidth, height: laneHeight }}
         onContextMenu={handleContextMenu}
         onDoubleClick={handleDoubleClick}
@@ -208,7 +208,7 @@ export function TrackLane({ track }: TrackLaneProps) {
 
         {isComingSoon ? (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
-            <div className="flex items-center gap-2 bg-daw-surface/80 backdrop-blur-sm px-4 py-2 rounded-lg border border-daw-border">
+            <div className="flex items-center gap-2 bg-[#2d2d2d]/80 backdrop-blur-sm px-4 py-2 rounded-lg border border-[#444]">
               <span className="text-lg">{TRACK_TYPE_CATALOG[trackType].emoji}</span>
               <span className="text-xs font-medium text-zinc-400">{TRACK_TYPE_CATALOG[trackType].label}</span>
               <span className="text-[9px] font-bold text-amber-400 bg-amber-400/10 px-1.5 py-0.5 rounded">Coming Soon</span>
@@ -227,7 +227,7 @@ export function TrackLane({ track }: TrackLaneProps) {
                 className="absolute inset-0 flex items-center justify-center cursor-pointer"
                 onClick={() => setOpenSequencerTrackId(track.id)}
               >
-                <div className="flex items-center gap-2 bg-daw-surface/60 backdrop-blur-sm px-4 py-2 rounded-lg border border-daw-border border-dashed">
+                <div className="flex items-center gap-2 bg-[#2d2d2d]/60 backdrop-blur-sm px-4 py-2 rounded-lg border border-[#444] border-dashed">
                   <span className="text-emerald-400 text-sm">SEQ</span>
                   <span className="text-xs text-zinc-400">Double-click to open sequencer editor</span>
                 </div>
@@ -248,7 +248,7 @@ export function TrackLane({ track }: TrackLaneProps) {
 
         {/* Bottom-edge resize handle */}
         <div
-          className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize bg-transparent hover:bg-indigo-500/40 transition-colors z-20"
+          className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize bg-transparent hover:bg-daw-accent/30 transition-colors z-20"
           onMouseDown={onResizeMouseDown}
         />
       </div>

--- a/src/components/tracks/AddTrackButton.tsx
+++ b/src/components/tracks/AddTrackButton.tsx
@@ -9,16 +9,19 @@ export function AddTrackButton() {
     <div className="flex gap-1 mx-2 my-2">
       <button
         onClick={() => setShowInstrumentPicker(true)}
-        className="flex-1 flex items-center justify-center gap-1 h-8 text-xs font-medium text-zinc-400 hover:text-zinc-200 bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
+        className="flex-1 flex items-center justify-center gap-1 h-7 text-[11px] font-medium text-zinc-400 hover:text-white bg-[#3a3a3a] hover:bg-[#484848] rounded transition-colors"
       >
         <span className="text-sm">+</span> Track
       </button>
       <button
         onClick={openFilePicker}
-        className="flex items-center justify-center gap-1 h-8 px-2 text-xs font-medium text-zinc-400 hover:text-zinc-200 bg-daw-surface-2 hover:bg-zinc-600 rounded transition-colors"
+        className="flex items-center justify-center gap-1 h-7 px-2 text-[11px] font-medium text-zinc-400 hover:text-white bg-[#3a3a3a] hover:bg-[#484848] rounded transition-colors"
         title="Import audio file"
       >
-        <span className="text-sm">📁</span>
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
+          <path d="M6 1v7M3 5l3 3 3-3" />
+          <path d="M1 9v1.5a.5.5 0 00.5.5h9a.5.5 0 00.5-.5V9" />
+        </svg>
       </button>
     </div>
   );

--- a/src/components/tracks/TrackEditModal.tsx
+++ b/src/components/tracks/TrackEditModal.tsx
@@ -82,7 +82,7 @@ export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
               onChange={(e) => setName(e.target.value)}
               onBlur={commitName}
               onKeyDown={(e) => { if (e.key === 'Enter') { commitName(); (e.target as HTMLInputElement).blur(); } }}
-              className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus:border-indigo-500/60"
+              className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus:border-daw-accent/60"
             />
           </div>
 
@@ -105,7 +105,7 @@ export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
                         ? 'ring-1 ring-offset-1 ring-offset-transparent'
                         : comingSoon
                           ? 'opacity-40 cursor-not-allowed'
-                          : 'hover:bg-zinc-700'
+                          : 'hover:bg-[#444]'
                     }`}
                     style={{
                       backgroundColor: isActive ? tti.color + '25' : undefined,
@@ -156,7 +156,7 @@ export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
                 <button
                   onClick={() => updateTrack(track.id, { muted: !track.muted })}
                   className={`w-7 h-6 text-[10px] font-bold rounded transition-colors ${
-                    track.muted ? 'bg-amber-600 text-white' : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300'
+                    track.muted ? 'bg-amber-600 text-white' : 'bg-[#333] text-zinc-500 hover:text-zinc-300'
                   }`}
                 >
                   M
@@ -164,7 +164,7 @@ export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
                 <button
                   onClick={() => updateTrack(track.id, { soloed: !track.soloed })}
                   className={`w-7 h-6 text-[10px] font-bold rounded transition-colors ${
-                    track.soloed ? 'bg-emerald-600 text-white' : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300'
+                    track.soloed ? 'bg-emerald-600 text-white' : 'bg-[#333] text-zinc-500 hover:text-zinc-300'
                   }`}
                 >
                   S
@@ -181,7 +181,7 @@ export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
               value={track.localCaption ?? ''}
               onChange={(e) => setTrackLocalCaption(track.id, e.target.value)}
               placeholder={track.displayName}
-              className="w-full bg-zinc-900 border border-zinc-700 rounded px-2.5 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-indigo-500/60"
+              className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-daw-accent/60"
             />
             <p className="text-[9px] text-zinc-600 mt-0.5">Defaults to track name if empty</p>
           </div>
@@ -215,7 +215,7 @@ export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
               <button
                 onClick={() => updateTrackMixer(track.id, { compressorEnabled: !compEnabled })}
                 className={`px-2 py-0.5 rounded text-[9px] font-bold transition-colors ${
-                  compEnabled ? 'bg-orange-600 text-white' : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300'
+                  compEnabled ? 'bg-orange-600 text-white' : 'bg-[#333] text-zinc-500 hover:text-zinc-300'
                 }`}
               >
                 {compEnabled ? 'ON' : 'OFF'}
@@ -263,7 +263,7 @@ export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
           </button>
           <button
             onClick={onClose}
-            className="px-4 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded transition-colors"
+            className="px-4 py-1.5 text-xs bg-daw-accent hover:bg-daw-accent-hover text-white rounded transition-colors"
           >
             Done
           </button>

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import type { Track } from '../../types/project';
 import { useProjectStore } from '../../store/projectStore';
-import { TRACK_CATALOG, TRACK_TYPE_CATALOG } from '../../constants/tracks';
+import { TRACK_CATALOG } from '../../constants/tracks';
 import { TrackEditModal } from './TrackEditModal';
 
 const MIN_LANE_HEIGHT = 40;
@@ -28,11 +28,9 @@ export function TrackHeader({
   const renameTrack = useProjectStore((s) => s.renameTrack);
   const removeTrack = useProjectStore((s) => s.removeTrack);
   const info = TRACK_CATALOG[track.trackName];
-  const typeInfo = TRACK_TYPE_CATALOG[track.trackType ?? 'stems'];
 
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
-
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(track.displayName);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -58,6 +56,7 @@ export function TrackHeader({
 
   const laneHeight = track.laneHeight ?? 64;
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
+  const isCompact = laneHeight < 52;
 
   const onHeightResizeDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -93,14 +92,13 @@ export function TrackHeader({
   return (
     <>
     <div
-      className={`relative flex flex-col justify-center gap-1 px-2 border-b border-daw-border group select-none ${
-        isDragOver ? 'bg-daw-surface-2' : ''
+      className={`relative flex items-center gap-1.5 px-1 border-b border-[#3a3a3a] group select-none ${
+        isDragOver ? 'bg-[#383838]' : 'bg-[#2d2d2d]'
       }`}
       style={{
-        height: track.laneHeight ?? 64,
-        borderLeft: `3px solid ${track.color}`,
-        borderTop: isDragOver && dragOverPosition === 'before' ? '2px solid #6366f1' : undefined,
-        borderBottom: isDragOver && dragOverPosition === 'after' ? '2px solid #6366f1' : undefined,
+        height: laneHeight,
+        borderTop: isDragOver && dragOverPosition === 'before' ? '2px solid var(--color-daw-accent)' : undefined,
+        borderBottom: isDragOver && dragOverPosition === 'after' ? '2px solid var(--color-daw-accent)' : undefined,
       }}
       draggable
       onDragStart={() => onDragStart(track.id)}
@@ -110,22 +108,32 @@ export function TrackHeader({
       onDoubleClick={handleHeaderDoubleClick}
       onContextMenu={handleHeaderContextMenu}
     >
-      {/* Top row: drag handle + type badge + emoji + name */}
-      <div className="flex items-center gap-1 min-w-0">
-        <div
-          className="flex-shrink-0 text-zinc-600 hover:text-zinc-400 cursor-grab active:cursor-grabbing text-sm leading-none select-none"
-          title="Drag to reorder"
-        >
-          ⠿
-        </div>
-        <span
-          className="flex-shrink-0 text-[8px] font-bold px-1 py-px rounded leading-tight"
-          style={{ backgroundColor: typeInfo.color + '25', color: typeInfo.color }}
-          title={typeInfo.label}
-        >
-          {typeInfo.abbr}
-        </span>
-        <span className="text-sm flex-shrink-0" title={info.displayName}>{info.emoji}</span>
+      {/* Color strip (left edge) */}
+      <div
+        className="absolute left-0 top-0 bottom-0 w-[4px] rounded-r-sm"
+        style={{ backgroundColor: track.color }}
+      />
+
+      {/* Drag handle */}
+      <div
+        className="flex-shrink-0 ml-1.5 text-zinc-600 hover:text-zinc-400 cursor-grab active:cursor-grabbing text-[10px] leading-none select-none"
+        title="Drag to reorder"
+      >
+        ⠿
+      </div>
+
+      {/* Instrument icon */}
+      <div
+        className="flex-shrink-0 w-6 h-6 rounded flex items-center justify-center text-sm"
+        style={{ backgroundColor: track.color + '20' }}
+        title={info.displayName}
+      >
+        {info.emoji}
+      </div>
+
+      {/* Name + controls column */}
+      <div className="flex-1 min-w-0 flex flex-col gap-0.5 py-0.5">
+        {/* Name */}
         {isEditing ? (
           <input
             ref={inputRef}
@@ -136,74 +144,91 @@ export function TrackHeader({
               if (e.key === 'Enter') commitRename();
               if (e.key === 'Escape') cancelEditing();
             }}
-            className="text-xs font-medium text-zinc-200 bg-zinc-700 rounded px-1 py-0.5 min-w-0 outline-none border border-indigo-500/60"
+            className="text-[11px] font-medium text-zinc-100 bg-[#1a1a1a] rounded px-1 py-px min-w-0 outline-none border border-daw-accent/60"
             autoFocus
           />
         ) : (
           <span
-            className="text-xs font-medium text-zinc-200 truncate cursor-text"
-            title={`${track.displayName} (double-click to rename)`}
-            onDoubleClick={startEditing}
+            className="text-[11px] font-medium text-zinc-200 truncate cursor-text leading-tight"
+            title={track.displayName}
+            onDoubleClick={(e) => { e.stopPropagation(); startEditing(); }}
           >
             {track.displayName}
           </span>
         )}
+
+        {/* Volume slider + M/S buttons (only in non-compact mode) */}
+        {!isCompact && (
+          <div className="flex items-center gap-1 w-full">
+            <input
+              type="range"
+              min="0"
+              max="100"
+              value={Math.round(track.volume * 100)}
+              onChange={(e) => updateTrack(track.id, { volume: parseInt(e.target.value) / 100 })}
+              className="flex-1 h-1 min-w-0"
+              title={`Volume: ${Math.round(track.volume * 100)}%`}
+            />
+          </div>
+        )}
       </div>
 
-      {/* Bottom row: volume + buttons */}
-      <div className="flex items-center gap-1.5 w-full">
-        <input
-          type="range"
-          min="0"
-          max="100"
-          value={Math.round(track.volume * 100)}
-          onChange={(e) => updateTrack(track.id, { volume: parseInt(e.target.value) / 100 })}
-          className="flex-1 h-1 min-w-0"
-          title={`Volume: ${Math.round(track.volume * 100)}%`}
-        />
-        <div className="flex items-center gap-0.5 flex-shrink-0">
-          <button
-            onClick={() => updateTrack(track.id, { muted: !track.muted })}
-            className={`w-6 h-5 text-[10px] font-bold rounded transition-colors ${
-              track.muted
-                ? 'bg-amber-600 text-white'
-                : 'bg-daw-surface-2 text-zinc-500 hover:text-zinc-300'
-            }`}
-            title="Mute"
-          >
-            M
-          </button>
-          <button
-            onClick={() => updateTrack(track.id, { soloed: !track.soloed })}
-            className={`w-6 h-5 text-[10px] font-bold rounded transition-colors ${
-              track.soloed
-                ? 'bg-emerald-600 text-white'
-                : 'bg-daw-surface-2 text-zinc-500 hover:text-zinc-300'
-            }`}
-            title="Solo"
-          >
-            S
-          </button>
-          <button
-            onClick={() => setEditModalOpen(true)}
-            className="w-6 h-5 text-[10px] font-bold rounded transition-colors bg-daw-surface-2 text-zinc-600 hover:text-zinc-300"
-            title="Edit track"
-          >
-            ⚙
-          </button>
-          <button
-            onClick={() => removeTrack(track.id)}
-            className="w-6 h-5 text-[10px] font-bold rounded bg-daw-surface-2 text-zinc-600 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
-            title="Remove track"
-          >
-            ×
-          </button>
-        </div>
+      {/* M/S/Delete buttons */}
+      <div className="flex items-center gap-px flex-shrink-0">
+        {/* Mute - speaker icon */}
+        <button
+          onClick={() => updateTrack(track.id, { muted: !track.muted })}
+          className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
+            track.muted
+              ? 'bg-amber-600/90 text-white'
+              : 'text-zinc-500 hover:text-zinc-300 hover:bg-[#444]'
+          }`}
+          title="Mute (M)"
+        >
+          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+            {track.muted ? (
+              <>
+                <path d="M1 4.5h2l3-3v9l-3-3H1z" fill="currentColor" stroke="none" />
+                <path d="M9 4l3 4M12 4L9 8" />
+              </>
+            ) : (
+              <>
+                <path d="M1 4.5h2l3-3v9l-3-3H1z" fill="currentColor" stroke="none" />
+                <path d="M9 3.5c1 .8 1 4.2 0 5" />
+              </>
+            )}
+          </svg>
+        </button>
+        {/* Solo - headphone icon */}
+        <button
+          onClick={() => updateTrack(track.id, { soloed: !track.soloed })}
+          className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
+            track.soloed
+              ? 'bg-emerald-600/90 text-white'
+              : 'text-zinc-500 hover:text-zinc-300 hover:bg-[#444]'
+          }`}
+          title="Solo (S)"
+        >
+          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
+            <path d="M2 5.5a4 4 0 018 0" />
+            <path d="M2 5.5v2a1 1 0 001 1h1v-3H2zM10 5.5v2a1 1 0 01-1 1H8v-3h2z" fill={track.soloed ? 'currentColor' : 'none'} />
+          </svg>
+        </button>
+        {/* Delete - hidden by default, visible on hover */}
+        <button
+          onClick={() => removeTrack(track.id)}
+          className="w-5 h-5 flex items-center justify-center rounded text-zinc-600 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
+          title="Remove track"
+        >
+          <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+            <path d="M1 1l6 6M7 1L1 7" />
+          </svg>
+        </button>
       </div>
 
       {/* Bottom-edge height resize handle */}
       <div
-        className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize bg-transparent hover:bg-indigo-500/40 transition-colors z-10"
+        className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize bg-transparent hover:bg-daw-accent/30 transition-colors z-10"
         onMouseDown={onHeightResizeDown}
       />
     </div>
@@ -213,19 +238,25 @@ export function TrackHeader({
       <>
         <div className="fixed inset-0 z-40" onClick={() => setCtxMenu(null)} onContextMenu={(e) => { e.preventDefault(); setCtxMenu(null); }} />
         <div
-          className="fixed z-50 bg-daw-surface border border-daw-border rounded shadow-xl py-1 min-w-[160px]"
+          className="fixed z-50 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[160px]"
           style={{ left: Math.min(ctxMenu.x, window.innerWidth - 180), top: Math.min(ctxMenu.y, window.innerHeight - 100) }}
         >
           <button
-            onClick={() => { setCtxMenu(null); setEditModalOpen(true); }}
-            className="w-full text-left px-3 py-1.5 text-xs text-zinc-200 hover:bg-daw-surface-2 transition-colors"
+            onClick={() => { setCtxMenu(null); startEditing(); }}
+            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
           >
-            Edit Track...
+            Rename Track
           </button>
-          <div className="my-1 border-t border-daw-border" />
+          <button
+            onClick={() => { setCtxMenu(null); setEditModalOpen(true); }}
+            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
+          >
+            Track Settings...
+          </button>
+          <div className="my-1 border-t border-[#555]" />
           <button
             onClick={() => { setCtxMenu(null); removeTrack(track.id); }}
-            className="w-full text-left px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/30 transition-colors"
+            className="w-full text-left px-3 py-1.5 text-[11px] text-red-400 hover:bg-red-600 hover:text-white transition-colors"
           >
             Delete Track
           </button>
@@ -233,7 +264,6 @@ export function TrackHeader({
       </>
     )}
 
-    {/* Edit modal */}
     {editModalOpen && (
       <TrackEditModal track={track} onClose={() => setEditModalOpen(false)} />
     )}

--- a/src/components/tracks/TrackInspector.tsx
+++ b/src/components/tracks/TrackInspector.tsx
@@ -26,7 +26,7 @@ export function TrackInspector({ track }: TrackInspectorProps) {
   }, [track.id, setTrackReverb]);
 
   return (
-    <div className="bg-zinc-950 border-b border-daw-border text-[10px] text-zinc-400 select-none overflow-y-auto" style={{ height: 220 }}>
+    <div className="bg-[#1e1e1e] border-b border-daw-border text-[10px] text-zinc-400 select-none overflow-y-auto" style={{ height: 220 }}>
       <div className="px-3 py-2 space-y-3">
       {/* Local caption */}
       <div>
@@ -38,7 +38,7 @@ export function TrackInspector({ track }: TrackInspectorProps) {
           value={track.localCaption ?? ''}
           onChange={(e) => setTrackLocalCaption(track.id, e.target.value)}
           placeholder={track.displayName}
-          className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-[10px] text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-daw-accent"
+          className="w-full bg-[#222] border border-[#444] rounded px-2 py-1 text-[10px] text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-daw-accent"
         />
         <p className="text-[9px] text-zinc-600 mt-0.5">Defaults to track name if empty</p>
       </div>
@@ -98,7 +98,7 @@ export function TrackInspector({ track }: TrackInspectorProps) {
             className={`px-1.5 py-0.5 rounded text-[9px] font-bold transition-colors ${
               compEnabled
                 ? 'bg-orange-600 text-white'
-                : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300'
+                : 'bg-[#333] text-zinc-500 hover:text-zinc-300'
             }`}
           >
             {compEnabled ? 'ON' : 'OFF'}

--- a/src/components/tracks/TrackList.tsx
+++ b/src/components/tracks/TrackList.tsx
@@ -45,7 +45,6 @@ export function TrackList() {
     setDragOverId(null);
   }, []);
 
-  // Width resize handle
   const resizeDragRef = useRef<{ startX: number; startW: number } | null>(null);
 
   const onResizeMouseDown = useCallback((e: React.MouseEvent) => {
@@ -71,7 +70,7 @@ export function TrackList() {
 
   return (
     <div
-      className="flex flex-col bg-daw-surface border-r border-daw-border relative shrink-0"
+      className="flex flex-col bg-[#2a2a2a] border-r border-[#1a1a1a] relative shrink-0"
       style={{ width: trackListWidth }}
       onDragLeave={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget as Node)) {
@@ -80,7 +79,9 @@ export function TrackList() {
       }}
     >
       {/* Header spacer aligned with TimeRuler */}
-      <div className="h-6 border-b border-daw-border shrink-0" />
+      <div className="h-6 border-b border-[#3a3a3a] shrink-0 bg-[#333] flex items-center px-2">
+        <span className="text-[10px] text-zinc-500 uppercase tracking-wider font-medium">Tracks</span>
+      </div>
 
       <div className="flex-1 overflow-y-auto">
         {sortedTracks.map((track) => (
@@ -100,7 +101,7 @@ export function TrackList() {
 
       {/* Right-edge resize handle */}
       <div
-        className="absolute top-0 right-0 w-1.5 h-full cursor-col-resize bg-transparent hover:bg-indigo-500/40 transition-colors z-10"
+        className="absolute top-0 right-0 w-1.5 h-full cursor-col-resize bg-transparent hover:bg-daw-accent/30 transition-colors z-10"
         onMouseDown={onResizeMouseDown}
       />
     </div>

--- a/src/components/ui/DualRangeSlider.tsx
+++ b/src/components/ui/DualRangeSlider.tsx
@@ -73,7 +73,7 @@ export function DualRangeSlider({
       {/* Track */}
       <div
         ref={trackRef}
-        className="relative h-2 bg-zinc-700 rounded-full mx-2 mt-2"
+        className="relative h-2 bg-[#444] rounded-full mx-2 mt-2"
         style={{ userSelect: 'none' }}
       >
         {/* Filled region */}

--- a/src/components/ui/Knob.tsx
+++ b/src/components/ui/Knob.tsx
@@ -137,7 +137,7 @@ export function Knob({
           <path
             d={trackPath}
             fill="none"
-            stroke="#3f3f46"
+            stroke="#4a4a4a"
             strokeWidth={strokeWidth}
             strokeLinecap="round"
           />
@@ -145,7 +145,7 @@ export function Knob({
           <path
             d={fillPath}
             fill="none"
-            stroke="#6366f1"
+            stroke="#4a90d9"
             strokeWidth={strokeWidth}
             strokeLinecap="round"
           />
@@ -154,8 +154,8 @@ export function Knob({
             cx={radius}
             cy={radius}
             r={radius * 0.52}
-            fill="#27272a"
-            stroke="#52525b"
+            fill="#3c3c3c"
+            stroke="#5a5a5a"
             strokeWidth={1}
           />
           {/* Pointer tick */}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -261,10 +261,22 @@ export function useKeyboardShortcuts() {
           break;
         }
 
-        // Mixer toggle
-        case 'KeyM':
+        // Mixer toggle (X like GarageBand)
+        case 'KeyX':
           e.preventDefault();
           ui.setShowMixer(!ui.showMixer);
+          break;
+
+        // Smart Controls toggle (B like GarageBand)
+        case 'KeyB':
+          e.preventDefault();
+          ui.setShowSmartControls(!ui.showSmartControls);
+          break;
+
+        // Loop Browser / Assets toggle (O)
+        case 'KeyO':
+          e.preventDefault();
+          ui.setShowAssetsPanel(!ui.showAssetsPanel);
           break;
 
         // Help

--- a/src/index.css
+++ b/src/index.css
@@ -1,33 +1,40 @@
 @import "tailwindcss";
 
 @theme {
-  --color-daw-bg: #09090b;
-  --color-daw-surface: #18181b;
-  --color-daw-surface-2: #27272a;
-  --color-daw-border: #3f3f46;
-  --color-daw-accent: #6366f1;
-  --color-daw-accent-hover: #818cf8;
+  --color-daw-bg: #1e1e1e;
+  --color-daw-surface: #2d2d2d;
+  --color-daw-surface-2: #3c3c3c;
+  --color-daw-surface-3: #484848;
+  --color-daw-border: #4a4a4a;
+  --color-daw-accent: #4a90d9;
+  --color-daw-accent-hover: #5ba3ec;
   --color-daw-playhead: #ef4444;
-  --color-daw-grid-bar: #3f3f46;
-  --color-daw-grid-beat: #27272a;
+  --color-daw-grid-bar: #4a4a4a;
+  --color-daw-grid-beat: #333333;
+  --color-daw-region-audio: #4a8cc7;
+  --color-daw-region-midi: #5cb85c;
+  --color-daw-region-drummer: #d4a843;
+  --color-daw-region-sample: #9b59b6;
 }
 
 * {
   scrollbar-width: thin;
-  scrollbar-color: #3f3f46 transparent;
+  scrollbar-color: #4a4a4a transparent;
 }
 
 body {
   margin: 0;
   overflow: hidden;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 input[type="range"] {
   -webkit-appearance: none;
   appearance: none;
   height: 4px;
-  background: #3f3f46;
+  background: #4a4a4a;
   border-radius: 2px;
   outline: none;
 }
@@ -35,13 +42,21 @@ input[type="range"] {
 input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
-  background: #6366f1;
+  background: #4a90d9;
   cursor: pointer;
+  border: 1px solid rgba(255,255,255,0.15);
 }
 
 input[type="range"]::-webkit-slider-thumb:hover {
-  background: #818cf8;
+  background: #5ba3ec;
+}
+
+.gb-lcd {
+  background: linear-gradient(180deg, #1a1a1a 0%, #222222 100%);
+  border: 1px solid #555;
+  border-radius: 4px;
+  font-variant-numeric: tabular-nums;
 }

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -30,6 +30,10 @@ interface UIState {
   /** Track whose sequencer editor is currently open (bottom panel). */
   openSequencerTrackId: string | null;
   sequencerEditorHeight: number;
+  showSmartControls: boolean;
+  showLibrary: boolean;
+  /** Which bottom editor is visible: null = none, 'smart' = smart controls, 'editor' = region editor */
+  activeBottomPanel: 'smart' | 'editor' | null;
 
   setPixelsPerSecond: (pps: number) => void;
   zoomIn: () => void;
@@ -58,6 +62,9 @@ interface UIState {
   setExpandedTrackId: (id: string | null) => void;
   setOpenSequencerTrackId: (id: string | null) => void;
   setSequencerEditorHeight: (v: number) => void;
+  setShowSmartControls: (v: boolean) => void;
+  setShowLibrary: (v: boolean) => void;
+  setActiveBottomPanel: (v: 'smart' | 'editor' | null) => void;
 }
 
 const ZOOM_LEVELS = [10, 25, 50, 100, 200, 500];
@@ -86,6 +93,9 @@ export const useUIStore = create<UIState>((set) => ({
   expandedTrackId: null,
   openSequencerTrackId: null,
   sequencerEditorHeight: 320,
+  showSmartControls: false,
+  showLibrary: false,
+  activeBottomPanel: null,
 
   setPixelsPerSecond: (pps) => set({ pixelsPerSecond: pps }),
 
@@ -142,4 +152,7 @@ export const useUIStore = create<UIState>((set) => ({
   setExpandedTrackId: (id) => set({ expandedTrackId: id }),
   setOpenSequencerTrackId: (id) => set({ openSequencerTrackId: id }),
   setSequencerEditorHeight: (v) => set({ sequencerEditorHeight: Math.min(600, Math.max(200, v)) }),
+  setShowSmartControls: (v) => set({ showSmartControls: v }),
+  setShowLibrary: (v) => set({ showLibrary: v }),
+  setActiveBottomPanel: (v) => set({ activeBottomPanel: v }),
 }));


### PR DESCRIPTION
## Summary

- Systematic UI refactor across 31 files to match GarageBand's visual style, layout structure, and interaction patterns
- New warm dark gray palette replacing old near-black zinc theme, with blue accent (#4a90d9) and region color tokens
- Redesigned Control Bar with centered transport, LCD display, and panel toggle buttons
- Compact GarageBand-style track headers with color strip, icon buttons, inline volume slider
- GarageBand-style rounded region blocks with gradient fill and glow selection
- New Smart Controls panel (B key) with context-sensitive knobs for Volume/Pan/EQ/Compressor
- Loop Browser redesign with search field and keyword filter buttons
- TimeRuler with cycle region yellow strip and subtler grid lines
- Updated keyboard shortcuts: X=Mixer, B=Smart Controls, O=Loop Browser

## Test plan

- [ ] Verify all theme colors are consistent across all panels
- [ ] Test Smart Controls panel toggle with B key
- [ ] Test Mixer toggle with X key (changed from M)
- [ ] Test Loop Browser toggle with O key
- [ ] Verify track headers render correctly at various lane heights
- [ ] Verify clip regions display with gradient fill and rounded corners
- [ ] Test all dialogs and modals for consistent styling
- [ ] Verify cycle/loop region renders as yellow strip on ruler


Made with [Cursor](https://cursor.com)