### PR TITLE
feat: stem export

### DIFF
--- a/src/engine/exportMix.ts
+++ b/src/engine/exportMix.ts
@@ -171,3 +171,15 @@ export async function exportMixToWav(
   const rendered = await offlineCtx.startRendering();
   return audioBufferToWavBlob(rendered);
 }
+
+/**
+ * Render a single track's clips to a stereo WAV blob.
+ * Same pipeline as exportMixToWav but semantically scoped to one track.
+ */
+export async function exportStemToWav(
+  clips: ExportClip[],
+  totalDuration: number,
+  sampleRate: number = 48000,
+): Promise<Blob> {
+  return exportMixToWav(clips, totalDuration, sampleRate);
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -32,6 +32,10 @@ import {
   DEFAULT_GENERATION,
 } from '../constants/defaults';
 import { saveProject as saveProjectToIDB } from '../services/projectStorage';
+import { exportStemToWav, type ExportClip } from '../engine/exportMix';
+import { loadAudioBlobByKey } from '../services/audioFileManager';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+import { renderMidiTrackOffline, renderSequencerTrackOffline } from '../engine/offlineRender';
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
   return (60 / bpm) * timeSig;
@@ -164,6 +168,9 @@ interface ProjectState {
   getTotalDuration: () => number;
   /** Actual audio duration without timeline padding: max(clip ends) */
   getAudioDuration: () => number;
+
+  /** Export each track as a separate WAV file (stem export). */
+  exportStems: () => Promise<void>;
 }
 
 function computeTotalDuration(
@@ -1962,6 +1969,57 @@ export const useProjectStore = create<ProjectState>()(
       }
     }
     return Math.max(MIN_TIMELINE_DURATION, maxEnd);
+  },
+
+  exportStems: async () => {
+    const project = get().project;
+    if (!project) return;
+
+    const engine = getAudioEngine();
+    const totalDuration = project.totalDuration;
+
+    for (const track of project.tracks) {
+      const clips: ExportClip[] = [];
+
+      if (track.trackType === 'pianoRoll') {
+        for (const clip of track.clips) {
+          const notes = clip.midiData?.notes ?? [];
+          if (notes.length === 0) continue;
+          const buffer = await renderMidiTrackOffline(
+            notes, clip.startTime, project.bpm,
+            track.synthPreset ?? 'piano', totalDuration,
+          );
+          clips.push({ startTime: 0, buffer, volume: track.volume, pan: track.pan ?? 0, effects: track.effects });
+        }
+      }
+
+      if (track.trackType === 'sequencer' && track.sequencerPattern) {
+        const buffer = await renderSequencerTrackOffline(
+          track.sequencerPattern, project.bpm, totalDuration, track.drumKit ?? '808',
+        );
+        clips.push({ startTime: 0, buffer, volume: track.volume, pan: track.pan ?? 0, effects: track.effects });
+      }
+
+      for (const clip of track.clips) {
+        if (clip.generationStatus === 'ready' && clip.isolatedAudioKey) {
+          const blob = await loadAudioBlobByKey(clip.isolatedAudioKey);
+          if (blob) {
+            const buffer = await engine.decodeAudioData(blob);
+            clips.push({ startTime: clip.startTime, buffer, volume: track.volume, pan: track.pan ?? 0, effects: track.effects });
+          }
+        }
+      }
+
+      if (clips.length === 0) continue;
+
+      const wavBlob = await exportStemToWav(clips, totalDuration);
+      const url = URL.createObjectURL(wavBlob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${project.name}_${track.displayName}.wav`;
+      a.click();
+      URL.revokeObjectURL(url);
+    }
   },
 }),
     {

--- a/tests/unit/exportStem.test.ts
+++ b/tests/unit/exportStem.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { exportStemToWav, type ExportClip } from '../../src/engine/exportMix';
+
+function createMockAudioBuffer(lengthInSamples: number, sampleRate: number): AudioBuffer {
+  const data = new Float32Array(lengthInSamples);
+  return {
+    numberOfChannels: 2,
+    sampleRate,
+    length: lengthInSamples,
+    duration: lengthInSamples / sampleRate,
+    getChannelData: () => data,
+  } as unknown as AudioBuffer;
+}
+
+describe('exportStemToWav', () => {
+  it('renders clips to a WAV blob with correct RIFF header', async () => {
+    const sampleRate = 8000;
+    const totalDuration = 1;
+    const lengthInSamples = sampleRate * totalDuration;
+
+    const mockRenderedBuffer = createMockAudioBuffer(lengthInSamples, sampleRate);
+
+    const mockGainNode = {
+      gain: { value: 1 },
+      connect: vi.fn(),
+    };
+
+    const mockSource = {
+      buffer: null as AudioBuffer | null,
+      connect: vi.fn(),
+      start: vi.fn(),
+    };
+
+    const MockOfflineAudioContext = vi.fn(function (this: Record<string, unknown>) {
+      this.createBufferSource = vi.fn(() => mockSource);
+      this.createGain = vi.fn(() => mockGainNode);
+      this.createStereoPanner = vi.fn(() => ({
+        pan: { value: 0 },
+        connect: vi.fn(),
+      }));
+      this.destination = {};
+      this.startRendering = vi.fn(async () => mockRenderedBuffer);
+    });
+
+    vi.stubGlobal('OfflineAudioContext', MockOfflineAudioContext);
+
+    const clips: ExportClip[] = [
+      {
+        startTime: 0,
+        buffer: createMockAudioBuffer(lengthInSamples, sampleRate),
+        volume: 0.8,
+      },
+    ];
+
+    const blob = await exportStemToWav(clips, totalDuration, sampleRate);
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('audio/wav');
+
+    const arrayBuffer = await blob.arrayBuffer();
+    const view = new DataView(arrayBuffer);
+    const riff = String.fromCharCode(
+      view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3),
+    );
+    expect(riff).toBe('RIFF');
+
+    const wave = String.fromCharCode(
+      view.getUint8(8), view.getUint8(9), view.getUint8(10), view.getUint8(11),
+    );
+    expect(wave).toBe('WAVE');
+
+    expect(view.getUint32(24, true)).toBe(sampleRate);
+    expect(mockSource.start).toHaveBeenCalledWith(0);
+    expect(mockGainNode.gain.value).toBe(0.8);
+
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `exportStemToWav()` in `src/engine/exportMix.ts` — renders a single track's clips to a stereo WAV blob
- Add `exportStems` store action in `src/store/projectStore.ts` — iterates all tracks and downloads each as a separate WAV file (audio clips, MIDI piano roll, and sequencer patterns)
- Add unit test verifying WAV output with correct RIFF header

## Test plan
- [x] `npx vitest run tests/unit/exportStem.test.ts` — passes
- [x] `npm run build` — succeeds with 0 errors
- [x] All 98 existing unit tests pass
- [ ] Manual test: open project with multiple tracks, call `window.__store.getState().exportStems()` — downloads one WAV per track

🤖 Generated with [Claude Code](https://claude.com/claude-code)