### PR TITLE
feat: clip versioning, multi-clip drag, context alignment, and Apple selection colors

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -39,6 +39,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const removeClip = useProjectStore((s) => s.removeClip);
   const duplicateClip = useProjectStore((s) => s.duplicateClip);
   const batchDuplicateClips = useProjectStore((s) => s.batchDuplicateClips);
+  const batchMoveClips = useProjectStore((s) => s.batchMoveClips);
   const setActiveVersion = useProjectStore((s) => s.setActiveVersion);
   const project = useProjectStore((s) => s.project);
   const { generateClip } = useGeneration();
@@ -115,6 +116,9 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     dragRef.current = false;
     let isShiftCopy = e.shiftKey;
 
+    const isMultiSelected = selectedClipIds.size > 1 && selectedClipIds.has(clip.id);
+    let lastBatchOffset = 0;
+
     const clipW = clip.duration * pixelsPerSecond;
     const clipH = clipBlockRef.current?.offsetHeight ?? 48;
     const clipRect = clipBlockRef.current?.getBoundingClientRect();
@@ -131,14 +135,29 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
       if (mode === 'move') {
         if (isShiftCopy) {
-          updateClip(clip.id, { startTime: origStart });
+          if (isMultiSelected && lastBatchOffset !== 0) {
+            batchMoveClips([...selectedClipIds], -lastBatchOffset);
+            lastBatchOffset = 0;
+          } else {
+            updateClip(clip.id, { startTime: origStart });
+          }
         } else {
           const isFineMove = ev.metaKey || ev.ctrlKey;
           let newStart = isFineMove
             ? Math.round((origStart + deltaSec) * 100) / 100
             : snapToGrid(origStart + deltaSec, bpm, 1);
           newStart = Math.max(0, Math.min(newStart, totalDuration - origDuration));
-          updateClip(clip.id, { startTime: newStart });
+          const timeOffset = newStart - origStart;
+
+          if (isMultiSelected) {
+            const delta = timeOffset - lastBatchOffset;
+            if (delta !== 0) {
+              batchMoveClips([...selectedClipIds], delta);
+              lastBatchOffset = timeOffset;
+            }
+          } else {
+            updateClip(clip.id, { startTime: newStart });
+          }
         }
 
         const closest = findClosestLane(ev.clientY);
@@ -170,12 +189,10 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         const shift = newStart - origStart;
         let newAudioOffset = origAudioOffset + shift;
 
-        // Can't reveal past start of audio buffer — clamp
         if (newAudioOffset < 0) {
           newAudioOffset = 0;
           newStart = origStart - origAudioOffset;
         }
-        // Can't trim past end of audio buffer
         if (newAudioOffset > origAudioDuration - MIN_CLIP_DURATION) {
           newAudioOffset = origAudioDuration - MIN_CLIP_DURATION;
           newStart = origStart + (newAudioOffset - origAudioOffset);
@@ -205,14 +222,19 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           : snapToGrid(origStart + deltaSec, bpm, 1));
 
         if (ev.shiftKey && closest) {
-          updateClip(clip.id, { startTime: origStart });
+          if (isMultiSelected && lastBatchOffset !== 0) {
+            batchMoveClips([...selectedClipIds], -lastBatchOffset);
+            lastBatchOffset = 0;
+          } else {
+            updateClip(clip.id, { startTime: origStart });
+          }
           const timeOffset = dropStart - origStart;
-          if (selectedClipIds.size > 1 && selectedClipIds.has(clip.id)) {
+          if (isMultiSelected) {
             batchDuplicateClips([...selectedClipIds], timeOffset);
           } else {
             duplicateClipToTrack(clip.id, closest.trackId, dropStart);
           }
-        } else if (closest && closest.trackId !== track.id) {
+        } else if (closest && closest.trackId !== track.id && !isMultiSelected) {
           moveClipToTrack(clip.id, closest.trackId);
         }
       }
@@ -220,7 +242,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
-  }, [clip.id, clip.startTime, clip.duration, clip.audioOffset, clip.audioDuration, pixelsPerSecond, project, updateClip, getDragMode, track.id, moveClipToTrack, duplicateClipToTrack, batchDuplicateClips, selectedClipIds, findClosestLane]);
+  }, [clip.id, clip.startTime, clip.duration, clip.audioOffset, clip.audioDuration, pixelsPerSecond, project, updateClip, getDragMode, track.id, moveClipToTrack, duplicateClipToTrack, batchDuplicateClips, batchMoveClips, selectedClipIds, findClosestLane]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -294,7 +316,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         ref={clipBlockRef}
         className={`absolute top-1 bottom-1 rounded-md select-none overflow-hidden
           ${statusStyles[clip.generationStatus] ?? ''}
-          ${isSelected ? 'ring-2 ring-white/80 ring-offset-1 ring-offset-transparent' : ''}
+          ${isSelected ? 'ring-2 ring-offset-1 ring-offset-transparent' : ''}
           ${dragGhost && dragGhost.targetTrackId && !dragGhost.isShiftCopy ? 'opacity-0' : ''}
         `}
         style={{
@@ -302,7 +324,8 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           width: Math.max(width, 4),
           background: `linear-gradient(180deg, ${hexToRgba(track.color, 0.45)} 0%, ${hexToRgba(track.color, 0.28)} 100%)`,
           borderLeft: `3px solid ${track.color}`,
-          boxShadow: isSelected ? `0 0 8px ${hexToRgba(track.color, 0.3)}` : 'none',
+          boxShadow: isSelected ? '0 0 10px rgba(0, 122, 255, 0.45), inset 0 0 0 1px rgba(0, 122, 255, 0.3)' : 'none',
+          ...(isSelected ? { '--tw-ring-color': 'rgba(0, 122, 255, 0.85)' } as React.CSSProperties : {}),
         }}
         data-clip-block
         onMouseDown={handleMouseDown}
