### PR TITLE
feat: automation toggle button (A) on TrackHeader

### DIFF
--- a/.llm/todo.md
+++ b/.llm/todo.md
@@ -7,14 +7,14 @@
 
 ## Priority 1: Test Coverage Foundation
 
-- [ ] Write Vitest unit tests for uiStore (panel toggles, selection state)
+- [x] Write Vitest unit tests for uiStore (panel toggles, selection state)
 - [ ] Write Vitest unit tests for generationStore (queue management, status)
 - [ ] Write Vitest unit tests for color utilities (src/utils/color.ts)
-- [ ] Write Vitest unit tests for WAV export utilities (src/utils/wav.ts)
-- [ ] Write Vitest unit tests for waveform peak calculation (src/utils/waveformPeaks.ts)
+- [x] Write Vitest unit tests for WAV export utilities (src/utils/wav.ts)
+- [x] Write Vitest unit tests for waveform peak calculation (src/utils/waveformPeaks.ts)
 - [ ] Write Vitest unit tests for audio downsample utility (src/utils/audioDownsample.ts)
 - [ ] Write Vitest unit tests for generationPipeline service state machine
-- [ ] Write Vitest unit tests for automation types (normalizedToMixerValue, automationParamEquals)
+- [x] Write Vitest unit tests for automation types (normalizedToMixerValue, automationParamEquals)
 - [ ] Write Playwright E2E test: sequencer workflow (add track, toggle steps, verify pattern)
 - [ ] Write Playwright E2E test: piano roll workflow (add track, add notes via store API)
 - [ ] Write Playwright E2E test: mixer operations (volume, pan, mute, solo)

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -234,6 +234,41 @@ export function TrackHeader({
             <circle cx="6" cy="6" r="3.25" fill={isArmed ? 'currentColor' : 'none'} />
           </svg>
         </button>
+        {/* Automation toggle */}
+        <button
+          onClick={() => {
+            const project = useProjectStore.getState().project;
+            if (!project) return;
+            const hasLane = (project.automationLanes ?? []).some((l) => l.trackId === track.id);
+            if (!hasLane) {
+              // Create a default volume automation lane with 2 points
+              useProjectStore.getState().addAutomationPoint(
+                track.id,
+                { type: 'mixer', param: 'volume' },
+                { time: 0, value: track.volume },
+              );
+              useProjectStore.getState().addAutomationPoint(
+                track.id,
+                { type: 'mixer', param: 'volume' },
+                { time: project.totalDuration, value: track.volume },
+              );
+            } else {
+              // Clear all automation for this track
+              for (const lane of (project.automationLanes ?? []).filter((l) => l.trackId === track.id)) {
+                useProjectStore.getState().clearAutomationLane(track.id, lane.parameter);
+              }
+            }
+          }}
+          className={`w-5 h-5 flex items-center justify-center rounded text-[9px] font-bold transition-colors ${
+            (useProjectStore.getState().project?.automationLanes ?? []).some((l) => l.trackId === track.id)
+              ? 'bg-amber-600/80 text-white'
+              : 'text-zinc-500 hover:text-amber-400 hover:bg-[#444]'
+          }`}
+          title="Toggle automation lane (A)"
+          aria-label={`Toggle automation ${track.displayName}`}
+        >
+          A
+        </button>
         {/* Delete - hidden by default, visible on hover */}
         <button
           onClick={() => removeTrack(track.id)}


### PR DESCRIPTION
Adds A button on each track header to create/remove automation lanes. Creates volume automation by default with start/end points matching current track volume. Amber when active.