### PR TITLE
feat: split stereo pan mode

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -88,6 +88,8 @@ interface ProjectState {
 
   updateProject: (updates: Partial<Pick<Project, 'globalCaption' | 'bpm' | 'keyScale' | 'timeSignature' | 'name' | 'masterVolume' | 'measures'>>) => void;
   updateTrackMixer: (trackId: string, updates: Partial<Pick<Track, 'pan' | 'eqLowGain' | 'eqMidGain' | 'eqHighGain' | 'compressorEnabled' | 'compressorThreshold' | 'compressorRatio'>>) => void;
+  setPanMode: (trackId: string, mode: 'stereo' | 'dual-mono') => void;
+  setDualMonoPan: (trackId: string, left: number, right: number) => void;
   setTrackLocalCaption: (trackId: string, caption: string) => void;
   setTrackReverb: (trackId: string, mix: number, roomSize: number) => void;
 
@@ -362,6 +364,37 @@ export const useProjectStore = create<ProjectState>()(
         updatedAt: Date.now(),
         tracks: state.project.tracks.map((t) =>
           t.id === trackId ? { ...t, ...updates } : t,
+        ),
+      },
+    });
+  },
+
+  setPanMode: (trackId, mode) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, panMode: mode } : t,
+        ),
+      },
+    });
+  },
+
+  setDualMonoPan: (trackId, left, right) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const clamp = (v: number) => Math.max(-1, Math.min(1, v));
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, panLeft: clamp(left), panRight: clamp(right) } : t,
         ),
       },
     });

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -189,6 +189,9 @@ export interface Track {
   drumKit?: DrumKitName;
   // Mixer / channel-strip settings
   pan?: number;               // -1 (full left) to +1 (full right), default 0
+  panMode?: 'stereo' | 'dual-mono';  // default 'stereo'
+  panLeft?: number;            // dual-mono left channel pan, -1 to +1, default -1
+  panRight?: number;           // dual-mono right channel pan, -1 to +1, default 1
   eqLowGain?: number;         // dB ±15, low shelf at 250 Hz, default 0
   eqMidGain?: number;         // dB ±15, peak at 1 kHz, default 0
   eqHighGain?: number;        // dB ±15, high shelf at 8 kHz, default 0

--- a/tests/unit/splitStereoPan.test.ts
+++ b/tests/unit/splitStereoPan.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Project } from '../../src/types/project';
+import { useProjectStore } from '../../src/store/projectStore';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+function makeProject(): Project {
+  return {
+    id: 'project-1',
+    name: 'Test Project',
+    createdAt: 1,
+    updatedAt: 1,
+    bpm: 120,
+    keyScale: 'C major',
+    timeSignature: 4,
+    totalDuration: 128,
+    measures: 64,
+    tracks: [
+      {
+        id: 'track-1',
+        trackName: 'vocals',
+        displayName: 'Vocals',
+        color: '#ff0000',
+        order: 0,
+        volume: 0.8,
+        muted: false,
+        soloed: false,
+        clips: [],
+      },
+    ],
+    generationDefaults: {
+      inferenceSteps: 20,
+      guidanceScale: 7.5,
+      shift: 0,
+      thinking: false,
+      model: 'test-model',
+    },
+    globalCaption: '',
+    automationLanes: [],
+    assets: [],
+  };
+}
+
+describe('split stereo pan', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+  });
+
+  it('setPanMode switches a track between stereo and dual-mono', () => {
+    const store = useProjectStore.getState();
+    store.setProject(makeProject());
+
+    store.setPanMode('track-1', 'dual-mono');
+    expect(useProjectStore.getState().project!.tracks[0].panMode).toBe('dual-mono');
+
+    store.setPanMode('track-1', 'stereo');
+    expect(useProjectStore.getState().project!.tracks[0].panMode).toBe('stereo');
+  });
+
+  it('setDualMonoPan sets left/right pan and clamps to [-1, 1]', () => {
+    const store = useProjectStore.getState();
+    store.setProject(makeProject());
+
+    store.setDualMonoPan('track-1', -0.5, 0.75);
+    const track1 = useProjectStore.getState().project!.tracks[0];
+    expect(track1.panLeft).toBe(-0.5);
+    expect(track1.panRight).toBe(0.75);
+
+    // Values outside [-1, 1] should be clamped
+    store.setDualMonoPan('track-1', -2, 3);
+    const track2 = useProjectStore.getState().project!.tracks[0];
+    expect(track2.panLeft).toBe(-1);
+    expect(track2.panRight).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `panMode`, `panLeft`, `panRight` fields to `Track` type for dual-mono panning
- Add `setPanMode(trackId, mode)` and `setDualMonoPan(trackId, left, right)` store actions
- Values are clamped to [-1, 1] range

## Test plan
- [x] `setPanMode` switches between 'stereo' and 'dual-mono'
- [x] `setDualMonoPan` sets left/right pan values
- [x] Out-of-range values are clamped to [-1, 1]
- [x] All 99 existing unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)