### PR TITLE
fix: robust E2E tests — stable selectors + CI-safe setup

### DIFF
--- a/tests/e2e/project-lifecycle.spec.ts
+++ b/tests/e2e/project-lifecycle.spec.ts
@@ -4,7 +4,9 @@ test.describe('Project Lifecycle', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     // Wait for the app to fully load
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
+    // Wait for the store to be exposed by the app
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
   });
 
   test('app loads without errors', async ({ page }) => {

--- a/tests/e2e/transport.spec.ts
+++ b/tests/e2e/transport.spec.ts
@@ -3,7 +3,9 @@ import { test, expect } from '@playwright/test';
 test.describe('Transport Controls', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
+    // Wait for the store to be exposed by the app
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
     // Create a project so the DAW UI is visible
     await page.evaluate(() => {
       const store = (window as any).__store;


### PR DESCRIPTION
Root causes: (1) networkidle never fires because app retries ECONNREFUSED 8001; (2) aria-label selector too fragile. Fix: domcontentloaded + waitForFunction + data-testid + 60s webServer timeout.