### PR TITLE
fix: wire EffectsEngine into TrackNode audio graph

### DIFF
--- a/docs/plans/fix-effects-engine-wiring.md
+++ b/docs/plans/fix-effects-engine-wiring.md
@@ -1,0 +1,139 @@
+# Fix: Wire EffectsEngine into TrackNode Audio Graph
+
+## 1. Current Signal Chain in TrackNode (Web Audio API)
+
+```
+source → inputGain → panNode → eqLow → eqMid → eqHigh
+                                                   ├→ dryGain ──────────→ sumGain → compressor → volumeGain → destination
+                                                   └→ convolver → wetGain ─┘
+```
+
+All nodes are native `AudioNode` instances created from a single `AudioContext` (48 kHz,
+owned by `AudioEngine`). The chain is wired once in the `TrackNode` constructor and never
+re-wired.
+
+## 2. Why EffectsEngine Nodes Are Never Heard
+
+`EffectsEngine.rebuildChain()` creates **Tone.js** `ToneAudioNode` instances (EQ3,
+Compressor, Reverb, FeedbackDelay, Distortion, Filter) and connects them to each other
+internally via `nodes[i].node.connect(nodes[i+1].node)`. However:
+
+- **No connection to TrackNode**: The first node in the Tone chain has no input from
+  `eqHigh`, and the last node has no output to `dryGain`/`sumGain`. The chain floats
+  disconnected.
+- **AudioContext mismatch**: Tone.js creates its own `Tone.getContext()` AudioContext by
+  default. TrackNode uses `AudioEngine.ctx`. Two different contexts cannot share nodes —
+  `connect()` across contexts throws.
+- **EffectChain.tsx** calls `effectsEngine.rebuildChain()` and `updateEffectParams()` but
+  never tells `TrackNode` to splice anything into its graph.
+
+## 3. Proposed Fix
+
+**Principle**: Keep it minimal. Don't rewrite TrackNode in Tone.js. Instead, expose the
+Tone chain's underlying native `AudioNode` endpoints and splice them into TrackNode's
+existing Web Audio graph.
+
+### 3a. Force Tone.js onto our AudioContext
+
+In `AudioEngine` constructor (or a one-time init), call:
+
+```ts
+import * as Tone from 'tone';
+Tone.setContext(this.ctx);   // before any Tone nodes are created
+```
+
+This makes all subsequent `new Tone.*()` calls use our 48 kHz context. Must happen before
+the first `EffectsEngine.rebuildChain()`.
+
+### 3b. Add splice helpers to EffectsEngine
+
+```ts
+// EffectsEngine.ts — new public methods
+
+/** Native AudioNode input of the chain (first node's input). null = no active effects. */
+getInputNode(trackId: string): AudioNode | null {
+  const nodes = this.chains.get(trackId);
+  if (!nodes?.length) return null;
+  return (nodes[0].node as any).input ?? (nodes[0].node as any)._nativeAudioNode;
+}
+
+/** Native AudioNode output of the chain (last node's output). */
+getOutputNode(trackId: string): AudioNode | null {
+  const nodes = this.chains.get(trackId);
+  if (!nodes?.length) return null;
+  return (nodes[nodes.length - 1].node as any).output ?? (nodes[nodes.length - 1].node as any)._nativeAudioNode;
+}
+```
+
+> Tone.js `ToneAudioNode` exposes `.input` and `.output` properties that are native
+> `AudioNode` or `GainNode` references. These are the stable API for bridging.
+
+### 3c. Add `spliceEffects()` to TrackNode
+
+```ts
+// TrackNode.ts — new field + method
+private effectsInput: AudioNode | null = null;
+private effectsOutput: AudioNode | null = null;
+
+spliceEffects(input: AudioNode | null, output: AudioNode | null) {
+  // Disconnect old splice point: eqHigh → dryGain
+  this.eqHigh.disconnect(this.dryGain);
+  this.eqHigh.disconnect(this.convolver);
+
+  if (this.effectsOutput) {
+    this.effectsOutput.disconnect(this.dryGain);
+    this.effectsOutput.disconnect(this.convolver);
+  }
+
+  if (input && output) {
+    // eqHigh → effects input ... effects output → dryGain / convolver
+    this.eqHigh.connect(input);
+    output.connect(this.dryGain);
+    output.connect(this.convolver);
+  } else {
+    // No effects — restore direct path
+    this.eqHigh.connect(this.dryGain);
+    this.eqHigh.connect(this.convolver);
+  }
+
+  this.effectsInput = input;
+  this.effectsOutput = output;
+}
+```
+
+### 3d. Call spliceEffects after every rebuildChain
+
+In `EffectChain.tsx` (or a new wiring hook), after `effectsEngine.rebuildChain()`:
+
+```ts
+const trackNode = audioEngine.getOrCreateTrackNode(track.id);
+const inp = effectsEngine.getInputNode(track.id);
+const out = effectsEngine.getOutputNode(track.id);
+trackNode.spliceEffects(inp, out);
+```
+
+## 4. Files to Change
+
+| File | Change |
+|---|---|
+| `src/engine/AudioEngine.ts` | Add `Tone.setContext(this.ctx)` in constructor (1 line + import) |
+| `src/engine/EffectsEngine.ts` | Add `getInputNode()` / `getOutputNode()` methods (~16 lines) |
+| `src/engine/TrackNode.ts` | Add `spliceEffects()` method + two private fields (~20 lines) |
+| `src/components/mixer/EffectChain.tsx` | After `rebuildChain()`, call `spliceEffects` via audioEngine ref (~5 lines in useEffect + applyPreset) |
+
+**Total**: ~45 lines of new code, 0 lines of deleted logic.
+
+## 5. Tone.js → Web Audio Bridge Notes
+
+- `Tone.setContext(ctx)` must be called **before** any `new Tone.*()`. If called late,
+  existing nodes remain on the old context and are silently broken. Guard with an
+  `assert` or init flag.
+- `ToneAudioNode.input` / `.output` are `AudioNode | undefined`. For compound nodes
+  (EQ3 has 3 internal bands), `.input` is the shared input gain and `.output` is the
+  merged output — safe to use as splice points.
+- Tone.js Reverb generates an IR asynchronously (`Tone.Reverb.generate()`). After
+  `rebuildChain`, the reverb may be silent for ~100ms until the IR resolves. Consider
+  awaiting `.ready` before splicing, or accept the brief gap.
+- `dispose()` on a Tone node disconnects its underlying native nodes. The existing
+  `disposeChain()` already handles this, but `spliceEffects(null, null)` must be called
+  **before** dispose to restore the direct eqHigh→dryGain path.

