### PR TITLE
feat: unified Loop Library with presets, assets, drag-to-timeline

### DIFF
--- a/src/components/assets/LoopBrowser.tsx
+++ b/src/components/assets/LoopBrowser.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useUIStore } from '../../store/uiStore';
+import { useProjectStore } from '../../store/projectStore';
 import {
   LOOP_DEFINITIONS,
   LoopCategory,
@@ -8,9 +9,15 @@ import {
   getLoopDuration,
   formatDuration,
 } from '../../engine/LoopLibrary';
+import { loadAudioBlobByKey } from '../../services/audioFileManager';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+import type { AssetClip } from '../../types/project';
 import * as Tone from 'tone';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
+
+type Tab = 'presets' | 'myLoops';
+type AssetFilter = 'all' | 'starred' | 'generated' | 'uploaded';
 
 const CATEGORIES: Array<'All' | LoopCategory> = ['All', 'Drums', 'Bass', 'Keys', 'Synth'];
 
@@ -109,9 +116,42 @@ function MiniWaveform({ data, color, height = 32 }: { data: number[] | null; col
   );
 }
 
-// ─── Loop Item Component ────────────────────────────────────────────────────
+// ─── SVG Mini Waveform for Assets ───────────────────────────────────────────
 
-function LoopItem({
+function SvgMiniWaveform({ peaks, color }: { peaks: number[] | null; color: string }) {
+  if (!peaks || peaks.length === 0) return <div className="w-full h-full bg-white/5 rounded" />;
+  const w = 60;
+  const h = 20;
+  const step = w / peaks.length;
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" className="rounded bg-white/5">
+      {peaks.map((p, i) => {
+        const barH = Math.max(p * (h - 2), 0.5);
+        return (
+          <rect
+            key={i}
+            x={i * step}
+            y={(h - barH) / 2}
+            width={Math.max(step * 0.7, 0.5)}
+            height={barH}
+            fill={color}
+            opacity={0.7}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function fmtDuration(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+// ─── Preset Loop Item Component ─────────────────────────────────────────────
+
+function PresetLoopItem({
   def,
   isPreviewing,
   onPreview,
@@ -179,6 +219,96 @@ function LoopItem({
   );
 }
 
+// ─── Asset Loop Item Component ──────────────────────────────────────────────
+
+function AssetLoopItem({
+  asset,
+  isPreviewing,
+  onPreview,
+  onStar,
+  onDelete,
+  onDragStart,
+}: {
+  asset: AssetClip;
+  isPreviewing: boolean;
+  onPreview: (asset: AssetClip) => void;
+  onStar: (e: React.MouseEvent, assetId: string) => void;
+  onDelete: (e: React.MouseEvent, assetId: string) => void;
+  onDragStart: (e: React.DragEvent, asset: AssetClip) => void;
+}) {
+  return (
+    <div
+      className={`group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-grab transition-colors ${
+        isPreviewing ? 'bg-white/10' : 'hover:bg-white/5'
+      }`}
+      draggable
+      onDragStart={(e) => onDragStart(e, asset)}
+    >
+      <button
+        className={`shrink-0 w-6 h-6 rounded-full flex items-center justify-center transition-colors ${
+          isPreviewing
+            ? 'bg-violet-500 text-white'
+            : 'bg-white/5 text-white/40 group-hover:text-white/70 group-hover:bg-white/10'
+        }`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onPreview(asset);
+        }}
+      >
+        {isPreviewing ? (
+          <svg className="h-2.5 w-2.5 fill-current" viewBox="0 0 16 16"><rect x="2" y="2" width="12" height="12"/></svg>
+        ) : (
+          <svg className="h-2.5 w-2.5 fill-current ml-0.5" viewBox="0 0 16 16"><polygon points="3,2 14,8 3,14"/></svg>
+        )}
+      </button>
+
+      <div className="shrink-0">
+        <SvgMiniWaveform peaks={asset.waveformPeaks} color="#6b7280" />
+      </div>
+
+      <div className="flex-1 min-w-0 overflow-hidden">
+        <div className="flex items-center gap-1">
+          <span className={`shrink-0 text-[8px] px-1 py-px rounded font-medium ${
+            asset.source === 'uploaded'
+              ? 'bg-amber-500/20 text-amber-400'
+              : 'bg-violet-500/20 text-violet-400'
+          }`}>
+            {asset.source === 'uploaded' ? 'IMP' : 'AI'}
+          </span>
+          <span className="text-[10px] text-white/70 truncate">
+            {asset.prompt || asset.trackDisplayName}
+          </span>
+        </div>
+        <div className="flex items-center gap-1 mt-0.5">
+          <span className="text-[9px] text-white/40 truncate">{asset.trackDisplayName}</span>
+          <span className="text-[9px] text-white/20">{fmtDuration(asset.duration)}</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-0.5 shrink-0">
+        <button
+          onClick={(e) => onStar(e, asset.id)}
+          className={`w-5 h-5 flex items-center justify-center rounded text-[10px] transition-colors ${
+            asset.starred
+              ? 'text-yellow-400 hover:text-yellow-300'
+              : 'text-zinc-600 hover:text-zinc-400 opacity-0 group-hover:opacity-100'
+          }`}
+          title={asset.starred ? 'Remove star' : 'Star'}
+        >
+          {asset.starred ? '\u2605' : '\u2606'}
+        </button>
+        <button
+          onClick={(e) => onDelete(e, asset.id)}
+          className="w-5 h-5 flex items-center justify-center rounded text-[10px] text-zinc-600 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
+          title="Remove"
+        >
+          \u00d7
+        </button>
+      </div>
+    </div>
+  );
+}
+
 // ─── Main Loop Browser Component ────────────────────────────────────────────
 
 export function LoopBrowser() {
@@ -191,24 +321,50 @@ export function LoopBrowser() {
   const setPreviewingId = useUIStore((s) => s.setPreviewingLoopId);
   const toggleBrowser = useUIStore((s) => s.toggleLoopBrowser);
 
+  const project = useProjectStore((s) => s.project);
+  const removeAsset = useProjectStore((s) => s.removeAsset);
+  const toggleAssetStar = useProjectStore((s) => s.toggleAssetStar);
+
+  const [activeTab, setActiveTab] = useState<Tab>('presets');
+  const [assetFilter, setAssetFilter] = useState<AssetFilter>('all');
   const [previewWaveform, setPreviewWaveform] = useState<number[] | null>(null);
   const [width, setWidth] = useState(240);
   const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
-  const filteredLoops = LOOP_DEFINITIONS.filter((def) => {
+  // ── Presets filtering ──
+  const filteredPresets = LOOP_DEFINITIONS.filter((def) => {
     const matchesCategory = category === 'All' || def.category === category;
     const matchesSearch = search === '' || def.name.toLowerCase().includes(search.toLowerCase());
     return matchesCategory && matchesSearch;
   });
 
-  const handlePreview = useCallback(async (def: LoopDefinition) => {
+  // ── Assets filtering ──
+  const allAssets = useMemo<AssetClip[]>(() => project?.assets ?? [], [project?.assets]);
+
+  const filteredAssets = useMemo(() => {
+    let list = allAssets;
+    if (assetFilter === 'starred') list = list.filter((a) => a.starred);
+    else if (assetFilter === 'generated') list = list.filter((a) => a.source !== 'uploaded');
+    else if (assetFilter === 'uploaded') list = list.filter((a) => a.source === 'uploaded');
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      list = list.filter((a) =>
+        (a.prompt ?? '').toLowerCase().includes(q) ||
+        (a.trackDisplayName ?? '').toLowerCase().includes(q)
+      );
+    }
+    return list;
+  }, [allAssets, assetFilter, search]);
+
+  // ── Preview handlers ──
+  const handlePresetPreview = useCallback(async (def: LoopDefinition) => {
     if (previewingId === def.id) {
       stopPreview();
       setPreviewingId(null);
       setPreviewWaveform(null);
       return;
     }
-
     try {
       const { audioBuffer, waveformData } = await loadLoop(def);
       await playPreview(audioBuffer);
@@ -219,6 +375,31 @@ export function LoopBrowser() {
     }
   }, [previewingId, setPreviewingId]);
 
+  const handleAssetPreview = useCallback(async (asset: AssetClip) => {
+    if (previewingId === asset.id) {
+      stopPreview();
+      setPreviewingId(null);
+      setPreviewWaveform(null);
+      return;
+    }
+    try {
+      const audioKey = asset.isolatedAudioKey ?? asset.cumulativeMixKey;
+      if (!audioKey) return;
+      const blob = await loadAudioBlobByKey(audioKey);
+      if (!blob) return;
+      const engine = getAudioEngine();
+      await engine.resume();
+      const arrayBuffer = await blob.arrayBuffer();
+      const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
+      await playPreview(audioBuffer);
+      setPreviewingId(asset.id);
+      setPreviewWaveform(asset.waveformPeaks);
+    } catch (err) {
+      console.error('Failed to preview asset:', err);
+    }
+  }, [previewingId, setPreviewingId]);
+
+  // ── Stop preview on close ──
   useEffect(() => {
     if (!isOpen) {
       stopPreview();
@@ -227,15 +408,33 @@ export function LoopBrowser() {
     }
   }, [isOpen, setPreviewingId]);
 
-  const handleDragStart = useCallback((e: React.DragEvent, def: LoopDefinition) => {
+  // ── Drag handlers ──
+  const handlePresetDragStart = useCallback((e: React.DragEvent, def: LoopDefinition) => {
     e.dataTransfer.setData('application/x-loop-id', def.id);
     e.dataTransfer.effectAllowed = 'copy';
   }, []);
 
+  const handleAssetDragStart = useCallback((e: React.DragEvent, asset: AssetClip) => {
+    e.dataTransfer.setData('application/x-asset-id', asset.id);
+    e.dataTransfer.effectAllowed = 'copy';
+  }, []);
+
+  // ── Asset actions ──
+  const handleStar = useCallback((e: React.MouseEvent, assetId: string) => {
+    e.stopPropagation();
+    toggleAssetStar(assetId);
+  }, [toggleAssetStar]);
+
+  const handleDelete = useCallback((e: React.MouseEvent, assetId: string) => {
+    e.stopPropagation();
+    removeAsset(assetId);
+  }, [removeAsset]);
+
+  // ── Resize ──
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
       if (!resizeRef.current) return;
-      const dx = e.clientX - resizeRef.current.startX;
+      const dx = resizeRef.current.startX - e.clientX;
       setWidth(Math.max(180, Math.min(400, resizeRef.current.startWidth + dx)));
     };
     const handleMouseUp = () => {
@@ -253,11 +452,20 @@ export function LoopBrowser() {
 
   if (!isOpen) return null;
 
-  const previewingDef = previewingId ? LOOP_DEFINITIONS.find(d => d.id === previewingId) : null;
+  const previewingPresetDef = activeTab === 'presets' && previewingId
+    ? LOOP_DEFINITIONS.find(d => d.id === previewingId)
+    : null;
+
+  const assetFilters: { id: AssetFilter; label: string }[] = [
+    { id: 'all', label: 'All' },
+    { id: 'starred', label: '\u2605' },
+    { id: 'generated', label: 'AI' },
+    { id: 'uploaded', label: 'Imported' },
+  ];
 
   return (
     <div
-      className="relative flex flex-col bg-[#111126] border-r border-white/10 shrink-0 select-none"
+      className="relative flex flex-col bg-[#111126] border-l border-white/10 shrink-0 select-none"
       style={{ width }}
     >
       {/* Header */}
@@ -285,50 +493,127 @@ export function LoopBrowser() {
         </div>
       </div>
 
-      {/* Category pills */}
-      <div className="flex gap-1 px-2 py-1.5 border-b border-white/5 overflow-x-auto shrink-0">
-        {CATEGORIES.map((cat) => {
-          const isActive = category === cat;
-          return (
-            <button
-              key={cat}
-              onClick={() => setCategory(cat)}
-              className={`px-2 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap transition-colors ${
-                isActive
-                  ? (CATEGORY_ACTIVE_COLORS[cat] ?? CATEGORY_ACTIVE_COLORS.All)
-                  : (CATEGORY_COLORS[cat] ?? CATEGORY_COLORS.All)
-              }`}
-            >
-              {cat}
-            </button>
-          );
-        })}
+      {/* Tab buttons */}
+      <div className="flex border-b border-white/5 shrink-0">
+        <button
+          onClick={() => setActiveTab('presets')}
+          className={`flex-1 py-1.5 text-[10px] font-medium uppercase tracking-wider transition-colors ${
+            activeTab === 'presets'
+              ? 'text-violet-300 border-b-2 border-violet-500'
+              : 'text-white/30 hover:text-white/50'
+          }`}
+        >
+          Presets
+        </button>
+        <button
+          onClick={() => setActiveTab('myLoops')}
+          className={`flex-1 py-1.5 text-[10px] font-medium uppercase tracking-wider transition-colors ${
+            activeTab === 'myLoops'
+              ? 'text-violet-300 border-b-2 border-violet-500'
+              : 'text-white/30 hover:text-white/50'
+          }`}
+        >
+          My Loops
+          {allAssets.length > 0 && (
+            <span className="ml-1 text-[9px] text-white/20">{allAssets.length}</span>
+          )}
+        </button>
       </div>
 
-      {/* Loop list */}
-      <div className="flex-1 overflow-y-auto px-1 py-1">
-        {filteredLoops.length === 0 ? (
-          <div className="text-center text-white/20 text-xs py-8">
-            No loops found
+      {/* ── Presets Tab ── */}
+      {activeTab === 'presets' && (
+        <>
+          {/* Category pills */}
+          <div className="flex gap-1 px-2 py-1.5 border-b border-white/5 overflow-x-auto shrink-0">
+            {CATEGORIES.map((cat) => {
+              const isActive = category === cat;
+              return (
+                <button
+                  key={cat}
+                  onClick={() => setCategory(cat)}
+                  className={`px-2 py-0.5 rounded-full text-[10px] font-medium whitespace-nowrap transition-colors ${
+                    isActive
+                      ? (CATEGORY_ACTIVE_COLORS[cat] ?? CATEGORY_ACTIVE_COLORS.All)
+                      : (CATEGORY_COLORS[cat] ?? CATEGORY_COLORS.All)
+                  }`}
+                >
+                  {cat}
+                </button>
+              );
+            })}
           </div>
-        ) : (
-          filteredLoops.map((def) => (
-            <LoopItem
-              key={def.id}
-              def={def}
-              isPreviewing={previewingId === def.id}
-              onPreview={handlePreview}
-              onDragStart={handleDragStart}
-            />
-          ))
-        )}
-      </div>
+
+          {/* Preset loop list */}
+          <div className="flex-1 overflow-y-auto px-1 py-1">
+            {filteredPresets.length === 0 ? (
+              <div className="text-center text-white/20 text-xs py-8">
+                No loops found
+              </div>
+            ) : (
+              filteredPresets.map((def) => (
+                <PresetLoopItem
+                  key={def.id}
+                  def={def}
+                  isPreviewing={previewingId === def.id}
+                  onPreview={handlePresetPreview}
+                  onDragStart={handlePresetDragStart}
+                />
+              ))
+            )}
+          </div>
+        </>
+      )}
+
+      {/* ── My Loops Tab ── */}
+      {activeTab === 'myLoops' && (
+        <>
+          {/* Filter pills */}
+          <div className="flex gap-1 px-2 py-1.5 border-b border-white/5 flex-wrap shrink-0">
+            {assetFilters.map((f) => (
+              <button
+                key={f.id}
+                onClick={() => setAssetFilter(f.id)}
+                className={`px-2 py-0.5 text-[10px] rounded-full font-medium transition-colors ${
+                  assetFilter === f.id
+                    ? 'bg-violet-500/30 text-violet-200'
+                    : 'bg-white/5 text-white/30 hover:bg-white/10 hover:text-white/50'
+                }`}
+              >
+                {f.label}
+              </button>
+            ))}
+            <span className="text-[9px] text-white/20 self-center ml-auto">{filteredAssets.length} items</span>
+          </div>
+
+          {/* Asset list */}
+          <div className="flex-1 overflow-y-auto px-1 py-1">
+            {filteredAssets.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-24 text-white/20 text-xs gap-1">
+                <span>No loops yet</span>
+                <span className="text-[9px] text-white/10">Generate or import audio to see it here</span>
+              </div>
+            ) : (
+              filteredAssets.map((asset) => (
+                <AssetLoopItem
+                  key={asset.id}
+                  asset={asset}
+                  isPreviewing={previewingId === asset.id}
+                  onPreview={handleAssetPreview}
+                  onStar={handleStar}
+                  onDelete={handleDelete}
+                  onDragStart={handleAssetDragStart}
+                />
+              ))
+            )}
+          </div>
+        </>
+      )}
 
       {/* Preview section */}
-      {previewingDef && (
+      {previewingPresetDef && (
         <div className="border-t border-white/5 px-2 py-2 shrink-0">
           <div className="flex items-center justify-between mb-1">
-            <span className="text-[10px] text-white/50 truncate">{previewingDef.name}</span>
+            <span className="text-[10px] text-white/50 truncate">{previewingPresetDef.name}</span>
             <button
               className="text-white/30 hover:text-white/60"
               onClick={() => {
@@ -348,9 +633,9 @@ export function LoopBrowser() {
         </div>
       )}
 
-      {/* Resize handle */}
+      {/* Resize handle (left edge) */}
       <div
-        className="absolute right-0 top-0 bottom-0 w-1 cursor-ew-resize hover:bg-violet-500/30 transition-colors"
+        className="absolute left-0 top-0 bottom-0 w-1 cursor-ew-resize hover:bg-violet-500/30 transition-colors"
         onMouseDown={(e) => {
           resizeRef.current = { startX: e.clientX, startWidth: width };
           document.body.style.cursor = 'ew-resize';

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -50,9 +50,8 @@ export function AppShell() {
 
       <div className="flex flex-1 min-h-0">
         {project && <TrackList />}
-        {project && <AssetsPanel />}
-        {project && <LoopBrowser />}
         <Timeline />
+        {project && <LoopBrowser />}
       </div>
 
       {project && <SmartControlsPanel />}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -72,23 +72,19 @@ export function Timeline() {
   const [normalDrag, setNormalDrag] = useState<DragRect | null>(null);
   const [fileDragOver, setFileDragOver] = useState(false);
   const dragCounterRef = useRef(0);
-  const { importAudioBufferToTrack, importMultipleFiles } = useAudioImport();
+  const { importAudioBufferToTrack, importMultipleFiles, importLoopToTrack, importAssetToTrack } = useAudioImport();
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
-    if (
-      e.dataTransfer.types.includes('Files')
-      || e.dataTransfer.types.includes('application/x-loop-id')
-    ) {
+    const types = e.dataTransfer.types;
+    if (types.includes('Files') || types.includes('application/x-loop-id') || types.includes('application/x-asset-id')) {
       e.preventDefault();
       e.dataTransfer.dropEffect = 'copy';
     }
   }, []);
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
-    if (
-      e.dataTransfer.types.includes('Files')
-      || e.dataTransfer.types.includes('application/x-loop-id')
-    ) {
+    const types = e.dataTransfer.types;
+    if (types.includes('Files') || types.includes('application/x-loop-id') || types.includes('application/x-asset-id')) {
       e.preventDefault();
       dragCounterRef.current++;
       setFileDragOver(true);
@@ -108,15 +104,19 @@ export function Timeline() {
     dragCounterRef.current = 0;
     setFileDragOver(false);
 
+    // Handle preset loop drop -> create new sample track
     const loopId = e.dataTransfer.getData('application/x-loop-id');
     if (loopId) {
-      const { LOOP_DEFINITIONS, loadLoop } = await import('../../engine/LoopLibrary');
-      const def = LOOP_DEFINITIONS.find((item) => item.id === loopId);
-      if (!def) return;
-      const { audioBuffer } = await loadLoop(def);
-      const track = addTrack('custom', 'sample');
-      updateTrack(track.id, { displayName: def.name });
-      await importAudioBufferToTrack(audioBuffer, def.name, track.id, 0);
+      const newTrack = addTrack('custom', 'sample');
+      await importLoopToTrack(loopId, newTrack.id, 0);
+      return;
+    }
+
+    // Handle asset drop -> create new sample track
+    const assetId = e.dataTransfer.getData('application/x-asset-id');
+    if (assetId) {
+      const newTrack = addTrack('custom', 'sample');
+      await importAssetToTrack(assetId, newTrack.id, 0);
       return;
     }
 
@@ -124,7 +124,7 @@ export function Timeline() {
     if (files.length > 0) {
       await importMultipleFiles(files);
     }
-  }, [addTrack, importAudioBufferToTrack, importMultipleFiles, updateTrack]);
+  }, [addTrack, importMultipleFiles, importLoopToTrack, importAssetToTrack]);
 
   // Safety net: if a child (e.g. TrackLane) stops propagation on drop,
   // the Timeline's own handleDrop never fires. Listen globally to clear the overlay.

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -86,7 +86,7 @@ export function TrackLane({ track }: TrackLaneProps) {
     startTime: number; duration: number;
   } | null>(null);
 
-  const { importAudioBufferToTrack, importAudioToTrack } = useAudioImport();
+  const { importAudioBufferToTrack, importAudioToTrack, importLoopToTrack, importAssetToTrack } = useAudioImport();
   const [fileDragOver, setFileDragOver] = useState(false);
 
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
@@ -178,10 +178,8 @@ export function TrackLane({ track }: TrackLaneProps) {
   }, []);
 
   const handleFileDragOver = useCallback((e: React.DragEvent) => {
-    if (
-      e.dataTransfer.types.includes('Files')
-      || e.dataTransfer.types.includes('application/x-loop-id')
-    ) {
+    const types = e.dataTransfer.types;
+    if (types.includes('Files') || types.includes('application/x-loop-id') || types.includes('application/x-asset-id')) {
       e.preventDefault();
       e.stopPropagation();
       e.dataTransfer.dropEffect = 'copy';
@@ -204,25 +202,29 @@ export function TrackLane({ track }: TrackLaneProps) {
     const rawTime = laneX / pixelsPerSecond;
     const startTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1));
 
+    // Handle preset loop drop
     const loopId = e.dataTransfer.getData('application/x-loop-id');
     if (loopId) {
-      const { LOOP_DEFINITIONS, loadLoop } = await import('../../engine/LoopLibrary');
-      const def = LOOP_DEFINITIONS.find((item) => item.id === loopId);
-      if (!def) return;
-      const { audioBuffer } = await loadLoop(def);
-      await importAudioBufferToTrack(audioBuffer, def.name, track.id, startTime);
+      await importLoopToTrack(loopId, track.id, startTime);
       return;
     }
 
+    // Handle asset drop
+    const assetId = e.dataTransfer.getData('application/x-asset-id');
+    if (assetId) {
+      await importAssetToTrack(assetId, track.id, startTime);
+      return;
+    }
+
+    // Handle file drop
     const files = e.dataTransfer.files;
     if (!files.length) return;
-
     for (const file of Array.from(files)) {
       if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
         await importAudioToTrack(file, track.id, startTime);
       }
     }
-  }, [project, pixelsPerSecond, track.id, importAudioBufferToTrack, importAudioToTrack]);
+  }, [project, pixelsPerSecond, track.id, importAudioToTrack, importLoopToTrack, importAssetToTrack]);
 
   const hasClips = track.clips.length > 0;
 

--- a/src/engine/LoopLibrary.ts
+++ b/src/engine/LoopLibrary.ts
@@ -64,23 +64,33 @@ function extractPeaks(buffer: AudioBuffer, numSamples = 256): number[] {
 
 // ─── Drum Loop Generators ───────────────────────────────────────────────────
 
+// Tiny offset so the first note is not at exactly t=0 in Tone.Offline
+const T0 = 0.005;
+
+// Helper: create a hi-hat–like NoiseSynth (replaces MetalSynth which
+// crashes in Tone.Offline due to "start time must be strictly greater")
+function makeHat(volume: number) {
+  const filter = new Tone.Filter({ frequency: 8000, type: 'highpass' }).toDestination();
+  return new Tone.NoiseSynth({
+    noise: { type: 'white' },
+    envelope: { attack: 0.001, decay: 0.04, sustain: 0, release: 0.01 },
+    volume,
+  }).connect(filter);
+}
+
 async function generate808Boom(duration: number): Promise<AudioBuffer> {
-  const buffer = await Tone.Offline(({ transport }) => {
-    transport.bpm.value = 90;
+  const buffer = await Tone.Offline(() => {
     const kick = new Tone.MembraneSynth({
       pitchDecay: 0.08,
       octaves: 6,
       oscillator: { type: 'sine' },
       envelope: { attack: 0.006, decay: 0.5, sustain: 0, release: 0.5 },
     }).toDestination();
-    const hat = new Tone.MetalSynth({
-      envelope: { attack: 0.001, decay: 0.05, release: 0.01 },
-      harmonicity: 5.1, modulationIndex: 32, resonance: 4000, octaves: 1.5, volume: -12,
-    }).toDestination();
+    const hat = makeHat(-12);
 
     const beatTime = 60 / 90;
     for (let bar = 0; bar < 4; bar++) {
-      const offset = bar * 4 * beatTime;
+      const offset = T0 + bar * 4 * beatTime;
       kick.triggerAttackRelease('C1', '8n', offset);
       kick.triggerAttackRelease('C1', '8n', offset + 2 * beatTime);
       kick.triggerAttackRelease('C1', '8n', offset + 2.75 * beatTime);
@@ -88,14 +98,12 @@ async function generate808Boom(duration: number): Promise<AudioBuffer> {
         hat.triggerAttackRelease('16n', offset + i * beatTime * 0.5);
       }
     }
-    transport.start(0);
   }, duration);
   return toAudioBuffer(buffer);
 }
 
 async function generateRockSteady(duration: number): Promise<AudioBuffer> {
-  const buffer = await Tone.Offline(({ transport }) => {
-    transport.bpm.value = 120;
+  const buffer = await Tone.Offline(() => {
     const kick = new Tone.MembraneSynth({
       pitchDecay: 0.05, octaves: 4,
       envelope: { attack: 0.005, decay: 0.3, sustain: 0, release: 0.3 },
@@ -105,14 +113,11 @@ async function generateRockSteady(duration: number): Promise<AudioBuffer> {
       envelope: { attack: 0.001, decay: 0.15, sustain: 0, release: 0.1 },
       volume: -6,
     }).toDestination();
-    const hat = new Tone.MetalSynth({
-      envelope: { attack: 0.001, decay: 0.04, release: 0.01 },
-      harmonicity: 5.1, modulationIndex: 32, resonance: 4000, octaves: 1.5, volume: -14,
-    }).toDestination();
+    const hat = makeHat(-14);
 
     const beat = 60 / 120;
     for (let bar = 0; bar < 4; bar++) {
-      const o = bar * 4 * beat;
+      const o = T0 + bar * 4 * beat;
       kick.triggerAttackRelease('C1', '8n', o);
       kick.triggerAttackRelease('C1', '8n', o + 2 * beat);
       snare.triggerAttackRelease('8n', o + beat);
@@ -121,14 +126,12 @@ async function generateRockSteady(duration: number): Promise<AudioBuffer> {
         hat.triggerAttackRelease('16n', o + i * beat * 0.5);
       }
     }
-    transport.start(0);
   }, duration);
   return toAudioBuffer(buffer);
 }
 
 async function generateShuffleBlues(duration: number): Promise<AudioBuffer> {
-  const buffer = await Tone.Offline(({ transport }) => {
-    transport.bpm.value = 95;
+  const buffer = await Tone.Offline(() => {
     const kick = new Tone.MembraneSynth({
       pitchDecay: 0.05, octaves: 4,
       envelope: { attack: 0.005, decay: 0.3, sustain: 0, release: 0.3 },
@@ -138,15 +141,12 @@ async function generateShuffleBlues(duration: number): Promise<AudioBuffer> {
       envelope: { attack: 0.002, decay: 0.12, sustain: 0, release: 0.1 },
       volume: -8,
     }).toDestination();
-    const hat = new Tone.MetalSynth({
-      envelope: { attack: 0.001, decay: 0.03, release: 0.01 },
-      harmonicity: 5.1, modulationIndex: 32, resonance: 4000, octaves: 1.5, volume: -14,
-    }).toDestination();
+    const hat = makeHat(-14);
 
     const beat = 60 / 95;
     const triplet = beat / 3;
     for (let bar = 0; bar < 4; bar++) {
-      const o = bar * 4 * beat;
+      const o = T0 + bar * 4 * beat;
       kick.triggerAttackRelease('C1', '8n', o);
       kick.triggerAttackRelease('C1', '8n', o + 2 * beat);
       snare.triggerAttackRelease('8n', o + beat);
@@ -156,22 +156,19 @@ async function generateShuffleBlues(duration: number): Promise<AudioBuffer> {
         hat.triggerAttackRelease('32n', o + i * beat + triplet * 2);
       }
     }
-    transport.start(0);
   }, duration);
   return toAudioBuffer(buffer);
 }
 
 async function generateTrapHiHats(duration: number): Promise<AudioBuffer> {
-  const buffer = await Tone.Offline(({ transport }) => {
-    transport.bpm.value = 140;
+  const buffer = await Tone.Offline(() => {
     const kick = new Tone.MembraneSynth({
       pitchDecay: 0.08, octaves: 6,
       envelope: { attack: 0.006, decay: 0.5, sustain: 0, release: 0.4 },
     }).toDestination();
-    const hat = new Tone.MetalSynth({
-      envelope: { attack: 0.001, decay: 0.03, release: 0.005 },
-      harmonicity: 5.1, modulationIndex: 32, resonance: 4000, octaves: 1.5, volume: -10,
-    }).toDestination();
+    // Two hat voices for overlapping rapid-fire patterns
+    const hat1 = makeHat(-10);
+    const hat2 = makeHat(-10);
     const snare = new Tone.NoiseSynth({
       noise: { type: 'white' },
       envelope: { attack: 0.001, decay: 0.15, sustain: 0, release: 0.05 },
@@ -180,26 +177,26 @@ async function generateTrapHiHats(duration: number): Promise<AudioBuffer> {
 
     const beat = 60 / 140;
     for (let bar = 0; bar < 4; bar++) {
-      const o = bar * 4 * beat;
+      const o = T0 + bar * 4 * beat;
       kick.triggerAttackRelease('C1', '8n', o);
       kick.triggerAttackRelease('C1', '8n', o + 2.5 * beat);
       snare.triggerAttackRelease('8n', o + beat);
       snare.triggerAttackRelease('8n', o + 3 * beat);
+      // Main 16th-note hi-hats
       for (let i = 0; i < 16; i++) {
-        hat.triggerAttackRelease('32n', o + i * beat * 0.25);
+        hat1.triggerAttackRelease('32n', o + i * beat * 0.25);
       }
+      // Rapid rolls on beat 4 (use second voice to avoid overlap)
       for (let i = 0; i < 4; i++) {
-        hat.triggerAttackRelease('32n', o + 3 * beat + i * beat * 0.125);
+        hat2.triggerAttackRelease('32n', o + 3 * beat + i * beat * 0.125);
       }
     }
-    transport.start(0);
   }, duration);
   return toAudioBuffer(buffer);
 }
 
 async function generateLoFiDrums(duration: number): Promise<AudioBuffer> {
-  const buffer = await Tone.Offline(({ transport }) => {
-    transport.bpm.value = 85;
+  const buffer = await Tone.Offline(() => {
     const kick = new Tone.MembraneSynth({
       pitchDecay: 0.05, octaves: 4,
       envelope: { attack: 0.01, decay: 0.3, sustain: 0, release: 0.3 },
@@ -210,14 +207,11 @@ async function generateLoFiDrums(duration: number): Promise<AudioBuffer> {
       envelope: { attack: 0.005, decay: 0.1, sustain: 0, release: 0.1 },
       volume: -8,
     }).toDestination();
-    const hat = new Tone.MetalSynth({
-      envelope: { attack: 0.001, decay: 0.04, release: 0.01 },
-      harmonicity: 5.1, modulationIndex: 32, resonance: 3000, octaves: 1, volume: -16,
-    }).toDestination();
+    const hat = makeHat(-16);
 
     const beat = 60 / 85;
     for (let bar = 0; bar < 4; bar++) {
-      const o = bar * 4 * beat;
+      const o = T0 + bar * 4 * beat;
       kick.triggerAttackRelease('C1', '8n', o);
       kick.triggerAttackRelease('C1', '8n', o + 1.75 * beat);
       kick.triggerAttackRelease('C1', '8n', o + 2.5 * beat);
@@ -227,7 +221,6 @@ async function generateLoFiDrums(duration: number): Promise<AudioBuffer> {
         hat.triggerAttackRelease('32n', o + i * beat * 0.5);
       }
     }
-    transport.start(0);
   }, duration);
   return toAudioBuffer(buffer);
 }

--- a/src/hooks/useAudioImport.ts
+++ b/src/hooks/useAudioImport.ts
@@ -1,10 +1,11 @@
 import { useCallback } from 'react';
 import { useProjectStore } from '../store/projectStore';
 import { getAudioEngine } from './useAudioEngine';
-import { saveAudioBlob } from '../services/audioFileManager';
+import { saveAudioBlob, loadAudioBlobByKey } from '../services/audioFileManager';
 import { computeWaveformPeaks } from '../utils/waveformPeaks';
 import { audioBufferToWavBlob } from '../utils/wav';
 import { toastSuccess } from './useToast';
+import { LOOP_DEFINITIONS, loadLoop } from '../engine/LoopLibrary';
 
 function trimAudioBuffer(
   engine: ReturnType<typeof getAudioEngine>,
@@ -156,11 +157,87 @@ export function useAudioImport() {
     input.click();
   }, [importMultipleFiles]);
 
+  const importLoopToTrack = useCallback(async (loopId: string, trackId: string, startTime: number) => {
+    const project = useProjectStore.getState().project;
+    if (!project) return;
+
+    const def = LOOP_DEFINITIONS.find((d) => d.id === loopId);
+    if (!def) return;
+
+    const { audioBuffer, waveformData } = await loadLoop(def);
+    const duration = audioBuffer.duration;
+    const clipDuration = Math.min(duration, project.totalDuration - startTime);
+    if (clipDuration <= 0) return;
+
+    const clip = addClip(trackId, {
+      startTime,
+      duration: clipDuration,
+      prompt: `Loop: ${def.name}`,
+      lyrics: '',
+    });
+
+    const wavBlob = audioBufferToWavBlob(audioBuffer);
+    const isolatedKey = await saveAudioBlob(project.id, clip.id, 'isolated', wavBlob);
+    const peaks = computeWaveformPeaks(audioBuffer, 200);
+
+    updateClipStatus(clip.id, 'ready', {
+      isolatedAudioKey: isolatedKey,
+      waveformPeaks: peaks,
+      audioDuration: clipDuration,
+      audioOffset: 0,
+      source: 'uploaded',
+    });
+  }, [addClip, updateClipStatus]);
+
+  const importAssetToTrack = useCallback(async (assetId: string, trackId: string, startTime: number) => {
+    const project = useProjectStore.getState().project;
+    if (!project) return;
+
+    const asset = (project.assets ?? []).find((a) => a.id === assetId);
+    if (!asset) return;
+
+    const audioKey = asset.isolatedAudioKey ?? asset.cumulativeMixKey;
+    if (!audioKey) return;
+
+    const blob = await loadAudioBlobByKey(audioKey);
+    if (!blob) return;
+
+    const engine = getAudioEngine();
+    await engine.resume();
+    const arrayBuffer = await blob.arrayBuffer();
+    const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
+
+    const duration = audioBuffer.duration;
+    const clipDuration = Math.min(duration, project.totalDuration - startTime);
+    if (clipDuration <= 0) return;
+
+    const clip = addClip(trackId, {
+      startTime,
+      duration: clipDuration,
+      prompt: asset.prompt || `From: ${asset.trackDisplayName}`,
+      lyrics: '',
+    });
+
+    const wavBlob = audioBufferToWavBlob(audioBuffer);
+    const isolatedKey = await saveAudioBlob(project.id, clip.id, 'isolated', wavBlob);
+    const peaks = asset.waveformPeaks ?? computeWaveformPeaks(audioBuffer, 200);
+
+    updateClipStatus(clip.id, 'ready', {
+      isolatedAudioKey: isolatedKey,
+      waveformPeaks: peaks,
+      audioDuration: clipDuration,
+      audioOffset: 0,
+      source: asset.source,
+    });
+  }, [addClip, updateClipStatus]);
+
   return {
     importAudioFile,
     importAudioBufferToTrack,
     importAudioToTrack,
     importMultipleFiles,
     openFilePicker,
+    importLoopToTrack,
+    importAssetToTrack,
   };
 }


### PR DESCRIPTION
## Summary
- Rewrote LoopBrowser with two tabs: **Presets** (15 built-in Tone.js loops) and **My Loops** (user-uploaded & AI-generated assets with star/delete/filter)
- Moved Loop Library panel to the **right side** to avoid blocking the track list
- Added **drag-and-drop** support for both presets and assets onto track lanes and empty timeline area
- Fixed all 5 **drum loop generators** that crashed in `Tone.Offline` by replacing `MetalSynth` with `NoiseSynth`+`Filter`

## Test plan
- [ ] Open Loop Browser → verify Presets tab shows 15 loops with categories
- [ ] Switch to My Loops tab → verify filter pills and empty state
- [ ] Click play on any drum loop (808 Boom, etc.) → verify audio plays
- [ ] Drag a preset loop onto a track lane → verify clip created with waveform
- [ ] Drag a preset to empty timeline → verify new track created
- [ ] Generate/import audio → verify it appears in My Loops tab
- [ ] Star/delete assets in My Loops → verify state updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)