### PR TITLE
feat: metronome sound + volume options

### DIFF
--- a/src/store/__tests__/transportStore.test.ts
+++ b/src/store/__tests__/transportStore.test.ts
@@ -3,7 +3,6 @@ import { useTransportStore } from '../transportStore';
 
 describe('transportStore', () => {
   beforeEach(() => {
-    // Reset store to initial state before each test
     useTransportStore.setState({
       isPlaying: false,
       isRecording: false,
@@ -13,6 +12,8 @@ describe('transportStore', () => {
       loopStart: 0,
       loopEnd: 0,
       metronomeEnabled: false,
+      metronomeSound: 'click',
+      metronomeVolume: 0.5,
     });
   });
 
@@ -78,6 +79,26 @@ describe('transportStore', () => {
       expect(useTransportStore.getState().metronomeEnabled).toBe(true);
       useTransportStore.getState().toggleMetronome();
       expect(useTransportStore.getState().metronomeEnabled).toBe(false);
+    });
+  });
+
+  describe('metronome sound and volume', () => {
+    it('setMetronomeSound changes metronome sound', () => {
+      expect(useTransportStore.getState().metronomeSound).toBe('click');
+      useTransportStore.getState().setMetronomeSound('woodblock');
+      expect(useTransportStore.getState().metronomeSound).toBe('woodblock');
+      useTransportStore.getState().setMetronomeSound('beep');
+      expect(useTransportStore.getState().metronomeSound).toBe('beep');
+    });
+
+    it('setMetronomeVolume sets volume clamped to 0-1', () => {
+      expect(useTransportStore.getState().metronomeVolume).toBe(0.5);
+      useTransportStore.getState().setMetronomeVolume(0.8);
+      expect(useTransportStore.getState().metronomeVolume).toBe(0.8);
+      useTransportStore.getState().setMetronomeVolume(-0.5);
+      expect(useTransportStore.getState().metronomeVolume).toBe(0);
+      useTransportStore.getState().setMetronomeVolume(1.5);
+      expect(useTransportStore.getState().metronomeVolume).toBe(1);
     });
   });
 

--- a/src/store/transportStore.ts
+++ b/src/store/transportStore.ts
@@ -11,6 +11,8 @@ interface TransportState {
   loopStart: number;
   loopEnd: number;
   metronomeEnabled: boolean;
+  metronomeSound: 'click' | 'woodblock' | 'beep';
+  metronomeVolume: number;
 
   play: () => void;
   pause: () => void;
@@ -26,6 +28,8 @@ interface TransportState {
   toggleLoop: () => void;
   setLoopRegion: (start: number, end: number) => void;
   toggleMetronome: () => void;
+  setMetronomeSound: (sound: 'click' | 'woodblock' | 'beep') => void;
+  setMetronomeVolume: (volume: number) => void;
 }
 
 export const useTransportStore = create<TransportState>((set) => ({
@@ -39,6 +43,8 @@ export const useTransportStore = create<TransportState>((set) => ({
   loopStart: 0,
   loopEnd: 0,
   metronomeEnabled: false,
+  metronomeSound: 'click',
+  metronomeVolume: 0.5,
 
   play: () => set({ isPlaying: true }),
   pause: () => set({ isPlaying: false }),
@@ -66,4 +72,6 @@ export const useTransportStore = create<TransportState>((set) => ({
   toggleLoop: () => set((s) => ({ loopEnabled: !s.loopEnabled })),
   setLoopRegion: (start, end) => set({ loopStart: start, loopEnd: end }),
   toggleMetronome: () => set((s) => ({ metronomeEnabled: !s.metronomeEnabled })),
+  setMetronomeSound: (sound) => set({ metronomeSound: sound }),
+  setMetronomeVolume: (volume) => set({ metronomeVolume: Math.max(0, Math.min(1, volume)) }),
 }));


### PR DESCRIPTION
## Summary
- Add `metronomeSound` state (`'click' | 'woodblock' | 'beep'`, default `'click'`) and `setMetronomeSound()` action to transport store
- Add `metronomeVolume` state (`0-1`, default `0.5`) and `setMetronomeVolume()` action with clamping to transport store
- Add 2 unit tests covering sound selection and volume clamping

## Test plan
- [x] `setMetronomeSound` cycles through all three sound types
- [x] `setMetronomeVolume` clamps values to 0-1 range
- [x] All 16 transport store tests pass
- [x] No new type errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)