### PR TITLE
feat: wire AutomationEngine to transport + store actions

### DIFF
--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -6,6 +6,7 @@ import { getAudioEngine } from './useAudioEngine';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { synthEngine } from '../engine/SynthEngine';
 import { drumEngine } from '../engine/DrumEngine';
+import { automationEngine } from '../engine/AutomationEngine';
 import { useRecording } from './useRecording';
 
 const DRUM_PAD_INDEX_BY_SAMPLE_KEY: Record<string, number> = {
@@ -247,6 +248,12 @@ export function useTransport() {
       }
     }
 
+    // Start automation playback
+    const allLanes = project?.automationLanes ?? [];
+    if (allLanes.length > 0) {
+      automationEngine.start(allLanes, () => getAudioEngine().getCurrentTime());
+    }
+
     useTransportStore.getState().play();
   }, []);
 
@@ -258,6 +265,7 @@ export function useTransport() {
     const time = engine.getCurrentTime();
     engine.stop();
     synthEngine.releaseAll();
+    automationEngine.stop();
     useTransportStore.getState().pause();
     useTransportStore.getState().seek(time);
   }, [isRecording, stopRecording]);
@@ -269,6 +277,7 @@ export function useTransport() {
     const engine = getAudioEngine();
     engine.stop();
     synthEngine.releaseAll();
+    automationEngine.stop();
     useTransportStore.getState().stop();
   }, [isRecording, stopRecording]);
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -17,7 +17,11 @@ import type {
   PianoRollGrid,
   TrackEffect,
   TrackEffectType,
+  AutomationParameter,
+  AutomationPoint,
+  AutomationLane,
 } from '../types/project';
+import { automationParamEquals } from '../types/project';
 import { TRACK_CATALOG, DEFAULT_DRUM_KIT } from '../constants/tracks';
 import {
   DEFAULT_BPM,
@@ -142,6 +146,12 @@ interface ProjectState {
   updateTrackEffect: (trackId: string, effectId: string, updates: Partial<TrackEffect>) => void;
   removeTrackEffect: (trackId: string, effectId: string) => void;
   reorderTrackEffect: (trackId: string, fromIndex: number, toIndex: number) => void;
+
+  // Automation
+  addAutomationPoint: (trackId: string, parameter: AutomationParameter, point: AutomationPoint) => void;
+  removeAutomationPoint: (trackId: string, parameter: AutomationParameter, pointIndex: number) => void;
+  updateAutomationPoint: (trackId: string, parameter: AutomationParameter, pointIndex: number, updates: Partial<AutomationPoint>) => void;
+  clearAutomationLane: (trackId: string, parameter: AutomationParameter) => void;
 
   getTrackById: (trackId: string) => Track | undefined;
   getClipById: (clipId: string) => Clip | undefined;
@@ -1747,6 +1757,60 @@ export const useProjectStore = create<ProjectState>()(
         }),
       },
     });
