### PR TITLE
feat: track freeze/unfreeze data model

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -150,6 +150,10 @@ interface ProjectState {
   removeTrackEffect: (trackId: string, effectId: string) => void;
   reorderTrackEffect: (trackId: string, fromIndex: number, toIndex: number) => void;
 
+  // Track freeze
+  freezeTrack: (trackId: string) => void;
+  unfreezeTrack: (trackId: string) => void;
+
   // Automation
   addAutomationPoint: (trackId: string, parameter: AutomationParameter, point: AutomationPoint) => void;
   removeAutomationPoint: (trackId: string, parameter: AutomationParameter, pointIndex: number) => void;
@@ -1917,6 +1921,38 @@ export const useProjectStore = create<ProjectState>()(
       (l: AutomationLane) => !(l.trackId === trackId && automationParamEquals(l.parameter, parameter)),
     );
     set({ project: { ...state.project, updatedAt: Date.now(), automationLanes: lanes } });
+  },
+
+  // ─── Track Freeze ──────────────────────────────────────────────────────────
+
+  freezeTrack: (trackId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, frozen: true } : t,
+        ),
+      },
+    });
+  },
+
+  unfreezeTrack: (trackId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, frozen: false, frozenAudioKey: undefined } : t,
+        ),
+      },
+    });
   },
 
   getTrackById: (trackId) => {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -203,6 +203,10 @@ export interface Track {
   localCaption?: string;
   /** Per-track lane height in pixels (default 64, min 40, max 200). */
   laneHeight?: number;
+  /** Whether the track is frozen (rendered to audio for CPU savings). */
+  frozen?: boolean;
+  /** IndexedDB key of the frozen audio bounce. */
+  frozenAudioKey?: string;
 }
 
 /** Persistent asset entry — survives clip/track removal. Only deleted explicitly from the Assets panel. */

--- a/tests/unit/trackFreeze.test.ts
+++ b/tests/unit/trackFreeze.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Project } from '../../src/types/project';
+import { useProjectStore } from '../../src/store/projectStore';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+function makeProject(): Project {
+  return {
+    id: 'project-1',
+    name: 'Test Project',
+    createdAt: 1,
+    updatedAt: 1,
+    bpm: 120,
+    keyScale: 'C major',
+    timeSignature: 4,
+    totalDuration: 128,
+    measures: 64,
+    tracks: [],
+    generationDefaults: {
+      inferenceSteps: 20,
+      guidanceScale: 7.5,
+      shift: 0,
+      thinking: false,
+      model: 'test-model',
+    },
+    globalCaption: '',
+    automationLanes: [],
+    assets: [],
+  };
+}
+
+describe('track freeze / unfreeze', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+  });
+
+  it('freezeTrack sets frozen=true on the target track', () => {
+    const store = useProjectStore.getState();
+    store.setProject(makeProject());
+    const track = store.addTrack('drums');
+
+    useProjectStore.getState().freezeTrack(track.id);
+
+    const updated = useProjectStore.getState().project!.tracks.find((t) => t.id === track.id)!;
+    expect(updated.frozen).toBe(true);
+  });
+
+  it('unfreezeTrack sets frozen=false and clears frozenAudioKey', () => {
+    const store = useProjectStore.getState();
+    store.setProject(makeProject());
+    const track = store.addTrack('vocals');
+
+    // Simulate a frozen track with audio key
+    useProjectStore.getState().freezeTrack(track.id);
+    // Manually set frozenAudioKey to simulate bounce
+    useProjectStore.setState({
+      project: {
+        ...useProjectStore.getState().project!,
+        tracks: useProjectStore.getState().project!.tracks.map((t) =>
+          t.id === track.id ? { ...t, frozenAudioKey: 'audio-key-123' } : t,
+        ),
+      },
+    });
+
+    useProjectStore.getState().unfreezeTrack(track.id);
+
+    const updated = useProjectStore.getState().project!.tracks.find((t) => t.id === track.id)!;
+    expect(updated.frozen).toBe(false);
+    expect(updated.frozenAudioKey).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `frozen?: boolean` and `frozenAudioKey?: string` fields to the `Track` interface
- Add `freezeTrack(trackId)` and `unfreezeTrack(trackId)` store actions with undo support
- `unfreezeTrack` clears both `frozen` flag and `frozenAudioKey`

## Test plan
- [x] `freezeTrack` sets `frozen=true` on target track
- [x] `unfreezeTrack` sets `frozen=false` and clears `frozenAudioKey`
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] All 99 unit tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)