### PR TITLE
fix: resolve transport playback and dual AudioContext sync issues

### DIFF
--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -323,7 +323,9 @@ export function PianoRoll() {
     // ─── Playback cursor ──────────────────────────────────────────────────
     if (clip) {
       const clipStartBeat = clip.startTime * (bpm / 60);
-      const currentBeat = currentTime * (bpm / 60) - clipStartBeat;
+      // Read currentTime directly from store to avoid RAF loop restart on each frame
+      const liveTime = useTransportStore.getState().currentTime;
+      const currentBeat = liveTime * (bpm / 60) - clipStartBeat;
       const clipDurationBeats = clip.duration * (bpm / 60);
       if (currentBeat >= 0 && currentBeat <= clipDurationBeats) {
         const cx = beatToX(currentBeat);
@@ -396,7 +398,7 @@ export function PianoRoll() {
     }
   }, [
     notes, bpm, prZoomX, prZoomY, prScrollX, prScrollY, gridSize, drawMode,
-    selectedNoteIds, currentTime, clip, velocityHeight,
+    selectedNoteIds, clip, velocityHeight,
     beatToX, pitchToY, pixelsPerBeat, keyHeight, gridBeats,
   ]);
 

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -387,6 +387,34 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           </div>
         )}
 
+        {/* MIDI note thumbnail */}
+        {isMidiClip && clip.midiData && clip.midiData.notes.length > 0 && (
+          <div className="absolute inset-0 overflow-hidden pointer-events-none" style={{ top: 14 }}>
+            <svg width="100%" height="100%" preserveAspectRatio="none"
+              viewBox={`0 0 ${width} 100`}
+            >
+              {(() => {
+                const notes = clip.midiData!.notes;
+                const bpm = project?.bpm ?? 120;
+                const secPerBeat = 60 / bpm;
+                const clipDur = clip.duration;
+                const pitches = notes.map(n => n.pitch);
+                const minP = Math.min(...pitches);
+                const maxP = Math.max(...pitches);
+                const range = Math.max(maxP - minP, 12);
+                const pad = 2;
+                return notes.map((n, i) => {
+                  const x = (n.startBeat * secPerBeat / clipDur) * width;
+                  const w = Math.max((n.durationBeats * secPerBeat / clipDur) * width, 1);
+                  const y = 100 - ((n.pitch - minP + pad) / (range + pad * 2)) * 100;
+                  const h = Math.max(100 / (range + pad * 2), 2);
+                  return <rect key={i} x={x} y={y} width={w} height={h} fill={track.color} opacity={0.8} rx={0.5} />;
+                });
+              })()}
+            </svg>
+          </div>
+        )}
+
         {/* Label */}
         <div className="absolute top-0 left-1.5 text-[9px] font-medium text-white truncate leading-4 z-10 drop-shadow-sm pointer-events-none"
           style={{ right: totalVersions >= 1 ? '52px' : '6px' }}

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -44,6 +44,9 @@ export class AudioEngine {
   private _lastClips: ClipScheduleInfo[] = [];
   private _lastTotalDuration = 0;
 
+  // MIDI event scheduler — fires callbacks when currentTime reaches scheduled time
+  private _midiEvents: { time: number; callback: () => void; fired: boolean }[] = [];
+
   // Metronome
   private _metronomeGain: GainNode;
   private _metronomeSources: OscillatorNode[] = [];
@@ -219,6 +222,19 @@ export class AudioEngine {
     }
   }
 
