### PR TITLE
fix: Library panel (Y) — connect AssetsPanel to showLibrary flag

### DIFF
--- a/docs/plans/fix-library-panel.md
+++ b/docs/plans/fix-library-panel.md
@@ -1,0 +1,227 @@
+# Fix Plan: Library Panel (Y shortcut)
+
+## 1. What the Library Panel Should Show
+
+The **Library panel** (toggled with **Y** shortcut or the leftmost toolbar button) is conceptually a
+**left-side project asset browser** — similar to GarageBand's "Library" or Logic Pro's "Browser".
+In this DAW context it should display:
+
+- All **AI-generated clips** saved to the project's asset store (`project.assets`)
+- All **imported/uploaded audio clips** saved to the asset store
+- Each entry shows: mini waveform preview, prompt/name, track origin, duration, star status
+- Filter tabs: All / Starred / AI-generated / Imported
+- A search box to filter by prompt or track name
+- Click-to-select (highlights the clip on the timeline)
+- Star / remove buttons per asset
+
+This is essentially the same content as the `AssetsPanel` component (which already exists and is
+fully implemented). The Library (Y) and the Assets Panel appear to be the same concept under two
+different names.
+
+---
+
+## 2. Current State
+
+### 2a. Toolbar button — IMPLEMENTED (but broken)
+**File:** `src/components/layout/Toolbar.tsx`, lines 66–87
+
+```tsx
+const showLibrary = useUIStore((s) => s.showLibrary);
+const setShowLibrary = useUIStore((s) => s.setShowLibrary);
+// ...
+<ControlBarButton
+  active={showLibrary}
+  onClick={() => setShowLibrary(!showLibrary)}
+  title="Library (Y)"
+  disabled={!project}
+>
+```
+
+The button exists, is wired up, and toggles `uiStore.showLibrary`. ✅
+
+### 2b. `uiStore` state — IMPLEMENTED
+**File:** `src/store/uiStore.ts`, lines 39, 90, 140, 222
+
+```ts
+showLibrary: boolean;          // line 39 (interface)
+setShowLibrary: (v: boolean) => void;  // line 90 (interface)
+showLibrary: false,            // line 140 (initial state)
+setShowLibrary: (v) => set({ showLibrary: v }),  // line 222 (action)
+```
+
+State exists and updates correctly. ✅
+
+### 2c. Keyboard shortcut — MISSING ❌
+**File:** `src/hooks/useKeyboardShortcuts.ts`
+
+The `Y` key / `KeyY` case is **completely absent** from the `switch (e.code)` block (lines ~185–265).
+The toolbar tooltip says "Library (Y)" but pressing Y does nothing.
+
+Also, the Keyboard Shortcuts dialog (`src/components/dialogs/KeyboardShortcutsDialog.tsx`) does **not**
+list "Y → Library" in its Panels section (lines 55–62). Only X (Mixer), B (Smart Controls), O (Loop
+Browser) are listed.
+
+### 2d. Panel rendering in AppShell — MISSING ❌
+**File:** `src/components/layout/AppShell.tsx`
+
+`showLibrary` is **never read or used** in `AppShell`. No `<LibraryPanel />` or `<AssetsPanel />` is
+rendered when `showLibrary` is true. There is no import of `AssetsPanel` either.
+
+### 2e. AssetsPanel — FULLY IMPLEMENTED but disconnected
+**File:** `src/components/assets/AssetsPanel.tsx`
+
+`AssetsPanel` is a complete, working component. It:
+- Reads `showAssetsPanel` from `uiStore` (not `showLibrary`)
+- Has resize handle, search, filter tabs, asset list with waveform, star/delete actions
+- Returns `null` when `showAssetsPanel` is false or no project
+
+It is **not mounted anywhere in AppShell**. It reads `showAssetsPanel`, not `showLibrary`.
+
+There are now **two separate boolean flags** for what is conceptually the same panel:
+- `showLibrary` — controlled by Y shortcut + toolbar button
+- `showAssetsPanel` — read by `AssetsPanel` but never set by anything in the current UI
+
+---
+
+## 3. Root Cause
+
+The Library panel was partially wired up (store state + toolbar button) but the developer forgot to:
+1. Mount the actual panel component in `AppShell`
+2. Connect the correct store flag (`showLibrary` vs `showAssetsPanel`)
+3. Add the `Y` keyboard shortcut handler
+4. Add `Y → Library` to the keyboard shortcuts help dialog
+
+The `AssetsPanel` component was built separately and uses a different flag (`showAssetsPanel`) that
+was never tied to the Library button/shortcut. The two halves were never connected.
+
+---
+
+## 4. Exact Files and Lines to Change
+
+### File 1: `src/components/layout/AppShell.tsx`
+
+**What to change:** Import and mount `AssetsPanel`, placed inside the main flex row next to `TrackList`.
+
+- **Add import** (around line 18, after other panel imports):
+  ```tsx
+  import { AssetsPanel } from '../assets/AssetsPanel';
+  ```
+
+- **Add render** (inside the `<div className="flex flex-1 min-h-0">` block, currently lines 52–55):
+  ```tsx
+  {project && <TrackList />}
+  {project && <AssetsPanel />}   {/* ← ADD THIS */}
+  {project && <LoopBrowser />}
+  <Timeline />
+  ```
+
+  The Library panel should appear on the **left**, between `TrackList` and the rest. (Or right side —
+  design decision; left matches GarageBand convention.)
+
+---
+
+### File 2: `src/components/assets/AssetsPanel.tsx`
+
+**What to change:** Switch from reading `showAssetsPanel` to reading `showLibrary`.
+
+- **Line 35** — change selector:
+  ```tsx
+  // BEFORE:
+  const showAssetsPanel = useUIStore((s) => s.showAssetsPanel);
+  // AFTER:
+  const showLibrary = useUIStore((s) => s.showLibrary);
+  ```
+
+- **Line 37** — remove `assetsPanelWidth` / `setAssetsPanelWidth` if desired, or keep for resize
+  (they can stay — the resize drag logic and width state still work fine).
+
+- **Line 72** (guard clause) — change condition:
+  ```tsx
+  // BEFORE:
+  if (!showAssetsPanel || !project) return null;
+  // AFTER:
+  if (!showLibrary || !project) return null;
+  ```
+
+- **Header label** (line ~100) — optionally rename from "Loop Browser" to "Library":
+  ```tsx
+  // BEFORE:
+  <span className="...">Loop Browser</span>
+  // AFTER:
+  <span className="...">Library</span>
+  ```
+
+---
+
+### File 3: `src/hooks/useKeyboardShortcuts.ts`
+
+**What to change:** Add `KeyY` case to the non-mod shortcut switch block.
+
+- **Location:** Inside the `switch (e.code)` block (around line 253, after the `KeyO` case).
+
+  ```ts
+  // Library toggle (Y)
+  case 'KeyY':
+    e.preventDefault();
+    ui.setShowLibrary(!ui.showLibrary);
+    break;
+  ```
+
+---
+
+### File 4: `src/components/dialogs/KeyboardShortcutsDialog.tsx`
+
+**What to change:** Add `Y → Library` entry to the Panels section.
+
+- **Location:** Inside `SECTIONS`, in the `'Panels'` section rows array (around line 55–62):
+
+  ```ts
+  {
+    title: 'Panels',
+    rows: [
+      { keys: ['Y'],  description: 'Toggle Library' },   // ← ADD
+      { keys: ['X'],  description: 'Toggle Mixer' },
+      { keys: ['B'],  description: 'Toggle Smart Controls' },
+      { keys: ['O'],  description: 'Toggle Loop Browser' },
+    ],
+  },
+  ```
+
+---
+
+## 5. Optional Cleanup (not required for fix)
+
+- **`src/store/uiStore.ts`:** The `showAssetsPanel` and `setShowAssetsPanel` state/actions (lines 32,
+  73, 134, 204) can be **removed** or **deprecated** once `AssetsPanel` is driven by `showLibrary`.
+  If nothing else reads `showAssetsPanel`, remove it to avoid confusion.
+
+- **`src/components/layout/Toolbar.tsx`:** Confirm `disabled={!project}` on the Library button
+  (line 89) is intentional — looks correct as-is.
+
+---
+
+## 6. Implementation Steps (in order)
+
+1. **Edit `AssetsPanel.tsx`** — switch `showAssetsPanel` → `showLibrary` (2 lines + optional label).
+2. **Edit `AppShell.tsx`** — add `import { AssetsPanel }` and mount `{project && <AssetsPanel />}`
+   in the correct position in the flex row.
+3. **Edit `useKeyboardShortcuts.ts`** — add `case 'KeyY':` to the switch block.
+4. **Edit `KeyboardShortcutsDialog.tsx`** — add `{ keys: ['Y'], description: 'Toggle Library' }`
+   to the Panels section.
+5. **(Optional) Clean up `uiStore.ts`** — remove dead `showAssetsPanel` + `setShowAssetsPanel` if
+   nothing else uses them. Search codebase for `showAssetsPanel` first to verify.
+6. **Test:** Press Y → Library opens. Press Y again → closes. Toolbar Library button toggles correctly.
+   Panel shows AI clips, filter tabs work, search works, star/delete work.
+
+---
+
+## 7. Summary Table
+
+| Component | File | Issue | Fix |
+|---|---|---|---|
+| Toolbar button | `Toolbar.tsx:85–87` | ✅ works | No change |
+| Store state | `uiStore.ts:39,140,222` | ✅ works | No change (remove `showAssetsPanel` optional) |
+| Y key shortcut | `useKeyboardShortcuts.ts` | ❌ missing | Add `case 'KeyY'` |
+| Panel mounted | `AppShell.tsx` | ❌ missing | Import + render `AssetsPanel` |
+| Panel flag | `AssetsPanel.tsx:35,72` | ❌ wrong flag | Change `showAssetsPanel` → `showLibrary` |
+| Shortcut help | `KeyboardShortcutsDialog.tsx` | ❌ missing | Add Y → Library row |

