### PR TITLE
fix: keyboard shortcuts dialog scrollable (closes #118)

### DIFF
--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -129,7 +129,8 @@ export function KeyboardShortcutsDialog() {
         </div>
 
         {/* Body */}
-        <div className="flex-1 overflow-y-auto px-5 py-4 grid grid-cols-2 gap-x-8 gap-y-5 min-h-0">
+        <div className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
+          <div className="grid grid-cols-2 gap-x-8 gap-y-5">
           {SECTIONS.map((section) => (
             <div key={section.title}>
               <h3 className="text-[10px] font-bold uppercase tracking-widest text-zinc-500 mb-2">
@@ -149,6 +150,7 @@ export function KeyboardShortcutsDialog() {
               </div>
             </div>
           ))}
+          </div>
         </div>
 
         {/* Footer */}


### PR DESCRIPTION
## Problem
The Keyboard Shortcuts dialog content gets truncated when taller than the viewport, with no scrollbar appearing.

## Root Cause
The body container had both `grid` and `overflow-y-auto` on the same element. CSS grid on the scrollable container prevented overflow from triggering correctly.

## Fix
Separated the scrollable wrapper from the grid layout:
- Outer div: `flex-1 overflow-y-auto min-h-0` (handles scrolling)
- Inner div: `grid grid-cols-2 gap-x-8 gap-y-5` (handles layout)

The outer dialog already had `max-h-[85vh]` and `flex flex-col`, so with this separation the scroll now works correctly.

Closes #118