### PR TITLE
feat: data-testid + data-clip-id for E2E drag testing

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -329,6 +329,8 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           ...(isSelected ? { '--tw-ring-color': 'rgba(0, 122, 255, 0.85)' } as React.CSSProperties : {}),
         }}
         data-clip-block
+        data-clip-id={clip.id}
+        data-testid={`clip-${clip.id}`}
         onMouseDown={handleMouseDown}
         onClick={handleClick}
         onDoubleClick={handleDoubleClick}

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -234,6 +234,7 @@ export function TrackLane({ track }: TrackLaneProps) {
     <>
       <div
         data-track-id={track.id}
+        data-testid={`track-lane-${track.id}`}
         className={`relative border-b border-[#333] ${fileDragOver ? 'bg-blue-900/20' : ''}`}
         style={{ width: totalWidth, height: laneHeight }}
         onContextMenu={handleContextMenu}


### PR DESCRIPTION
Add stable data attributes to ClipBlock and TrackLane for Playwright E2E tests. Per drag testing research.