--- a/src/components/mixer/EffectChain.tsx
+++ b/src/components/mixer/EffectChain.tsx
@@ -24,6 +24,7 @@ const Trash2 = ({ className }: { className?: string }) => (
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { effectsEngine } from '../../engine/EffectsEngine';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
 import type {
   TrackEffect,
   TrackEffectType,
@@ -414,6 +415,15 @@ function EffectDevice({
     updateTrackEffect(track.id, effect.id, { params: preset.params } as Partial<TrackEffect>);
     effectsEngine.updateEffectParams(track.id, effect.id, preset.params, effect.type);
     effectsEngine.rebuildChain(track.id, track.effects ?? []);
+    // Wire Tone.js effect chain into the TrackNode audio graph
+    const engine = getAudioEngine();
+    const trackNode = engine.getOrCreateTrackNode(track.id);
+    if (trackNode) {
+      trackNode.spliceEffects(
+        effectsEngine.getInputNode(track.id),
+        effectsEngine.getOutputNode(track.id),
+      );
+    }
   };
 
   return (
@@ -557,6 +567,15 @@ export function EffectChain() {
   useEffect(() => {
     if (!track) return;
     effectsEngine.rebuildChain(track.id, track.effects ?? []);
+    // Wire rebuilt Tone.js chain into TrackNode audio graph
+    const engine = getAudioEngine();
+    const trackNode = engine.getOrCreateTrackNode(track.id);
+    if (trackNode) {
+      trackNode.spliceEffects(
+        effectsEngine.getInputNode(track.id),
+        effectsEngine.getOutputNode(track.id),
+      );
+    }
   }, [track?.id, effectsKey, track?.effects?.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Resize handle

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -1,3 +1,4 @@
+import * as Tone from 'tone';
 import { TrackNode } from './TrackNode';
 import type { SequencerPattern } from '../types/project';
 
@@ -53,6 +54,8 @@ export class AudioEngine {
 
   constructor() {
     this.ctx = new AudioContext({ sampleRate: 48000 });
+    // Share our AudioContext with Tone.js so EffectsEngine nodes live on the same graph
+    Tone.setContext(this.ctx as unknown as Tone.BaseContext);
     this.masterGain = this.ctx.createGain();
     this.masterGain.connect(this.ctx.destination);
     this._metronomeGain = this.ctx.createGain();

--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -202,6 +202,28 @@ class EffectsEngine {
     return this.chains.get(trackId) ?? [];
   }
 
+  /**
+   * Returns the native AudioNode input of this track's effect chain, or null if empty.
+   * Tone.js ToneAudioNode exposes `.input` which is a native AudioNode suitable for connect().
+   */
+  getInputNode(trackId: string): AudioNode | null {
+    const nodes = this.chains.get(trackId);
+    if (!nodes?.length) return null;
+    const toneNode = nodes[0].node as unknown as { input?: AudioNode };
+    return toneNode.input ?? null;
+  }
+
+  /**
+   * Returns the native AudioNode output of this track's effect chain, or null if empty.
+   * Tone.js ToneAudioNode exposes `.output` which is a native AudioNode suitable for connect().
+   */
+  getOutputNode(trackId: string): AudioNode | null {
+    const nodes = this.chains.get(trackId);
+    if (!nodes?.length) return null;
+    const toneNode = nodes[nodes.length - 1].node as unknown as { output?: AudioNode };
+    return toneNode.output ?? null;
+  }
+
   disposeChain(trackId: string) {
     const nodes = this.chains.get(trackId);
     if (!nodes) return;

--- a/src/engine/TrackNode.ts
+++ b/src/engine/TrackNode.ts
@@ -26,6 +26,8 @@ export class TrackNode {
   private _soloActive = false;
   private _reverbMix = 0;
   private _reverbRoomSize = 0.5;
+  private _effectsInput: AudioNode | null = null;
+  private _effectsOutput: AudioNode | null = null;
 
   constructor(private ctx: AudioContext, destination: AudioNode) {
     this.inputGain  = ctx.createGain();
@@ -199,6 +201,36 @@ export class TrackNode {
       }
     }
     this.convolver.buffer = ir;
+  }
+
+  // -----------------------------------------------------------------------
+
+  /**
+   * Splice an external effects chain (from EffectsEngine) between eqHigh and dryGain/convolver.
+   * Pass null/null to remove effects and restore the direct path.
+   */
+  spliceEffects(input: AudioNode | null, output: AudioNode | null) {
+    // Disconnect current splice point
+    try { this.eqHigh.disconnect(this.dryGain); } catch {}
+    try { this.eqHigh.disconnect(this.convolver); } catch {}
+
+    if (this._effectsOutput) {
+      try { this._effectsOutput.disconnect(this.dryGain); } catch {}
+      try { this._effectsOutput.disconnect(this.convolver); } catch {}
+    }
+
+    if (input && output) {
+      this.eqHigh.connect(input);
+      output.connect(this.dryGain);
+      output.connect(this.convolver);
+    } else {
+      // Restore direct path
+      this.eqHigh.connect(this.dryGain);
+      this.eqHigh.connect(this.convolver);
+    }
+
+    this._effectsInput = input;
+    this._effectsOutput = output;
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
The Mixer effects panel (EQ3, compressor, reverb, delay, distortion, filter) was purely cosmetic — Tone.js nodes floated disconnected. Now:
- Tone.setContext(ctx) shares AudioContext
- getInputNode/getOutputNode expose native AudioNode endpoints
- spliceEffects() inserts the chain between eqHigh and dryGain
- Wired in EffectChain.tsx after every rebuildChain call