--- a/docs/plans/next-priorities.md
+++ b/docs/plans/next-priorities.md
@@ -1,0 +1,132 @@
+# ACE-Step DAW — Top 5 Next Priorities
+
+> Analysis date: 2025-03-18
+> Scope: `src/` directory, offline/local-only improvements
+> Goal: highest user-impact items that complete or polish existing features
+
+---
+
+## 1. Wire MIDI + Sequencer Real-Time Playback
+
+**Problem:** Users can draw MIDI notes in the Piano Roll and program drum patterns in the Step Sequencer, but pressing Play produces **no sound** for those tracks. Only pre-rendered audio clips (AI stems, imported samples) are audible. `SynthEngine.scheduleClip()` exists but is never called; `AudioEngine.scheduleSequencer()` has scheduling logic but is not invoked from the transport hook.
+
+**User impact:** HIGH — This is the single biggest broken promise in the DAW. Every creative workflow that starts with "draw some notes" dead-ends at silence.
+
+**Estimated complexity:** Medium (2–3 days). The engines are already built; the gap is wiring them into the playback loop.
+
+**Files to touch:**
+| File | Change |
+|------|--------|
+| `src/hooks/useTransport.ts` | Call `synthEngine.scheduleClip()` for piano-roll tracks and `audioEngine.scheduleSequencer()` for sequencer tracks inside the play handler, before/alongside `engine.schedulePlayback()` |
+| `src/engine/SynthEngine.ts` | Verify `scheduleClip()` handles seek offset and loop boundaries correctly |
+| `src/engine/AudioEngine.ts` | Verify `scheduleSequencer()` tiles patterns across the full transport range and respects mute/solo |
+
+**Existing plan:** `docs/plans/fix-midi-sequencer-playback.md`
+
+---
+
+## 2. Fix Loop Browser Visibility + Drag-to-Timeline
+
+**Problem (two linked bugs):**
+1. The **Loop Browser** button (`O` shortcut) toggles the wrong panel (`AssetsPanel`, which is empty) instead of the `LoopBrowser` component that holds 15 built-in loops.
+2. Even if the browser were visible, **dropping a loop onto the timeline does nothing** — drop handlers only check for `Files`, not `application/x-loop-id`.
+
+**User impact:** HIGH — The loop library is a marquee feature for quick song sketching. Both discovery and insertion are broken.
+
+**Estimated complexity:** Low (< 1 day). Toolbar toggle fix is a one-liner; drop handling requires adding a branch in two event handlers.
+
+**Files to touch:**
+| File | Change |
+|------|--------|
+| `src/components/layout/Toolbar.tsx` | Change the "Loop Browser" button to toggle `loopBrowserOpen` (uiStore) instead of `showAssetsPanel` |
+| `src/components/layout/AppShell.tsx` | Render `<LoopBrowser>` when `loopBrowserOpen` is true (may already be partially wired) |
+| `src/components/timeline/TrackLane.tsx` | In `onDrop`, check for `application/x-loop-id`; resolve the loop, decode audio, and call `importAudioBufferToTrack` |
+| `src/components/timeline/Timeline.tsx` | Mirror the same loop-id drop handling in `handleDrop` for drops on empty space |
+
+**Existing plans:** `docs/plans/fix-loop-browser.md`, `docs/plans/fix-loop-drag-to-timeline.md`
+
+---
+
+## 3. Add a Toast / Notification System
+
+**Problem:** The app gives **zero user-visible feedback** for operations that succeed, fail, or take a long time:
+- AI generation completes → no notification
+- WAV export finishes → no "saved!" confirmation
+- Network/API error during generation → silent `console.error`
+- Microphone permission denied → silent failure
+- Project saved → no acknowledgement
+
+Users are left guessing whether actions worked, especially during background generation.
+
+**User impact:** HIGH — Every user hits this on every session. It erodes trust in the app and causes redundant retries.
+
+**Estimated complexity:** Low–Medium (1–2 days). Add a lightweight toast component (or a dependency like `sonner` / `react-hot-toast`), then sprinkle `toast()` calls at key points.
+
+**Files to touch:**
+| File | Change |
+|------|--------|
+| `src/components/ui/Toast.tsx` (new) | Minimal toast container + hook, or integrate a library |
+| `src/components/layout/AppShell.tsx` | Mount the toast container |
+| `src/store/generationStore.ts` / `generationPipeline.ts` | Toast on generation start, success, error |
+| `src/components/dialogs/ExportDialog.tsx` | Toast on export success/failure |
+| `src/engine/RecordingEngine.ts` | Toast on mic permission denied |
+| `src/store/projectStore.ts` | Toast on project save/load |
+
+---
+
+## 4. Wire Automation Playback
+
+**Problem:** The `AutomationEngine` class exists with full breakpoint interpolation logic, and users can draw automation lanes (volume, pan) on the timeline. But the engine is **never called during playback** — automation data is stored and displayed but has no audible effect.
+
+**User impact:** MEDIUM — Automation is an intermediate-to-advanced feature, but the fact that the UI exists and "works" visually while doing nothing audibly is a confusing UX trap.
+
+**Estimated complexity:** Medium (1–2 days). The engine is complete; the work is scheduling parameter updates during the playback RAF loop and ensuring automation values are applied to TrackNode gain/pan.
+
+**Files to touch:**
+| File | Change |
+|------|--------|
+| `src/hooks/useTransport.ts` | In the RAF playback loop, call `automationEngine.getValueAtTime(trackId, param, currentBeat)` and apply to the corresponding TrackNode |
+| `src/engine/AutomationEngine.ts` | Ensure `getValueAtTime` handles edge cases (no points, single point, extrapolation) |
+| `src/engine/AudioEngine.ts` | Expose a method to set track gain/pan at runtime (e.g., `setTrackParam(trackId, param, value)`) if one doesn't exist |
+| `src/components/timeline/AutomationLane.tsx` | (Optional) Add a visual playhead indicator showing current automation value |
+
+---
+
+## 5. Persist UI Layout State Across Reloads
+
+**Problem:** Panel sizes (mixer height, piano roll height, sequencer editor height), scroll positions, selected tracks, and editor open/close states all reset to defaults on page reload. The `uiStore` has no `persist` middleware, unlike `projectStore` which uses IndexedDB.
+
+**User impact:** MEDIUM — Power users who arrange their workspace lose their layout every reload or browser restart, causing repeated friction.
+
+**Estimated complexity:** Low (< 1 day). Add Zustand `persist` middleware to `uiStore` with a localStorage or IndexedDB backend, selecting only layout-related keys (not ephemeral selection state).
+
+**Files to touch:**
+| File | Change |
+|------|--------|
+| `src/store/uiStore.ts` | Wrap the store with `persist(...)` middleware; pick keys like `mixerHeight`, `pianoRollHeight`, `sequencerEditorHeight`, `showMixer`, `showEffects`, `editorMode` |
+| (No other files needed) | |
+
+---
+
+## Priority Matrix
+
+| # | Improvement | User Impact | Complexity | Blocking? |
+|---|-------------|-------------|------------|-----------|
+| 1 | MIDI + Sequencer playback | HIGH | Medium | Yes — core feature broken |
+| 2 | Loop Browser + drag-to-timeline | HIGH | Low | Yes — feature invisible |
+| 3 | Toast / notification system | HIGH | Low–Med | No, but affects all flows |
+| 4 | Automation playback | MEDIUM | Medium | No — advanced feature |
+| 5 | Persist UI layout | MEDIUM | Low | No — QoL polish |
+
+**Recommended order:** 2 → 1 → 3 → 5 → 4
+(Start with the quickest high-impact fix, then tackle the critical playback gap, then layer on feedback and polish.)
+
+---
+
+## Honorable Mentions (Not Top 5)
+
+- **Undo/redo efficiency:** Works but uses `structuredClone` of full state; delta-based storage would be faster for large projects.
+- **AudioContext leak in RecordingEngine:** New context created on each `requestPermission()` call; should reuse or dispose.
+- **Component splitting:** PianoRoll.tsx (600+ lines) and projectStore.ts (1000+ lines) are large and would benefit from decomposition for maintainability.
+- **Test coverage:** Zero test files — any refactoring is risky without regression protection.
+- **Console.log cleanup:** 20+ `[GenerationPipeline]` logs pollute DevTools.

