### PR TITLE
feat: MIDI quantize store action + tests (46/46 pass)

### DIFF
--- a/src/components/pianoroll/PianoRollCanvas.tsx
+++ b/src/components/pianoroll/PianoRollCanvas.tsx
@@ -65,6 +65,7 @@ export function PianoRollCanvas({
   const addMidiNote = useProjectStore((s) => s.addMidiNote);
   const removeMidiNote = useProjectStore((s) => s.removeMidiNote);
   const updateMidiNote = useProjectStore((s) => s.updateMidiNote);
+  const quantizeMidiNotes = useProjectStore((s) => s.quantizeMidiNotes);
   const beginDrag = useProjectStore((s) => s.beginDrag);
   const endDrag = useProjectStore((s) => s.endDrag);
 
@@ -691,10 +692,7 @@ export function PianoRollCanvas({
 
       if (key === 'q' && !e.metaKey && !e.ctrlKey && selectedNoteIds.size > 0) {
         e.preventDefault();
-        for (const noteId of selectedNoteIds) {
-          const note = notes.find((candidate) => candidate.id === noteId);
-          if (note) updateMidiNote(clip.id, noteId, { startBeat: Math.max(0, snapBeat(note.startBeat)) });
-        }
+        quantizeMidiNotes(clip.id, Array.from(selectedNoteIds), gridBeats);
         return;
       }
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -141,6 +141,7 @@ interface ProjectState {
   addMidiNote: (clipId: string, note: Omit<MidiNote, 'id'> & { id?: string }) => string | undefined;
   updateMidiNote: (clipId: string, noteId: string, updates: Partial<MidiNote>) => void;
   removeMidiNote: (clipId: string, noteId: string) => void;
+  quantizeMidiNotes: (clipId: string, noteIds: string[], gridBeats: number) => void;
   setMidiGrid: (clipId: string, grid: PianoRollGrid) => void;
   addTrackEffect: (trackId: string, type: TrackEffectType) => string | undefined;
   updateTrackEffect: (trackId: string, effectId: string, updates: Partial<TrackEffect>) => void;
@@ -1645,6 +1646,37 @@ export const useProjectStore = create<ProjectState>()(
                   midiData: {
                     ...clip.midiData,
                     notes: clip.midiData.notes.filter((note) => note.id !== noteId),
+                  },
+                }
+              : clip,
+          ),
+        })),
+      },
+    });
+  },
+
+  quantizeMidiNotes: (clipId, noteIds, gridBeats) => {
+    const state = get();
+    if (!state.project || gridBeats <= 0) return;
+    _pushHistory(state.project);
+    const noteIdSet = new Set(noteIds);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) => ({
+          ...track,
+          clips: track.clips.map((clip) =>
+            clip.id === clipId && clip.midiData
+              ? {
+                  ...clip,
+                  midiData: {
+                    ...clip.midiData,
+                    notes: clip.midiData.notes.map((note) =>
+                      noteIdSet.has(note.id)
+                        ? { ...note, startBeat: Math.round(note.startBeat / gridBeats) * gridBeats }
+                        : note,
+                    ),
                   },
                 }
               : clip,

--- a/tests/unit/projectStore.test.ts
+++ b/tests/unit/projectStore.test.ts
@@ -161,4 +161,49 @@ describe('projectStore', () => {
       ]);
     });
   });
+
+  describe('quantizeMidiNotes', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject();
+    });
+
+    it('snaps selected note startBeats to the nearest grid line', () => {
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = useProjectStore.getState().ensureMidiClip(track.id);
+      const noteId1 = useProjectStore.getState().addMidiNote(clip.id, {
+        pitch: 60, startBeat: 0.3, durationBeats: 1, velocity: 100,
+      })!;
+      const noteId2 = useProjectStore.getState().addMidiNote(clip.id, {
+        pitch: 64, startBeat: 1.7, durationBeats: 1, velocity: 80,
+      })!;
+      const noteId3 = useProjectStore.getState().addMidiNote(clip.id, {
+        pitch: 67, startBeat: 3.1, durationBeats: 0.5, velocity: 90,
+      })!;
+
+      // Quantize notes 1 and 2 to quarter-note grid (1 beat), leave note 3 alone
+      useProjectStore.getState().quantizeMidiNotes(clip.id, [noteId1, noteId2], 1);
+
+      const notes = useProjectStore.getState().project!.tracks[0].clips[0].midiData!.notes;
+      const n1 = notes.find(n => n.id === noteId1)!;
+      const n2 = notes.find(n => n.id === noteId2)!;
+      const n3 = notes.find(n => n.id === noteId3)!;
+
+      expect(n1.startBeat).toBe(0);   // 0.3 → 0
+      expect(n2.startBeat).toBe(2);   // 1.7 → 2
+      expect(n3.startBeat).toBe(3.1); // unchanged
+    });
+
+    it('quantizes to eighth-note grid (0.5 beats)', () => {
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = useProjectStore.getState().ensureMidiClip(track.id);
+      const noteId = useProjectStore.getState().addMidiNote(clip.id, {
+        pitch: 60, startBeat: 0.6, durationBeats: 1, velocity: 100,
+      })!;
+
+      useProjectStore.getState().quantizeMidiNotes(clip.id, [noteId], 0.5);
+
+      const note = useProjectStore.getState().project!.tracks[0].clips[0].midiData!.notes[0];
+      expect(note.startBeat).toBe(0.5); // 0.6 → 0.5
+    });
+  });
 });


### PR DESCRIPTION
New store action: quantizeMidiNotes(clipId, noteIds, gridBeats). Snaps selected notes to nearest grid line. PianoRoll Q shortcut now uses this action. 2 new unit tests.