### PR TITLE
feat: Loop Browser drag-to-timeline + importAudioBufferToTrack

### DIFF
--- a/docs/plans/fix-export-wav-midi-seq.md
+++ b/docs/plans/fix-export-wav-midi-seq.md
@@ -1,0 +1,57 @@
+# Plan: Export WAV for MIDI + Sequencer Tracks
+
+## User Story
+As a user, I want to click Export and get a WAV file that includes my Piano Roll melodies and Sequencer drum patterns, not just AI-generated audio.
+
+## Problem
+Export WAV button is disabled when there are no AI-generated audio blobs (`isolatedAudioKey`). MIDI and Sequencer tracks have no audio blobs — they only play in real-time via SynthEngine/DrumEngine.
+
+## Current Export Flow
+`src/engine/exportMix.ts` (or similar):
+- Collects clips with `isolatedAudioKey` or `cumulativeMixKey`
+- Loads AudioBuffers from IndexedDB
+- Mixes them into a stereo WAV at 48kHz
+- Downloads the WAV file
+
+## Solution: Offline Render MIDI + Sequencer to AudioBuffer
+
+### Approach: Use Tone.Offline to render each track
+```typescript
+// For pianoRoll tracks:
+const buffer = await Tone.Offline(async ({ transport }) => {
+  const synth = new Tone.PolySynth(Tone.Synth).toDestination();
+  // configure synth preset...
+  for (const note of clip.midiData.notes) {
+    const startSec = note.startBeat * (60 / bpm);
+    const durSec = note.durationBeats * (60 / bpm);
+    const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
+    transport.schedule((time) => {
+      synth.triggerAttackRelease(freq, durSec, time, note.velocity);
+    }, startSec);
+  }
+  transport.start();
+}, totalDuration, 2, 48000);
+
+// For sequencer tracks:
+// Similar approach with DrumEngine sounds in Tone.Offline
+```
+
+### Integration Points:
+1. **Export dialog** — Remove the `disabled` check (or make it check for ANY content, not just audio blobs)
+2. **Export function** — Before mixing, render MIDI/Seq tracks to AudioBuffers via Tone.Offline
+3. **Mix** — Combine rendered MIDI/Seq buffers with any AI audio blobs
+
+### Alternative simpler approach:
+Before export, render each MIDI/Seq track to an AudioBuffer, store it temporarily, then proceed with existing export pipeline.
+
+## Files to Touch
+- `src/engine/exportMix.ts` or wherever export logic lives
+- `src/components/dialogs/ExportDialog.tsx` or similar — remove disabled condition
+- May need utility functions for MIDI→AudioBuffer and Seq→AudioBuffer offline rendering
+
+## Verification
+1. Create Piano Roll track with notes
+2. Create Sequencer track with drum pattern
+3. Click Export → WAV file downloads
+4. Open WAV in audio player → hear both melody and drums
+5. `npm run build` passes 0 errors

--- a/docs/plans/fix-loop-drag-to-timeline.md
+++ b/docs/plans/fix-loop-drag-to-timeline.md
@@ -1,75 +1,116 @@
 # Plan: Fix Loop Browser Drag-to-Timeline
 
 ## User Story
-As a user, I want to drag a loop from the Loop Browser and drop it onto a track in the timeline, so that it creates a new Sample clip with that loop's audio.
+As a user, I want to drag a loop from the Loop Browser and drop it onto a track in the timeline, so that it creates a new audio clip with that loop's rendered audio.
 
 ## Problem
 Loop Browser items set `dataTransfer.setData('application/x-loop-id', def.id)` on drag start.
-Timeline's `handleDrop` only processes `e.dataTransfer.files` (audio file imports) — it ignores `x-loop-id`.
+Timeline's `handleDrop` only processes `e.dataTransfer.files` — ignores `x-loop-id`.
+TrackLane also doesn't handle loop drops.
 