@@ -346,13 +369,13 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
         {/* Label */}
         <div className="absolute top-0 left-1.5 text-[9px] font-medium text-white truncate leading-4 z-10 drop-shadow-sm pointer-events-none"
-          style={{ right: totalVersions > 1 ? '52px' : '6px' }}
+          style={{ right: totalVersions >= 1 ? '52px' : '6px' }}
         >
           {clip.prompt || '(no prompt)'}
         </div>
 
-        {/* Version navigation — only visible when multiple versions exist */}
-        {totalVersions > 1 && (
+        {/* Version navigation — visible whenever at least one version exists */}
+        {totalVersions >= 1 && (
           <div
             className="absolute top-0 right-0.5 flex items-center gap-0.5 z-20"
             onClick={(e) => e.stopPropagation()}
@@ -370,12 +393,21 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
               {activeVersionIdx + 1}/{totalVersions}
             </span>
             <button
-              onClick={(e) => { e.stopPropagation(); setActiveVersion(clip.id, activeVersionIdx + 1); }}
-              disabled={activeVersionIdx >= totalVersions - 1}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (activeVersionIdx < totalVersions - 1) {
+                  setActiveVersion(clip.id, activeVersionIdx + 1);
+                } else {
+                  regenerateClip(clip.id);
+                }
+              }}
+              disabled={clip.generationStatus === 'generating' || clip.generationStatus === 'queued'}
               className="text-[8px] text-white/80 hover:text-white disabled:opacity-30 px-0.5 leading-4 transition-opacity"
-              title="Next version"
+              title={activeVersionIdx >= totalVersions - 1 ? 'Generate new version' : 'Next version'}
             >
-              ▶
+              {clip.generationStatus === 'generating' || clip.generationStatus === 'queued'
+                ? <span className="inline-block w-2 h-2 border border-white/80 border-t-transparent rounded-full animate-spin" />
+                : '▶'}
             </button>
           </div>
         )}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -323,7 +323,7 @@ export function Timeline() {
             <GridOverlay />
             <Playhead />
 
-            {/* Committed context window overlay — scoped to selected track lanes */}
+            {/* Committed context window overlay — Apple Teal (#5AC8FA) */}
             {ctxLeft !== null && ctxWidth !== null && ctxVRange && (
               <div
                 className="absolute pointer-events-none z-10"
@@ -332,23 +332,23 @@ export function Timeline() {
                   width: ctxWidth,
                   top: ctxVRange.top,
                   height: ctxVRange.height,
-                  background: 'rgba(59, 130, 246, 0.10)',
-                  borderLeft: '2px solid rgba(96, 165, 250, 0.7)',
-                  borderRight: '2px solid rgba(96, 165, 250, 0.7)',
-                  borderTop: '2px solid rgba(96, 165, 250, 0.4)',
-                  borderBottom: '2px solid rgba(96, 165, 250, 0.4)',
+                  background: 'rgba(90, 200, 250, 0.10)',
+                  borderLeft: '2px solid rgba(90, 200, 250, 0.7)',
+                  borderRight: '2px solid rgba(90, 200, 250, 0.7)',
+                  borderTop: '2px solid rgba(90, 200, 250, 0.35)',
+                  borderBottom: '2px solid rgba(90, 200, 250, 0.35)',
                 }}
               >
                 <span
-                  className="absolute top-0.5 left-1 text-[9px] font-mono text-blue-300 select-none"
-                  style={{ background: 'rgba(30,30,50,0.7)', padding: '0 3px', borderRadius: 3 }}
+                  className="absolute top-0.5 left-1 text-[9px] font-mono select-none"
+                  style={{ color: '#5AC8FA', background: 'rgba(20,30,40,0.75)', padding: '0 4px', borderRadius: 3 }}
                 >
                   context window
                 </span>
               </div>
             )}
 
