### PR TITLE
feat: chord stamp — 12 shapes + store action + 8 tests

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -143,6 +143,7 @@ interface ProjectState {
   updateMidiNote: (clipId: string, noteId: string, updates: Partial<MidiNote>) => void;
   removeMidiNote: (clipId: string, noteId: string) => void;
   quantizeMidiNotes: (clipId: string, noteIds: string[], gridBeats: number) => void;
+  stampChord: (clipId: string, rootPitch: number, intervals: number[], startBeat: number, durationBeats: number, velocity?: number) => string[];
   setMidiGrid: (clipId: string, grid: PianoRollGrid) => void;
   addTrackEffect: (trackId: string, type: TrackEffectType) => string | undefined;
   updateTrackEffect: (trackId: string, effectId: string, updates: Partial<TrackEffect>) => void;
@@ -1713,6 +1714,50 @@ export const useProjectStore = create<ProjectState>()(
         })),
       },
     });
+  },
+
+  stampChord: (clipId, rootPitch, intervals, startBeat, durationBeats, velocity = 100) => {
+    const state = get();
+    if (!state.project) return [];
+    _pushHistory(state.project);
+    const noteIds: string[] = [];
+    const pitches = intervals.map((i) => rootPitch + i).filter((p) => p <= 127);
+    for (const pitch of pitches) {
+      const id = crypto.randomUUID();
+      noteIds.push(id);
+      // Use addMidiNote internally (but we batch in one history push)
+    }
+    // Batch add all chord notes in one state update
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) => ({
+          ...track,
+          clips: track.clips.map((clip) =>
+            clip.id === clipId && clip.midiData
+              ? {
+                  ...clip,
+                  midiData: {
+                    ...clip.midiData,
+                    notes: [
+                      ...clip.midiData.notes,
+                      ...pitches.map((pitch, i) => ({
+                        id: noteIds[i],
+                        pitch,
+                        startBeat,
+                        durationBeats,
+                        velocity,
+                      })),
+                    ],
+                  },
+                }
+              : clip,
+          ),
+        })),
+      },
+    });
+    return noteIds;
   },
 
   setMidiGrid: (clipId, grid) => {

--- a/src/utils/chords.ts
+++ b/src/utils/chords.ts
@@ -1,0 +1,40 @@
+/**
+ * chords.ts — Musical chord definitions for the chord stamp tool.
+ */
+
+export interface ChordShape {
+  name: string;
+  abbr: string;
+  intervals: number[]; // semitones from root
+}
+
+export const CHORD_SHAPES: ChordShape[] = [
+  { name: 'Major', abbr: 'maj', intervals: [0, 4, 7] },
+  { name: 'Minor', abbr: 'min', intervals: [0, 3, 7] },
+  { name: 'Diminished', abbr: 'dim', intervals: [0, 3, 6] },
+  { name: 'Augmented', abbr: 'aug', intervals: [0, 4, 8] },
+  { name: 'Major 7th', abbr: 'maj7', intervals: [0, 4, 7, 11] },
+  { name: 'Minor 7th', abbr: 'min7', intervals: [0, 3, 7, 10] },
+  { name: 'Dominant 7th', abbr: '7', intervals: [0, 4, 7, 10] },
+  { name: 'Suspended 2nd', abbr: 'sus2', intervals: [0, 2, 7] },
+  { name: 'Suspended 4th', abbr: 'sus4', intervals: [0, 5, 7] },
+  { name: 'Power (5th)', abbr: '5', intervals: [0, 7] },
+  { name: 'Add 9', abbr: 'add9', intervals: [0, 4, 7, 14] },
+  { name: 'Minor Add 9', abbr: 'madd9', intervals: [0, 3, 7, 14] },
+];
+
+/**
+ * Generate MIDI pitches for a chord at a given root note.
+ */
+export function chordPitches(rootPitch: number, shape: ChordShape): number[] {
+  return shape.intervals.map((interval) => rootPitch + interval).filter((p) => p <= 127);
+}
+
+/**
+ * Get note name from MIDI pitch (e.g., 60 → "C4").
+ */
+export function pitchToNoteName(pitch: number): string {
+  const names = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+  const octave = Math.floor(pitch / 12) - 1;
+  return `${names[pitch % 12]}${octave}`;
+}

--- a/tests/unit/chords.test.ts
+++ b/tests/unit/chords.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { chordPitches, pitchToNoteName, CHORD_SHAPES } from '../../src/utils/chords';
+import { useProjectStore } from '../../src/store/projectStore';
+
+describe('chords', () => {
+  describe('chordPitches', () => {
+    it('generates C major chord (C4 E4 G4)', () => {
+      const major = CHORD_SHAPES.find((s) => s.abbr === 'maj')!;
+      expect(chordPitches(60, major)).toEqual([60, 64, 67]);
+    });
+
+    it('generates A minor chord (A3 C4 E4)', () => {
+      const minor = CHORD_SHAPES.find((s) => s.abbr === 'min')!;
+      expect(chordPitches(57, minor)).toEqual([57, 60, 64]);
+    });
+
+    it('generates G7 chord', () => {
+      const dom7 = CHORD_SHAPES.find((s) => s.abbr === '7')!;
+      expect(chordPitches(67, dom7)).toEqual([67, 71, 74, 77]);
+    });
+
+    it('clips pitches above 127', () => {
+      const major = CHORD_SHAPES.find((s) => s.abbr === 'maj')!;
+      const result = chordPitches(126, major);
+      expect(result).toEqual([126]); // 130 and 133 clipped
+    });
+  });
+
+  describe('pitchToNoteName', () => {
+    it('converts middle C', () => {
+      expect(pitchToNoteName(60)).toBe('C4');
+    });
+
+    it('converts A4 (440Hz)', () => {
+      expect(pitchToNoteName(69)).toBe('A4');
+    });
+  });
+
+  describe('stampChord (store action)', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject();
+    });
+
+    it('stamps a major chord (3 notes) at once', () => {
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = useProjectStore.getState().ensureMidiClip(track.id);
+      const major = CHORD_SHAPES.find((s) => s.abbr === 'maj')!;
+
+      const noteIds = useProjectStore.getState().stampChord(
+        clip.id, 60, major.intervals, 0, 1, 100
+      );
+
+      expect(noteIds).toHaveLength(3);
+      const notes = useProjectStore.getState().project!.tracks[0].clips[0].midiData!.notes;
+      expect(notes).toHaveLength(3);
+      expect(notes.map((n) => n.pitch).sort()).toEqual([60, 64, 67]);
+      expect(notes.every((n) => n.velocity === 100)).toBe(true);
+    });
+
+    it('is undoable as a single action', () => {
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = useProjectStore.getState().ensureMidiClip(track.id);
+      const minor = CHORD_SHAPES.find((s) => s.abbr === 'min')!;
+
+      useProjectStore.getState().stampChord(clip.id, 60, minor.intervals, 0, 1);
+
+      expect(useProjectStore.getState().project!.tracks[0].clips[0].midiData!.notes).toHaveLength(3);
+
+      useProjectStore.getState().undo();
+
+      expect(useProjectStore.getState().project!.tracks[0].clips[0].midiData!.notes).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
stampChord() batch-adds chord notes. 12 shapes (maj/min/7th/sus/dim/aug/5/add9). 8 tests. 90/90 pass.