### PR TITLE
feat: add unit tests for sequencer swing (#116)

### DIFF
--- a/src/store/__tests__/projectStore.test.ts
+++ b/src/store/__tests__/projectStore.test.ts
@@ -247,6 +247,32 @@ describe('projectStore', () => {
     });
   });
 
+  describe('updateSequencerSwing', () => {
+    let trackId: string;
+
+    beforeEach(() => {
+      useProjectStore.getState().createProject();
+      const track = useProjectStore.getState().addTrack('drums', 'sequencer');
+      trackId = track.id;
+    });
+
+    it('sets swing amount on a sequencer pattern', () => {
+      useProjectStore.getState().updateSequencerSwing(trackId, 0.67);
+      const track = useProjectStore.getState().project!.tracks[0];
+      expect(track.sequencerPattern!.swing).toBe(0.67);
+    });
+
+    it('clamps swing value to 0–1 range', () => {
+      useProjectStore.getState().updateSequencerSwing(trackId, 1.5);
+      const track1 = useProjectStore.getState().project!.tracks[0];
+      expect(track1.sequencerPattern!.swing).toBe(1);
+
+      useProjectStore.getState().updateSequencerSwing(trackId, -0.3);
+      const track2 = useProjectStore.getState().project!.tracks[0];
+      expect(track2.sequencerPattern!.swing).toBe(0);
+    });
+  });
+
   describe('MIDI actions', () => {
     let clipId: string;
 


### PR DESCRIPTION
## Summary

Adds 2 unit tests for the `updateSequencerSwing` store action, completing test coverage for the swing/groove feature (Issue #116).

The swing feature itself (type, store action, toolbar UI, and DrumEngine playback offset) was already fully implemented. This PR adds the missing test coverage.

## Changes

- **`src/store/__tests__/projectStore.test.ts`**: Added `updateSequencerSwing` test suite
  - Test: sets swing amount on a sequencer pattern (0.67)
  - Test: clamps swing value to 0–1 range (rejects values >1 and <0)

## Verification

- All 30 tests pass (`vitest run`)
- TypeScript compiles with no errors (`tsc --noEmit`)

Closes #116