### PR TITLE
feat: add VitePress documentation site with GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build documentation
+        run: npm run docs:build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ github.event.repository.html_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,266 @@
         "@vitejs/plugin-react": "^4.0.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitepress": "^1.6.4"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.15.2.tgz",
+      "integrity": "sha512-rF7vRVE61E0QORw8e2NNdnttcl3jmFMWS9B4hhdga12COe+lMa26bQLfcBn/Nbp9/AF/8gXdaRCPsVns3CnjsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.49.2.tgz",
+      "integrity": "sha512-XyvKCm0RRmovMI/ChaAVjTwpZhXdbgt3iZofK914HeEHLqD1MUFFVLz7M0+Ou7F56UkHXwRbpHwb9xBDNopprQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.49.2.tgz",
+      "integrity": "sha512-jq/3qvtmj3NijZlhq7A1B0Cl41GfaBpjJxcwukGsYds6aMSCWrEAJ9pUqw/C9B3hAmILYKl7Ljz3N9SFvekD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.49.2.tgz",
+      "integrity": "sha512-bn0biLequn3epobCfjUqCxlIlurLr4RHu7RaE4trgN+RDcUq6HCVC3/yqq1hwbNYpVtulnTOJzcaxYlSr1fnuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.49.2.tgz",
+      "integrity": "sha512-z14wfFs1T3eeYbCArC8pvntAWsPo9f6hnUGoj8IoRUJTwgJiiySECkm8bmmV47/x0oGHfsVn3kBdjMX0yq0sNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.49.2.tgz",
+      "integrity": "sha512-GpRf7yuuAX93+Qt0JGEJZwgtL0MFdjFO9n7dn8s2pA9mTjzl0Sc5+uTk1VPbIAuf7xhCP9Mve+URGb6J+EYxgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.49.2.tgz",
+      "integrity": "sha512-HZwApmNkp0DiAjZcLYdQLddcG4Agb88OkojiAHGgcm5DVXobT5uSZ9lmyrbw/tmQBJwgu2CNw4zTyXoIB7YbPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.49.2.tgz",
+      "integrity": "sha512-y1IOpG6OSmTpGg/CT0YBb/EAhR2nsC18QWp9Jy8HO9iGySpcwaTvs5kHa17daP3BMTwWyaX9/1tDTDQshZzXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.49.2.tgz",
+      "integrity": "sha512-YYJRjaZ2bqk923HxE4um7j/Cm3/xoSkF2HC2ZweOF8cXL3sqnlndSUYmCaxHFjNPWLaSHk2IfssX6J/tdKTULw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.49.2.tgz",
+      "integrity": "sha512-9WgH+Dha39EQQyGKCHlGYnxW/7W19DIrEbCEbnzwAMpGAv1yTWCHMPXHxYa+LcL3eCp2V/5idD1zHNlIKmHRHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.49.2.tgz",
+      "integrity": "sha512-K7Gp5u+JtVYgaVpBxF5rGiM+Ia8SsMdcAJMTDV93rwh00DKNllC19o1g+PwrDjDvyXNrnTEbofzbTs2GLfFyKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.49.2.tgz",
+      "integrity": "sha512-3UhYCcWX6fbtN8ABcxZlhaQEwXFh3CsFtARyyadQShHMPe3mJV9Wel4FpJTa+seugRkbezFz0tt6aPTZSYTBuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.49.2.tgz",
+      "integrity": "sha512-G94VKSGbsr+WjsDDOBe5QDQ82QYgxvpxRGJfCHZBnYKYsy/jv9qGIDb93biza+LJWizQBUtDj7bZzp3QZyzhPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.49.2.tgz",
+      "integrity": "sha512-UuihBGHafG/ENsrcTGAn5rsOffrCIRuHMOsD85fZGLEY92ate+BMTUqxz60dv5zerh8ZumN4bRm8eW2z9L11jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -315,6 +574,113 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/@docsearch/js/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -759,6 +1125,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.74",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.74.tgz",
+      "integrity": "sha512-yqaohfY6jnYjTVpuTkaBQHrWbdUrQyWXhau0r/0EZiNWYXPX/P8WWwl1DoLH5CbvDjjcWQw5J0zADhgCUklOqA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1166,6 +1549,93 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
@@ -1490,6 +1960,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1510,12 +2034,33 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1536,6 +2081,297 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.30.tgz",
+      "integrity": "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.30",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.30.tgz",
+      "integrity": "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
+      "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.30.tgz",
+      "integrity": "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
+      "integrity": "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.30.tgz",
+      "integrity": "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.30.tgz",
+      "integrity": "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.30.tgz",
+      "integrity": "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "vue": "3.5.30"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
+      "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.2.tgz",
+      "integrity": "sha512-1K0wtDaRONwfhL4h8bbJ9qTjmY6rhGgRvvagXkMBsAOMNr+3Q2SffHECh9DIuNVrMA1JwA0zCwhyepgBZVakng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.15.2",
+        "@algolia/client-abtesting": "5.49.2",
+        "@algolia/client-analytics": "5.49.2",
+        "@algolia/client-common": "5.49.2",
+        "@algolia/client-insights": "5.49.2",
+        "@algolia/client-personalization": "5.49.2",
+        "@algolia/client-query-suggestions": "5.49.2",
+        "@algolia/client-search": "5.49.2",
+        "@algolia/ingestion": "1.49.2",
+        "@algolia/monitoring": "1.49.2",
+        "@algolia/recommend": "5.49.2",
+        "@algolia/requester-browser-xhr": "5.49.2",
+        "@algolia/requester-fetch": "5.49.2",
+        "@algolia/requester-node-http": "5.49.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/automation-events": {
@@ -1559,6 +2395,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/browserslist": {
@@ -1616,12 +2462,72 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1648,6 +2554,16 @@
         }
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1658,12 +2574,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.19.0",
@@ -1677,6 +2614,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -1731,6 +2681,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1747,6 +2704,16 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
       }
     },
     "node_modules/fsevents": {
@@ -1781,11 +2748,80 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/idb-keyval": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -2091,6 +3127,21 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2110,6 +3161,143 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2144,6 +3332,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2165,9 +3372,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -2191,6 +3398,28 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/react": {
@@ -2223,6 +3452,40 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.57.1",
@@ -2275,6 +3538,14 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -2285,10 +3556,48 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2305,6 +3614,41 @@
         "automation-events": "^7.0.9",
         "tslib": "^2.7.0"
       }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
@@ -2354,6 +3698,17 @@
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2372,6 +3727,79 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2416,6 +3844,36 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -2493,6 +3951,560 @@
         }
       }
     },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitepress/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