+  /**
+   * Schedule a MIDI callback to fire when playback reaches the given time.
+   * Uses the same time base as the RAF-driven playhead, so it stays in sync
+   * with the Timeline and Piano Roll cursors.
+   */
+  scheduleMidiEvent(time: number, callback: () => void) {
+    this._midiEvents.push({ time, callback, fired: false });
+  }
+
+  clearMidiEvents() {
+    this._midiEvents = [];
+  }
+
   private _startTimeUpdate(totalDuration: number) {
     const tick = () => {
       if (!this._playing) return;
@@ -229,12 +245,21 @@ export class AudioEngine {
         // Reached end — notify listener (transport handles loop vs stop)
         this.stopAllSources();
         this._playing = false;
+        this._midiEvents = [];
         if (this._rafId !== null) {
           cancelAnimationFrame(this._rafId);
           this._rafId = null;
         }
         this._onEnded?.();
         return;
+      }
+
+      // Fire any MIDI events whose time has been reached
+      for (const evt of this._midiEvents) {
+        if (!evt.fired && currentTime >= evt.time) {
+          evt.fired = true;
+          evt.callback();
+        }
       }
 
       this._onTimeUpdate?.(currentTime);
@@ -251,6 +276,7 @@ export class AudioEngine {
     }
     this.stopAllSources();
     this.stopMetronome();
+    this.clearMidiEvents();
   }
 
   stopAllSources() {

--- a/src/engine/SynthEngine.ts
+++ b/src/engine/SynthEngine.ts
@@ -123,6 +123,13 @@ class SynthEngine {
     instance.synth.triggerRelease(freq);
   }
 
+  /** Release all currently sounding notes on all track synths. */
+  releaseAll() {
+    for (const instance of this.synths.values()) {
+      instance.synth.releaseAll();
+    }
+  }
+
   removeTrackSynth(trackId: string) {
     const instance = this.synths.get(trackId);
     if (!instance) return;

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useCallback } from 'react';
+import * as Tone from 'tone';
 import { AudioEngine } from '../engine/AudioEngine';
 import { useTransportStore } from '../store/transportStore';
 
@@ -26,7 +27,10 @@ export function useAudioEngine() {
   }, []);
 
   const resumeOnGesture = useCallback(async () => {
-    await engineRef.current.resume();
+    await Promise.all([
+      engineRef.current.resume(),
+      Tone.start(),
+    ]);
   }, []);
 
   return { engine: engineRef.current, resumeOnGesture };

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import * as Tone from 'tone';
 import { useTransportStore } from '../store/transportStore';
 import { useProjectStore } from '../store/projectStore';
@@ -58,16 +58,6 @@ function trimBuffer(
 export function useTransport() {
   const { isPlaying, currentTime } = useTransportStore();
   const project = useProjectStore((s) => s.project);
-  const scheduledTransportEventIdsRef = useRef<number[]>([]);
-
-  const clearScheduledTransportEvents = useCallback(() => {
-    const transport = Tone.getTransport();
-    transport.stop();
-    for (const id of scheduledTransportEventIdsRef.current) {
-      transport.clear(id);
-    }
-    scheduledTransportEventIdsRef.current = [];
-  }, []);
 
   const play = useCallback(async (fromTime?: number) => {
     const engine = getAudioEngine();
@@ -78,7 +68,7 @@ export function useTransport() {
     const proj = useProjectStore.getState().project;
     if (!proj) return;
 
-    clearScheduledTransportEvents();
+    engine.clearMidiEvents();
 
     // Sync master volume
     engine.masterVolume = proj.masterVolume ?? 1.0;
@@ -163,19 +153,16 @@ export function useTransport() {
       engine.scheduleMetronome(proj.bpm, proj.timeSignature, startFrom, effectiveEnd);
     }
 
-    const transport = Tone.getTransport();
-    transport.bpm.value = proj.bpm;
-    transport.timeSignature = proj.timeSignature;
-
+    // Schedule MIDI events using AudioEngine's time base (RAF-driven),
+    // so playhead and note triggering stay perfectly in sync.
     const secondsPerBeat = 60 / proj.bpm;
     const anySoloed = proj.tracks.some((track) => track.soloed);
 
     for (const track of proj.tracks) {
       if (track.trackType === 'pianoRoll') {
         const preset = track.synthPreset ?? 'piano';
-        const trackNode = engine.getOrCreateTrackNode(track.id);
         synthEngine.removeTrackSynth(track.id);
-        const synth = synthEngine.ensureTrackSynth(track.id, preset, trackNode.inputGain);
+        synthEngine.ensureTrackSynth(track.id, preset);
 
         for (const clip of track.clips) {
           const notes = clip.midiData?.notes ?? [];
@@ -191,11 +178,14 @@ export function useTransport() {
             const scheduledDuration = noteEnd - scheduledStart;
             const velocity = Math.max(0, Math.min(1, note.velocity));
             const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
+            const trackId = track.id;
 
-            const id = transport.schedule((time) => {
-              synth.triggerAttackRelease(freq, scheduledDuration, time, velocity);
-            }, scheduledStart);
-            scheduledTransportEventIdsRef.current.push(id);
+            engine.scheduleMidiEvent(scheduledStart, () => {
+              const synth = synthEngine.getSynth(trackId);
+              if (synth) {
+                synth.triggerAttackRelease(freq, scheduledDuration, undefined, velocity);
+              }
+            });
           }
         }
       }
@@ -238,47 +228,47 @@ export function useTransport() {
               );
               if (velocity <= 0) continue;
 
-              const id = transport.schedule(() => {
-                void drumEngine.triggerPad(track.id, padIndex, velocity, track.drumKit ?? '808');
-              }, stepTime);
-              scheduledTransportEventIdsRef.current.push(id);
+              const drumKit = track.drumKit ?? '808';
+              const trackId = track.id;
+              engine.scheduleMidiEvent(stepTime, () => {
+                void drumEngine.triggerPad(trackId, padIndex, velocity, drumKit);
+              });
             }
           }
         }
       }
     }
 
-    transport.start(undefined, startFrom);
     useTransportStore.getState().play();
-  }, [clearScheduledTransportEvents]);
+  }, []);
 
   const pause = useCallback(() => {
     const engine = getAudioEngine();
     const time = engine.getCurrentTime();
     engine.stop();
-    clearScheduledTransportEvents();
+    synthEngine.releaseAll();
     useTransportStore.getState().pause();
     useTransportStore.getState().seek(time);
-  }, [clearScheduledTransportEvents]);
+  }, []);
 
   const stop = useCallback(() => {
     const engine = getAudioEngine();
     engine.stop();
-    clearScheduledTransportEvents();
+    synthEngine.releaseAll();
     useTransportStore.getState().stop();
-  }, [clearScheduledTransportEvents]);
+  }, []);
 
   const seek = useCallback((time: number) => {
     const engine = getAudioEngine();
     if (engine.playing) {
       engine.stop();
-      clearScheduledTransportEvents();
+      synthEngine.releaseAll();
       useTransportStore.getState().seek(time);
       play(time);
     } else {
       useTransportStore.getState().seek(time);
     }
-  }, [clearScheduledTransportEvents, play]);
+  }, [play]);
 
   // Register the onEnded callback — respect loopEnabled
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix `InvalidAccessError` caused by connecting Tone.js AudioNodes to native AudioContext nodes (cross-context connection)
- Unify MIDI/Sequencer scheduling with AudioEngine's RAF-driven time base, replacing Tone.js Transport — eliminates Timeline vs PianoRoll playhead drift
- Initialize Tone.js AudioContext on first user gesture so PianoRoll keyboard produces sound immediately
- Add MIDI note thumbnail rendering in timeline clip blocks
- Fix PianoRoll playhead animation (smooth RAF-driven instead of React state-driven)
- Add `SynthEngine.releaseAll()` for clean pause/stop note cutoff