-            {/* Committed select window overlay — scoped to selected track lanes */}
+            {/* Committed select window overlay — Apple Purple (#AF52DE) */}
             {selLeft !== null && selWidth !== null && selVRange && (
               <div
                 className="absolute pointer-events-none z-10"
@@ -357,23 +357,23 @@ export function Timeline() {
                   width: selWidth,
                   top: selVRange.top,
                   height: selVRange.height,
-                  background: 'rgba(251, 146, 60, 0.10)',
-                  borderLeft: '2px solid rgba(251, 146, 60, 0.7)',
-                  borderRight: '2px solid rgba(251, 146, 60, 0.7)',
-                  borderTop: '2px solid rgba(251, 146, 60, 0.4)',
-                  borderBottom: '2px solid rgba(251, 146, 60, 0.4)',
+                  background: 'rgba(175, 82, 222, 0.10)',
+                  borderLeft: '2px solid rgba(175, 82, 222, 0.7)',
+                  borderRight: '2px solid rgba(175, 82, 222, 0.7)',
+                  borderTop: '2px solid rgba(175, 82, 222, 0.35)',
+                  borderBottom: '2px solid rgba(175, 82, 222, 0.35)',
                 }}
               >
                 <span
-                  className="absolute top-0.5 right-1 text-[9px] font-mono text-orange-300 select-none"
-                  style={{ background: 'rgba(30,30,50,0.7)', padding: '0 3px', borderRadius: 3 }}
+                  className="absolute top-0.5 right-1 text-[9px] font-mono select-none"
+                  style={{ color: '#AF52DE', background: 'rgba(20,20,35,0.75)', padding: '0 4px', borderRadius: 3 }}
                 >
                   select window
                 </span>
               </div>
             )}
 
-            {/* Live context drag overlay (blue) — vertically scoped */}
+            {/* Live context drag overlay — Apple Teal (#5AC8FA) */}
             {ctxDrag && (
               <div
                 className="absolute pointer-events-none z-10"
@@ -382,16 +382,16 @@ export function Timeline() {
                   width: ctxDrag.width,
                   top: ctxDrag.top,
                   height: ctxDrag.height,
-                  background: 'rgba(59, 130, 246, 0.15)',
-                  borderLeft: '1px solid rgba(96, 165, 250, 0.5)',
-                  borderRight: '1px solid rgba(96, 165, 250, 0.5)',
-                  borderTop: '1px solid rgba(96, 165, 250, 0.3)',
-                  borderBottom: '1px solid rgba(96, 165, 250, 0.3)',
+                  background: 'rgba(90, 200, 250, 0.12)',
+                  borderLeft: '1px solid rgba(90, 200, 250, 0.5)',
+                  borderRight: '1px solid rgba(90, 200, 250, 0.5)',
+                  borderTop: '1px solid rgba(90, 200, 250, 0.3)',
+                  borderBottom: '1px solid rgba(90, 200, 250, 0.3)',
                 }}
               />
             )}
 