+  },
+
+  // ─── Automation ───────────────────────────────────────────────────────────
+
+  addAutomationPoint: (trackId, parameter, point) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const lanes = [...(state.project.automationLanes ?? [])];
+    const matchLane = (l: AutomationLane) =>
+      l.trackId === trackId && automationParamEquals(l.parameter, parameter);
+    const existingLane = lanes.find(matchLane);
+    if (!existingLane) {
+      lanes.push({ id: uuidv4(), trackId, parameter, points: [point] });
+    } else {
+      const laneIdx = lanes.indexOf(existingLane);
+      lanes[laneIdx] = { ...existingLane, points: [...existingLane.points, point].sort((a, b) => a.time - b.time) };
+    }
+    set({ project: { ...state.project, updatedAt: Date.now(), automationLanes: lanes } });
+  },
+
+  removeAutomationPoint: (trackId, parameter, pointIndex) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const lanes = (state.project.automationLanes ?? []).map((lane) => {
+      if (lane.trackId !== trackId || !automationParamEquals(lane.parameter, parameter)) return lane;
+      return { ...lane, points: lane.points.filter((_: AutomationPoint, i: number) => i !== pointIndex) };
+    });
+    set({ project: { ...state.project, updatedAt: Date.now(), automationLanes: lanes } });
+  },
+
+  updateAutomationPoint: (trackId, parameter, pointIndex, updates) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const lanes = (state.project.automationLanes ?? []).map((lane) => {
+      if (lane.trackId !== trackId || !automationParamEquals(lane.parameter, parameter)) return lane;
+      const newPoints = lane.points.map((p: AutomationPoint, i: number) =>
+        i === pointIndex ? { ...p, ...updates } : p,
+      ).sort((a: AutomationPoint, b: AutomationPoint) => a.time - b.time);
+      return { ...lane, points: newPoints };
+    });
+    set({ project: { ...state.project, updatedAt: Date.now(), automationLanes: lanes } });
+  },
+
+  clearAutomationLane: (trackId, parameter) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const lanes = (state.project.automationLanes ?? []).filter(
+      (l: AutomationLane) => !(l.trackId === trackId && automationParamEquals(l.parameter, parameter)),
+    );
+    set({ project: { ...state.project, updatedAt: Date.now(), automationLanes: lanes } });
   },
 
   getTrackById: (trackId) => {

--- a/tests/unit/automationTypes.test.ts
+++ b/tests/unit/automationTypes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  automationParamEquals,
+  normalizedToMixerValue,
+  type AutomationParameter,
+} from '../../src/types/project';
+
+describe('automation types', () => {
+  describe('normalizedToMixerValue', () => {
+    it('maps normalized volume values directly', () => {
+      expect(normalizedToMixerValue('volume', 0)).toBe(0);
+      expect(normalizedToMixerValue('volume', 1)).toBe(1);
+    });
+
+    it('maps normalized pan values into the -1 to 1 range', () => {
+      expect(normalizedToMixerValue('pan', 0)).toBe(-1);
+      expect(normalizedToMixerValue('pan', 0.5)).toBe(0);
+      expect(normalizedToMixerValue('pan', 1)).toBe(1);
+    });
+  });
+
+  describe('automationParamEquals', () => {
+    it('returns true for identical automation params', () => {
+      const param: AutomationParameter = { type: 'mixer', param: 'volume' };
+
+      expect(automationParamEquals(param, { type: 'mixer', param: 'volume' })).toBe(true);
+    });
+
+    it('returns false for different automation params', () => {
+      const left: AutomationParameter = { type: 'mixer', param: 'volume' };
+      const right: AutomationParameter = { type: 'mixer', param: 'pan' };
+
+      expect(automationParamEquals(left, right)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/transportStore.test.ts
+++ b/tests/unit/transportStore.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useTransportStore } from '../../src/store/transportStore';
+
+describe('transportStore', () => {
+  beforeEach(() => {
+    useTransportStore.setState(useTransportStore.getInitialState(), true);
+  });
+
+  describe('play/pause/stop state transitions', () => {
+    it('plays, pauses, and stops transport state correctly', () => {
+      useTransportStore.getState().play();
+      expect(useTransportStore.getState().isPlaying).toBe(true);
+
+      useTransportStore.getState().pause();
+      expect(useTransportStore.getState().isPlaying).toBe(false);
+
+      useTransportStore.getState().seek(12.5);
+      useTransportStore.getState().play();
+      useTransportStore.getState().stop();
+
+      const state = useTransportStore.getState();
+      expect(state.isPlaying).toBe(false);
+      expect(state.currentTime).toBe(0);
+    });
+  });
+
+  describe('seek bounds', () => {
+    it('does not allow negative current time', () => {
+      useTransportStore.getState().seek(-3);
+
+      expect(useTransportStore.getState().currentTime).toBe(0);
+    });
+  });
+
+  describe('track arming', () => {
+    it('supports exclusive arming by default', () => {
+      useTransportStore.getState().armTrack('track-a');
+      useTransportStore.getState().toggleArmTrack('track-b');
+
+      expect(useTransportStore.getState().armedTrackIds).toEqual(['track-b']);
+    });
+
+    it('supports additive arming and disarming via toggleArmTrack', () => {
+      useTransportStore.getState().toggleArmTrack('track-a', false);
+      useTransportStore.getState().toggleArmTrack('track-b', false);
+      expect(useTransportStore.getState().armedTrackIds).toEqual(['track-a', 'track-b']);
+
+      useTransportStore.getState().toggleArmTrack('track-a', false);
+      expect(useTransportStore.getState().armedTrackIds).toEqual(['track-b']);
+    });
+
+    it('arms and disarms tracks directly', () => {
+      useTransportStore.getState().armTrack('track-a');
+      useTransportStore.getState().armTrack('track-a');
+      expect(useTransportStore.getState().armedTrackIds).toEqual(['track-a']);
+
+      useTransportStore.getState().disarmTrack('track-a');
+      expect(useTransportStore.getState().armedTrackIds).toEqual([]);
+    });
+  });
+
+  describe('recording and loop state', () => {
+    it('updates recording state', () => {
+      useTransportStore.getState().setIsRecording(true);
+      expect(useTransportStore.getState().isRecording).toBe(true);
+
+      useTransportStore.getState().setIsRecording(false);
+      expect(useTransportStore.getState().isRecording).toBe(false);
+    });
+
+    it('toggles loop state', () => {
+      useTransportStore.getState().toggleLoop();
+      expect(useTransportStore.getState().loopEnabled).toBe(true);
+
+      useTransportStore.getState().toggleLoop();
+      expect(useTransportStore.getState().loopEnabled).toBe(false);
+    });
+  });
+});

--- a/tests/unit/uiStore.test.ts
+++ b/tests/unit/uiStore.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useUIStore } from '../../src/store/uiStore';
+
+describe('uiStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useUIStore.setState(useUIStore.getInitialState(), true);
+  });
+
+  describe('pixelsPerSecond zoom', () => {
+    it('sets an explicit zoom level', () => {
+      useUIStore.getState().setPixelsPerSecond(200);
+
+      expect(useUIStore.getState().pixelsPerSecond).toBe(200);
+    });
+
+    it('zooms in through discrete levels and stops at the maximum', () => {
+      useUIStore.getState().setPixelsPerSecond(50);
+
+      useUIStore.getState().zoomIn();
+      expect(useUIStore.getState().pixelsPerSecond).toBe(100);
+
+      useUIStore.getState().zoomIn();
+      expect(useUIStore.getState().pixelsPerSecond).toBe(200);
+
+      useUIStore.getState().zoomIn();
+      expect(useUIStore.getState().pixelsPerSecond).toBe(500);
+
+      useUIStore.getState().zoomIn();
+      expect(useUIStore.getState().pixelsPerSecond).toBe(500);
+    });
+
+    it('zooms out through discrete levels and stops at the minimum', () => {
+      useUIStore.getState().setPixelsPerSecond(200);
+
+      useUIStore.getState().zoomOut();
+      expect(useUIStore.getState().pixelsPerSecond).toBe(100);
+
+      useUIStore.getState().zoomOut();
+      expect(useUIStore.getState().pixelsPerSecond).toBe(50);
+
+      useUIStore.getState().setPixelsPerSecond(10);
+      useUIStore.getState().zoomOut();
+      expect(useUIStore.getState().pixelsPerSecond).toBe(10);
+    });
+  });
+
+  describe('panel toggles', () => {
+    it('updates mixer, loop browser, and library panel visibility', () => {
+      useUIStore.getState().setShowMixer(true);
+      useUIStore.getState().toggleLoopBrowser();
+      useUIStore.getState().setShowLibrary(true);
+
+      let state = useUIStore.getState();
+      expect(state.showMixer).toBe(true);
+      expect(state.loopBrowserOpen).toBe(true);
+      expect(state.showLibrary).toBe(true);
+
+      useUIStore.getState().setShowMixer(false);
+      useUIStore.getState().toggleLoopBrowser();
+      useUIStore.getState().setShowLibrary(false);
+
+      state = useUIStore.getState();
+      expect(state.showMixer).toBe(false);
+      expect(state.loopBrowserOpen).toBe(false);
+      expect(state.showLibrary).toBe(false);
+    });
+  });
+
+  describe('selectedClipIds', () => {
+    it('adds, removes, and clears selected clip ids', () => {
+      useUIStore.getState().selectClip('clip-a');
+      expect(Array.from(useUIStore.getState().selectedClipIds)).toEqual(['clip-a']);
+
+      useUIStore.getState().selectClip('clip-b', true);
+      expect(Array.from(useUIStore.getState().selectedClipIds).sort()).toEqual(['clip-a', 'clip-b']);
+
+      useUIStore.getState().selectClip('clip-a', true);
+      expect(Array.from(useUIStore.getState().selectedClipIds)).toEqual(['clip-b']);
+
+      useUIStore.getState().deselectAll();
+      expect(useUIStore.getState().selectedClipIds.size).toBe(0);
+    });
+  });
+
+  describe('panel height constraints', () => {
+    it('clamps mixer height between 160 and 500', () => {
+      useUIStore.getState().setMixerHeight(120);
+      expect(useUIStore.getState().mixerHeight).toBe(160);
+
+      useUIStore.getState().setMixerHeight(640);
+      expect(useUIStore.getState().mixerHeight).toBe(500);
+    });
+
+    it('clamps piano roll height between 220 and 700', () => {
+      useUIStore.getState().setPianoRollHeight(180);
+      expect(useUIStore.getState().pianoRollHeight).toBe(220);
+
+      useUIStore.getState().setPianoRollHeight(760);
+      expect(useUIStore.getState().pianoRollHeight).toBe(700);
+    });
+  });
+});

--- a/tests/unit/wav.test.ts
+++ b/tests/unit/wav.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { audioBufferToWavBlob } from '../../src/utils/wav';
+
+function createAudioBufferMock(
+  channels: number[][],
+  sampleRate = 44100,
+): AudioBuffer {
+  return {
+    numberOfChannels: channels.length,
+    sampleRate,
+    length: channels[0]?.length ?? 0,
+    getChannelData: (channel: number) => Float32Array.from(channels[channel] ?? []),
+  } as AudioBuffer;
+}
+
+function readAscii(view: DataView, start: number, length: number): string {
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += String.fromCharCode(view.getUint8(start + i));
+  }
+  return result;
+}
+
+describe('audioBufferToWavBlob', () => {
+  it('creates a valid WAV header with RIFF, fmt, and data chunks', async () => {
+    const audioBuffer = createAudioBufferMock([[0, 0.25, -0.25, 1]], 48000);
+
+    const blob = audioBufferToWavBlob(audioBuffer);
+    const arrayBuffer = await blob.arrayBuffer();
+    const view = new DataView(arrayBuffer);
+
+    expect(blob.type).toBe('audio/wav');
+    expect(readAscii(view, 0, 4)).toBe('RIFF');
+    expect(readAscii(view, 8, 4)).toBe('WAVE');
+    expect(readAscii(view, 12, 4)).toBe('fmt ');
+    expect(readAscii(view, 36, 4)).toBe('data');
+    expect(view.getUint16(20, true)).toBe(1);
+    expect(view.getUint16(22, true)).toBe(1);
+    expect(view.getUint32(24, true)).toBe(48000);
+    expect(view.getUint16(34, true)).toBe(16);
+    expect(view.getUint32(40, true)).toBe(8);
+  });
+
+  it('encodes samples as signed 16-bit PCM', async () => {
+    const audioBuffer = createAudioBufferMock([[-1, -0.5, 0, 0.5, 1]]);
+
+    const arrayBuffer = await audioBufferToWavBlob(audioBuffer).arrayBuffer();
+    const view = new DataView(arrayBuffer);
+
+    expect(view.getInt16(44, true)).toBe(-32768);
+    expect(view.getInt16(46, true)).toBe(-16384);
+    expect(view.getInt16(48, true)).toBe(0);
+    expect(view.getInt16(50, true)).toBe(16383);
+    expect(view.getInt16(52, true)).toBe(32767);
+  });
+
+  it('handles mono and stereo channel layouts correctly', async () => {
+    const mono = createAudioBufferMock([[0.25, -0.25]]);
+    const stereo = createAudioBufferMock([[0.25, -0.25], [-0.5, 0.5]]);
+
+    const monoView = new DataView(await audioBufferToWavBlob(mono).arrayBuffer());
+    const stereoView = new DataView(await audioBufferToWavBlob(stereo).arrayBuffer());
+
+    expect(monoView.getUint16(22, true)).toBe(1);
+    expect(monoView.getUint16(32, true)).toBe(2);
+    expect(stereoView.getUint16(22, true)).toBe(2);
+    expect(stereoView.getUint16(32, true)).toBe(4);
+
+    expect(stereoView.getInt16(44, true)).toBe(8191);
+    expect(stereoView.getInt16(46, true)).toBe(-16384);
+    expect(stereoView.getInt16(48, true)).toBe(-8192);
+    expect(stereoView.getInt16(50, true)).toBe(16383);
+  });
+
+  it('handles an empty buffer edge case', async () => {
+    const audioBuffer = createAudioBufferMock([[]]);
+
+    const arrayBuffer = await audioBufferToWavBlob(audioBuffer).arrayBuffer();
+    const view = new DataView(arrayBuffer);
+
+    expect(arrayBuffer.byteLength).toBe(44);
+    expect(view.getUint32(4, true)).toBe(36);
+    expect(view.getUint32(40, true)).toBe(0);
+  });
+});

--- a/tests/unit/waveformPeaks.test.ts
+++ b/tests/unit/waveformPeaks.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { computeWaveformPeaks } from '../../src/utils/waveformPeaks';
+
+function createAudioBufferMock(samples: number[]): AudioBuffer {
+  return {
+    getChannelData: () => Float32Array.from(samples),
+  } as AudioBuffer;
+}
+
+describe('computeWaveformPeaks', () => {
+  it('returns the requested number of peaks', () => {
+    const peaks = computeWaveformPeaks(
+      createAudioBufferMock([0.1, -0.2, 0.5, -0.7, 0.9, -0.4, 0.3, -0.1]),
+      4,
+    );
+
+    expect(peaks).toHaveLength(4);
+    expect(peaks).toEqual([0.2, 0.7, 0.9, 0.3]);
+  });
+
+  it('keeps peak values between 0 and 1 for normalized source audio', () => {
+    const peaks = computeWaveformPeaks(
+      createAudioBufferMock([-1, -0.25, 0.75, 0.5, -0.9, 0.1]),
+      3,
+    );
+
+    expect(peaks.every((peak) => peak >= -1 && peak <= 1)).toBe(true);
+  });
+
+  it('returns all zeros for a silent buffer', () => {
+    const peaks = computeWaveformPeaks(createAudioBufferMock([0, 0, 0, 0]), 4);
+
+    expect(peaks).toEqual([0, 0, 0, 0]);
+  });
+
+  it('returns zeros when a single sample is spread across multiple requested peaks', () => {
+    const peaks = computeWaveformPeaks(createAudioBufferMock([0.75]), 4);
+
+    expect(peaks).toEqual([0, 0, 0, 0]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,6 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"]
 }


### PR DESCRIPTION
AutomationEngine (134 lines of dead code) now wired into transport play/stop cycle. 4 new store actions for CRUD on automation points. Agents can programmatically automate volume/pan via `window.__store.getState().addAutomationPoint(trackId, {type:"mixer",param:"volume"}, {time:0,value:0.5})`.

Also fixes build by excluding test files from tsconfig.json.