-## Root Cause
-`src/components/timeline/Timeline.tsx` handleDrop (~line 98):
-```typescript
-const handleDrop = useCallback(async (e: React.DragEvent) => {
-  const files = e.dataTransfer.files;
-  if (files.length > 0) {
-    await importMultipleFiles(files);  // only handles files
-  }
-}, [importMultipleFiles]);
-// MISSING: no handler for 'application/x-loop-id'
+## Architecture
+
+### Existing pipeline (for File imports):
+```
+File → arrayBuffer → decodeAudioData → AudioBuffer → audioBufferToWavBlob → saveAudioBlob → addClip + updateClipStatus
+```
+This lives in `src/hooks/useAudioImport.ts` (`importAudioToTrack`).
+
+### What we need for loops:
+```
+loopId → LOOP_DEFINITIONS.find → loadLoop(def) → AudioBuffer → (same pipeline as above)
 ```
 
 ## Solution
 
-**File: `src/components/timeline/Timeline.tsx`**
-
-In `handleDrop`, add loop-id handling before the file check:
+### 1. Add `importAudioBufferToTrack` to `useAudioImport.ts`
+New function that takes `(audioBuffer: AudioBuffer, name: string, trackId: string, startTime: number)` and follows the same pipeline as `importAudioToTrack` but skips the File decode step.
 
 ```typescript
