### PR TITLE
fix: ensure track name ellipsis works at default panel width (closes #121)

### DIFF
--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -178,7 +178,7 @@ export function TrackHeader({
           />
         ) : (
           <span
-            className="text-[11px] font-medium text-zinc-200 truncate cursor-text leading-tight"
+            className="text-[11px] font-medium text-zinc-200 block truncate cursor-text leading-tight"
             title={track.displayName}
             onDoubleClick={(e) => { e.stopPropagation(); startEditing(); }}
           >


### PR DESCRIPTION
## Problem
Track names are truncated at default panel width without visible ellipsis, and users have no way to see the full name.

## Fix
Added `block` display class to the track name `<span>` in `TrackHeader.tsx`. Tailwind's `truncate` utility (which sets `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`) requires a block-level element to take effect — it doesn't work on inline `<span>` elements.

The `title={track.displayName}` attribute was already present, providing the full track name as a tooltip on hover.

## Changes
- `src/components/tracks/TrackHeader.tsx`: Added `block` to the track name span's className

Closes #121