## Root Cause
The project used two independent AudioContexts (native `AudioContext` in `AudioEngine` + Tone.js context in `SynthEngine`). This caused:
1. `InvalidAccessError` when connecting synth nodes cross-context, silently aborting `play()` before `isPlaying` was set
2. Time drift between Timeline playhead (native context) and MIDI note triggering (Tone.js Transport)
3. Piano Roll keyboard clicks failing on first interaction (Tone.js context not resumed)

## Files Changed
- `src/engine/AudioEngine.ts` — Add `scheduleMidiEvent()` / `clearMidiEvents()` API
- `src/hooks/useTransport.ts` — Replace Tone.js Transport with AudioEngine MIDI events
- `src/hooks/useAudioEngine.ts` — Call `Tone.start()` in `resumeOnGesture`
- `src/engine/SynthEngine.ts` — Add `releaseAll()` method
- `src/components/pianoroll/PianoRoll.tsx` — Read time via `getState()` for smooth playhead
- `src/components/timeline/ClipBlock.tsx` — Add MIDI note thumbnail SVG

## Test plan
- [x] Play/Pause/Stop transport with pianoRoll track — verified working
- [x] PianoRoll playhead animates smoothly during playback
- [x] Timeline and PianoRoll playheads stay in sync
- [x] MIDI clip shows note thumbnail in timeline
- [x] Instrument selector (synth preset) dropdown works
- [x] `npx tsc --noEmit` — 0 errors
- [x] No console errors related to transport changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)