### PR TITLE
fix: wire Loop Browser to real LoopBrowser component with 15 loops

### DIFF
--- a/docs/plans/fix-loop-browser.md
+++ b/docs/plans/fix-loop-browser.md
@@ -1,0 +1,66 @@
+# Plan: Fix Loop Browser — Show 15 Built-in Loops
+
+## Problem
+The "Loop Browser (O)" toolbar button opens `AssetsPanel.tsx` which shows 0 items with tabs "All / ★ / AI / Imported". The real `LoopBrowser.tsx` component (which has 15 synthesized loops from `LoopLibrary.ts`) is never shown.
+
+## Root Cause
+In `src/components/layout/Toolbar.tsx` line 215-217:
+```tsx
+active={showAssetsPanel}
+onClick={() => setShowAssetsPanel(!showAssetsPanel)}
+title="Loop Browser (O)"
+```
+This toggles `showAssetsPanel` → renders `AssetsPanel.tsx` (empty asset manager with no loops).
+
+Meanwhile, `LoopBrowser.tsx` uses `loopBrowserOpen` from uiStore, which nothing toggles.
+
+Both components are rendered in `AppShell.tsx` lines 52-54:
+```tsx
+{project && <LoopBrowser />}
+...
+{project && <AssetsPanel />}
+```
+
+## Solution
+
+### Option A (Recommended): Replace AssetsPanel with LoopBrowser
+1. In `src/components/layout/Toolbar.tsx`:
+   - Change the Loop Browser button to toggle `loopBrowserOpen` instead of `showAssetsPanel`
+   - Import `toggleLoopBrowser` from uiStore
+
+2. In `src/components/layout/AppShell.tsx`:
+   - Keep `LoopBrowser` render (it already checks `loopBrowserOpen`)
+   - Remove or hide `AssetsPanel` (it's empty and confusing)
+
+### Changes Required
+
+**File 1: `src/components/layout/Toolbar.tsx`**
+- Line 64: Change `const showAssetsPanel = useUIStore(...)` → `const loopBrowserOpen = useUIStore((s) => s.loopBrowserOpen)`
+- Line 215-217: Change to use `loopBrowserOpen` and `toggleLoopBrowser`
+- Add import for `toggleLoopBrowser` if needed
+
+**File 2: `src/components/layout/AppShell.tsx`**
+- Remove `<AssetsPanel />` render (line 54)
+- Remove import of AssetsPanel (line 18)
+
+**File 3: Keyboard shortcut handler**
+- Find where "O" key is handled and make sure it toggles `loopBrowserOpen`
+- Check `src/hooks/useKeyboardShortcuts.ts` or wherever shortcuts are defined
+
+### Verification
+After fix:
+1. Click "Loop Browser (O)" button
+2. Should show the LoopBrowser panel with categories: All / Drums / Bass / Keys / Synth
+3. Should list 15 loops: 808 Boom, Rock Steady, Shuffle Blues, etc.
+4. Click a loop to preview (will synthesize via Tone.Offline)
+5. Drag a loop to timeline to add it
+
+### Build Check
+- `npm run build` must pass with 0 errors
+- No unused imports after removing AssetsPanel
+
+## Files to Touch
+- `src/components/layout/Toolbar.tsx`
+- `src/components/layout/AppShell.tsx`
+- `src/hooks/useKeyboardShortcuts.ts` (if shortcut wiring needed)
+- Optionally delete `src/components/assets/AssetsPanel.tsx` if fully replaced

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -15,7 +15,6 @@ import { SettingsDialog } from '../dialogs/SettingsDialog';
 import { ProjectListDialog } from '../dialogs/ProjectListDialog';
 import { KeyboardShortcutsDialog } from '../dialogs/KeyboardShortcutsDialog';
 import { MixerPanel } from '../mixer/MixerPanel';
-import { AssetsPanel } from '../assets/AssetsPanel';
 import { LoopBrowser } from '../assets/LoopBrowser';
 import { SequencerEditor } from '../sequencer/SequencerEditor';
 import { SmartControlsPanel } from '../controls/SmartControlsPanel';
@@ -51,7 +50,6 @@ export function AppShell() {
         {project && <TrackList />}
         {project && <LoopBrowser />}
         <Timeline />
-        {project && <AssetsPanel />}
       </div>
 
       {project && <SmartControlsPanel />}

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -61,8 +61,8 @@ export function Toolbar() {
   const setShowKeyboardShortcutsDialog = useUIStore((s) => s.setShowKeyboardShortcutsDialog);
   const showMixer = useUIStore((s) => s.showMixer);
   const setShowMixer = useUIStore((s) => s.setShowMixer);
-  const showAssetsPanel = useUIStore((s) => s.showAssetsPanel);
-  const setShowAssetsPanel = useUIStore((s) => s.setShowAssetsPanel);
+  const loopBrowserOpen = useUIStore((s) => s.loopBrowserOpen);
+  const toggleLoopBrowser = useUIStore((s) => s.toggleLoopBrowser);
   const showLibrary = useUIStore((s) => s.showLibrary);
   const setShowLibrary = useUIStore((s) => s.setShowLibrary);
   const showSmartControls = useUIStore((s) => s.showSmartControls);
@@ -212,8 +212,8 @@ export function Toolbar() {
           </svg>
         </ControlBarButton>
         <ControlBarButton
-          active={showAssetsPanel}
-          onClick={() => setShowAssetsPanel(!showAssetsPanel)}
+          active={loopBrowserOpen}
+          onClick={toggleLoopBrowser}
           title="Loop Browser (O)"
           disabled={!project}
         >

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -273,10 +273,10 @@ export function useKeyboardShortcuts() {
           ui.setShowSmartControls(!ui.showSmartControls);
           break;
 
-        // Loop Browser / Assets toggle (O)
+        // Loop Browser toggle (O)
         case 'KeyO':
           e.preventDefault();
-          ui.setShowAssetsPanel(!ui.showAssetsPanel);
+          ui.toggleLoopBrowser();
           break;
 
         // Help


### PR DESCRIPTION
## Bug
Loop Browser (O) button opened empty AssetsPanel (0 items) instead of real LoopBrowser (15 loops).

## Fix
- Toolbar: showAssetsPanel → loopBrowserOpen + toggleLoopBrowser
- AppShell: removed AssetsPanel render
- Keyboard shortcut: KeyO → toggleLoopBrowser()

## Result
Loop Browser now shows 15 synthesized loops in 4 categories: Drums (5), Bass (4), Keys (3), Synth (3)

Executed by Codex (gpt-5.4) from plan docs/plans/fix-loop-browser.md