### PR TITLE
feat: Export WAV for MIDI + Sequencer tracks (offline render)

### DIFF
--- a/docs/plans/fix-export-wav-midi-seq.md
+++ b/docs/plans/fix-export-wav-midi-seq.md
@@ -4,54 +4,110 @@
 As a user, I want to click Export and get a WAV file that includes my Piano Roll melodies and Sequencer drum patterns, not just AI-generated audio.
 
 ## Problem
-Export WAV button is disabled when there are no AI-generated audio blobs (`isolatedAudioKey`). MIDI and Sequencer tracks have no audio blobs — they only play in real-time via SynthEngine/DrumEngine.
+Export WAV button disabled when `readyClips.length === 0`. MIDI/Sequencer tracks have no `isolatedAudioKey` — they only play live.
 
 ## Current Export Flow
-`src/engine/exportMix.ts` (or similar):
-- Collects clips with `isolatedAudioKey` or `cumulativeMixKey`
-- Loads AudioBuffers from IndexedDB
-- Mixes them into a stereo WAV at 48kHz
-- Downloads the WAV file
-
-## Solution: Offline Render MIDI + Sequencer to AudioBuffer
-
-### Approach: Use Tone.Offline to render each track
-```typescript
-// For pianoRoll tracks:
-const buffer = await Tone.Offline(async ({ transport }) => {
-  const synth = new Tone.PolySynth(Tone.Synth).toDestination();
-  // configure synth preset...
-  for (const note of clip.midiData.notes) {
-    const startSec = note.startBeat * (60 / bpm);
-    const durSec = note.durationBeats * (60 / bpm);
-    const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
-    transport.schedule((time) => {
-      synth.triggerAttackRelease(freq, durSec, time, note.velocity);
-    }, startSec);
-  }
-  transport.start();
-}, totalDuration, 2, 48000);
-
-// For sequencer tracks:
-// Similar approach with DrumEngine sounds in Tone.Offline
+```
+ExportDialog.handleExport():
+  for each track:
+    for each clip with isolatedAudioKey:
+      load AudioBuffer from IndexedDB
+      push {startTime, buffer, volume}
+  exportMixToWav(clips, totalDuration) → OfflineAudioContext → WAV blob → download
 ```
 
-### Integration Points:
-1. **Export dialog** — Remove the `disabled` check (or make it check for ANY content, not just audio blobs)
-2. **Export function** — Before mixing, render MIDI/Seq tracks to AudioBuffers via Tone.Offline
-3. **Mix** — Combine rendered MIDI/Seq buffers with any AI audio blobs
+## Solution
 
-### Alternative simpler approach:
-Before export, render each MIDI/Seq track to an AudioBuffer, store it temporarily, then proceed with existing export pipeline.
+### 1. Add offline rendering functions in `src/engine/offlineRender.ts` (new file)
+
+```typescript
+import * as Tone from 'tone';
+import type { Track, MidiNote, SequencerPattern } from '../types/project';
+
+export async function renderMidiTrackOffline(
+  notes: MidiNote[], 
+  clipStartTime: number,
+  bpm: number, 
+  synthPreset: string,
+  totalDuration: number,
+  sampleRate: number = 48000
+): Promise<AudioBuffer> {
+  const buffer = await Tone.Offline(({ transport }) => {
+    const synth = new Tone.PolySynth(Tone.Synth).toDestination();
+    // Apply preset settings...
+    transport.bpm.value = bpm;
+    const secondsPerBeat = 60 / bpm;
+    
+    for (const note of notes) {
+      const startSec = clipStartTime + note.startBeat * secondsPerBeat;
+      const durSec = note.durationBeats * secondsPerBeat;
+      const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
+      transport.schedule((time) => {
+        synth.triggerAttackRelease(freq, durSec, time, note.velocity);
+      }, startSec);
+    }
+    transport.start();
+  }, totalDuration, 2, sampleRate);
+  
+  return buffer instanceof AudioBuffer ? buffer : buffer.get();
+}
+
+export async function renderSequencerTrackOffline(
+  pattern: SequencerPattern,
+  bpm: number,
+  totalDuration: number,
+  sampleRate: number = 48000
+): Promise<AudioBuffer> {
+  // Similar to renderMidiTrackOffline but uses DrumEngine-style synthesis
+}
+```
+
+### 2. Update `ExportDialog.tsx`
+
+In `handleExport`, before the existing clip collection loop, add:
+
+```typescript
+// Render MIDI tracks offline
+for (const track of project.tracks) {
+  if (track.muted) continue;
+  if (anySoloed && !track.soloed) continue;
+  
+  if (track.trackType === 'pianoRoll') {
+    for (const clip of track.clips) {
+      const notes = clip.midiData?.notes;
+      if (notes?.length) {
+        const buffer = await renderMidiTrackOffline(
+          notes, clip.startTime, project.bpm, 
+          track.synthPreset ?? 'piano', project.totalDuration
+        );
+        clips.push({ startTime: 0, buffer, volume: track.volume });
+      }
+    }
+  }
+  
+  if (track.trackType === 'sequencer' && track.sequencerPattern) {
+    const buffer = await renderSequencerTrackOffline(
+      track.sequencerPattern, project.bpm, project.totalDuration
+    );
+    clips.push({ startTime: 0, buffer, volume: track.volume });
+  }
+}
+```
+
+### 3. Change disabled condition
+
+```diff
+- disabled={exporting || readyClips.length === 0}
++ disabled={exporting || !hasExportableContent}
+```
+
+Where `hasExportableContent` is true if there are ready clips, MIDI notes, OR sequencer patterns.
 
 ## Files to Touch
-- `src/engine/exportMix.ts` or wherever export logic lives
-- `src/components/dialogs/ExportDialog.tsx` or similar — remove disabled condition
-- May need utility functions for MIDI→AudioBuffer and Seq→AudioBuffer offline rendering
+1. `src/engine/offlineRender.ts` — NEW: renderMidiTrackOffline + renderSequencerTrackOffline
+2. `src/components/dialogs/ExportDialog.tsx` — import and call offline renderers + fix disabled check
+3. `src/engine/SynthEngine.ts` — may need createSynthForPreset to be exported as standalone
 
-## Verification
-1. Create Piano Roll track with notes
-2. Create Sequencer track with drum pattern
-3. Click Export → WAV file downloads
-4. Open WAV in audio player → hear both melody and drums
-5. `npm run build` passes 0 errors
+## Build Check
+- `npm run build` must pass 0 errors
+- No unused imports

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
 import { loadAudioBlobByKey } from '../../services/audioFileManager';
 import { exportMixToWav } from '../../engine/exportMix';
+import { renderMidiTrackOffline, renderSequencerTrackOffline } from '../../engine/offlineRender';
 
 export function ExportDialog() {
   const show = useUIStore((s) => s.showExportDialog);
@@ -23,6 +24,33 @@ export function ExportDialog() {
       for (const track of project.tracks) {
         if (track.muted) continue;
         if (anySoloed && !track.soloed) continue;
+
+        if (track.trackType === 'pianoRoll') {
+          for (const clip of track.clips) {
+            const notes = clip.midiData?.notes ?? [];
+            if (notes.length === 0) continue;
+
+            const buffer = await renderMidiTrackOffline(
+              notes,
+              clip.startTime,
+              project.bpm,
+              track.synthPreset ?? 'piano',
+              project.totalDuration,
+            );
+            clips.push({ startTime: 0, buffer, volume: track.volume });
+          }
+        }
+
+        if (track.trackType === 'sequencer' && track.sequencerPattern) {
+          const buffer = await renderSequencerTrackOffline(
+            track.sequencerPattern,
+            project.bpm,
+            project.totalDuration,
+            track.drumKit ?? '808',
+          );
+          clips.push({ startTime: 0, buffer, volume: track.volume });
+        }
+
         for (const clip of track.clips) {
           if (clip.generationStatus === 'ready' && clip.isolatedAudioKey) {
             const blob = await loadAudioBlobByKey(clip.isolatedAudioKey);
@@ -50,8 +78,21 @@ export function ExportDialog() {
   };
 
   const readyClips = project.tracks.flatMap((t) =>
-    t.clips.filter((c) => c.generationStatus === 'ready'),
+    t.clips.filter((c) => c.generationStatus === 'ready' && c.isolatedAudioKey),
   );
+  const anySoloed = project.tracks.some((t) => t.soloed);
+  const hasExportableContent = project.tracks.some((track) => {
+    if (track.muted) return false;
+    if (anySoloed && !track.soloed) return false;
+
+    const hasReadyAudio = track.clips.some((clip) => clip.generationStatus === 'ready' && clip.isolatedAudioKey);
+    const hasMidiNotes = track.trackType === 'pianoRoll'
+      && track.clips.some((clip) => (clip.midiData?.notes?.length ?? 0) > 0);
+    const hasSequencerSteps = track.trackType === 'sequencer'
+      && track.sequencerPattern?.rows.some((row) => !row.muted && row.steps.some((step) => step.active));
+
+    return hasReadyAudio || hasMidiNotes || Boolean(hasSequencerSteps);
+  });
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
@@ -85,7 +126,7 @@ export function ExportDialog() {
           </button>
           <button
             onClick={handleExport}
-            disabled={exporting || readyClips.length === 0}
+            disabled={exporting || !hasExportableContent}
             className="px-4 py-1.5 text-xs font-medium bg-daw-accent hover:bg-daw-accent-hover text-white rounded transition-colors disabled:opacity-50"
           >
             {exporting ? 'Exporting...' : 'Export WAV'}

--- a/src/engine/DrumEngine.ts
+++ b/src/engine/DrumEngine.ts
@@ -43,40 +43,53 @@ export const BEAT_PAD_KEYS: string[] = [
 
 // ─── Synthesized Drum Sound Generators ──────────────────────────────────────
 
-function createKick808(): DrumVoice {
+function connectDrumNode<T extends Tone.ToneAudioNode>(node: T, connectTo?: Tone.InputNode): T {
+  if (connectTo) {
+    node.connect(connectTo);
+  } else {
+    node.toDestination();
+  }
+  return node;
+}
+
+function createKick808(connectTo?: Tone.InputNode): DrumVoice {
   const synth = new Tone.MembraneSynth({
     pitchDecay: 0.08, octaves: 6,
     oscillator: { type: 'sine' },
     envelope: { attack: 0.001, decay: 0.5, sustain: 0, release: 0.5 },
-  }).toDestination();
+  });
+  connectDrumNode(synth, connectTo);
   return {
     trigger: (time, vel = 1) => synth.triggerAttackRelease('C1', '8n', time, vel),
     dispose: () => synth.dispose(),
   };
 }
 
-function createKickAcoustic(): DrumVoice {
+function createKickAcoustic(connectTo?: Tone.InputNode): DrumVoice {
   const synth = new Tone.MembraneSynth({
     pitchDecay: 0.05, octaves: 4,
     oscillator: { type: 'sine' },
     envelope: { attack: 0.001, decay: 0.3, sustain: 0, release: 0.3 },
-  }).toDestination();
+  });
+  connectDrumNode(synth, connectTo);
   return {
     trigger: (time, vel = 1) => synth.triggerAttackRelease('D1', '8n', time, vel),
     dispose: () => synth.dispose(),
   };
 }
 
-function createSnare808(): DrumVoice {
+function createSnare808(connectTo?: Tone.InputNode): DrumVoice {
   const noise = new Tone.NoiseSynth({
     noise: { type: 'white' },
     envelope: { attack: 0.001, decay: 0.2, sustain: 0, release: 0.15 },
-  }).toDestination();
+  });
   const body = new Tone.MembraneSynth({
     pitchDecay: 0.03, octaves: 3,
     oscillator: { type: 'triangle' },
     envelope: { attack: 0.001, decay: 0.15, sustain: 0, release: 0.1 },
-  }).toDestination();
+  });
+  connectDrumNode(noise, connectTo);
+  connectDrumNode(body, connectTo);
   return {
     trigger: (time, vel = 1) => {
       noise.triggerAttackRelease('16n', time, vel * 0.7);
@@ -86,16 +99,18 @@ function createSnare808(): DrumVoice {
   };
 }
 
-function createSnareAcoustic(): DrumVoice {
+function createSnareAcoustic(connectTo?: Tone.InputNode): DrumVoice {
   const noise = new Tone.NoiseSynth({
     noise: { type: 'pink' },
     envelope: { attack: 0.001, decay: 0.15, sustain: 0, release: 0.1 },
-  }).toDestination();
+  });
   const body = new Tone.MembraneSynth({
     pitchDecay: 0.02, octaves: 2,
     oscillator: { type: 'sine' },
     envelope: { attack: 0.001, decay: 0.12, sustain: 0, release: 0.1 },
-  }).toDestination();
+  });
+  connectDrumNode(noise, connectTo);
+  connectDrumNode(body, connectTo);
   return {
     trigger: (time, vel = 1) => {
       noise.triggerAttackRelease('16n', time, vel * 0.8);
@@ -105,83 +120,91 @@ function createSnareAcoustic(): DrumVoice {
   };
 }
 
-function createHiHatClosed(): DrumVoice {
+function createHiHatClosed(connectTo?: Tone.InputNode): DrumVoice {
   const noise = new Tone.NoiseSynth({
     noise: { type: 'white' },
     envelope: { attack: 0.001, decay: 0.05, sustain: 0, release: 0.03 },
-  }).toDestination();
+  });
+  connectDrumNode(noise, connectTo);
   return {
     trigger: (time, vel = 1) => noise.triggerAttackRelease('32n', time, vel * 0.6),
     dispose: () => noise.dispose(),
   };
 }
 
-function createHiHatOpen(): DrumVoice {
+function createHiHatOpen(connectTo?: Tone.InputNode): DrumVoice {
   const noise = new Tone.NoiseSynth({
     noise: { type: 'white' },
     envelope: { attack: 0.001, decay: 0.3, sustain: 0, release: 0.2 },
-  }).toDestination();
+  });
+  connectDrumNode(noise, connectTo);
   return {
     trigger: (time, vel = 1) => noise.triggerAttackRelease('8n', time, vel * 0.6),
     dispose: () => noise.dispose(),
   };
 }
 
-function createClap(): DrumVoice {
+function createClap(connectTo?: Tone.InputNode): DrumVoice {
   const noise = new Tone.NoiseSynth({
     noise: { type: 'white' },
     envelope: { attack: 0.001, decay: 0.12, sustain: 0, release: 0.08 },
-  }).toDestination();
+  });
+  connectDrumNode(noise, connectTo);
   return {
     trigger: (time, vel = 1) => noise.triggerAttackRelease('16n', time, vel * 0.8),
     dispose: () => noise.dispose(),
   };
 }
 
-function createRim(): DrumVoice {
+function createRim(connectTo?: Tone.InputNode): DrumVoice {
   const synth = new Tone.MetalSynth({
     envelope: { attack: 0.001, decay: 0.05, release: 0.01 },
     harmonicity: 5.1, modulationIndex: 10, resonance: 8000, octaves: 0.5,
-  }).toDestination();
+  });
+  connectDrumNode(synth, connectTo);
   return {
     trigger: (time, vel = 1) => synth.triggerAttackRelease(400, '32n', time, vel * 0.5),
     dispose: () => synth.dispose(),
   };
 }
 
-function createTomHigh(): DrumVoice {
+function createTomHigh(connectTo?: Tone.InputNode): DrumVoice {
   const synth = new Tone.MembraneSynth({
     pitchDecay: 0.04, octaves: 3,
     oscillator: { type: 'sine' },
     envelope: { attack: 0.001, decay: 0.2, sustain: 0, release: 0.15 },
-  }).toDestination();
+  });
+  connectDrumNode(synth, connectTo);
   return {
     trigger: (time, vel = 1) => synth.triggerAttackRelease('G2', '8n', time, vel),
     dispose: () => synth.dispose(),
   };
 }
 
-function createTomLow(): DrumVoice {
+function createTomLow(connectTo?: Tone.InputNode): DrumVoice {
   const synth = new Tone.MembraneSynth({
     pitchDecay: 0.04, octaves: 3,
     oscillator: { type: 'sine' },
     envelope: { attack: 0.001, decay: 0.25, sustain: 0, release: 0.2 },
-  }).toDestination();
+  });
+  connectDrumNode(synth, connectTo);
   return {
     trigger: (time, vel = 1) => synth.triggerAttackRelease('D2', '8n', time, vel),
     dispose: () => synth.dispose(),
   };
 }
 
-function createCrash(): DrumVoice {
+function createCrash(connectTo?: Tone.InputNode): DrumVoice {
   const noise = new Tone.NoiseSynth({
     noise: { type: 'white' },
     envelope: { attack: 0.001, decay: 1.5, sustain: 0, release: 1.0 },
-  }).toDestination();
+  });
   const metal = new Tone.MetalSynth({
     envelope: { attack: 0.001, decay: 1.2, release: 0.5 },
     harmonicity: 5.1, modulationIndex: 32, resonance: 6000, octaves: 1.5,
-  }).toDestination();
+  });
+  connectDrumNode(noise, connectTo);
+  connectDrumNode(metal, connectTo);
   return {
     trigger: (time, vel = 1) => {
       noise.triggerAttackRelease('4n', time, vel * 0.4);
@@ -191,86 +214,93 @@ function createCrash(): DrumVoice {
   };
 }
 
-function createRide(): DrumVoice {
+function createRide(connectTo?: Tone.InputNode): DrumVoice {
   const metal = new Tone.MetalSynth({
     envelope: { attack: 0.001, decay: 0.6, release: 0.3 },
     harmonicity: 5.1, modulationIndex: 20, resonance: 5000, octaves: 1.0,
-  }).toDestination();
+  });
+  connectDrumNode(metal, connectTo);
   return {
     trigger: (time, vel = 1) => metal.triggerAttackRelease(400, '8n', time, vel * 0.4),
     dispose: () => metal.dispose(),
   };
 }
 
-function createShaker(): DrumVoice {
+function createShaker(connectTo?: Tone.InputNode): DrumVoice {
   const noise = new Tone.NoiseSynth({
     noise: { type: 'white' },
     envelope: { attack: 0.005, decay: 0.06, sustain: 0, release: 0.04 },
-  }).toDestination();
+  });
+  connectDrumNode(noise, connectTo);
   return {
     trigger: (time, vel = 1) => noise.triggerAttackRelease('32n', time, vel * 0.5),
     dispose: () => noise.dispose(),
   };
 }
 
-function createCowbell(): DrumVoice {
+function createCowbell(connectTo?: Tone.InputNode): DrumVoice {
   const synth = new Tone.MetalSynth({
     envelope: { attack: 0.001, decay: 0.2, release: 0.1 },
     harmonicity: 1.4, modulationIndex: 2, resonance: 4000, octaves: 0.5,
-  }).toDestination();
+  });
+  connectDrumNode(synth, connectTo);
   return {
     trigger: (time, vel = 1) => synth.triggerAttackRelease(560, '16n', time, vel * 0.6),
     dispose: () => synth.dispose(),
   };
 }
 
-function createConga(): DrumVoice {
+function createConga(connectTo?: Tone.InputNode): DrumVoice {
   const synth = new Tone.MembraneSynth({
     pitchDecay: 0.03, octaves: 2,
     oscillator: { type: 'sine' },
     envelope: { attack: 0.001, decay: 0.15, sustain: 0, release: 0.1 },
-  }).toDestination();
+  });
+  connectDrumNode(synth, connectTo);
   return {
     trigger: (time, vel = 1) => synth.triggerAttackRelease('A2', '16n', time, vel * 0.7),
     dispose: () => synth.dispose(),
   };
 }
 
-function createBongo(): DrumVoice {
+function createBongo(connectTo?: Tone.InputNode): DrumVoice {
   const synth = new Tone.MembraneSynth({
     pitchDecay: 0.02, octaves: 2,
     oscillator: { type: 'sine' },
     envelope: { attack: 0.001, decay: 0.1, sustain: 0, release: 0.08 },
-  }).toDestination();
+  });
+  connectDrumNode(synth, connectTo);
   return {
     trigger: (time, vel = 1) => synth.triggerAttackRelease('D3', '16n', time, vel * 0.7),
     dispose: () => synth.dispose(),
   };
 }
 
-function createTambourine(): DrumVoice {
+function createTambourine(connectTo?: Tone.InputNode): DrumVoice {
   const noise = new Tone.NoiseSynth({
     noise: { type: 'white' },
     envelope: { attack: 0.001, decay: 0.1, sustain: 0, release: 0.08 },
-  }).toDestination();
+  });
+  connectDrumNode(noise, connectTo);
   return {
     trigger: (time, vel = 1) => noise.triggerAttackRelease('16n', time, vel * 0.5),
     dispose: () => noise.dispose(),
   };
 }
 
-function createPerc(): DrumVoice {
+function createPerc(connectTo?: Tone.InputNode): DrumVoice {
   const synth = new Tone.MetalSynth({
     envelope: { attack: 0.001, decay: 0.08, release: 0.04 },
     harmonicity: 3.1, modulationIndex: 8, resonance: 3000, octaves: 0.5,
-  }).toDestination();
+  });
+  connectDrumNode(synth, connectTo);
   return {
     trigger: (time, vel = 1) => synth.triggerAttackRelease(200, '32n', time, vel * 0.5),
     dispose: () => synth.dispose(),
   };
 }
 
-type VoiceFactory = () => DrumVoice;
+type VoiceFactory = (connectTo?: Tone.InputNode) => DrumVoice;
 
 const KIT_FACTORIES: Record<DrumKitName, VoiceFactory[]> = {
   '808': [
@@ -298,6 +328,10 @@ const KIT_FACTORIES: Record<DrumKitName, VoiceFactory[]> = {
     createConga, createBongo, createTambourine, createPerc,
   ],
 };
+
+export function createDrumVoicesForKit(kit: DrumKitName, connectTo?: Tone.InputNode): DrumVoice[] {
+  return KIT_FACTORIES[kit].map((factory) => factory(connectTo));
+}
 
 // ─── Pattern Presets ─────────────────────────────────────────────────────────
 
@@ -408,8 +442,7 @@ class DrumEngine {
 
     this.disposeTrack(trackId);
 
-    const factories = KIT_FACTORIES[kit];
-    const voices: DrumVoice[] = factories.map((factory) => factory());
+    const voices = createDrumVoicesForKit(kit);
     this.voices.set(trackId, voices);
     this.currentKit.set(trackId, kit);
   }

--- a/src/engine/SynthEngine.ts
+++ b/src/engine/SynthEngine.ts
@@ -7,7 +7,7 @@ interface SynthInstance {
   gain: Tone.Gain;
 }
 
-function createSynthForPreset(preset: SynthPreset): Tone.PolySynth {
+export function createSynthForPreset(preset: SynthPreset): Tone.PolySynth {
   const synth = new Tone.PolySynth(Tone.Synth);
 
   switch (preset) {

--- a/src/engine/offlineRender.ts
+++ b/src/engine/offlineRender.ts
@@ -1,0 +1,135 @@
+import * as Tone from 'tone';
+import type { ToneAudioBuffer } from 'tone';
+import { createDrumVoicesForKit } from './DrumEngine';
+import { createSynthForPreset } from './SynthEngine';
+import type { DrumKitName, MidiNote, SequencerPattern, SynthPreset } from '../types/project';
+
+const DRUM_PAD_INDEX_BY_SAMPLE_KEY: Record<string, number> = {
+  kick: 0,
+  snare: 1,
+  closed_hh: 2,
+  open_hh: 3,
+  clap: 4,
+  rim: 5,
+  high_tom: 6,
+  low_tom: 7,
+  crash: 8,
+  ride: 9,
+  shaker: 10,
+  cowbell: 11,
+  conga: 12,
+  bongo: 13,
+  tambourine: 14,
+  perc: 15,
+};
+
+function toAudioBuffer(buffer: ToneAudioBuffer | AudioBuffer): AudioBuffer {
+  if (buffer instanceof AudioBuffer) {
+    return buffer;
+  }
+
+  const nativeBuffer = buffer.get();
+  if (!nativeBuffer) {
+    throw new Error('Offline render returned no AudioBuffer');
+  }
+
+  return nativeBuffer;
+}
+
+export async function renderMidiTrackOffline(
+  notes: MidiNote[],
+  clipStartTime: number,
+  bpm: number,
+  synthPreset: SynthPreset,
+  totalDuration: number,
+  sampleRate: number = 48000,
+): Promise<AudioBuffer> {
+  const buffer = await Tone.Offline(({ transport }) => {
+    const synth = createSynthForPreset(synthPreset);
+    const gain = new Tone.Gain(0.55).toDestination();
+    synth.connect(gain);
+
+    transport.bpm.value = bpm;
+    const secondsPerBeat = 60 / bpm;
+
+    for (const note of notes) {
+      const noteDuration = Math.max(0, note.durationBeats * secondsPerBeat);
+      const noteStart = clipStartTime + note.startBeat * secondsPerBeat;
+      const noteEnd = noteStart + noteDuration;
+      if (noteDuration <= 0 || noteEnd <= 0 || noteStart >= totalDuration) continue;
+
+      const velocity = Math.max(0, Math.min(1, note.velocity));
+      const frequency = Tone.Frequency(note.pitch, 'midi').toFrequency();
+      transport.schedule((time) => {
+        synth.triggerAttackRelease(frequency, noteDuration, time, velocity);
+      }, noteStart);
+    }
+
+    transport.start(0);
+  }, totalDuration, 2, sampleRate);
+
+  return toAudioBuffer(buffer);
+}
+
+export async function renderSequencerTrackOffline(
+  pattern: SequencerPattern,
+  bpm: number,
+  totalDuration: number,
+  drumKit: DrumKitName = '808',
+  sampleRate: number = 48000,
+): Promise<AudioBuffer> {
+  let voices: ReturnType<typeof createDrumVoicesForKit> = [];
+
+  try {
+    const buffer = await Tone.Offline(({ transport }) => {
+      const gain = new Tone.Gain(1).toDestination();
+      voices = createDrumVoicesForKit(drumKit, gain);
+
+      transport.bpm.value = bpm;
+
+      const totalSteps = pattern.stepsPerBar * pattern.bars;
+      const stepDuration = (60 / bpm) / (pattern.stepsPerBar / 4);
+      const patternDuration = totalSteps * stepDuration;
+      const loopCount = patternDuration > 0 ? Math.ceil(totalDuration / patternDuration) : 0;
+
+      for (let loopIndex = 0; loopIndex < loopCount; loopIndex++) {
+        const loopStart = loopIndex * patternDuration;
+
+        for (const row of pattern.rows) {
+          if (row.muted) continue;
+
+          const padIndex = DRUM_PAD_INDEX_BY_SAMPLE_KEY[row.sampleKey];
+          if (padIndex === undefined || !voices[padIndex]) continue;
+
+          for (let stepIndex = 0; stepIndex < row.steps.length; stepIndex++) {
+            const step = row.steps[stepIndex];
+            if (!step?.active) continue;
+
+            let swingOffset = 0;
+            if (pattern.swing > 0 && stepIndex % 2 === 1) {
+              swingOffset = stepDuration * pattern.swing * 0.5;
+            }
+
+            const stepTime = loopStart + stepIndex * stepDuration + swingOffset;
+            if (stepTime >= totalDuration) continue;
+
+            const velocity = Math.max(0, Math.min(1, step.velocity * row.volume));
+            if (velocity <= 0) continue;
+
+            transport.schedule((time) => {
+              voices[padIndex]?.trigger(time, velocity);
+            }, stepTime);
+          }
+        }
+      }
+
+      transport.start(0);
+    }, totalDuration, 2, sampleRate);
+
+    return toAudioBuffer(buffer);
+  } finally {
+    for (const voice of voices) {
+      voice.dispose();
+    }
+  }
+}


### PR DESCRIPTION
Piano Roll MIDI notes and Sequencer drum patterns now export to WAV via Tone.Offline rendering. Export button enabled for any project with content.