### PR TITLE
fix: prevent sequencer MIDI overlap with bounced audio clips

### DIFF
--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -194,6 +194,11 @@ export function useTransport() {
         if (track.muted) continue;
         if (anySoloed && !track.soloed) continue;
 
+        // Skip MIDI scheduling if the track already has bounced audio clips —
+        // otherwise the drum triggers overlap with the rendered audio.
+        const hasReadyClips = track.clips.some((c) => c.generationStatus === 'ready');
+        if (hasReadyClips) continue;
+
         const { sequencerPattern } = track;
         const stepDuration = (60 / proj.bpm) / (sequencerPattern.stepsPerBar / 4);
         const totalSteps = sequencerPattern.stepsPerBar * sequencerPattern.bars;


### PR DESCRIPTION
## Summary
- When a step sequencer pattern is bounced to the timeline, both the rendered audio clip AND the live MIDI drum triggers were playing simultaneously, causing overlapping/doubled sounds
- Added a check in `useTransport.ts` to skip MIDI scheduling for sequencer tracks that already have ready clips (bounced audio)

## Root Cause
In `useTransport.play()`, the playback loop schedules:
1. Bounced audio clips via `engine.schedulePlayback()` (lines 102-132)
2. MIDI drum triggers from `track.sequencerPattern` via `drumEngine.triggerPad()` (lines 193-239)

After bouncing, the track has both a ready clip and the sequencerPattern still present, so both play at once.

## Test plan
- [ ] Create a sequencer pattern with some drum hits
- [ ] Bounce the pattern to the timeline
- [ ] Play the timeline — should hear only the bounced audio, no doubled sounds
- [ ] Verify un-bounced sequencer tracks still play MIDI correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)