### PR TITLE
fix: effects always wired via useEffectsSync (not just when Mixer open)

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -26,6 +26,7 @@ import { useAudioEngine } from '../../hooks/useAudioEngine';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
+import { useEffectsSync } from '../../hooks/useEffectsSync';
 
 export function AppShell() {
   const { resumeOnGesture } = useAudioEngine();
@@ -57,6 +58,7 @@ export function AppShell() {
   }, [project]);
 
   useKeyboardShortcuts();
+  useEffectsSync(); // Keep effects chain synced with store — always, not just when Mixer is open
 
   return (
     <div className="flex flex-col h-screen bg-daw-bg text-zinc-300" onClick={handleClick}>

--- a/src/hooks/useEffectsSync.ts
+++ b/src/hooks/useEffectsSync.ts
@@ -1,0 +1,35 @@
+/**
+ * useEffectsSync.ts — Keeps the audio effect chain in sync with track store state.
+ *
+ * Previously, effects were only wired when the EffectChain panel was open.
+ * This hook runs at the app level and ensures effects are always applied,
+ * regardless of whether the Mixer/EffectChain UI is visible.
+ */
+import { useEffect } from 'react';
+import { useProjectStore } from '../store/projectStore';
+import { effectsEngine } from '../engine/EffectsEngine';
+import { getAudioEngine } from './useAudioEngine';
+
+export function useEffectsSync() {
+  const tracks = useProjectStore((s) => s.project?.tracks);
+
+  useEffect(() => {
+    if (!tracks) return;
+
+    const engine = getAudioEngine();
+
+    for (const track of tracks) {
+      const effects = track.effects ?? [];
+      // Build the Tone.js chain for this track
+      effectsEngine.rebuildChain(track.id, effects);
+      // Splice into the Web Audio signal path
+      const trackNode = engine.getOrCreateTrackNode(track.id);
+      if (trackNode) {
+        trackNode.spliceEffects(
+          effectsEngine.getInputNode(track.id),
+          effectsEngine.getOutputNode(track.id),
+        );
+      }
+    }
+  }, [tracks]);
+}


### PR DESCRIPTION
Bug: effects disconnected when Mixer panel closed. Fix: useEffectsSync hook in AppShell keeps effects always wired. Sprint 1 S1-03.