### PR TITLE
fix: resolve undo losing intermediate states during drag operations

### DIFF
--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -93,6 +93,8 @@ export function PianoRoll() {
   const addMidiNote = useProjectStore((s) => s.addMidiNote);
   const removeMidiNote = useProjectStore((s) => s.removeMidiNote);
   const updateMidiNote = useProjectStore((s) => s.updateMidiNote);
+  const beginDrag = useProjectStore((s) => s.beginDrag);
+  const endDrag = useProjectStore((s) => s.endDrag);
 
   const currentTime = useTransportStore((s) => s.currentTime);
 
@@ -456,6 +458,7 @@ export function PianoRoll() {
           const nx = beatToX(note.startBeat);
           const nw = Math.max(note.durationBeats * pixelsPerBeat, 4);
           if (x >= nx && x <= nx + nw) {
+            beginDrag();
             const newVel = Math.round(Math.max(1, Math.min(127, ((velAreaTop + velAreaH - y) / velAreaH) * 127)));
             updateMidiNote(clip.id, note.id, { velocity: newVel });
             dragRef.current = {
@@ -498,6 +501,7 @@ export function PianoRoll() {
           };
           addMidiNote(clip.id, newNote);
           if (previewEnabled) synthEngine.previewNote(pitch, 100, 0.3, synthPreset);
+          beginDrag();
           dragRef.current = {
             mode: 'resize-right', noteId: newNote.id,
             startMouseX: x, startMouseY: y,
@@ -519,6 +523,7 @@ export function PianoRoll() {
         } else if (!selectedNoteIds.has(hit.note.id)) {
           setSelectedNoteIds(new Set([hit.note.id]));
         }
+        beginDrag();
         dragRef.current = {
           mode: hit.edge === 'right' ? 'resize-right' : 'move',
           noteId: hit.note.id,
@@ -539,7 +544,7 @@ export function PianoRoll() {
     [
       clip, notes, drawMode, gridBeats, previewEnabled, synthPreset, velocityHeight,
       selectedNoteIds, beatToX, xToBeat, yToPitch, pitchToY, findNoteAt, snapBeat,
-      addMidiNote, removeMidiNote, updateMidiNote, pixelsPerBeat,
+      addMidiNote, removeMidiNote, updateMidiNote, pixelsPerBeat, beginDrag,
     ],
   );
 
@@ -652,6 +657,7 @@ export function PianoRoll() {
 
     const handleGlobalUp = () => {
       dividerDragRef.current = null;
+      if (dragRef.current) endDrag(); // re-enable normal history tracking
       dragRef.current = null;
     };
 
@@ -664,7 +670,7 @@ export function PianoRoll() {
   }, [
     clip, notes, pixelsPerBeat, gridBeats, velocityHeight, keyHeight,
     previewEnabled, synthPreset,
-    beatToX, pitchToY, yToPitch, snapBeat, updateMidiNote,
+    beatToX, pitchToY, yToPitch, snapBeat, updateMidiNote, endDrag,
   ]);
 
   // ─── Wheel (scroll/zoom) ──────────────────────────────────────────────────

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -99,6 +99,8 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
   const moveClipToTrack = useProjectStore((s) => s.moveClipToTrack);
   const duplicateClipToTrack = useProjectStore((s) => s.duplicateClipToTrack);
+  const beginDrag = useProjectStore((s) => s.beginDrag);
+  const endDrag = useProjectStore((s) => s.endDrag);
   const clipBlockRef = useRef<HTMLDivElement>(null);
 
   const findClosestLane = useCallback((clientY: number): { trackId: string; rect: DOMRect } | null => {
@@ -144,6 +146,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       const dx = ev.clientX - startX;
       const dy = ev.clientY - startY;
       if (Math.abs(dx) < 3 && Math.abs(dy) < 3 && !dragRef.current) return;
+      if (!dragRef.current) beginDrag(); // capture undo snapshot once on first drag movement
       dragRef.current = true;
       isShiftCopy = ev.shiftKey;
 
@@ -228,6 +231,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
       setDragGhost(null);
+      endDrag(); // re-enable normal history tracking
 
       if (mode === 'move' && dragRef.current) {
         const closest = findClosestLane(ev.clientY);
@@ -258,7 +262,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
-  }, [clip.id, clip.startTime, clip.duration, clip.audioOffset, clip.audioDuration, pixelsPerSecond, project, updateClip, getDragMode, track.id, moveClipToTrack, duplicateClipToTrack, batchDuplicateClips, batchMoveClips, selectedClipIds, findClosestLane]);
+  }, [clip.id, clip.startTime, clip.duration, clip.audioOffset, clip.audioDuration, pixelsPerSecond, project, updateClip, getDragMode, track.id, moveClipToTrack, duplicateClipToTrack, batchDuplicateClips, batchMoveClips, selectedClipIds, findClosestLane, beginDrag, endDrag]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -40,12 +40,29 @@ const TIMELINE_PADDING = 10; // seconds beyond last clip
 const _history: Project[] = [];
 const _future: Project[] = [];
 const MAX_HISTORY = 50;
+let _isDragging = false;
 
 function _pushHistory(project: Project | null) {
   if (!project) return;
+  // During drag operations, history is already captured by beginDrag — skip intermediate states
+  if (_isDragging) return;
   _history.push(structuredClone(project));
   if (_history.length > MAX_HISTORY) _history.shift();
   _future.length = 0;
+}
+
+/** Call before starting a drag/continuous operation. Captures undo snapshot once. */
+function _beginDrag(project: Project | null) {
+  if (!project || _isDragging) return;
+  _isDragging = true;
+  _history.push(structuredClone(project));
+  if (_history.length > MAX_HISTORY) _history.shift();
+  _future.length = 0;
+}
+
+/** Call when drag/continuous operation ends. Re-enables normal history tracking. */
+function _endDrag() {
+  _isDragging = false;
 }
 
 interface ProjectState {
@@ -60,6 +77,10 @@ interface ProjectState {
   }) => void;
   undo: () => void;
   redo: () => void;
+  /** Call before starting a drag/continuous operation to capture a single undo snapshot. */
+  beginDrag: () => void;
+  /** Call when a drag/continuous operation ends to re-enable normal history. */
+  endDrag: () => void;
 
   updateProject: (updates: Partial<Pick<Project, 'globalCaption' | 'bpm' | 'keyScale' | 'timeSignature' | 'name' | 'masterVolume' | 'measures'>>) => void;
   updateTrackMixer: (trackId: string, updates: Partial<Pick<Track, 'pan' | 'eqLowGain' | 'eqMidGain' | 'eqHighGain' | 'compressorEnabled' | 'compressorThreshold' | 'compressorRatio'>>) => void;
@@ -269,6 +290,15 @@ export const useProjectStore = create<ProjectState>()(
     if (state.project) _history.push(structuredClone(state.project));
     const next = _future.pop()!;
     set({ project: next });
+  },
+
+  beginDrag: () => {
+    const state = get();
+    _beginDrag(state.project);
+  },
+
+  endDrag: () => {
+    _endDrag();
   },
 
   createProject: (params) => {
@@ -1062,6 +1092,7 @@ export const useProjectStore = create<ProjectState>()(
   toggleSequencerStep: (trackId, rowId, stepIndex) => {
     const state = get();
     if (!state.project) return;
+    _pushHistory(state.project);
     set({
       project: {
         ...state.project,
@@ -1089,6 +1120,7 @@ export const useProjectStore = create<ProjectState>()(
   setSequencerStepVelocity: (trackId, rowId, stepIndex, velocity) => {
     const state = get();
     if (!state.project) return;
+    _pushHistory(state.project);
     set({
       project: {
         ...state.project,
@@ -1248,6 +1280,7 @@ export const useProjectStore = create<ProjectState>()(
   setSequencerRowVolume: (trackId, rowId, volume) => {
     const state = get();
     if (!state.project) return;
+    _pushHistory(state.project);
     set({
       project: {
         ...state.project,
@@ -1271,6 +1304,7 @@ export const useProjectStore = create<ProjectState>()(
   setSequencerRowPan: (trackId, rowId, pan) => {
     const state = get();
     if (!state.project) return;
+    _pushHistory(state.project);
     set({
       project: {
         ...state.project,
@@ -1294,6 +1328,7 @@ export const useProjectStore = create<ProjectState>()(
   toggleSequencerRowMute: (trackId, rowId) => {
     const state = get();
     if (!state.project) return;
+    _pushHistory(state.project);
     set({
       project: {
         ...state.project,
@@ -1414,6 +1449,7 @@ export const useProjectStore = create<ProjectState>()(
   renameSequencerRow: (trackId, rowId, name) => {
     const state = get();
     if (!state.project) return;
+    _pushHistory(state.project);
     set({
       project: {
         ...state.project,
@@ -1437,6 +1473,7 @@ export const useProjectStore = create<ProjectState>()(
   setSequencerRowColor: (trackId, rowId, color) => {
     const state = get();
     if (!state.project) return;
+    _pushHistory(state.project);
     set({
       project: {
         ...state.project,


### PR DESCRIPTION
## Summary
- Introduce `beginDrag()`/`endDrag()` mechanism so drag operations capture exactly one undo snapshot instead of flooding the history stack with 30-100 intermediate states per drag
- Fix clip move/resize, MIDI note move/resize/velocity drags to use the new drag-aware undo
- Add missing `_pushHistory()` calls to 7 sequencer operations (`toggleSequencerStep`, `setSequencerStepVelocity`, `setSequencerRowVolume`, `setSequencerRowPan`, `toggleSequencerRowMute`, `renameSequencerRow`, `setSequencerRowColor`)

## Test plan
- [ ] Drag a clip on the timeline, press Cmd+Z — should undo the entire drag in one step
- [ ] Resize a clip, press Cmd+Z — should undo the resize in one step
- [ ] Multi-select clips and drag, press Cmd+Z — should undo the batch move
- [ ] In Piano Roll, drag a MIDI note, press Cmd+Z — should undo in one step
- [ ] In Piano Roll, drag velocity bar, press Cmd+Z — should undo in one step
- [ ] Toggle a sequencer step, press Cmd+Z — should undo the toggle
- [ ] Redo (Cmd+Shift+Z) works correctly after each undo

🤖 Generated with [Claude Code](https://claude.com/claude-code)