-            {/* Live select drag overlay (orange) — vertically scoped */}
+            {/* Live select drag overlay — Apple Purple (#AF52DE) */}
             {selDrag && (
               <div
                 className="absolute pointer-events-none z-10"
@@ -400,16 +400,16 @@ export function Timeline() {
                   width: selDrag.width,
                   top: selDrag.top,
                   height: selDrag.height,
-                  background: 'rgba(251, 146, 60, 0.15)',
-                  borderLeft: '1px solid rgba(251, 146, 60, 0.5)',
-                  borderRight: '1px solid rgba(251, 146, 60, 0.5)',
-                  borderTop: '1px solid rgba(251, 146, 60, 0.3)',
-                  borderBottom: '1px solid rgba(251, 146, 60, 0.3)',
+                  background: 'rgba(175, 82, 222, 0.12)',
+                  borderLeft: '1px solid rgba(175, 82, 222, 0.5)',
+                  borderRight: '1px solid rgba(175, 82, 222, 0.5)',
+                  borderTop: '1px solid rgba(175, 82, 222, 0.3)',
+                  borderBottom: '1px solid rgba(175, 82, 222, 0.3)',
                 }}
               />
             )}
 
-            {/* Live rubber-band clip selection overlay (white/zinc) */}
+            {/* Live rubber-band clip selection overlay — Apple Blue (#007AFF) */}
             {normalDrag && (
               <div
                 className="absolute pointer-events-none z-10"
@@ -418,8 +418,8 @@ export function Timeline() {
                   width: normalDrag.width,
                   top: normalDrag.top,
                   height: normalDrag.height,
-                  background: 'rgba(255, 255, 255, 0.08)',
-                  border: '1px solid rgba(255, 255, 255, 0.3)',
+                  background: 'rgba(0, 122, 255, 0.10)',
+                  border: '1px solid rgba(0, 122, 255, 0.45)',
                 }}
               />
             )}

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -16,9 +16,9 @@ function trimBuffer(
   clipDuration: number,
 ): AudioBuffer {
   const sr = buffer.sampleRate;
-  const startSample = Math.floor(clipStartTime * sr);
+  const startSample = Math.round(clipStartTime * sr);
   const endSample = Math.min(
-    Math.floor((clipStartTime + clipDuration) * sr),
+    Math.round((clipStartTime + clipDuration) * sr),
     buffer.length,
   );
   const trimmedLength = Math.max(1, endSample - startSample);

--- a/src/services/audioFileManager.ts
+++ b/src/services/audioFileManager.ts
@@ -4,13 +4,18 @@ function makeKey(projectId: string, clipId: string, type: 'cumulative' | 'isolat
   return `audio:${projectId}:${clipId}:${type}`;
 }
 
+/**
+ * Save an audio blob with a unique versioned key so that previous generations
+ * are not overwritten (needed for clip version navigation).
+ */
 export async function saveAudioBlob(
   projectId: string,
   clipId: string,
   type: 'cumulative' | 'isolated',
   blob: Blob,
 ): Promise<string> {
-  const key = makeKey(projectId, clipId, type);
+  const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const key = `audio:${projectId}:${clipId}:${type}:${suffix}`;
   await set(key, blob);
   return key;
 }

--- a/src/services/contextAudioExtractor.ts
+++ b/src/services/contextAudioExtractor.ts
@@ -16,7 +16,11 @@ export interface ContextWindow {
 
 /**
  * Render all ready clips that overlap `contextWindow` into a single mixed WAV blob
- * cropped to exactly the context window duration.
+ * whose time axis starts at project time 0 (not ctxStart).
+ *
+ * The backend assumes src_audio sample 0 = project time 0, so we must produce
+ * a blob that spans [0, ctxEnd] to keep repainting_start / repainting_end
+ * (which use absolute project times) aligned with the audio content.
  *
  * Returns null if no clips have audio in the context window range.
  */
@@ -27,11 +31,10 @@ export async function extractContextAudio(ctx: ContextWindow): Promise<Blob | nu
 
   const ctxStart = ctx.startTime;
   const ctxEnd = ctx.endTime;
-  const ctxDuration = ctxEnd - ctxStart;
-  if (ctxDuration <= 0) return null;
+  if (ctxEnd <= ctxStart) return null;
 
   const sampleRate = 48000;
-  const frameLength = Math.ceil(ctxDuration * sampleRate);
+  const frameLength = Math.ceil(ctxEnd * sampleRate);
   const offlineCtx = new OfflineAudioContext(2, frameLength, sampleRate);
 
   const soloActive = project.tracks.some((t) => t.soloed);
@@ -99,8 +102,9 @@ export async function extractContextAudio(ctx: ContextWindow): Promise<Blob | nu
         }
       }
 