+      "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -2527,6 +4539,17 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "docs:dev": "vitepress dev website",
+    "docs:build": "vitepress build website",
+    "docs:preview": "vitepress preview website"
   },
   "dependencies": {
     "idb-keyval": "^6.2.0",
@@ -24,6 +27,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitepress": "^1.6.4"
   }
 }

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -1,0 +1,75 @@
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  title: 'ACE-Step DAW',
+  description: 'The AI-Powered Digital Audio Workstation',
+  head: [
+    ['meta', { name: 'theme-color', content: '#7c3aed' }],
+    ['meta', { property: 'og:title', content: 'ACE-Step DAW' }],
+    ['meta', { property: 'og:description', content: 'The AI-Powered Digital Audio Workstation' }],
+  ],
+  themeConfig: {
+    logo: '/logo.svg',
+    nav: [
+      { text: 'Guide', link: '/guide/getting-started' },
+      { text: 'Features', link: '/guide/features' },
+      { text: 'Roadmap', link: '/roadmap' },
+      { text: 'Changelog', link: '/changelog' },
+    ],
+    sidebar: [
+      {
+        text: 'Introduction',
+        items: [
+          { text: 'Getting Started', link: '/guide/getting-started' },
+          { text: 'Feature Overview', link: '/guide/features' },
+        ],
+      },
+      {
+        text: 'Tracks',
+        items: [
+          { text: 'Track Types', link: '/guide/tracks' },
+          { text: 'Piano Roll', link: '/guide/piano-roll' },
+          { text: 'Step Sequencer', link: '/guide/sequencer' },
+        ],
+      },
+      {
+        text: 'Production',
+        items: [
+          { text: 'Effects Chain', link: '/guide/effects' },
+          { text: 'Mixer', link: '/guide/mixer' },
+          { text: 'Automation', link: '/guide/automation' },
+          { text: 'Recording', link: '/guide/recording' },
+          { text: 'Loop Browser', link: '/guide/loop-browser' },
+        ],
+      },
+      {
+        text: 'AI Generation',
+        items: [
+          { text: 'AI Music Generation', link: '/guide/ai-generation' },
+        ],
+      },
+      {
+        text: 'Reference',
+        items: [
+          { text: 'Keyboard Shortcuts', link: '/guide/shortcuts' },
+          { text: 'Roadmap', link: '/roadmap' },
+          { text: 'Changelog', link: '/changelog' },
+        ],
+      },
+    ],
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/nicepkg/acestep-daw' },
+    ],
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright 2024-present ACE-Step DAW Contributors',
+    },
+    search: {
+      provider: 'local',
+    },
+  },
+  appearance: 'dark',
+  ignoreDeadLinks: [
+    /localhost/,
+  ],
+})

