### PR TITLE
feat: wire RecordingEngine — Record button, track arm, R shortcut

### DIFF
--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -3,6 +3,7 @@ import { useUIStore } from '../../store/uiStore';
 import { useTransportStore } from '../../store/transportStore';
 import { useAudioImport } from '../../hooks/useAudioImport';
 import { useTransport } from '../../hooks/useTransport';
+import { useRecording } from '../../hooks/useRecording';
 import { formatTime, formatBarsBeats } from '../../utils/time';
 
 function LCDDisplay() {
@@ -31,7 +32,7 @@ function ControlBarButton({
   children,
 }: {
   active?: boolean;
-  onClick: () => void;
+  onClick: () => void | Promise<void>;
   title: string;
   disabled?: boolean;
   children: React.ReactNode;
@@ -68,9 +69,11 @@ export function Toolbar() {
   const showSmartControls = useUIStore((s) => s.showSmartControls);
   const setShowSmartControls = useUIStore((s) => s.setShowSmartControls);
   const { openFilePicker } = useAudioImport();
+  const { toggleRecord } = useRecording();
 
   const { isPlaying, play, pause, stop } = useTransport();
   const loopEnabled = useTransportStore((s) => s.loopEnabled);
+  const isRecording = useTransportStore((s) => s.isRecording);
   const toggleLoop = useTransportStore((s) => s.toggleLoop);
   const metronomeEnabled = useTransportStore((s) => s.metronomeEnabled);
   const toggleMetronome = useTransportStore((s) => s.toggleMetronome);
@@ -133,7 +136,7 @@ export function Toolbar() {
       {/* Center: Transport controls */}
       <div className="flex items-center gap-0.5">
         {/* Rewind */}
-        <ControlBarButton onClick={stop} title="Go to Beginning (Enter)">
+        <ControlBarButton onClick={() => void stop()} title="Go to Beginning (Enter)">
           <svg width="14" height="12" viewBox="0 0 14 12" fill="currentColor">
             <rect x="0" y="1" width="2" height="10" rx="0.5" />
             <path d="M13 1L5 6l8 5V1z" />
@@ -141,7 +144,7 @@ export function Toolbar() {
         </ControlBarButton>
         {/* Play/Pause */}
         <button
-          onClick={() => (isPlaying ? pause() : play())}
+          onClick={() => void (isPlaying ? pause() : play())}
           className={`w-9 h-8 flex items-center justify-center rounded transition-colors ${
             isPlaying
               ? 'bg-daw-accent text-white'
@@ -160,9 +163,8 @@ export function Toolbar() {
             </svg>
           )}
         </button>
-        {/* Record placeholder */}
-        <ControlBarButton onClick={() => {}} title="Record (R)" disabled>
-          <div className="w-3.5 h-3.5 rounded-full bg-red-500 opacity-60" />
+        <ControlBarButton onClick={() => void toggleRecord()} title="Record (R)" active={isRecording}>
+          <div className={`w-3.5 h-3.5 rounded-full bg-red-500 ${isRecording ? 'animate-pulse' : 'opacity-60'}`} />
         </ControlBarButton>
       </div>
 

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { TRACK_CATALOG } from '../../constants/tracks';
 import { TrackEditModal } from './TrackEditModal';
+import { useRecording } from '../../hooks/useRecording';
 
 const MIN_LANE_HEIGHT = 40;
 const MAX_LANE_HEIGHT = 400;
@@ -30,6 +31,7 @@ export function TrackHeader({
   const removeTrack = useProjectStore((s) => s.removeTrack);
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
   const setOpenEffectChainTrackId = useUIStore((s) => s.setOpenEffectChainTrackId);
+  const { armedTrackIds, toggleArmTrack } = useRecording();
   const info = TRACK_CATALOG[track.trackName];
 
   const [editModalOpen, setEditModalOpen] = useState(false);
@@ -60,6 +62,7 @@ export function TrackHeader({
   const laneHeight = track.laneHeight ?? 64;
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
   const isCompact = laneHeight < 52;
+  const isArmed = armedTrackIds.includes(track.id) || !!track.armed;
 
   const onHeightResizeDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -215,6 +218,20 @@ export function TrackHeader({
           <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
             <path d="M2 5.5a4 4 0 018 0" />
             <path d="M2 5.5v2a1 1 0 001 1h1v-3H2zM10 5.5v2a1 1 0 01-1 1H8v-3h2z" fill={track.soloed ? 'currentColor' : 'none'} />
+          </svg>
+        </button>
+        <button
+          onClick={() => toggleArmTrack(track.id)}
+          className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
+            isArmed
+              ? 'bg-red-600/90 text-white'
+              : 'text-red-400 hover:text-red-300 hover:bg-[#444]'
+          }`}
+          title="Record arm"
+          aria-label={`Record arm ${track.displayName}`}
+        >
+          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
+            <circle cx="6" cy="6" r="3.25" fill={isArmed ? 'currentColor' : 'none'} />
           </svg>
         </button>
         {/* Delete - hidden by default, visible on hover */}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -5,6 +5,7 @@ import { useProjectStore } from '../store/projectStore';
 import { useTransportStore } from '../store/transportStore';
 import { useGenerationStore } from '../store/generationStore';
 import { generateSingleClip } from '../services/generationPipeline';
+import { useRecording } from './useRecording';
 
 function isInputFocused(e: KeyboardEvent): boolean {
   return (
@@ -19,6 +20,7 @@ const DEFAULT_PIXELS_PER_SECOND = 50;
 
 export function useKeyboardShortcuts() {
   const { play, pause, stop, seek } = useTransport();
+  const { toggleRecord } = useRecording();
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -218,6 +220,11 @@ export function useKeyboardShortcuts() {
         case 'KeyL':
           e.preventDefault();
           transport.toggleLoop();
+          break;
+
+        case 'KeyR':
+          e.preventDefault();
+          void toggleRecord();
           break;
 
         case 'ArrowLeft':

--- a/src/hooks/useRecording.ts
+++ b/src/hooks/useRecording.ts
@@ -1,0 +1,142 @@
+import { useCallback, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { recordingEngine } from '../engine/RecordingEngine';
+import { useTransportStore } from '../store/transportStore';
+import { useProjectStore } from '../store/projectStore';
+import { toastError, toastInfo, toastSuccess } from './useToast';
+import { saveAudioBlob } from '../services/audioFileManager';
+import { computeWaveformPeaks } from '../utils/waveformPeaks';
+import { audioBufferToWavBlob } from '../utils/wav';
+
+export function useRecording() {
+  const isRecording = useTransportStore((s) => s.isRecording);
+  const armedTrackIds = useTransportStore((s) => s.armedTrackIds);
+  const setIsRecording = useTransportStore((s) => s.setIsRecording);
+  const storeArmTrack = useTransportStore((s) => s.armTrack);
+  const storeDisarmTrack = useTransportStore((s) => s.disarmTrack);
+  const storeToggleArmTrack = useTransportStore((s) => s.toggleArmTrack);
+  const addClip = useProjectStore((s) => s.addClip);
+  const updateClipStatus = useProjectStore((s) => s.updateClipStatus);
+  const updateTrack = useProjectStore((s) => s.updateTrack);
+  const [hasPermission, setHasPermission] = useState(recordingEngine.hasPermission);
+
+  const armTrack = useCallback((id: string) => {
+    storeArmTrack(id);
+    recordingEngine.setMonitoring(id, true);
+    updateTrack(id, { armed: true });
+  }, [storeArmTrack, updateTrack]);
+
+  const disarmTrack = useCallback((id: string) => {
+    storeDisarmTrack(id);
+    recordingEngine.setMonitoring(id, false);
+    updateTrack(id, { armed: false });
+  }, [storeDisarmTrack, updateTrack]);
+
+  const toggleArmTrack = useCallback((id: string) => {
+    const armed = useTransportStore.getState().armedTrackIds.includes(id);
+    if (armed) {
+      disarmTrack(id);
+      return;
+    }
+    storeToggleArmTrack(id);
+    recordingEngine.setMonitoring(id, true);
+    updateTrack(id, { armed: true });
+  }, [disarmTrack, storeToggleArmTrack, updateTrack]);
+
+  const stopRecording = useCallback(async () => {
+    const project = useProjectStore.getState().project;
+    if (!project) {
+      setIsRecording(false);
+      return;
+    }
+
+    const sessionStartTimes = new Map<string, number>();
+    for (const trackId of useTransportStore.getState().armedTrackIds) {
+      const session = recordingEngine.getSession(trackId);
+      if (session) {
+        sessionStartTimes.set(trackId, session.startTime);
+      }
+    }
+
+    const results = await recordingEngine.stopAllRecordings();
+    let createdCount = 0;
+
+    for (const [trackId, result] of results.entries()) {
+      const clip = addClip(trackId, {
+        startTime: sessionStartTimes.get(trackId) ?? useTransportStore.getState().currentTime,
+        duration: result.duration,
+        prompt: 'Recording',
+        lyrics: '',
+        source: 'uploaded',
+      });
+      const wavBlob = audioBufferToWavBlob(result.audioBuffer);
+      const isolatedAudioKey = await saveAudioBlob(project.id, clip.id, 'isolated', wavBlob);
+      const waveformPeaks = computeWaveformPeaks(result.audioBuffer, 200);
+
+      updateClipStatus(clip.id, 'ready', {
+        isolatedAudioKey,
+        waveformPeaks,
+        audioDuration: result.duration,
+        audioOffset: 0,
+        source: 'uploaded',
+      });
+      createdCount += 1;
+    }
+
+    setIsRecording(false);
+
+    if (createdCount > 0) {
+      toastSuccess('Recording saved');
+    }
+  }, [addClip, setIsRecording, updateClipStatus]);
+
+  const toggleRecord = useCallback(async () => {
+    if (useTransportStore.getState().isRecording) {
+      await stopRecording();
+      return;
+    }
+
+    const currentArmedTrackIds = useTransportStore.getState().armedTrackIds;
+    if (currentArmedTrackIds.length === 0) {
+      toastError('Arm a track first');
+      return;
+    }
+
+    const granted = await recordingEngine.requestPermission();
+    setHasPermission(granted);
+    if (!granted) {
+      toastError('Microphone access denied');
+      return;
+    }
+
+    setIsRecording(true);
+    const transportTime = useTransportStore.getState().currentTime;
+    let startedCount = 0;
+
+    for (const trackId of currentArmedTrackIds) {
+      const started = await recordingEngine.startRecording(trackId, uuidv4(), transportTime);
+      if (started) {
+        startedCount += 1;
+      }
+    }
+
+    if (startedCount === 0) {
+      setIsRecording(false);
+      toastError('Unable to start recording');
+      return;
+    }
+
+    toastInfo('Recording started');
+  }, [setIsRecording, stopRecording]);
+
+  return {
+    isRecording,
+    armedTrackIds,
+    toggleRecord,
+    stopRecording,
+    armTrack,
+    disarmTrack,
+    toggleArmTrack,
+    hasPermission,
+  };
+}

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -6,6 +6,7 @@ import { getAudioEngine } from './useAudioEngine';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { synthEngine } from '../engine/SynthEngine';
 import { drumEngine } from '../engine/DrumEngine';
+import { useRecording } from './useRecording';
 
 const DRUM_PAD_INDEX_BY_SAMPLE_KEY: Record<string, number> = {
   kick: 0,
@@ -57,7 +58,9 @@ function trimBuffer(
 
 export function useTransport() {
   const { isPlaying, currentTime } = useTransportStore();
+  const isRecording = useTransportStore((s) => s.isRecording);
   const project = useProjectStore((s) => s.project);
+  const { stopRecording } = useRecording();
 
   const play = useCallback(async (fromTime?: number) => {
     const engine = getAudioEngine();
@@ -242,21 +245,27 @@ export function useTransport() {
     useTransportStore.getState().play();
   }, []);
 
-  const pause = useCallback(() => {
+  const pause = useCallback(async () => {
+    if (isRecording) {
+      await stopRecording();
+    }
     const engine = getAudioEngine();
     const time = engine.getCurrentTime();
     engine.stop();
     synthEngine.releaseAll();
     useTransportStore.getState().pause();
     useTransportStore.getState().seek(time);
-  }, []);
+  }, [isRecording, stopRecording]);
 
-  const stop = useCallback(() => {
+  const stop = useCallback(async () => {
+    if (isRecording) {
+      await stopRecording();
+    }
     const engine = getAudioEngine();
     engine.stop();
     synthEngine.releaseAll();
     useTransportStore.getState().stop();
-  }, []);
+  }, [isRecording, stopRecording]);
 
   const seek = useCallback((time: number) => {
     const engine = getAudioEngine();

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -89,7 +89,7 @@ interface ProjectState {
 
   addTrack: (trackName: TrackName, trackType?: TrackType) => Track;
   removeTrack: (trackId: string) => void;
-  updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'laneHeight' | 'trackType' | 'synthPreset' | 'drumKit'>>) => void;
+  updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'armed' | 'laneHeight' | 'trackType' | 'synthPreset' | 'drumKit'>>) => void;
   renameTrack: (trackId: string, newName: string) => void;
   reorderTrack: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
 

--- a/src/store/transportStore.ts
+++ b/src/store/transportStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 
 interface TransportState {
   isPlaying: boolean;
+  isRecording: boolean;
+  armedTrackIds: string[];
   currentTime: number;
   loopEnabled: boolean;
   loopStart: number;
@@ -11,6 +13,10 @@ interface TransportState {
   play: () => void;
   pause: () => void;
   stop: () => void;
+  setIsRecording: (v: boolean) => void;
+  armTrack: (id: string) => void;
+  disarmTrack: (id: string) => void;
+  toggleArmTrack: (id: string) => void;
   seek: (time: number) => void;
   setCurrentTime: (time: number) => void;
   toggleLoop: () => void;
@@ -20,6 +26,8 @@ interface TransportState {
 
 export const useTransportStore = create<TransportState>((set) => ({
   isPlaying: false,
+  isRecording: false,
+  armedTrackIds: [],
   currentTime: 0,
   loopEnabled: false,
   loopStart: 0,
@@ -29,6 +37,18 @@ export const useTransportStore = create<TransportState>((set) => ({
   play: () => set({ isPlaying: true }),
   pause: () => set({ isPlaying: false }),
   stop: () => set({ isPlaying: false, currentTime: 0 }),
+  setIsRecording: (v) => set({ isRecording: v }),
+  armTrack: (id) => set((s) => (
+    s.armedTrackIds.includes(id) ? s : { armedTrackIds: [...s.armedTrackIds, id] }
+  )),
+  disarmTrack: (id) => set((s) => ({
+    armedTrackIds: s.armedTrackIds.filter((trackId) => trackId !== id),
+  })),
+  toggleArmTrack: (id) => set((s) => ({
+    armedTrackIds: s.armedTrackIds.includes(id)
+      ? s.armedTrackIds.filter((trackId) => trackId !== id)
+      : [...s.armedTrackIds, id],
+  })),
   seek: (time) => set({ currentTime: Math.max(0, time) }),
   setCurrentTime: (time) => set({ currentTime: time }),
   toggleLoop: () => set((s) => ({ loopEnabled: !s.loopEnabled })),

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -181,6 +181,7 @@ export interface Track {
   volume: number;
   muted: boolean;
   soloed: boolean;
+  armed?: boolean;
   clips: Clip[];
   sequencerPattern?: SequencerPattern;
   synthPreset?: SynthPreset;


### PR DESCRIPTION
RecordingEngine (522 lines) was never imported anywhere. Now fully wired:
- Track arm buttons (red circle next to M/S)
- Record button enabled with pulsing indicator
- R keyboard shortcut
- Stop/pause auto-finalizes recordings
- Clip created with waveform peaks + WAV in IndexedDB

8 files changed, 142 new lines in useRecording.ts