### PR TITLE
fix: mixer empty message no longer contradicts visible Master fader (#122)

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -163,15 +163,15 @@ export function MixerPanel() {
       />
       <div className="flex-1 overflow-x-auto overflow-y-hidden">
         <div className="flex items-stretch h-full">
+          {project.tracks.length === 0 && (
+            <div className="flex-1 flex items-center justify-center text-sm text-zinc-600">
+              Add tracks to see mixer channels
+            </div>
+          )}
           {project.tracks.map((track) => (
             <ChannelStrip key={track.id} track={track} faderHeight={faderHeight} />
           ))}
           <MasterStrip faderHeight={faderHeight} />
-          {project.tracks.length === 0 && (
-            <div className="flex-1 flex items-center justify-center text-sm text-zinc-600">
-              Add tracks to see the mixer
-            </div>
-          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem
The mixer panel shows "Add tracks to see the mixer" even though the Master fader is already visible, creating a contradictory UX.

## Fix
- Moved the empty-state message **before** the MasterStrip so it appears to the left of the Master fader
- Changed wording from "Add tracks to see the mixer" → "Add tracks to see mixer channels" since the mixer (Master fader) is already visible
- Master fader always renders last (rightmost), regardless of track count

Fixes #122