### PR TITLE
feat: track color palette (16 Ableton-style colors)

### DIFF
--- a/src/constants/colorPalette.ts
+++ b/src/constants/colorPalette.ts
@@ -1,0 +1,40 @@
+/**
+ * 16 DAW-standard track colors inspired by Ableton Live's palette.
+ * Used for automatic track color assignment.
+ */
+export const TRACK_COLOR_PALETTE: string[] = [
+  '#FF6B6B', // Red
+  '#FF9F43', // Orange
+  '#FECA57', // Yellow
+  '#BADC58', // Yellow-Green
+  '#6AB04C', // Green
+  '#22A6B3', // Teal
+  '#7ED6DF', // Cyan
+  '#4A90D9', // Blue
+  '#686DE0', // Indigo
+  '#BE2EDD', // Purple
+  '#E056A0', // Magenta
+  '#FF7979', // Salmon
+  '#F8A5C2', // Pink
+  '#C4A35A', // Gold
+  '#95AAB5', // Slate
+  '#A29BFE', // Lavender
+];
+
+/**
+ * Returns the next unused color from the palette.
+ * Cycles through the palette sequentially, skipping colors already in use.
+ * If all colors are used, wraps around and picks based on count.
+ */
+export function getNextTrackColor(existingColors: string[]): string {
+  const normalised = new Set(existingColors.map((c) => c.toUpperCase()));
+
+  for (const color of TRACK_COLOR_PALETTE) {
+    if (!normalised.has(color.toUpperCase())) {
+      return color;
+    }
+  }
+
+  // All 16 used — cycle based on count
+  return TRACK_COLOR_PALETTE[existingColors.length % TRACK_COLOR_PALETTE.length];
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_GENERATION,
 } from '../constants/defaults';
 import { saveProject as saveProjectToIDB } from '../services/projectStorage';
+import { getNextTrackColor } from '../constants/colorPalette';
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
   return (60 / bpm) * timeSig;
@@ -415,7 +416,7 @@ export const useProjectStore = create<ProjectState>()(
       trackType: resolvedType,
       trackName,
       displayName,
-      color: info.color,
+      color: getNextTrackColor(state.project.tracks.map((t) => t.color)),
       order: maxOrder + 1,
       volume: 0.8,
       muted: false,

--- a/tests/unit/colorPalette.test.ts
+++ b/tests/unit/colorPalette.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { TRACK_COLOR_PALETTE, getNextTrackColor } from '../../src/constants/colorPalette';
+
+describe('getNextTrackColor', () => {
+  it('returns the first palette color when no tracks exist', () => {
+    expect(getNextTrackColor([])).toBe(TRACK_COLOR_PALETTE[0]);
+  });
+
+  it('skips colors already in use and returns the next unused one', () => {
+    const used = [TRACK_COLOR_PALETTE[0], TRACK_COLOR_PALETTE[1]];
+    expect(getNextTrackColor(used)).toBe(TRACK_COLOR_PALETTE[2]);
+  });
+
+  it('wraps around when all 16 colors are used', () => {
+    const allUsed = [...TRACK_COLOR_PALETTE];
+    const result = getNextTrackColor(allUsed);
+    expect(TRACK_COLOR_PALETTE).toContain(result);
+    expect(result).toBe(TRACK_COLOR_PALETTE[allUsed.length % TRACK_COLOR_PALETTE.length]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `TRACK_COLOR_PALETTE` constant with 16 DAW-standard colors (Ableton-inspired)
- Add `getNextTrackColor(existingColors)` that picks the next unused palette color
- Update `addTrack` in `projectStore` to use palette-based color assignment instead of static per-instrument colors

## Test plan
- [ ] Verify `getNextTrackColor` returns first color when no tracks exist
- [ ] Verify it skips already-used colors
- [ ] Verify it wraps around when all 16 are used
- [ ] 3 unit tests included and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)