### PR TITLE
test: E2E piano roll (5) + mixer (7) tests

### DIFF
--- a/.llm/todo.md
+++ b/.llm/todo.md
@@ -16,8 +16,8 @@
 - [ ] Write Vitest unit tests for generationPipeline service state machine
 - [x] Write Vitest unit tests for automation types (normalizedToMixerValue, automationParamEquals)
 - [x] Write Playwright E2E test: sequencer workflow (add track, toggle steps, verify pattern)
-- [ ] Write Playwright E2E test: piano roll workflow (add track, add notes via store API)
-- [ ] Write Playwright E2E test: mixer operations (volume, pan, mute, solo)
+- [x] Write Playwright E2E test: piano roll workflow (add track, add notes via store API)
+- [x] Write Playwright E2E test: mixer operations (volume, pan, mute, solo)
 - [ ] Write Playwright E2E test: effect chain (add/remove/reorder effects)
 - [ ] Write Playwright E2E test: keyboard shortcuts (Space=play, Ctrl+Z=undo)
 

--- a/tests/e2e/mixer.spec.ts
+++ b/tests/e2e/mixer.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Mixer Operations', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
+    await page.evaluate(() => {
+      const store = (window as any).__store;
+      store.getState().createProject({ name: 'Mixer Test' });
+      store.getState().addTrack('drums');
+      store.getState().addTrack('bass');
+    });
+  });
+
+  test('tracks have default volume of 0.8', async ({ page }) => {
+    const volumes = await page.evaluate(() => {
+      const store = (window as any).__store;
+      return store.getState().project?.tracks.map((t: any) => t.volume);
+    });
+    expect(volumes).toEqual([0.8, 0.8]);
+  });
+
+  test('can update track volume', async ({ page }) => {
+    const volume = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const trackId = store.getState().project?.tracks[0]?.id;
+      store.getState().updateTrack(trackId, { volume: 0.5 });
+      return store.getState().project?.tracks[0]?.volume;
+    });
+    expect(volume).toBe(0.5);
+  });
+
+  test('can mute a track', async ({ page }) => {
+    const muted = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const trackId = store.getState().project?.tracks[0]?.id;
+      store.getState().updateTrack(trackId, { muted: true });
+      return store.getState().project?.tracks[0]?.muted;
+    });
+    expect(muted).toBe(true);
+  });
+
+  test('can solo a track', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const trackId = store.getState().project?.tracks[0]?.id;
+      store.getState().updateTrack(trackId, { soloed: true });
+      const tracks = store.getState().project?.tracks;
+      return {
+        track0Soloed: tracks[0].soloed,
+        track1Soloed: tracks[1].soloed,
+      };
+    });
+    expect(result.track0Soloed).toBe(true);
+    expect(result.track1Soloed).toBe(false);
+  });
+
+  test('can update track pan via mixer API', async ({ page }) => {
+    const pan = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const trackId = store.getState().project?.tracks[0]?.id;
+      store.getState().updateTrackMixer(trackId, { pan: -0.5 });
+      return store.getState().project?.tracks[0]?.pan;
+    });
+    expect(pan).toBe(-0.5);
+  });
+
+  test('can add and remove effects', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const trackId = store.getState().project?.tracks[0]?.id;
+      const effectId = store.getState().addTrackEffect(trackId, 'reverb');
+      const countAfterAdd = store.getState().project?.tracks[0]?.effects?.length ?? 0;
+      if (effectId) store.getState().removeTrackEffect(trackId, effectId);
+      const countAfterRemove = store.getState().project?.tracks[0]?.effects?.length ?? 0;
+      return { countAfterAdd, countAfterRemove };
+    });
+    expect(result.countAfterAdd).toBe(1);
+    expect(result.countAfterRemove).toBe(0);
+  });
+
+  test('can duplicate a track', async ({ page }) => {
+    const trackCount = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const trackId = store.getState().project?.tracks[0]?.id;
+      store.getState().duplicateTrack(trackId);
+      return store.getState().project?.tracks.length;
+    });
+    expect(trackCount).toBe(3); // 2 original + 1 duplicate
+  });
+});

--- a/tests/e2e/piano-roll.spec.ts
+++ b/tests/e2e/piano-roll.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Piano Roll Workflow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
+    await page.evaluate(() => {
+      const store = (window as any).__store;
+      store.getState().createProject({ name: 'Piano Roll Test' });
+    });
+  });
+
+  test('can add a keyboard track with pianoRoll type', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      return { trackType: track.trackType, displayName: track.displayName };
+    });
+    expect(result.trackType).toBe('pianoRoll');
+  });
+
+  test('can create a MIDI clip via ensureMidiClip', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = store.getState().ensureMidiClip(track.id);
+      return {
+        hasMidiData: !!clip.midiData,
+        notesCount: clip.midiData?.notes?.length ?? -1,
+      };
+    });
+    expect(result.hasMidiData).toBe(true);
+    expect(result.notesCount).toBe(0);
+  });
+
+  test('can add MIDI notes via store API', async ({ page }) => {
+    const noteCount = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = store.getState().ensureMidiClip(track.id);
+      store.getState().addMidiNote(clip.id, { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 100 });
+      store.getState().addMidiNote(clip.id, { pitch: 64, startBeat: 1, durationBeats: 1, velocity: 80 });
+      store.getState().addMidiNote(clip.id, { pitch: 67, startBeat: 2, durationBeats: 0.5, velocity: 90 });
+      return store.getState().project?.tracks[0]?.clips[0]?.midiData?.notes?.length ?? 0;
+    });
+    expect(noteCount).toBe(3);
+  });
+
+  test('can quantize MIDI notes via store API', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = store.getState().ensureMidiClip(track.id);
+      const noteId = store.getState().addMidiNote(clip.id, { pitch: 60, startBeat: 0.3, durationBeats: 1, velocity: 100 });
+      store.getState().quantizeMidiNotes(clip.id, [noteId], 1);
+      const note = store.getState().project?.tracks[0]?.clips[0]?.midiData?.notes[0];
+      return note?.startBeat;
+    });
+    expect(result).toBe(0); // 0.3 quantized to 0
+  });
+
+  test('can remove a MIDI note', async ({ page }) => {
+    const noteCount = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = store.getState().ensureMidiClip(track.id);
+      const noteId = store.getState().addMidiNote(clip.id, { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 100 });
+      store.getState().addMidiNote(clip.id, { pitch: 64, startBeat: 1, durationBeats: 1, velocity: 80 });
+      store.getState().removeMidiNote(clip.id, noteId);
+      return store.getState().project?.tracks[0]?.clips[0]?.midiData?.notes?.length ?? 0;
+    });
+    expect(noteCount).toBe(1);
+  });
+});


### PR DESCRIPTION
12 new E2E tests: piano roll workflow (MIDI create/add/quantize/remove) + mixer operations (volume/mute/solo/pan/effects/duplicate). Store-first approach.