### PR TITLE
docs: CI-must-pass-before-merge rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,9 @@ Every 10 versions (v0.0.20, v0.0.30...), review all installed skills:
 ## Red Lines (absolute prohibitions)
 
 - ❌ Never push directly to main
+- ❌ Never merge a PR before CI passes — if CI fails, add fix commits until green
+- ✅ After creating a PR, check CI status via GitHub API before merging
+- ✅ If CI was red, understand the root cause before fixing (don't guess)
 - ❌ Never publish a release without deep-tested GIF demos
 - ❌ Never code without competitive research (except hotfixes)
 - ❌ Never skip browser testing before release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,3 +162,5 @@ When using Claude Code on this project, install these skills for better UX outpu
 - Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
 - Identity: `user.name: ChuxiJ`, `user.email: junmin@acestudio.ai`
 - Never push directly to main — always use PR workflow
+- Never merge a PR before CI passes — check CI status first, fix if red
+- If CI fails: understand root cause → add fix commit → wait for green → then merge


### PR DESCRIPTION
Added rule: never merge before CI passes. Learned from 7 PRs merged with failing E2E.