--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -1,0 +1,42 @@
+:root {
+  --vp-c-brand-1: #7c3aed;
+  --vp-c-brand-2: #6d28d9;
+  --vp-c-brand-3: #5b21b6;
+  --vp-c-brand-soft: rgba(124, 58, 237, 0.14);
+}
+
+.dark {
+  --vp-c-brand-1: #a78bfa;
+  --vp-c-brand-2: #8b5cf6;
+  --vp-c-brand-3: #7c3aed;
+  --vp-c-brand-soft: rgba(167, 139, 250, 0.14);
+}
+
+:root {
+  --vp-button-brand-border: transparent;
+  --vp-button-brand-text: #fff;
+  --vp-button-brand-bg: var(--vp-c-brand-1);
+  --vp-button-brand-hover-border: transparent;
+  --vp-button-brand-hover-text: #fff;
+  --vp-button-brand-hover-bg: var(--vp-c-brand-2);
+  --vp-button-brand-active-border: transparent;
+  --vp-button-brand-active-text: #fff;
+  --vp-button-brand-active-bg: var(--vp-c-brand-3);
+}
+
+:root {
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(135deg, #a78bfa 10%, #7c3aed 40%, #5b21b6 100%);
+  --vp-home-hero-image-background-image: linear-gradient(135deg, rgba(124, 58, 237, 0.3) 10%, rgba(91, 33, 182, 0.2) 100%);
+  --vp-home-hero-image-filter: blur(44px);
+}
+
+.VPFeature {
+  border: 1px solid var(--vp-c-brand-soft) !important;
+  transition: border-color 0.3s, transform 0.3s;
+}
+
+.VPFeature:hover {
+  border-color: var(--vp-c-brand-1) !important;
+  transform: translateY(-2px);
+}

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from 'vitepress/theme'
+import './custom.css'
+
+export default DefaultTheme

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to ACE-Step DAW are documented here.
+
+## v0.1.0 — Initial Release
+
+The first public release of ACE-Step DAW.
+
+### Tracks
+- 4 track types: Stems, Sample, Sequencer, Piano Roll
+- 12 named instruments with color-coded headers
+- Clip operations: move, resize, split, duplicate, delete
+- Per-clip audio cropping for sample tracks
+
+### AI Generation
+- LEGO pipeline with sequential multi-track generation
+- Cover mode for AI-powered style transfer
+- Repaint mode for selective time-range regeneration
+- Vocal2BGM for generating accompaniment from vocals
+- 16 generation presets across 8 genres
+- Audio analysis: BPM, key, genre, time signature detection
+- DiT and LM model selection with LoRA support
+
+### Piano Roll
+- Canvas-based MIDI editor with grid snap (1/4, 1/8, 1/16, 1/32)
+- Velocity lane with color gradient display
+- Draw mode for rapid note entry
+- 6 synth presets: Piano, Strings, Pad, Lead, Bass, Organ
+
+### Step Sequencer
+- FL Studio-inspired pattern grid (8, 16, 32 steps)
+- Swing control and per-step velocity
+- 16-pad beat pads with QWERTY keyboard mapping
+- 4 drum kits: 808, Acoustic, Electronic, Lo-Fi
+- Per-row volume, pan, mute, clone, and rename
+
+### Mixer & Effects
+- Per-track volume, pan, mute, solo with master fader
+- 6 effects: EQ3, Compressor, Reverb, Delay, Distortion, Filter
+- Per-track integrated EQ, compressor, and reverb
+- Real-time gain reduction metering
+- Effect presets for all processors
+
+### Recording
+- Microphone input with device selection
+- Count-in (off, 1 bar, 2 bars) and metronome
+- Real-time level metering and monitoring
+- WAV output at 48kHz stereo 16-bit PCM
+
+### Automation
+- Breakpoint-based envelopes for volume and pan
+- Per-point curve control (ease-in, linear, ease-out)
+- Real-time interpolation during playback
+
+### Loop Browser
+- 15 built-in synthesized loops (drums, bass, keys, synth)
+- Search and category filtering
+- Preview playback and drag-to-timeline
+
+### Project
+- IndexedDB auto-save with undo/redo (50 states)
+- WAV export with real-time mixing
+- Full keyboard shortcut system

--- a/website/guide/ai-generation.md
+++ b/website/guide/ai-generation.md
@@ -1,0 +1,130 @@
+# AI Music Generation
+
+ACE-Step DAW integrates a powerful AI engine for generating, transforming, and analyzing music. The system supports four generation modes and automatic audio analysis.
+
+## LEGO Pipeline
+
+The core generation mode. Tracks are generated sequentially, with each new track receiving the cumulative mix of all previously generated tracks as musical context.
+
+### How It Works
+
+1. Tracks are generated in a fixed order: Drums → Bass → Guitar → Keyboard → Percussion → Strings → Synth → FX → Brass → Woodwinds → Backing Vocals → Vocals
+2. Each generation receives the cumulative audio from prior tracks
+3. The AI uses this context to produce parts that harmonically and rhythmically fit the existing mix
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+### Generation Parameters
+
+| Parameter | Description |
+|---|---|
+| **Prompt** | Describe the style and character of the track |
+| **Global Caption** | Overall song description shared across all tracks |
+| **Lyrics** | Lyrics text (for vocal tracks) |
+| **Instruction** | Additional generation guidance |
+| **BPM** | Tempo (auto-detected or manual) |
+| **Key** | Musical key (auto-detected or manual) |
+| **Seed** | Random seed for reproducibility |
+| **Batch Size** | Number of variations to generate |
+| **Inference Steps** | Quality/speed tradeoff |
+| **Guidance Scale** | How closely to follow the prompt |
+
+### Using LEGO Generation
+
+1. Add a stems track and select an instrument
+2. Press `Cmd/Ctrl + G` to generate from silence, or `Cmd/Ctrl + Shift + G` to generate with context
+3. Configure parameters in the generation dialog
+4. Wait for the generation to complete (status tracked in real time)
+5. Preview the result — regenerate if needed
+
+::: tip
+Generate drums first. They provide the rhythmic foundation that all subsequent tracks build on.
+:::
+
+## Cover Mode
+
+Transform existing audio into a new style while preserving the original structure and timing.
+
+| Parameter | Description |
+|---|---|
+| **Caption** | Describe the target style |
+| **Lyrics** | Updated lyrics (optional) |
+| **Cover Strength** | 0.0 (identical) to 1.0 (fully transformed) |
+
+**Use cases:** Convert a rock track to jazz, change the vocal style, reimagine a section in a different genre.
+
+## Repaint Mode
+
+Regenerate a specific time range within an existing clip while preserving the surrounding audio.
+
+| Parameter | Description |
+|---|---|
+| **Prompt** | Describe what the new section should sound like |
+| **Repainting Start** | Start time in seconds |
+| **Repainting End** | End time in seconds |
+
+**Use cases:** Fix a section that does not fit, try a different melodic idea in the chorus, replace a drum fill.
+
+## Vocal2BGM
+
+Generate an instrumental accompaniment track from a vocal recording.
+
+| Parameter | Description |
+|---|---|
+| **Source** | Vocal track audio |
+| **Caption** | Style description for the accompaniment |
+
+The AI analyzes the vocal and generates fitting instrumental parts.
+
+## Generation Presets
+
+16 built-in presets with suggested BPM, key, and lyrics templates:
+
+| Genre | Presets |
+|---|---|
+| **Pop** | Upbeat Pop, Pop Ballad |
+| **Rock** | Classic Rock, Indie Rock |
+| **Jazz** | Smooth Jazz, Bebop |
+| **Electronic** | House, Synthwave |
+| **Hip-Hop** | Boom Bap, Trap |
+| **Classical** | Orchestral, Piano Sonata |
+| **Lo-Fi** | Lo-Fi Chill, Lo-Fi Jazz |
+| **Ambient** | Space Ambient, Nature Ambient |
+
+## Audio Analysis
+
+The AI engine can analyze any audio clip to detect:
+
+- **BPM** — Tempo detection
+- **Key** — Musical key and scale
+- **Genre** — Style classification
+- **Time Signature** — Meter detection
+
+Analysis results are stored as clip metadata and used to inform subsequent generations.
+
+## Generation Status
+
+Each generation task progresses through these states:
+
+| Status | Meaning |
+|---|---|
+| `empty` | No generation started |
+| `queued` | Waiting in the generation queue |
+| `generating` | AI model is generating audio |
+| `processing` | Post-processing the result |
+| `ready` | Generation complete — audio available |
+| `error` | Generation failed |
+| `stale` | Context has changed — may need regeneration |
+
+## Model Configuration
+
+The generation engine supports:
+
+- **DiT model** selection (Diffusion Transformer)
+- **LM model** selection (Language Model)
+- **LoRA** support for fine-tuned models
+- Model initialization via the backend API
+
+::: warning Known Limitation
+AI generation requires a running backend server. Core DAW features (editing, mixing, playback) work offline, but generation needs the AI inference service.
+:::

--- a/website/guide/automation.md
+++ b/website/guide/automation.md
@@ -1,0 +1,73 @@
+# Automation Envelopes
+
+Automation envelopes let you change track parameters over time — creating fades, panning sweeps, and dynamic mixes that evolve throughout the song.
+
+## Supported Parameters
+
+| Parameter | Range | Description |
+|---|---|---|
+| **Volume** | 0 to 1 | Track loudness over time |
+| **Pan** | -1 to +1 | Stereo position over time (stored as 0 to 1, mapped to -1 to +1) |
+
+## How Automation Works
+
+Each automation lane contains a series of **breakpoints** — time/value pairs that define the parameter's shape over time.
+
+```
+Point A (0s, 0.8) ──── Point B (4s, 0.2) ──── Point C (8s, 1.0)
+```
+
+The engine interpolates smoothly between breakpoints during playback, creating continuous parameter changes.
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+## Breakpoint Properties
+
+| Property | Description |
+|---|---|
+| **Time** | Position in seconds |
+| **Value** | Parameter value (0 to 1) |
+| **Curve** | -1 (ease-in) to 0 (linear) to +1 (ease-out) |
+
+### Curve Types
+
+| Curve | Value | Behavior |
+|---|---|---|
+| Ease-in | -1 | Slow start, fast end |
+| Linear | 0 | Constant rate of change |
+| Ease-out | +1 | Fast start, slow end |
+
+## Common Automation Patterns
+
+### Fade In
+Set volume from 0 to 1 over the intro:
+- Point 1: time = 0s, value = 0
+- Point 2: time = 4s, value = 1
+
+### Fade Out
+Gradually reduce volume at the end:
+- Point 1: time = 56s, value = 1
+- Point 2: time = 60s, value = 0, curve = +1 (ease-out for natural decay)
+
+### Pan Sweep
+Move audio from left to right:
+- Point 1: time = 0s, value = 0 (hard left)
+- Point 2: time = 8s, value = 1 (hard right)
+
+### Volume Duck
+Drop volume for a vocal section:
+- Point 1: time = 8s, value = 0.8
+- Point 2: time = 8.5s, value = 0.3
+- Point 3: time = 16s, value = 0.3
+- Point 4: time = 16.5s, value = 0.8
+
+## Tips
+
+- Use **ease-out curves** for fade-outs — they sound more natural than linear fades
+- Automate pad and ambient tracks to keep the mix interesting over long sections
+- Volume automation is great for creating builds and drops in electronic music
+- Keep automation points sparse — fewer points with curves often sound smoother than many points
+
+::: warning Known Limitation
+Automation is currently limited to volume and pan. Effect parameter automation (e.g., filter cutoff over time) is planned for a future release.
+:::

--- a/website/guide/effects.md
+++ b/website/guide/effects.md
@@ -1,0 +1,108 @@
+# Effects Chain
+
+Every track in ACE-Step DAW has a serial effects chain with 6 built-in processors. Effects are applied in order, and each can be independently enabled or disabled.
+
+## Effect Chain Order
+
+Effects process audio in series:
+
+```
+Input → EQ3 → Compressor → Reverb → Delay → Distortion → Filter → Output
+```
+
+Each effect has its own enable/disable toggle — bypassed effects pass audio through unchanged.
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+## EQ3 — 3-Band Equalizer
+
+Shape the frequency balance of your track with low, mid, and high bands.
+
+| Parameter | Range | Description |
+|---|---|---|
+| Low Gain | -15 to +15 dB | Low shelf at 250 Hz |
+| Mid Gain | -15 to +15 dB | Mid band |
+| High Gain | -15 to +15 dB | High shelf at 8 kHz |
+
+**Presets:** Flat, Bass Boost, Presence, Warmth
+
+## Compressor
+
+Control dynamic range with real-time gain reduction metering.
+
+| Parameter | Range | Description |
+|---|---|---|
+| Threshold | -24 to 0 dB | Level where compression starts |
+| Ratio | 1:1 to 20:1 | Compression intensity |
+| Attack | ms | How fast compression engages |
+| Release | ms | How fast compression releases |
+| Knee | 0 to 6 dB | Transition smoothness |
+
+**Presets:** Gentle, Vocal, Drum Bus, Limit
+
+::: tip
+Watch the gain reduction meter to ensure you are not over-compressing. 3-6 dB of reduction is a good starting point.
+:::
+
+## Reverb
+
+Add spatial depth and ambience.
+
+| Parameter | Range | Description |
+|---|---|---|
+| Decay | 0.5 to 5 s | Reverb tail length |
+| Pre-Delay | 0 to 100 ms | Gap before reverb starts |
+| Mix | 0 to 1 | Wet/dry balance |
+
+**Presets:** Room, Hall, Chamber, Plate
+
+## Delay
+
+Create echoes and rhythmic repeats.
+
+| Parameter | Range | Description |
+|---|---|---|
+| Time | 10 ms to 1 s | Delay between repeats |
+| Feedback | 0 to 0.95 | Number of repeats (higher = more) |
+| Mix | 0 to 1 | Wet/dry balance |
+
+**Presets:** Slap, Echo, Long
+
+## Distortion
+
+Add harmonic saturation from subtle warmth to aggressive fuzz.
+
+| Parameter | Range | Description |
+|---|---|---|
+| Type | Soft Clip / Overdrive / Fuzz | Saturation curve |
+| Amount | 0 to 1 | Distortion intensity |
+| Mix | 0 to 1 | Wet/dry balance |
+
+## Filter
+
+Multimode filter with optional LFO modulation.
+
+| Parameter | Range | Description |
+|---|---|---|
+| Type | Lowpass / Highpass / Bandpass | Filter mode |
+| Frequency | 20 Hz to 20 kHz | Cutoff frequency |
+| Resonance | 0 to 20 | Resonant peak at cutoff |
+| LFO Rate | 0.1 to 20 Hz | Modulation speed |
+| LFO Depth | 0 to 1 | Modulation amount |
+
+**Presets:** Low Pass, High Pass, Wah LFO
+
+::: tip
+Enable the **LFO** on a lowpass filter to create auto-wah and filter sweep effects.
+:::
+
+## Tips
+
+- Start with EQ to clean up the tone, then add compression for consistency
+- Use reverb sparingly on bass instruments — it can muddy the low end
+- A short slap delay (30-80 ms) adds width without obvious echoes
+- Stack subtle distortion with a filter sweep for evolving textures
+
+::: warning Known Limitation
+Effect parameter changes apply in real time for most effects. However, changing the distortion type requires an internal rebuild of the audio node.
+:::

--- a/website/guide/features.md
+++ b/website/guide/features.md
@@ -1,0 +1,56 @@
+# Feature Overview
+
+ACE-Step DAW packs a full production toolkit into the browser. Here is everything it offers.
+
+## Tracks & Editing
+
+| Feature | Description |
+|---------|-------------|
+| **4 Track Types** | Stems, Sample, Sequencer, Piano Roll |
+| **12 Instruments** | Vocals, Guitar, Bass, Drums, Keyboard, Strings, Synth, Brass, Woodwinds, Percussion, FX, Custom |
+| **Piano Roll** | Canvas-based MIDI editor with velocity lanes, grid snap (1/4 to 1/32), draw mode |
+| **Step Sequencer** | 8/16/32-step patterns, swing control, per-row volume and pan |
+| **Beat Pads** | 16-pad grid with QWERTY keyboard mapping and velocity |
+| **Clip Editing** | Move, resize, split (`S`), duplicate (`Cmd+D`), crop audio regions |
+
+## AI Music Generation
+
+| Feature | Description |
+|---------|-------------|
+| **LEGO Pipeline** | Sequential multi-track generation with cumulative context |
+| **Cover** | Style transfer with adjustable strength |
+| **Repaint** | Regenerate a specific time range within a clip |
+| **Vocal2BGM** | Generate instrumental accompaniment from vocals |
+| **16 Presets** | Pop, Rock, Jazz, Electronic, Hip-Hop, Classical, Lo-Fi, Ambient |
+| **Audio Analysis** | AI-powered BPM, key, genre, and time signature detection |
+
+## Mixing & Effects
+
+| Feature | Description |
+|---------|-------------|
+| **Mixer Panel** | Per-track volume, pan, mute, solo with master fader |
+| **EQ3** | 3-band equalizer with shelf frequencies |
+| **Compressor** | Threshold, ratio, attack, release, knee with gain reduction metering |
+| **Reverb** | Room, Hall, Chamber, Plate presets |
+| **Delay** | Slap, Echo, Long presets with feedback control |
+| **Distortion** | Soft clip, Overdrive, Fuzz modes |
+| **Filter** | Lowpass, Highpass, Bandpass with optional LFO modulation |
+
+## Production Tools
+
+| Feature | Description |
+|---------|-------------|
+| **Recording** | Mic input with count-in, metronome, level metering |
+| **Automation** | Breakpoint envelopes for volume and pan with curve control |
+| **Loop Browser** | 15 built-in synthesized loops (drums, bass, keys, synth) |
+| **6 Synth Presets** | Piano, Strings, Pad, Lead, Bass, Organ |
+| **4 Drum Kits** | 808, Acoustic, Electronic, Lo-Fi |
+
+## Project Management
+
+| Feature | Description |
+|---------|-------------|
+| **Auto-Save** | Projects persist to IndexedDB automatically |
+| **Undo/Redo** | Up to 50 history states (`Cmd+Z` / `Cmd+Shift+Z`) |
+| **WAV Export** | 48kHz stereo 16-bit PCM export |
+| **Offline** | Runs entirely in the browser — no server required for core features |

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -1,0 +1,61 @@
+# Getting Started
+
+ACE-Step DAW is a browser-based digital audio workstation powered by AI music generation. It runs entirely in your browser — no installation required beyond cloning the repo.
+
+## Prerequisites
+
+- **Node.js** 18 or later
+- **npm** 9 or later
+- A modern browser (Chrome or Edge recommended for best Web Audio support)
+
+## Installation
+
+```bash
+git clone https://github.com/nicepkg/acestep-daw.git
+cd acestep-daw
+npm install
+```
+
+## Running the DAW
+
+```bash
+npm run dev
+```
+
+This starts the Vite development server. Open [http://localhost:5173](http://localhost:5173) in your browser.
+
+## Your First Project
+
+1. **Create a new project** — Press `Cmd/Ctrl + N` or use the project menu.
+2. **Add a track** — Press `Cmd/Ctrl + Shift + I` to open the instrument picker. Choose from 12 named instruments (Drums, Bass, Guitar, Vocals, etc.) or create a custom track.
+3. **Choose a track type** — Each track can be a Stems, Sample, Sequencer, or Piano Roll track.
+4. **Add content** — Depending on your track type:
+   - **Stems**: Use AI generation (`Cmd/Ctrl + G`) to create instrument parts
+   - **Sample**: Import audio files by dragging them onto the timeline
+   - **Sequencer**: Click steps in the pattern grid to build drum patterns
+   - **Piano Roll**: Press `E` to open the editor and draw MIDI notes
+5. **Mix** — Press `X` to open the mixer. Adjust volume, pan, and add effects.
+6. **Export** — Press `Cmd/Ctrl + Shift + E` to export your project as a WAV file.
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+## Project Structure
+
+Your projects are saved automatically to IndexedDB in your browser. Each project stores:
+
+- Track configuration and clip data
+- Audio blobs (recorded and AI-generated)
+- Mixer settings and effect chains
+- Automation envelopes
+- Undo/redo history (up to 50 states)
+
+::: tip
+Projects persist across browser sessions. Use `Cmd/Ctrl + O` to browse and switch between saved projects.
+:::
+
+## Next Steps
+
+- [Feature Overview](/guide/features) — See everything ACE-Step DAW can do
+- [Track Types](/guide/tracks) — Learn about the 4 track types
+- [AI Generation](/guide/ai-generation) — Generate music with the LEGO pipeline
+- [Keyboard Shortcuts](/guide/shortcuts) — Speed up your workflow

--- a/website/guide/loop-browser.md
+++ b/website/guide/loop-browser.md
@@ -1,0 +1,86 @@
+# Loop Browser
+
+The loop browser provides 15 built-in synthesized loops that you can preview, search, and drag onto the timeline.
+
+## Opening the Loop Browser
+
+Press `O` to toggle the loop browser / assets panel.
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+## Built-in Loops
+
+### Drums
+
+| Loop | BPM | Bars | Character |
+|---|---|---|---|
+| 808 Boom | 90 | 4 | Classic 808-style kick pattern |
+| Rock Steady | 120 | 4 | Solid rock beat |
+| Shuffle Blues | 95 | 4 | Shuffled hi-hat groove |
+| Trap Hi-Hats | 140 | 4 | Rapid hi-hat rolls |
+| Lo-Fi Drums | 85 | 4 | Laid-back, crunchy beat |
+
+### Bass
+
+| Loop | BPM | Bars | Key | Character |
+|---|---|---|---|---|
+| Sub Bass | 90 | 4 | Cm | Deep sub bass |
+| Walking Bass | 120 | 4 | C | Jazz walking bass line |
+| Funk Slap | 110 | 4 | Em | Funky slap bass |
+| Synth Bass | 128 | 4 | Cm | Pulsing synth bass |
+
+### Keys
+
+| Loop | BPM | Bars | Key | Character |
+|---|---|---|---|---|
+| Piano Ballad | 80 | 4 | C | Gentle piano chords |
+| Rhodes Groove | 100 | 4 | Eb | Smooth Rhodes progression |
+| Ambient Pad | 70 | 8 | C | Evolving pad texture |
+
+### Synth
+
+| Loop | BPM | Bars | Key | Character |
+|---|---|---|---|---|
+| Arp Cascade | 128 | 4 | C | Arpeggiated synth |
+| Lead Line | 120 | 4 | Cm | Melodic synth lead |
+| Pluck Stab | 130 | 4 | Cm | Short pluck chords |
+
+## Using the Loop Browser
+
+### Search
+
+Type in the search bar to filter loops by name.
+
+### Filter by Category
+
+Click the category tabs to filter:
+- **All** — Show all loops
+- **Drums** — Drum loops only
+- **Bass** — Bass loops only
+- **Keys** — Keyboard loops only
+- **Synth** — Synth loops only
+
+### Preview
+
+Click a loop to preview it. Click again to stop playback.
+
+### Add to Timeline
+
+Drag a loop from the browser onto the timeline to insert it as a new clip.
+
+## How Loops Work
+
+All loops are **synthesized on demand** using Tone.js — no external audio files are required. Each loop is generated the first time you preview or use it, then cached for instant access.
+
+Waveform peaks are extracted for visual display in both the browser and the timeline.
+
+## Tips
+
+- Use the **808 Boom** and **Sub Bass** loops together for a hip-hop foundation
+- The **Ambient Pad** loop (8 bars) works well as a background texture — layer it under other instruments
+- Combine **Rock Steady** drums with **Walking Bass** for an instant jazz-rock groove
+- Loops inherit the project BPM — they will time-stretch to match your tempo
+
+::: warning Known Limitation
+Custom loop import is not yet supported. The 15 built-in loops are synthesized — you cannot add your own loops to the browser at this time.
+:::

--- a/website/guide/mixer.md
+++ b/website/guide/mixer.md
@@ -1,0 +1,84 @@
+# Mixer
+
+The mixer panel provides per-track channel strips and a master fader for controlling the final mix.
+
+## Opening the Mixer
+
+Press `X` to toggle the mixer panel. It appears at the bottom of the DAW interface and can be resized by dragging the top divider.
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+## Channel Strip
+
+Each track has a channel strip with the following controls:
+
+| Control | Range | Description |
+|---|---|---|
+| **Volume** | 0 to 1 | Exponential scaling for natural loudness response |
+| **Pan** | -1 (L) to +1 (R) | Stereo position |
+| **Mute** | On/Off | Silence the track |
+| **Solo** | On/Off | Solo this track (exclusive — mutes all others) |
+
+## Master Fader
+
+The master fader controls the global output volume.
+
+| Parameter | Range | Default |
+|---|---|---|
+| Volume | 0 to 2.0 | 1.0 |
+
+::: tip
+Keep the master fader at 1.0 and use individual track volumes to balance the mix. Only boost the master if the overall level is too quiet after mixing.
+:::
+
+## Per-Track EQ
+
+Each channel strip includes a built-in 3-band EQ:
+
+- **Low** shelf at 250 Hz (±15 dB)
+- **Mid** band (±15 dB)
+- **High** shelf at 8 kHz (±15 dB)
+
+Default: all bands at 0 dB (flat).
+
+## Per-Track Compressor
+
+A built-in compressor is available on every channel:
+
+| Parameter | Default |
+|---|---|
+| Threshold | -24 dB |
+| Ratio | 4:1 |
+| Knee | Configurable |
+| Attack/Release | Configurable |
+
+Includes a gain reduction meter for visual feedback.
+
+## Per-Track Reverb
+
+A simple reverb send built into each channel:
+
+| Parameter | Range | Default |
+|---|---|---|
+| Mix | 0 to 1 | 0 (off) |
+| Room Size | 0 to 1 | — |
+
+## Mixing Workflow
+
+1. **Set levels** — Start with all faders at 0.7 and adjust relative to the loudest element
+2. **Pan for width** — Spread instruments across the stereo field. Keep kick, bass, and vocals centered.
+3. **Solo to check** — Solo each track to listen for issues before mixing back in
+4. **Add EQ** — Cut problem frequencies, boost character
+5. **Compress** — Tame dynamics on vocals and drums
+6. **Add reverb** — A touch of reverb on most tracks, more on vocals and snare
+
+## Tips
+
+- Use **solo** to check individual tracks, but always make mixing decisions with all tracks playing
+- Cut frequencies with EQ more than you boost — subtraction often sounds more natural
+- Keep the master meter below clipping (0 dB)
+- The mixer height is resizable — drag the top edge for more or less screen space
+
+::: warning Known Limitation
+The mixer does not currently support aux sends or bus routing. All effects are applied per-track in the effect chain.
+:::

--- a/website/guide/piano-roll.md
+++ b/website/guide/piano-roll.md
@@ -1,0 +1,87 @@
+# Piano Roll
+
+The Piano Roll is a canvas-based MIDI editor for composing melodies, chords, and bass lines with built-in synth playback.
+
+## Opening the Piano Roll
+
+1. Select a Piano Roll clip on the timeline
+2. Press `E` or double-click the clip to open the editor
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+## Interface Layout
+
+| Area | Description |
+|---|---|
+| **MIDI Keyboard** | 56px sidebar on the left showing note names (C, C#, D, etc.) with octave labels. Black keys are shaded. |
+| **Note Grid** | Main editing area. Notes appear as colored rectangles. |
+| **Velocity Lane** | 60px strip below the grid showing velocity bars for each note. Resizable via drag divider. |
+| **Toolbar** | Grid size selector, draw mode toggle, zoom controls. |
+
+## Drawing Notes
+
+1. Enable **Draw Mode** by pressing `B` or clicking the draw mode toggle
+2. Click on the grid to place a note
+3. Drag left/right while placing to set duration
+4. Notes snap to the selected grid size
+
+## Editing Notes
+
+| Action | How |
+|---|---|
+| **Move** | Drag the center of a note |
+| **Resize** | Drag the left or right edge |
+| **Delete** | Select and press `Delete` or `Backspace` |
+| **Select multiple** | Click with modifier keys or box-select |
+| **Preview** | Hover over a note to hear it |
+
+## Grid Snap
+
+Four grid sizes are available:
+
+- **1/4** — Quarter notes
+- **1/8** — Eighth notes
+- **1/16** — Sixteenth notes (default)
+- **1/32** — Thirty-second notes
+
+All note placement and resizing snaps to the selected grid.
+
+## Velocity
+
+Each note has a velocity value from 0 to 127 that controls its volume and intensity.
+
+- Velocity is shown in the **velocity lane** as vertical bars
+- Color gradient: low velocity = blue, high velocity = red/orange
+- Edit velocity by dragging bars in the velocity lane
+
+## Synth Presets
+
+Each piano roll track includes 6 built-in synth presets:
+
+| Preset | Waveform | Character |
+|---|---|---|
+| **Piano** | Triangle | Soft attack, medium sustain |
+| **Strings** | Sawtooth | Slow attack, long release |
+| **Pad** | Sine | Very slow attack, ambient |
+| **Lead** | Square | Sharp attack, cutting |
+| **Bass** | Sawtooth | Punchy, short |
+| **Organ** | Sine | Instant attack, no release |
+
+## Navigation
+
+| Action | Shortcut |
+|---|---|
+| Zoom X/Y | Scroll wheel with `Cmd/Ctrl` |
+| Pan/Scroll | Scroll wheel |
+| Toggle draw mode | `B` |
+
+## Tips
+
+- Use **1/16 grid** for detailed melodies, **1/4 grid** for chord pads
+- Lower velocities work well for ghost notes in drum programming
+- The velocity color gradient makes it easy to spot dynamic variation at a glance
+- Combine with the [Effects Chain](/guide/effects) to shape your synth sound
+
+::: warning Known Limitation
+The piano roll currently supports single-track editing only. Multi-track MIDI overlay is not yet available.
+:::

--- a/website/guide/recording.md
+++ b/website/guide/recording.md
@@ -1,0 +1,73 @@
+# Recording
+
+ACE-Step DAW supports microphone recording directly into sample tracks with real-time monitoring and level metering.
+
+## Setup
+
+1. **Allow microphone access** — Your browser will prompt for permission when you first use recording
+2. **Select input device** — Open Settings (`Cmd/Ctrl + ,`) to choose from available microphone inputs
+3. **Arm a track** — Select the track you want to record into
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+## Recording Controls
+
+### Count-In
+
+Three modes are available in Settings:
+
+| Mode | Behavior |
+|---|---|
+| **Off** | Recording starts immediately |
+| **1 Bar** | One bar of metronome clicks before recording |
+| **2 Bars** | Two bars of metronome clicks before recording |
+
+### Metronome
+
+| Mode | Behavior |
+|---|---|
+| **Always On** | Click plays during playback and recording |
+| **Recording Only** | Click plays only while recording |
+| **Off** | No metronome |
+
+### Input Gain
+
+Adjust the input gain to control recording levels. The level meter shows:
+- **Current dB** — Real-time input level
+- **Peak** — Maximum level reached (helps detect clipping)
+
+### Monitoring
+
+Enable monitoring to hear your input in real time through your speakers or headphones.
+
+::: tip
+Use headphones when monitoring is enabled to avoid feedback loops between your speakers and microphone.
+:::
+
+## Recording a Take
+
+1. Select or create a sample track
+2. Position the playhead where you want to start
+3. Configure count-in and metronome preferences
+4. Press the record button
+5. After the count-in, recording begins — a waveform displays in real time
+6. Press stop or the record button again to finish
+7. The recording appears as a new clip on the track
+
+## Output Format
+
+Recordings are saved as WAV files:
+- **Sample Rate:** 48 kHz
+- **Channels:** 2 (stereo)
+- **Bit Depth:** 16-bit PCM
+
+## Tips
+
+- Check your input level before recording — aim for peaks around -6 dB to leave headroom
+- Use the 1-bar count-in to get into rhythm before your take starts
+- Record multiple takes and keep the best one — you can always delete unwanted clips
+- After recording, use clip cropping to trim silence from the start and end
+
+::: warning Known Limitation
+Recording is limited to one track at a time. Multi-track simultaneous recording is not yet supported.
+:::

--- a/website/guide/sequencer.md
+++ b/website/guide/sequencer.md
@@ -1,0 +1,91 @@
+# Step Sequencer & Beat Pads
+
+The step sequencer is an FL Studio-inspired drum pattern editor for creating rhythmic patterns with a grid interface and real-time beat pads.
+
+## Pattern Configuration
+
+| Setting | Options | Default |
+|---|---|---|
+| Steps per bar | 8, 16, 32 | 16 |
+| Bars | 1 to 4 | 1 |
+| Swing | 0.0 to 1.0 | 0.0 (straight) |
+
+Swing offsets the timing of odd-numbered steps. At 0 the rhythm is perfectly straight; at 0.67 you get a heavy shuffle feel.
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+## Step Grid
+
+The grid displays rows (one per drum sound) and columns (one per step).
+
+**To toggle a step:** Click it. Active steps light up in the row's accent color.
+
+**Per-step velocity:** Each active step has an adjustable velocity (0 to 1) that controls its playback volume.
+
+## Drum Rows
+
+Each row represents a drum sound. You can have 8 or more rows per pattern.
+
+**Per-row controls:**
+
+| Control | Description |
+|---|---|
+| Volume | 0 to 1, controls row loudness |
+| Pan | -1 (left) to +1 (right) |
+| Mute | Silence the row |
+| Clone | Duplicate the row |
+| Remove | Delete the row |
+| Rename | Change the row label |
+
+## Drum Kits
+
+Four built-in kits to choose from:
+
+| Kit | Character |
+|---|---|
+| **808** | Classic electronic — boomy kick, snappy snare |
+| **Acoustic** | Natural drum kit sounds |
+| **Electronic** | Modern electronic percussion |
+| **Lo-Fi** | Warm, crunchy, lo-fi textures |
+
+**Default rows:** Kick, Snare, Closed Hi-Hat, Open Hi-Hat
+
+**Extended rows:** + Clap, Rim, Low Tom, High Tom
+
+## Beat Pads
+
+A 16-pad grid (4 x 4) for triggering drum sounds in real time.
+
+### QWERTY Keyboard Mapping
+
+```
+ 1  2  3  4
+ Q  W  E  R
+ A  S  D  F
+ Z  X  C  V
+```
+
+Press any mapped key to trigger the corresponding pad with LED-style visual feedback.
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+## Step-by-Step: Building a Pattern
+
+1. **Select a kit** — Choose 808, Acoustic, Electronic, or Lo-Fi
+2. **Set steps and bars** — 16 steps / 1 bar is a good starting point
+3. **Program the kick** — Click steps 1, 5, 9, 13 for a four-on-the-floor pattern
+4. **Add snare** — Click steps 5 and 13 for a standard backbeat
+5. **Layer hi-hats** — Click every other step (1, 3, 5, 7, ...) for eighth-note hats
+6. **Adjust swing** — Try 0.3 to 0.5 for a natural groove
+7. **Fine-tune velocity** — Lower the velocity on off-beat hats for a more human feel
+
+## Tips
+
+- Use **32 steps** for detailed hi-hat rolls and trap-style patterns
+- Combine swing with velocity variation for a natural, human feel
+- Use the **beat pads** to audition sounds before programming them in the grid
+- Clone a row and pitch-shift it for layered percussion
+
+::: warning Known Limitation
+Sequencer patterns are fixed-length per bar. Variable-length patterns within a single track are not yet supported.
+:::

--- a/website/guide/shortcuts.md
+++ b/website/guide/shortcuts.md
@@ -1,0 +1,100 @@
+# Keyboard Shortcuts
+
+A complete reference of all keyboard shortcuts in ACE-Step DAW.
+
+## Transport
+
+| Shortcut | Action |
+|---|---|
+| `Space` | Play / Pause |
+| `Enter` | Stop |
+| `L` | Toggle loop mode |
+| `←` | Seek back 5 seconds |
+| `→` | Seek forward 5 seconds |
+
+## Zoom & Navigation
+
+| Shortcut | Action |
+|---|---|
+| `Cmd/Ctrl + =` | Zoom in |
+| `Cmd/Ctrl + -` | Zoom out |
+| `Cmd/Ctrl + 0` | Reset zoom (50 px/s) |
+
+## Clips
+
+| Shortcut | Action |
+|---|---|
+| `Cmd/Ctrl + A` | Select all clips |
+| `Cmd/Ctrl + D` | Duplicate selected clip |
+| `Cmd/Ctrl + Enter` | Generate selected clip |
+| `Delete` / `Backspace` | Delete selected clip(s) |
+| `E` | Edit clip (open piano roll / editor) |
+| `S` | Split clip at playhead |
+
+## Panels
+
+| Shortcut | Action |
+|---|---|
+| `X` | Toggle mixer |
+| `B` | Toggle smart controls / draw mode |
+| `O` | Toggle loop browser / assets |
+| `Shift + /` (`?`) | Show shortcuts dialog |
+
+## Project
+
+| Shortcut | Action |
+|---|---|
+| `Cmd/Ctrl + N` | New project |
+| `Cmd/Ctrl + O` | Open project list |
+| `Cmd/Ctrl + ,` | Settings |
+| `Cmd/Ctrl + Shift + E` | Export to WAV |
+
+## Tracks
+
+| Shortcut | Action |
+|---|---|
+| `Cmd/Ctrl + Shift + I` | Add track (instrument picker) |
+
+## AI Generation
+
+| Shortcut | Action |
+|---|---|
+| `Cmd/Ctrl + G` | Generate from silence |
+| `Cmd/Ctrl + Shift + G` | Generate with context |
+
+## Undo / Redo
+
+| Shortcut | Action |
+|---|---|
+| `Cmd/Ctrl + Z` | Undo |
+| `Cmd/Ctrl + Shift + Z` | Redo |
+
+## Modal & Dialogs
+
+| Shortcut | Action |
+|---|---|
+| `Escape` | Close topmost modal |
+
+Escape follows a priority order: clip editor → batch generate → dialogs → deselect all.
+
+## Piano Roll
+
+| Shortcut | Action |
+|---|---|
+| `B` | Toggle draw mode |
+| `Delete` / `Backspace` | Delete selected notes |
+| Scroll wheel | Scroll |
+| `Cmd/Ctrl` + scroll | Zoom |
+
+## Beat Pads
+
+The 16 beat pads are mapped to a 4x4 QWERTY grid:
+
+```
+ 1  2  3  4
+ Q  W  E  R
+ A  S  D  F
+ Z  X  C  V
+```
+
+Press any key to trigger the corresponding pad.

--- a/website/guide/tracks.md
+++ b/website/guide/tracks.md
@@ -1,0 +1,94 @@
+# Track Types
+
+ACE-Step DAW supports four distinct track types, each optimized for different production workflows.
+
+## Stems Track
+
+Stems tracks are powered by the AI generation engine. Each stems track represents an isolated instrument part generated through the LEGO pipeline.
+
+**How it works:**
+1. Add a stems track and select an instrument (e.g., Drums, Bass, Guitar)
+2. Configure generation parameters — prompt, lyrics, BPM, key
+3. Press `Cmd/Ctrl + G` to generate
+4. The AI generates audio in context, receiving the cumulative mix of previously generated tracks
+
+**Generation order:**
+Drums → Bass → Guitar → Keyboard → Percussion → Strings → Synth → FX → Brass → Woodwinds → Backing Vocals → Vocals
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+::: tip
+You can regenerate any track out of order. The engine will use whatever valid cumulative context is available.
+:::
+
+## Sample Track
+
+Sample tracks hold imported audio clips. Drag audio files onto the timeline or use the file picker to add them.
+
+**Features:**
+- Per-clip audio cropping via `audioOffset` and `audioDuration`
+- Move and resize clips on the timeline
+- Split clips at the playhead with `S`
+- Duplicate clips with `Cmd/Ctrl + D`
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+::: tip
+Sample tracks are great for recording takes. Record mic input directly into a sample track, then edit the resulting clip.
+:::
+
+## Sequencer Track
+
+An FL Studio-inspired drum pattern editor for creating rhythmic patterns.
+
+**Features:**
+- Configurable step count: 8, 16, or 32 steps per bar
+- 1 to 4 bars per pattern
+- Swing control (0 = straight, 0.67 = heavy swing)
+- Up to 8+ drum rows per pattern
+- Per-row volume, pan, and mute controls
+- 4 drum kits: 808, Acoustic, Electronic, Lo-Fi
+- 16-pad beat pads with QWERTY keyboard mapping (`1-4`, `Q-R`, `A-F`, `Z-V`)
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+See [Step Sequencer](/guide/sequencer) for the full guide.
+
+## Piano Roll Track
+
+A canvas-based MIDI note editor with built-in synth playback.
+
+**Features:**
+- Grid snap: 1/4, 1/8, 1/16, 1/32 note divisions
+- Velocity lane with color-coded display (blue → red)
+- Draw mode (`B` key) for rapid note entry
+- MIDI keyboard sidebar showing note names
+- 6 synth presets: Piano, Strings, Pad, Lead, Bass, Organ
+- Independent X/Y zoom and scroll
+
+<!-- ![Demo](/images/placeholder.svg) -->
+
+See [Piano Roll](/guide/piano-roll) for the full guide.
+
+## Adding Tracks
+
+Press `Cmd/Ctrl + Shift + I` to open the instrument picker. Choose from 12 named instruments:
+
+| Instrument | Typical Track Type |
+|---|---|
+| Drums | Sequencer or Stems |
+| Bass | Piano Roll or Stems |
+| Guitar | Stems or Sample |
+| Keyboard | Piano Roll or Stems |
+| Vocals | Stems or Sample |
+| Strings | Stems or Piano Roll |
+| Synth | Piano Roll or Stems |
+| Brass | Stems |
+| Woodwinds | Stems |
+| Percussion | Sequencer or Stems |
+| FX | Stems |
+| Custom | Any |
+
+::: warning Known Limitation
+Each track type has its own clip format. You cannot convert a sequencer pattern into a piano roll clip or vice versa.
+:::

--- a/website/index.md
+++ b/website/index.md
@@ -1,0 +1,60 @@
+---
+layout: home
+
+hero:
+  name: ACE-Step DAW
+  text: The AI-Powered DAW
+  tagline: A full-featured browser-based digital audio workstation with AI music generation, built on Tone.js and React.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/nicepkg/acestep-daw
+
+features:
+  - icon: "\U0001F3B5"
+    title: 4 Track Types
+    details: Stems, Sample, Sequencer, and Piano Roll tracks — everything you need from drum patterns to MIDI melodies.
+  - icon: "\U0001F916"
+    title: AI Music Generation
+    details: LEGO pipeline generates tracks sequentially with cumulative context. Plus Cover, Repaint, and Vocal2BGM modes.
+  - icon: "\U0001F39B\uFE0F"
+    title: Pro Mixer & Effects
+    details: Per-track EQ, compressor, reverb, delay, distortion, and filter with LFO. Full mixer with volume, pan, mute, and solo.
+  - icon: "\U0001F3B9"
+    title: Piano Roll Editor
+    details: Canvas-based MIDI editor with velocity lanes, grid snap, draw mode, and 6 built-in synth presets.
+  - icon: "\U0001F941"
+    title: Step Sequencer & Beat Pads
+    details: FL Studio-inspired drum pattern editor with 16-pad QWERTY-mapped beat pads and configurable swing.
+  - icon: "\U0001F3A4"
+    title: Recording Engine
+    details: Record directly from your microphone with count-in, metronome, real-time level metering, and monitoring.
+  - icon: "\U0001F4C8"
+    title: Automation Envelopes
+    details: Breakpoint-based automation for volume and pan with per-point curve control and smooth interpolation.
+  - icon: "\U0001F501"
+    title: Loop Browser
+    details: 15 built-in synthesized loops across drums, bass, keys, and synth categories. Search, preview, and drag to timeline.
+  - icon: "\U0001F4BE"
+    title: Offline & Persistent
+    details: Runs entirely in the browser. Projects auto-save to IndexedDB with full undo/redo history. Export to WAV.
+---
+
+## Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/nicepkg/acestep-daw.git
+cd acestep-daw
+
+# Install dependencies
+npm install
+
+# Start the development server
+npm run dev
+```
+
+Open [http://localhost:5173](http://localhost:5173) and start making music.

--- a/website/public/images/placeholder.svg
+++ b/website/public/images/placeholder.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <rect width="800" height="400" fill="#1a1a2e" rx="8"/>
+  <rect x="20" y="20" width="760" height="360" fill="#16213e" rx="6" stroke="#7c3aed" stroke-width="2" stroke-dasharray="8,4"/>
+  <text x="400" y="190" text-anchor="middle" fill="#7c3aed" font-family="system-ui, sans-serif" font-size="24" font-weight="600">Demo GIF Coming Soon</text>
+  <text x="400" y="225" text-anchor="middle" fill="#666" font-family="system-ui, sans-serif" font-size="14">Screenshot or animated demo will be added here</text>
+</svg>

--- a/website/roadmap.md
+++ b/website/roadmap.md
@@ -1,0 +1,63 @@
+# Roadmap
+
+What has shipped and what is planned for ACE-Step DAW.
+
+## Shipped (v0.1.0)
+
+- 4 track types: Stems, Sample, Sequencer, Piano Roll
+- AI generation: LEGO pipeline, Cover, Repaint, Vocal2BGM
+- 16 generation presets across 8 genres
+- Audio analysis (BPM, key, genre, time signature)
+- 6 built-in effects: EQ3, Compressor, Reverb, Delay, Distortion, Filter
+- Mixer panel with per-track volume, pan, mute, solo
+- Per-track EQ, compressor, and reverb
+- Canvas-based piano roll with velocity lanes
+- FL Studio-inspired step sequencer with beat pads
+- 4 drum kits (808, Acoustic, Electronic, Lo-Fi)
+- 6 synth presets (Piano, Strings, Pad, Lead, Bass, Organ)
+- Microphone recording with count-in and metronome
+- Automation envelopes for volume and pan
+- Loop browser with 15 synthesized loops
+- WAV export (48kHz stereo 16-bit PCM)
+- IndexedDB persistence with undo/redo (50 states)
+- Keyboard shortcuts for all major actions
+
+## Planned
+
+### Tracks & Editing
+- [ ] Multi-track MIDI overlay in piano roll
+- [ ] Track grouping and folder tracks
+- [ ] Variable-length sequencer patterns
+- [ ] MIDI import/export
+- [ ] Audio warp and time-stretching
+- [ ] Track freeze (render to audio for CPU savings)
+
+### Effects & Mixing
+- [ ] Aux sends and bus routing
+- [ ] Effect parameter automation (filter cutoff, etc.)
+- [ ] More effect types (chorus, flanger, phaser)
+- [ ] Sidechain compression
+- [ ] Spectrum analyzer and metering
+
+### AI Generation
+- [ ] Real-time generation preview
+- [ ] Custom model upload
+- [ ] In-browser inference (no server required)
+- [ ] Stem separation from mixed audio
+
+### Recording & Loops
+- [ ] Multi-track simultaneous recording
+- [ ] Custom loop import
+- [ ] Loop time-stretch to project BPM
+- [ ] Audio-to-MIDI conversion
+
+### Project & Export
+- [ ] MP3 and FLAC export
+- [ ] Cloud project storage
+- [ ] Collaboration (shared sessions)
+- [ ] Project templates
+
+### Platform
+- [ ] PWA support (install as desktop app)
+- [ ] Mobile-responsive layout
+- [ ] Plugin system for custom effects and instruments


### PR DESCRIPTION
Adds a complete documentation website:
- VitePress site in website/ directory
- Full feature guides (Piano Roll, Effects, Sequencer, AI Generation, etc.)
- Roadmap page
- Changelog
- GitHub Actions workflow for auto-deploy to GitHub Pages
- Dark theme with purple ACE-Step branding

Deploys automatically on push to main via .github/workflows/docs.yml