-      // Schedule at the correct offset within the context window
-      const scheduleTime = overlapStart - ctxStart;
+      // Schedule at absolute project time so the blob's time axis matches
+      // the repainting_start / repainting_end coordinates sent to the backend
+      const scheduleTime = overlapStart;
       const source = offlineCtx.createBufferSource();
       source.buffer = cropped;
       source.connect(offlineCtx.destination);

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -66,15 +66,11 @@ export async function regenerateClip(clipId: string): Promise<void> {
   genStore.setIsGenerating(true);
 
   try {
-    const store = useProjectStore.getState();
-    // Save the current "ready" state as a version before overwriting
-    store.saveClipVersion(clipId);
-
     const previousBlob = await getPreviousCumulativeBlob(clipId);
     await generateClipInternal(clipId, previousBlob, {});
 
     // Save the newly generated result as the latest version
-    store.saveClipVersion(clipId);
+    useProjectStore.getState().saveClipVersion(clipId);
   } finally {
     useGenerationStore.getState().setIsGenerating(false);
   }
@@ -93,6 +89,9 @@ export async function generateSingleClip(clipId: string, options?: { sharedSeed?
     const previousBlob = await getPreviousCumulativeBlob(clipId);
     console.log(`[GenerationPipeline] generateSingleClip: clip=${clipId}, previousBlob=${previousBlob ? `${previousBlob.size} bytes` : 'null'}`);
     await generateClipInternal(clipId, previousBlob, options ? { sharedSeed: options.sharedSeed } : {});
+
+    // Save as version so the version arrows appear immediately
+    useProjectStore.getState().saveClipVersion(clipId);
   } finally {
     useGenerationStore.getState().setIsGenerating(false);
   }
@@ -359,9 +358,9 @@ async function generateClipInternal(
     const clipDuration = currentClip?.duration ?? clip.duration;
 
     const sampleRate = fullBuffer.sampleRate;
-    const startSample = Math.floor(clipStart * sampleRate);
+    const startSample = Math.round(clipStart * sampleRate);
     const endSample = Math.min(
-      Math.floor((clipStart + clipDuration) * sampleRate),
+      Math.round((clipStart + clipDuration) * sampleRate),
       fullBuffer.length,
     );
     const trimmedLength = Math.max(1, endSample - startSample);
@@ -473,6 +472,8 @@ export async function generateBatch(options: GenerateBatchOptions): Promise<void
           }),
         ),
       );