--- a/src/components/assets/AssetsPanel.tsx
+++ b/src/components/assets/AssetsPanel.tsx
@@ -37,7 +37,7 @@ function fmtDuration(sec: number): string {
 }
 
 export function AssetsPanel() {
-  const showAssetsPanel = useUIStore((s) => s.showAssetsPanel);
+  const showLibrary = useUIStore((s) => s.showLibrary);
   const assetsPanelWidth = useUIStore((s) => s.assetsPanelWidth);
   const setAssetsPanelWidth = useUIStore((s) => s.setAssetsPanelWidth);
   const selectClip = useUIStore((s) => s.selectClip);
@@ -100,7 +100,7 @@ export function AssetsPanel() {
     removeAsset(assetId);
   }, [removeAsset]);
 
-  if (!showAssetsPanel || !project) return null;
+  if (!showLibrary || !project) return null;
 
   const filters: { id: Filter; label: string }[] = [
     { id: 'all', label: 'All' },
@@ -123,7 +123,7 @@ export function AssetsPanel() {
           <circle cx="5" cy="5" r="3.5" />
           <path d="M8 8l2.5 2.5" strokeLinecap="round" />
         </svg>
-        <span className="text-[10px] text-zinc-500 uppercase tracking-wider font-medium">Loop Browser</span>
+        <span className="text-[10px] text-zinc-500 uppercase tracking-wider font-medium">Library</span>
       </div>
 
       {/* Search */}

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -65,6 +65,7 @@ const SECTIONS: Section[] = [
   {
     title: 'Panels',
     rows: [
+      { keys: ['Y'],                    description: 'Toggle Library' },
       { keys: ['X'],                    description: 'Toggle Mixer' },
       { keys: ['B'],                    description: 'Toggle Smart Controls' },
       { keys: ['O'],                    description: 'Toggle Loop Browser' },

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -15,6 +15,7 @@ import { SettingsDialog } from '../dialogs/SettingsDialog';
 import { ProjectListDialog } from '../dialogs/ProjectListDialog';
 import { KeyboardShortcutsDialog } from '../dialogs/KeyboardShortcutsDialog';
 import { MixerPanel } from '../mixer/MixerPanel';
+import { AssetsPanel } from '../assets/AssetsPanel';
 import { LoopBrowser } from '../assets/LoopBrowser';
 import { SequencerEditor } from '../sequencer/SequencerEditor';
 import { SmartControlsPanel } from '../controls/SmartControlsPanel';
@@ -48,6 +49,7 @@ export function AppShell() {
 
       <div className="flex flex-1 min-h-0">
         {project && <TrackList />}
+        {project && <AssetsPanel />}
         {project && <LoopBrowser />}
         <Timeline />
       </div>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -279,6 +279,12 @@ export function useKeyboardShortcuts() {
           ui.toggleLoopBrowser();
           break;
 
+        // Library toggle (Y)
+        case 'KeyY':
+          e.preventDefault();
+          ui.setShowLibrary(!ui.showLibrary);
+          break;
+
         // Help
         case 'Slash':
           // ? key (Shift+/ on most keyboards)


### PR DESCRIPTION
Library button and Y shortcut now open the fully-implemented AssetsPanel. Root cause was two disconnected halves: toolbar toggled showLibrary, but AssetsPanel read showAssetsPanel and was never mounted in AppShell.