### PR TITLE
feat: track groups / folder tracks data model (closes #112)

### DIFF
--- a/src/store/__tests__/trackGroups.test.ts
+++ b/src/store/__tests__/trackGroups.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('Track Groups', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+  });
+
+  it('createGroupTrack creates a group track with isGroup=true and collapsed=false', () => {
+    const group = useProjectStore.getState().createGroupTrack('Strings Section');
+
+    expect(group.isGroup).toBe(true);
+    expect(group.collapsed).toBe(false);
+    expect(group.displayName).toBe('Strings Section');
+    expect(group.clips).toEqual([]);
+
+    const project = useProjectStore.getState().project!;
+    expect(project.tracks).toHaveLength(1);
+    expect(project.tracks[0].id).toBe(group.id);
+  });
+
+  it('moveTrackToGroup assigns parentTrackId and getGroupVolume averages children volumes', () => {
+    const group = useProjectStore.getState().createGroupTrack('My Group');
+    const track1 = useProjectStore.getState().addTrack('vocals');
+    const track2 = useProjectStore.getState().addTrack('bass');
+
+    useProjectStore.getState().updateTrack(track1.id, { volume: 0.6 });
+    useProjectStore.getState().updateTrack(track2.id, { volume: 1.0 });
+
+    useProjectStore.getState().moveTrackToGroup(track1.id, group.id);
+    useProjectStore.getState().moveTrackToGroup(track2.id, group.id);
+
+    const tracks = useProjectStore.getState().project!.tracks;
+    expect(tracks.find((t) => t.id === track1.id)!.parentTrackId).toBe(group.id);
+    expect(tracks.find((t) => t.id === track2.id)!.parentTrackId).toBe(group.id);
+
+    // Group volume = average of children: (0.6 + 1.0) / 2 = 0.8
+    const vol = useProjectStore.getState().getGroupVolume(group.id);
+    expect(vol).toBeCloseTo(0.8);
+  });
+
+  it('toggleGroupCollapse toggles the collapsed state back and forth', () => {
+    const group = useProjectStore.getState().createGroupTrack('Folder');
+    expect(group.collapsed).toBe(false);
+
+    useProjectStore.getState().toggleGroupCollapse(group.id);
+    let g = useProjectStore.getState().project!.tracks.find((t) => t.id === group.id)!;
+    expect(g.collapsed).toBe(true);
+
+    useProjectStore.getState().toggleGroupCollapse(group.id);
+    g = useProjectStore.getState().project!.tracks.find((t) => t.id === group.id)!;
+    expect(g.collapsed).toBe(false);
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -156,6 +156,12 @@ interface ProjectState {
   updateAutomationPoint: (trackId: string, parameter: AutomationParameter, pointIndex: number, updates: Partial<AutomationPoint>) => void;
   clearAutomationLane: (trackId: string, parameter: AutomationParameter) => void;
 
+  // Track grouping / folder tracks
+  createGroupTrack: (name: string) => Track;
+  moveTrackToGroup: (trackId: string, groupId: string | null) => void;
+  toggleGroupCollapse: (groupId: string) => void;
+  getGroupVolume: (groupId: string) => number;
+
   getTrackById: (trackId: string) => Track | undefined;
   getClipById: (clipId: string) => Clip | undefined;
   getTrackForClip: (clipId: string) => Track | undefined;
@@ -1917,6 +1923,79 @@ export const useProjectStore = create<ProjectState>()(
       (l: AutomationLane) => !(l.trackId === trackId && automationParamEquals(l.parameter, parameter)),
     );
     set({ project: { ...state.project, updatedAt: Date.now(), automationLanes: lanes } });
+  },
+
+  createGroupTrack: (name) => {
+    const state = get();
+    if (!state.project) throw new Error('No project');
+    _pushHistory(state.project);
+    const existingOrders = state.project.tracks.map((t) => t.order);
+    const maxOrder = existingOrders.length > 0 ? Math.max(...existingOrders) : 0;
+    const track: Track = {
+      id: uuidv4(),
+      trackName: 'custom',
+      displayName: name,
+      color: '#71717a',
+      order: maxOrder + 1,
+      volume: 0.8,
+      muted: false,
+      soloed: false,
+      clips: [],
+      isGroup: true,
+      collapsed: false,
+      effects: [],
+    };
+    const newTracks = [...state.project.tracks, track];
+    set({ project: { ...state.project, updatedAt: Date.now(), tracks: newTracks } });
+    return track;
+  },
+
+  moveTrackToGroup: (trackId, groupId) => {
+    const state = get();
+    if (!state.project) return;
+    if (groupId !== null) {
+      const group = state.project.tracks.find((t) => t.id === groupId);
+      if (!group || !group.isGroup) return;
+    }
+    const track = state.project.tracks.find((t) => t.id === trackId);
+    if (!track || track.isGroup) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, parentTrackId: groupId ?? undefined } : t,
+        ),
+      },
+    });
+  },
+
+  toggleGroupCollapse: (groupId) => {
+    const state = get();
+    if (!state.project) return;
+    const group = state.project.tracks.find((t) => t.id === groupId);
+    if (!group || !group.isGroup) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === groupId ? { ...t, collapsed: !t.collapsed } : t,
+        ),
+      },
+    });
+  },
+
+  getGroupVolume: (groupId) => {
+    const state = get();
+    if (!state.project) return 0;
+    const children = state.project.tracks.filter(
+      (t) => t.parentTrackId === groupId && !t.isGroup,
+    );
+    if (children.length === 0) return 0;
+    return children.reduce((sum, t) => sum + t.volume, 0) / children.length;
   },
 
   getTrackById: (trackId) => {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -183,6 +183,10 @@ export interface Track {
   soloed: boolean;
   armed?: boolean;
   clips: Clip[];
+  // Track grouping / folder tracks
+  parentTrackId?: string;
+  isGroup?: boolean;
+  collapsed?: boolean;
   sequencerPattern?: SequencerPattern;
   synthPreset?: SynthPreset;
   effects?: TrackEffect[];


### PR DESCRIPTION
## Summary

Implements the data model for track grouping / folder tracks (issue #112). No UI — store layer only.

## Changes

### `src/types/project.ts`
- Added `parentTrackId?: string` to `Track` — links a child track to its group
- Added `isGroup?: boolean` — marks a track as a folder/group container
- Added `collapsed?: boolean` — UI collapse state for the group

### `src/store/projectStore.ts`
- `createGroupTrack(name)` — creates a new group/folder track
- `moveTrackToGroup(trackId, groupId | null)` — assigns a track to a group (or ungroups with `null`); rejects nesting groups inside groups
- `toggleGroupCollapse(groupId)` — toggles the `collapsed` flag on a group track
- `getGroupVolume(groupId)` — returns the **average volume** of all direct children (summed, then averaged)

### `src/store/__tests__/trackGroups.test.ts`
- 3 unit tests covering all new actions
- All 163 tests pass

## Testing

```
npx vitest run
# Test Files  17 passed (17)
# Tests       163 passed (163)
```