-const handleDrop = useCallback(async (e: React.DragEvent) => {
-  e.preventDefault();
-  dragCounterRef.current = 0;
-  setFileDragOver(false);
+const importAudioBufferToTrack = useCallback(async (
+  audioBuffer: AudioBuffer, name: string, trackId: string, startTime: number
+) => {
+  const project = useProjectStore.getState().project;
+  if (!project) return;
   
-  // Handle loop drag from Loop Browser
-  const loopId = e.dataTransfer.getData('application/x-loop-id');
-  if (loopId) {
-    // Find which track was dropped on via y position
-    const dropY = e.clientY;
-    // Find track from sorted tracks by y position... OR just add to first sample track
-    // Simple approach: load the loop and add as Sample clip to the track under cursor
-    const { LOOP_DEFINITIONS, loadLoop } = await import('../../engine/LoopLibrary');
-    const def = LOOP_DEFINITIONS.find(d => d.id === loopId);
-    if (def && project) {
-      try {
-        const { audioBuffer } = await loadLoop(def);
-        // Convert AudioBuffer to Blob for storage
-        // ... store as sample clip on nearest track
-      } catch (err) {
-        console.error('Failed to load loop:', err);
-      }
-    }
-    return;
-  }
+  const duration = audioBuffer.duration;
+  const clipDuration = Math.min(duration, project.totalDuration - startTime);
+  if (clipDuration <= 0) return;
   
-  // Handle file drop (existing behavior)
-  const files = e.dataTransfer.files;
-  if (files.length > 0) {
-    await importMultipleFiles(files);
-  }
-}, [importMultipleFiles, project]);
+  const clip = addClip(trackId, {
+    startTime,
+    duration: clipDuration,
+    prompt: `Loop: ${name}`,
+    lyrics: '',
+  });
+  
+  const wavBlob = audioBufferToWavBlob(audioBuffer);
+  const isolatedKey = await saveAudioBlob(project.id, clip.id, 'isolated', wavBlob);
+  const peaks = computeWaveformPeaks(audioBuffer, 200);
+  
+  updateClipStatus(clip.id, 'ready', {
+    isolatedAudioKey: isolatedKey,
+    waveformPeaks: peaks,
+    audioDuration: duration,
+    audioOffset: 0,
+    source: 'uploaded',
+  });
+}, [addClip, updateClipStatus]);
 ```
 
-**Also: Add dragOver visual feedback** on track lanes when a loop is being dragged over them.
+### 2. Handle loop drop in `TrackLane.tsx`
+TrackLane already has `importAudioToTrack`. Add loop-id drop handling:
+
+```typescript
+// In TrackLane's onDrop handler:
+const loopId = e.dataTransfer.getData('application/x-loop-id');
+if (loopId) {
+  const { LOOP_DEFINITIONS, loadLoop } = await import('../../engine/LoopLibrary');
+  const def = LOOP_DEFINITIONS.find(d => d.id === loopId);
+  if (def) {
+    const { audioBuffer } = await loadLoop(def);
+    const dropX = e.clientX - laneRect.left;
+    const startTime = Math.max(0, dropX / pixelsPerSecond);
+    await importAudioBufferToTrack(audioBuffer, def.name, track.id, startTime);
+  }
+  return;
+}
+```
+
+### 3. Add `onDragOver` to TrackLane
+Need `e.preventDefault()` on dragOver to allow drops:
+```typescript
+onDragOver={(e) => {
+  if (e.dataTransfer.types.includes('application/x-loop-id') || 
+      e.dataTransfer.types.includes('Files')) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  }
+}}
+```
+
+### 4. Timeline.tsx — also handle loop-id in handleDrop
+If dropped on the timeline background (not a specific track lane), create a new sample track:
+```typescript
+const loopId = e.dataTransfer.getData('application/x-loop-id');
+if (loopId) {
+  // Load loop and create new sample track + clip
+  // Similar to importAudioFile which creates a new track
+}
+```
 
 ## Files to Touch
-- `src/components/timeline/Timeline.tsx` — add loop-id drop handler
-- May need `src/services/audioFileManager.ts` — for saving AudioBuffer as blob
+1. `src/hooks/useAudioImport.ts` — add `importAudioBufferToTrack`
+2. `src/components/timeline/TrackLane.tsx` — add loop-id drop handler + dragOver
+3. `src/components/timeline/Timeline.tsx` — add loop-id fallback in handleDrop
+4. Return `importAudioBufferToTrack` from the hook
 
 ## Verification
-1. Open Loop Browser, drag "808 Boom" to Keyboard track lane
-2. Expected: New "Sample" clip appears on that track
-3. Click play — should hear the loop
+1. Open Loop Browser (O), drag "808 Boom" to Keyboard track lane → New clip appears
+2. Open Loop Browser (O), drag "Walking Bass" to empty timeline area → New sample track + clip
+3. Click play — hear the loop audio
+4. `npm run build` passes 0 errors
 
-## Note
-This is lower priority than fix-midi-sequencer-playback.md
+## Build Check
+- `npm run build` must pass 0 errors
+- No unused imports

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -54,6 +54,8 @@ function getTrackVerticalRange(
 
 export function Timeline() {
   const project = useProjectStore((s) => s.project);
+  const addTrack = useProjectStore((s) => s.addTrack);
+  const updateTrack = useProjectStore((s) => s.updateTrack);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const setPixelsPerSecond = useUIStore((s) => s.setPixelsPerSecond);
   const contextWindow = useUIStore((s) => s.contextWindow);
@@ -70,17 +72,23 @@ export function Timeline() {
   const [normalDrag, setNormalDrag] = useState<DragRect | null>(null);
   const [fileDragOver, setFileDragOver] = useState(false);
   const dragCounterRef = useRef(0);
-  const { importMultipleFiles } = useAudioImport();
+  const { importAudioBufferToTrack, importMultipleFiles } = useAudioImport();
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
-    if (e.dataTransfer.types.includes('Files')) {
+    if (
+      e.dataTransfer.types.includes('Files')
+      || e.dataTransfer.types.includes('application/x-loop-id')
+    ) {
       e.preventDefault();
       e.dataTransfer.dropEffect = 'copy';
     }
   }, []);
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
-    if (e.dataTransfer.types.includes('Files')) {
+    if (
+      e.dataTransfer.types.includes('Files')
+      || e.dataTransfer.types.includes('application/x-loop-id')
+    ) {
       e.preventDefault();
       dragCounterRef.current++;
       setFileDragOver(true);
@@ -99,11 +107,24 @@ export function Timeline() {
     e.preventDefault();
     dragCounterRef.current = 0;
     setFileDragOver(false);
+
+    const loopId = e.dataTransfer.getData('application/x-loop-id');
+    if (loopId) {
+      const { LOOP_DEFINITIONS, loadLoop } = await import('../../engine/LoopLibrary');
+      const def = LOOP_DEFINITIONS.find((item) => item.id === loopId);
+      if (!def) return;
+      const { audioBuffer } = await loadLoop(def);
+      const track = addTrack('custom', 'sample');
+      updateTrack(track.id, { displayName: def.name });
+      await importAudioBufferToTrack(audioBuffer, def.name, track.id, 0);
+      return;
+    }
+
     const files = e.dataTransfer.files;
     if (files.length > 0) {
       await importMultipleFiles(files);
     }
-  }, [importMultipleFiles]);
+  }, [addTrack, importAudioBufferToTrack, importMultipleFiles, updateTrack]);
 
   // Safety net: if a child (e.g. TrackLane) stops propagation on drop,
   // the Timeline's own handleDrop never fires. Listen globally to clear the overlay.

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -86,7 +86,7 @@ export function TrackLane({ track }: TrackLaneProps) {
     startTime: number; duration: number;
   } | null>(null);
 
-  const { importAudioToTrack } = useAudioImport();
+  const { importAudioBufferToTrack, importAudioToTrack } = useAudioImport();
   const [fileDragOver, setFileDragOver] = useState(false);
 
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
@@ -178,7 +178,10 @@ export function TrackLane({ track }: TrackLaneProps) {
   }, []);
 
   const handleFileDragOver = useCallback((e: React.DragEvent) => {
-    if (e.dataTransfer.types.includes('Files')) {
+    if (
+      e.dataTransfer.types.includes('Files')
+      || e.dataTransfer.types.includes('application/x-loop-id')
+    ) {
       e.preventDefault();
       e.stopPropagation();
       e.dataTransfer.dropEffect = 'copy';
@@ -194,20 +197,32 @@ export function TrackLane({ track }: TrackLaneProps) {
     e.preventDefault();
     e.stopPropagation();
     setFileDragOver(false);
-    const files = e.dataTransfer.files;
-    if (!files.length || !project) return;
+    if (!project) return;
 
     const rect = e.currentTarget.getBoundingClientRect();
     const laneX = e.clientX - rect.left;
     const rawTime = laneX / pixelsPerSecond;
     const startTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1));
 
+    const loopId = e.dataTransfer.getData('application/x-loop-id');
+    if (loopId) {
+      const { LOOP_DEFINITIONS, loadLoop } = await import('../../engine/LoopLibrary');
+      const def = LOOP_DEFINITIONS.find((item) => item.id === loopId);
+      if (!def) return;
+      const { audioBuffer } = await loadLoop(def);
+      await importAudioBufferToTrack(audioBuffer, def.name, track.id, startTime);
+      return;
+    }
+
+    const files = e.dataTransfer.files;
+    if (!files.length) return;
+
     for (const file of Array.from(files)) {
       if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
         await importAudioToTrack(file, track.id, startTime);
       }
     }
-  }, [project, pixelsPerSecond, track.id, importAudioToTrack]);
+  }, [project, pixelsPerSecond, track.id, importAudioBufferToTrack, importAudioToTrack]);
 
   const hasClips = track.clips.length > 0;
 

--- a/src/hooks/useAudioImport.ts
+++ b/src/hooks/useAudioImport.ts
@@ -1,15 +1,76 @@
 import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { useProjectStore } from '../store/projectStore';
 import { getAudioEngine } from './useAudioEngine';
 import { saveAudioBlob } from '../services/audioFileManager';
 import { computeWaveformPeaks } from '../utils/waveformPeaks';
 import { audioBufferToWavBlob } from '../utils/wav';
 
+function trimAudioBuffer(
+  engine: ReturnType<typeof getAudioEngine>,
+  audioBuffer: AudioBuffer,
+  clipDuration: number,
+): AudioBuffer {
+  const sampleRate = audioBuffer.sampleRate;
+  const trimmedLength = Math.min(
+    Math.floor(clipDuration * sampleRate),
+    audioBuffer.length,
+  );
+  const trimmedBuffer = engine.ctx.createBuffer(
+    audioBuffer.numberOfChannels,
+    trimmedLength,
+    sampleRate,
+  );
+  for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+    const src = audioBuffer.getChannelData(ch);
+    const dst = trimmedBuffer.getChannelData(ch);
+    for (let i = 0; i < trimmedLength; i++) {
+      dst[i] = src[i];
+    }
+  }
+  return trimmedBuffer;
+}
+
 export function useAudioImport() {
   const addTrack = useProjectStore((s) => s.addTrack);
   const addClip = useProjectStore((s) => s.addClip);
   const updateClipStatus = useProjectStore((s) => s.updateClipStatus);
+
+  const importAudioBufferToTrack = useCallback(async (
+    audioBuffer: AudioBuffer,
+    name: string,
+    trackId: string,
+    startTime: number,
+  ) => {
+    const project = useProjectStore.getState().project;
+    if (!project) return;
+
+    const engine = getAudioEngine();
+    await engine.resume();
+
+    const duration = audioBuffer.duration;
+    const clipDuration = Math.min(duration, project.totalDuration - startTime);
+    if (clipDuration <= 0) return;
+
+    const clip = addClip(trackId, {
+      startTime,
+      duration: clipDuration,
+      prompt: `Imported: ${name}`,
+      lyrics: '',
+    });
+
+    const trimmedBuffer = trimAudioBuffer(engine, audioBuffer, clipDuration);
+    const wavBlob = audioBufferToWavBlob(trimmedBuffer);
+    const isolatedKey = await saveAudioBlob(project.id, clip.id, 'isolated', wavBlob);
+    const peaks = computeWaveformPeaks(trimmedBuffer, 200);
+
+    updateClipStatus(clip.id, 'ready', {
+      isolatedAudioKey: isolatedKey,
+      waveformPeaks: peaks,
+      audioDuration: clipDuration,
+      audioOffset: 0,
+      source: 'uploaded',
+    });
+  }, [addClip, updateClipStatus]);
 
   const importAudioFile = useCallback(async (file: File) => {
     const project = useProjectStore.getState().project;
@@ -38,24 +99,7 @@ export function useAudioImport() {
       lyrics: '',
     });
 
-    // Trim the buffer to clip duration if needed
-    const sampleRate = audioBuffer.sampleRate;
-    const trimmedLength = Math.min(
-      Math.floor(clipDuration * sampleRate),
-      audioBuffer.length,
-    );
-    const trimmedBuffer = engine.ctx.createBuffer(
-      audioBuffer.numberOfChannels,
-      trimmedLength,
-      sampleRate,
-    );
-    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
-      const src = audioBuffer.getChannelData(ch);
-      const dst = trimmedBuffer.getChannelData(ch);
-      for (let i = 0; i < trimmedLength; i++) {
-        dst[i] = src[i];
-      }
-    }
+    const trimmedBuffer = trimAudioBuffer(engine, audioBuffer, clipDuration);
 
     // Convert to WAV and store
     const wavBlob = audioBufferToWavBlob(trimmedBuffer);
@@ -83,47 +127,8 @@ export function useAudioImport() {
 
     const arrayBuffer = await file.arrayBuffer();
     const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
-    const duration = audioBuffer.duration;
-    const clipDuration = Math.min(duration, project.totalDuration - startTime);
-    if (clipDuration <= 0) return;
-
-    const clip = addClip(trackId, {
-      startTime,
-      duration: clipDuration,
-      prompt: `Imported: ${file.name}`,
-      lyrics: '',
-    });
-
-    const sampleRate = audioBuffer.sampleRate;
-    const trimmedLength = Math.min(
-      Math.floor(clipDuration * sampleRate),
-      audioBuffer.length,
-    );
-    const trimmedBuffer = engine.ctx.createBuffer(
-      audioBuffer.numberOfChannels,
-      trimmedLength,
-      sampleRate,
-    );
-    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
-      const src = audioBuffer.getChannelData(ch);
-      const dst = trimmedBuffer.getChannelData(ch);
-      for (let i = 0; i < trimmedLength; i++) {
-        dst[i] = src[i];
-      }
-    }
-
-    const wavBlob = audioBufferToWavBlob(trimmedBuffer);
-    const isolatedKey = await saveAudioBlob(project.id, clip.id, 'isolated', wavBlob);
-    const peaks = computeWaveformPeaks(trimmedBuffer, 200);
-
-    updateClipStatus(clip.id, 'ready', {
-      isolatedAudioKey: isolatedKey,
-      waveformPeaks: peaks,
-      audioDuration: clipDuration,
-      audioOffset: 0,
-      source: 'uploaded',
-    });
-  }, [addClip, updateClipStatus]);
+    await importAudioBufferToTrack(audioBuffer, file.name, trackId, startTime);
+  }, [importAudioBufferToTrack]);
 
   const importMultipleFiles = useCallback(async (files: FileList | File[]) => {
     for (const file of Array.from(files)) {
@@ -146,5 +151,11 @@ export function useAudioImport() {
     input.click();
   }, [importMultipleFiles]);
 
-  return { importAudioFile, importAudioToTrack, importMultipleFiles, openFilePicker };
+  return {
+    importAudioFile,
+    importAudioBufferToTrack,
+    importAudioToTrack,
+    importMultipleFiles,
+    openFilePicker,
+  };
 }


### PR DESCRIPTION
Drag loops from Loop Browser to track lanes or empty timeline. Creates audio clips with waveform + isolatedAudioKey.