### PR TITLE
feat: exclusive arm + count-in wiring (Ableton UX parity)

### DIFF
--- a/docs/research-notes/recording-ux-gaps.md
+++ b/docs/research-notes/recording-ux-gaps.md
@@ -1,0 +1,100 @@
+# Recording UX Gap Analysis: ACE-Step DAW vs Ableton Live 12
+
+Source: [Ableton Live 12 Manual — Recording New Clips](https://www.ableton.com/en/live-manual/12/recording-new-clips/)
+Date: 2026-03-18
+
+---
+
+## Top 5 Gaps
+
+### Gap 1: No Exclusive Arm / Multi-Arm Modifier (HIGH VALUE)
+
+**Ableton behavior:** Click arm = exclusive (disarms all others). Cmd/Ctrl+click = additive multi-arm. Multi-select tracks then click arm = arm all selected. Arming auto-selects the track (opens its device chain).
+**Our behavior:** `toggleArmTrack` is always additive. No exclusive-arm default, no modifier key handling, no track auto-selection on arm.
+**Edge cases:** Ableton's exclusive arm prevents accidentally recording to forgotten tracks — a common source of wasted takes.
+
+### Gap 2: Count-In Not Wired to Record Flow (HIGH VALUE)
+
+**Ableton behavior:** Count-in (None / 1 bar / 2 bars) fires before recording starts. LCD shows negative bars-beats-sixteenths in blue (e.g., `-2.1.1` → `1.1.1`). Metronome always audible during count-in regardless of "only while recording" setting. Transport does NOT advance during count-in.
+**Our behavior:** `RecordingEngine.playCountIn()` exists with click sounds, but `useRecording.toggleRecord()` never calls it. Count-in is effectively dead code. No LCD visual feedback for count-in state.
+**Parameters:** CountInLength type supports `'off' | '1bar' | '2bars'` — matches Ableton's range. Missing: UI to select count-in length, integration into record flow.
+
+### Gap 3: No Punch-In / Punch-Out Recording (MEDIUM VALUE)
+
+**Ableton behavior:** Punch-in/out switches tie to the loop brace positions. Punch-in prevents recording before loop start; punch-out stops recording at loop end. Enables "warm-up" pre-roll. Loop recording retains all passes — double-click clip to access earlier takes in Sample Editor.
+**Our behavior:** No punch-in/out concept. Loop toggle exists in transport but has no relationship to recording boundaries. Recording runs from press-to-stop with no positional constraints.
+**Visual feedback:** Ableton shows distinct punch regions on the timeline with shaded non-record zones.
+
+### Gap 4: No Recording Undo / Take Management (MEDIUM VALUE)
+
+**Ableton behavior:** Undo removes the last recording take as a single action. Record quantization is a separate undo step (undo quantize without losing the take). During MIDI overdub, undo removes the last pass while keeping earlier layers. "Capture MIDI" retroactively saves played notes even when not recording.
+**Our behavior:** `stopRecording` creates a clip via `addClip` + `updateClipStatus`. No undo integration — once saved, the only option is manual clip deletion. No take stacking or capture-after-the-fact.
+
+### Gap 5: No Audio Monitoring Mode Selection (LOWER VALUE)
+
+**Ableton behavior:** Three modes per track: **Auto** (monitor when armed + not playing), **In** (always monitor input), **Off** (never monitor). Auto is the default and prevents feedback loops during playback.
+**Our behavior:** `setMonitoring(trackId, boolean)` is binary on/off, set to `true` whenever a track is armed. No Auto mode that silences monitoring during playback. Risk of feedback when playing back a track while armed.
+
+---
+
+## Implementation Recommendations (Top 3)
+
+### 1. Exclusive Arm with Modifier Keys
+
+**Files:** `useRecording.ts`, `TrackHeader.tsx`, `transportStore.ts`
+
+**Changes:**
+- `toggleArmTrack(id, exclusive?: boolean)` — when `exclusive=true` (default), disarm all other tracks first
+- `TrackHeader` arm button: pass `e.metaKey || e.ctrlKey` to toggle additive mode
+  ```tsx
+  onClick={(e) => toggleArmTrack(track.id, !(e.metaKey || e.ctrlKey))}
+  ```
+- Add `disarmAll()` to transportStore for batch disarm
+- On arm, auto-select the track (set `selectedTrackId` in uiStore)
+- Keyboard shortcut: number keys 1-9 to arm track by index (Ableton convention)
+
+**Effort:** Small. Mostly plumbing a boolean through existing functions.
+
+### 2. Wire Count-In into Record Flow
+
+**Files:** `useRecording.ts`, `Toolbar.tsx` (or new CountInSelector), `RecordingEngine.ts`
+
+**Changes:**
+- In `toggleRecord()`, before `startRecording()`, call `await recordingEngine.playCountIn(bpm, beatsPerBar, onBeat)`
+- `onBeat` callback updates a new `countInRemaining` field in transportStore
+- LCD display shows count-in state: negative bar position in accent color (e.g., blue/cyan text)
+- Add count-in length selector near metronome button (dropdown: Off / 1 Bar / 2 Bars)
+- During count-in: disable stop button, show pulsing indicator on record button
+- Transport position must NOT advance during count-in (count-in is pre-transport)
+
+**Visual spec:**
+- LCD text color changes to `text-cyan-400` during count-in
+- Record button pulses at beat rate during count-in
+- Count-in beats shown as `-1.1`, `-1.2`, `-1.3`, `-1.4` → recording starts at `1.1.1`
+
+**Effort:** Medium. Engine support exists; need UI integration + transport store fields.
+
+### 3. Recording Undo (Single-Action Take Removal)
+
+**Files:** `useRecording.ts`, `projectStore.ts` (undo system)
+
+**Changes:**
+- After `stopRecording` creates clips, push a single undo entry that groups all created clip IDs
+- Undo action: remove all clips from that recording pass + delete their audio files
+- Store `lastRecordingClipIds: string[]` in transportStore for quick "undo last take"
+- Keyboard shortcut: Cmd+Z already works if projectStore has undo — just ensure `addClip` is wrapped in an undo group
+- If projectStore lacks undo: implement a minimal undo stack (action + inverse action pairs)
+
+**Effort:** Medium-Large depending on existing undo infrastructure. Check if projectStore already has undo support; if not, this becomes the prerequisite.
+
+---
+
+## Priority Matrix
+
+| Gap | User Impact | Effort | Priority |
+|-----|-----------|--------|----------|
+| Exclusive arm | Prevents wasted takes, matches muscle memory | S | **P0** |
+| Count-in wiring | Critical for timing; code 80% exists | M | **P0** |
+| Punch-in/out | Pro feature, needs loop-region work | L | P2 |
+| Recording undo | Safety net, depends on undo infra | M-L | **P1** |
+| Monitor modes | Prevents feedback, niche until multi-track | S-M | P2 |

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -8,17 +8,26 @@ import { formatTime, formatBarsBeats } from '../../utils/time';
 
 function LCDDisplay() {
   const currentTime = useTransportStore((s) => s.currentTime);
+  const countInActive = useTransportStore((s) => s.countInActive);
+  const countInBeat = useTransportStore((s) => s.countInBeat);
   const project = useProjectStore((s) => s.project);
   const barsBeats = project
     ? formatBarsBeats(currentTime, project.bpm, project.timeSignature)
     : '1.1.00';
 
+  // During count-in: show negative beat count in cyan (Ableton convention)
+  const displayBarsBeats = countInActive ? `${countInBeat}` : barsBeats;
+  const barsBeatsColor = countInActive ? 'text-cyan-400 animate-pulse' : 'text-green-400';
+
   return (
     <div className="gb-lcd flex items-center gap-3 px-3 py-1 min-w-[200px] justify-center">
-      <span className="text-[13px] font-mono text-green-400 tracking-wider">{barsBeats}</span>
+      <span className={`text-[13px] font-mono tracking-wider ${barsBeatsColor}`}>{displayBarsBeats}</span>
       <span className="text-[11px] font-mono text-zinc-400">{formatTime(currentTime)}</span>
-      {project && (
+      {project && !countInActive && (
         <span className="text-[11px] font-mono text-zinc-500">{project.bpm} bpm</span>
+      )}
+      {countInActive && (
+        <span className="text-[11px] font-mono text-red-400 animate-pulse">REC</span>
       )}
     </div>
   );

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -221,7 +221,7 @@ export function TrackHeader({
           </svg>
         </button>
         <button
-          onClick={() => toggleArmTrack(track.id)}
+          onClick={(e) => toggleArmTrack(track.id, !(e.metaKey || e.ctrlKey))}
           className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
             isArmed
               ? 'bg-red-600/90 text-white'

--- a/src/hooks/useRecording.ts
+++ b/src/hooks/useRecording.ts
@@ -15,6 +15,8 @@ export function useRecording() {
   const storeArmTrack = useTransportStore((s) => s.armTrack);
   const storeDisarmTrack = useTransportStore((s) => s.disarmTrack);
   const storeToggleArmTrack = useTransportStore((s) => s.toggleArmTrack);
+  const storeDisarmAll = useTransportStore((s) => s.disarmAll);
+  const setCountIn = useTransportStore((s) => s.setCountIn);
   const addClip = useProjectStore((s) => s.addClip);
   const updateClipStatus = useProjectStore((s) => s.updateClipStatus);
   const updateTrack = useProjectStore((s) => s.updateTrack);
@@ -32,16 +34,33 @@ export function useRecording() {
     updateTrack(id, { armed: false });
   }, [storeDisarmTrack, updateTrack]);
 
-  const toggleArmTrack = useCallback((id: string) => {
-    const armed = useTransportStore.getState().armedTrackIds.includes(id);
-    if (armed) {
+  /**
+   * Toggle arm on a track.
+   * exclusive=true (default): Ableton convention — disarms all other tracks first.
+   * exclusive=false: additive (Cmd/Ctrl+click behavior).
+   */
+  const toggleArmTrack = useCallback((id: string, exclusive = true) => {
+    const state = useTransportStore.getState();
+    const isArmed = state.armedTrackIds.includes(id);
+
+    if (isArmed) {
       disarmTrack(id);
       return;
     }
-    storeToggleArmTrack(id);
+
+    // Exclusive arm: disarm all others first
+    if (exclusive) {
+      for (const prevId of state.armedTrackIds) {
+        recordingEngine.setMonitoring(prevId, false);
+        updateTrack(prevId, { armed: false });
+      }
+      storeDisarmAll();
+    }
+
+    storeToggleArmTrack(id, false); // false = additive since we already cleared
     recordingEngine.setMonitoring(id, true);
     updateTrack(id, { armed: true });
-  }, [disarmTrack, storeToggleArmTrack, updateTrack]);
+  }, [disarmTrack, storeToggleArmTrack, storeDisarmAll, updateTrack]);
 
   const stopRecording = useCallback(async () => {
     const project = useProjectStore.getState().project;
@@ -109,6 +128,19 @@ export function useRecording() {
       return;
     }
 
+    // Play count-in if configured (default: 1 bar)
+    const project = useProjectStore.getState().project;
+    const bpm = project?.bpm ?? 120;
+    const beatsPerBar = (typeof project?.timeSignature === 'number' ? project.timeSignature : 4);
+
+    if (recordingEngine.getCountInLength() !== 'off') {
+      setCountIn(true, -(beatsPerBar * (recordingEngine.getCountInLength() === '1bar' ? 1 : 2)));
+      await recordingEngine.playCountIn(bpm, beatsPerBar, (_bar, _beat, remaining) => {
+        setCountIn(true, -remaining);
+      });
+      setCountIn(false, 0);
+    }
+
     setIsRecording(true);
     const transportTime = useTransportStore.getState().currentTime;
     let startedCount = 0;
@@ -127,7 +159,7 @@ export function useRecording() {
     }
 
     toastInfo('Recording started');
-  }, [setIsRecording, stopRecording]);
+  }, [setIsRecording, setCountIn, stopRecording]);
 
   return {
     isRecording,

--- a/src/store/transportStore.ts
+++ b/src/store/transportStore.ts
@@ -4,6 +4,8 @@ interface TransportState {
   isPlaying: boolean;
   isRecording: boolean;
   armedTrackIds: string[];
+  countInActive: boolean;
+  countInBeat: number; // 0 = not counting in, negative = beats remaining
   currentTime: number;
   loopEnabled: boolean;
   loopStart: number;
@@ -14,9 +16,11 @@ interface TransportState {
   pause: () => void;
   stop: () => void;
   setIsRecording: (v: boolean) => void;
+  setCountIn: (active: boolean, beat?: number) => void;
   armTrack: (id: string) => void;
   disarmTrack: (id: string) => void;
-  toggleArmTrack: (id: string) => void;
+  disarmAll: () => void;
+  toggleArmTrack: (id: string, exclusive?: boolean) => void;
   seek: (time: number) => void;
   setCurrentTime: (time: number) => void;
   toggleLoop: () => void;
@@ -28,6 +32,8 @@ export const useTransportStore = create<TransportState>((set) => ({
   isPlaying: false,
   isRecording: false,
   armedTrackIds: [],
+  countInActive: false,
+  countInBeat: 0,
   currentTime: 0,
   loopEnabled: false,
   loopStart: 0,
@@ -38,17 +44,23 @@ export const useTransportStore = create<TransportState>((set) => ({
   pause: () => set({ isPlaying: false }),
   stop: () => set({ isPlaying: false, currentTime: 0 }),
   setIsRecording: (v) => set({ isRecording: v }),
+  setCountIn: (active, beat = 0) => set({ countInActive: active, countInBeat: beat }),
   armTrack: (id) => set((s) => (
     s.armedTrackIds.includes(id) ? s : { armedTrackIds: [...s.armedTrackIds, id] }
   )),
   disarmTrack: (id) => set((s) => ({
     armedTrackIds: s.armedTrackIds.filter((trackId) => trackId !== id),
   })),
-  toggleArmTrack: (id) => set((s) => ({
-    armedTrackIds: s.armedTrackIds.includes(id)
-      ? s.armedTrackIds.filter((trackId) => trackId !== id)
-      : [...s.armedTrackIds, id],
-  })),
+  disarmAll: () => set({ armedTrackIds: [] }),
+  toggleArmTrack: (id, exclusive = true) => set((s) => {
+    const isArmed = s.armedTrackIds.includes(id);
+    if (isArmed) {
+      // Always disarm when already armed
+      return { armedTrackIds: s.armedTrackIds.filter((tid) => tid !== id) };
+    }
+    // Arm: exclusive by default (Ableton convention), additive with modifier
+    return { armedTrackIds: exclusive ? [id] : [...s.armedTrackIds, id] };
+  }),
   seek: (time) => set({ currentTime: Math.max(0, time) }),
   setCurrentTime: (time) => set({ currentTime: time }),
   toggleLoop: () => set((s) => ({ loopEnabled: !s.loopEnabled })),


### PR DESCRIPTION
Two P0 recording UX gaps fixed per competitive analysis against Ableton Live 12:

1. **Exclusive arm**: click = exclusive, Cmd+click = additive (Ableton default)
2. **Count-in wired**: LCD shows cyan countdown, REC pulse, then recording starts

Research: docs/research-notes/recording-ux-gaps.md