### PR TITLE
feat: duplicate track — store action + context menu + 2 tests

### DIFF
--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -29,6 +29,7 @@ export function TrackHeader({
   const updateTrack = useProjectStore((s) => s.updateTrack);
   const renameTrack = useProjectStore((s) => s.renameTrack);
   const removeTrack = useProjectStore((s) => s.removeTrack);
+  const duplicateTrack = useProjectStore((s) => s.duplicateTrack);
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
   const setOpenEffectChainTrackId = useUIStore((s) => s.setOpenEffectChainTrackId);
   const { armedTrackIds, toggleArmTrack } = useRecording();
@@ -342,6 +343,12 @@ export function TrackHeader({
             className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
           >
             Track Settings...
+          </button>
+          <button
+            onClick={() => { setCtxMenu(null); duplicateTrack(track.id); }}
+            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
+          >
+            Duplicate Track
           </button>
           <div className="my-1 border-t border-[#555]" />
           <button

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -93,6 +93,7 @@ interface ProjectState {
 
   addTrack: (trackName: TrackName, trackType?: TrackType) => Track;
   removeTrack: (trackId: string) => void;
+  duplicateTrack: (trackId: string) => Track | undefined;
   updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'armed' | 'laneHeight' | 'trackType' | 'synthPreset' | 'drumKit' | 'color'>>) => void;
   renameTrack: (trackId: string, newName: string) => void;
   reorderTrack: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
@@ -480,6 +481,34 @@ export const useProjectStore = create<ProjectState>()(
         tracks: newTracks,
       },
     });
+  },
+
+  duplicateTrack: (trackId) => {
+    const state = get();
+    if (!state.project) return undefined;
+    const source = state.project.tracks.find((t) => t.id === trackId);
+    if (!source) return undefined;
+    _pushHistory(state.project);
+    const newId = crypto.randomUUID();
+    const clonedTrack: Track = {
+      ...JSON.parse(JSON.stringify(source)),
+      id: newId,
+      displayName: `${source.displayName} (copy)`,
+      clips: source.clips.map((clip) => ({
+        ...JSON.parse(JSON.stringify(clip)),
+        id: crypto.randomUUID(),
+      })),
+    };
+    const newTracks = [...state.project.tracks, clonedTrack];
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        tracks: newTracks,
+      },
+    });
+    return clonedTrack;
   },
 
   updateTrack: (trackId, updates) => {

--- a/tests/unit/projectStore.test.ts
+++ b/tests/unit/projectStore.test.ts
@@ -207,3 +207,33 @@ describe('projectStore', () => {
     });
   });
 });
+
+  describe('duplicateTrack', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject();
+    });
+
+    it('duplicates a track with all clips', () => {
+      const original = useProjectStore.getState().addTrack('drums');
+      useProjectStore.getState().addClip(original.id, {
+        startTime: 0, duration: 30, prompt: 'test beat', lyrics: '',
+      });
+
+      const duplicate = useProjectStore.getState().duplicateTrack(original.id);
+
+      expect(duplicate).toBeDefined();
+      expect(duplicate!.id).not.toBe(original.id);
+      expect(duplicate!.displayName).toBe('Drums (copy)');
+      expect(duplicate!.clips).toHaveLength(1);
+      expect(duplicate!.clips[0].id).not.toBe(original.clips[0]?.id);
+      expect(duplicate!.clips[0].prompt).toBe('test beat');
+
+      const tracks = useProjectStore.getState().project!.tracks;
+      expect(tracks).toHaveLength(2);
+    });
+
+    it('returns undefined for non-existent track', () => {
+      const result = useProjectStore.getState().duplicateTrack('nonexistent');
+      expect(result).toBeUndefined();
+    });
+  });


### PR DESCRIPTION
duplicateTrack(trackId) deep-clones with new IDs. Context menu option + 2 unit tests. 48/48 pass.