+      const store = useProjectStore.getState();
+      for (const { clipId } of tracks) store.saveClipVersion(clipId);
     } else {
       // Context mode — sequential; each track's output feeds the next
       let previousCumulativeBlob: Blob | null = null;
@@ -506,6 +507,7 @@ export async function generateBatch(options: GenerateBatchOptions): Promise<void
         firstCall = false;
         prevClipId = clipId;
         previousCumulativeBlob = await generateClipInternal(clipId, previousCumulativeBlob, opts);
+        useProjectStore.getState().saveClipVersion(clipId);
       }
     }
   } finally {
@@ -574,6 +576,8 @@ export async function generateFromAddLayer(opts: AddLayerOptions): Promise<void>
       lyricsOverride: opts.lyrics,
       chunkMaskMode: opts.chunkMaskMode,
     });
+
+    useProjectStore.getState().saveClipVersion(clip.id);
   } finally {
     useGenerationStore.getState().setIsGenerating(false);
   }
@@ -649,6 +653,8 @@ export async function generateFromMultiTrack(opts: MultiTrackGenerateOptions): P
           }),
         ),
       );
+      const st = useProjectStore.getState();
+      for (const { clipId } of batchTracks) st.saveClipVersion(clipId);
     } else {
       // Context mode — sequential generation, each builds on previous
       let previousCumulativeBlob = contextBlob;
@@ -669,6 +675,7 @@ export async function generateFromMultiTrack(opts: MultiTrackGenerateOptions): P
         }
         prevClipId = clipId;
         previousCumulativeBlob = await generateClipInternal(clipId, previousCumulativeBlob, clipOpts);
+        useProjectStore.getState().saveClipVersion(clipId);
       }
     }
   } finally {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -71,6 +71,7 @@ interface ProjectState {
   moveClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => void;
   duplicateClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => Clip | undefined;
   batchDuplicateClips: (clipIds: string[], timeOffset: number) => void;
+  batchMoveClips: (clipIds: string[], timeOffset: number) => void;
 
   removeAsset: (assetId: string) => void;
   toggleAssetStar: (assetId: string) => void;
@@ -807,6 +808,28 @@ export const useProjectStore = create<ProjectState>()(
       const extra = newClipsPerTrack.get(t.id);
       return extra ? { ...t, clips: [...t.clips, ...extra] } : t;
     });
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        tracks: newTracks,
+      },
+    });
+  },
+
+  batchMoveClips: (clipIds, timeOffset) => {
+    const state = get();
+    if (!state.project || clipIds.length === 0 || timeOffset === 0) return;
+    const idSet = new Set(clipIds);
+    const newTracks = state.project.tracks.map((t) => ({
+      ...t,
+      clips: t.clips.map((c) =>
+        idSet.has(c.id)
+          ? { ...c, startTime: Math.max(0, c.startTime + timeOffset) }
+          : c,
+      ),
+    }));
     set({
       project: {
         ...state.project,


### PR DESCRIPTION
## Summary

- **Clip version auto-regen**: Save version on first generation so navigation arrows appear immediately; right arrow auto-triggers new generation at latest version with a loading spinner; unique IndexedDB keys per generation fix version playback switching
- **Multi-clip drag move**: Add `batchMoveClips` store action so rubber-band or Cmd+A selected clips all move together when dragging any one of them
- **Context audio alignment**: Render context audio blob from project time 0 (not ctxStart) so `repainting_start`/`repainting_end` coordinates align correctly with the audio content, fixing timing offset in context-generated tracks
- **Sample rounding**: Use `Math.round` instead of `Math.floor` for sample boundary calculations in generation trimming and playback to eliminate off-by-one errors
- **Apple selection colors**: Adopt Apple HIG palette -- Blue (#007AFF) for clip selection, Purple (#AF52DE) for select window, Teal (#5AC8FA) for context window

## Test plan

- [ ] Generate a clip and verify version arrows (1/1) appear immediately
- [ ] Click right arrow to auto-regenerate, verify spinner and new version
- [ ] Switch between versions and verify playback uses correct audio
- [ ] Rubber-band select or Cmd+A multiple clips, drag to move -- all should move together
- [ ] Generate from context with ctxStart > 0, verify audio aligns correctly
- [ ] Verify selection, select window, and context window each have distinct colors


Made with [Cursor](https://cursor.com)