### PR TITLE
feat: input monitoring for recording tracks

### DIFF
--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
-import type { Track } from '../../types/project';
+import type { Track, InputMonitoringMode } from '../../types/project';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { TRACK_CATALOG } from '../../constants/tracks';
@@ -30,6 +30,7 @@ export function TrackHeader({
   const renameTrack = useProjectStore((s) => s.renameTrack);
   const removeTrack = useProjectStore((s) => s.removeTrack);
   const duplicateTrack = useProjectStore((s) => s.duplicateTrack);
+  const setInputMonitoring = useProjectStore((s) => s.setInputMonitoring);
 
   // Check if any track is soloed — if so, non-soloed tracks are "implied muted"
   const anySoloed = useProjectStore((s) => s.project?.tracks.some((t) => t.soloed) ?? false);
@@ -68,6 +69,11 @@ export function TrackHeader({
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
   const isCompact = laneHeight < 52;
   const isArmed = armedTrackIds.includes(track.id) || !!track.armed;
+  const monitorMode: InputMonitoringMode = track.inputMonitoring ?? 'off';
+  const cycleMonitor = useCallback(() => {
+    const next: Record<InputMonitoringMode, InputMonitoringMode> = { off: 'auto', auto: 'on', on: 'off' };
+    setInputMonitoring(track.id, next[monitorMode]);
+  }, [track.id, monitorMode, setInputMonitoring]);
 
   const onHeightResizeDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -255,6 +261,25 @@ export function TrackHeader({
         >
           <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
             <circle cx="6" cy="6" r="3.25" fill={isArmed ? 'currentColor' : 'none'} />
+          </svg>
+        </button>
+        {/* Input monitoring — cycles off → auto → on */}
+        <button
+          onClick={cycleMonitor}
+          className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
+            monitorMode === 'on'
+              ? 'bg-cyan-600/90 text-white'
+              : monitorMode === 'auto'
+                ? 'bg-cyan-600/50 text-cyan-200'
+                : 'text-zinc-500 hover:text-cyan-400 hover:bg-[#444]'
+          }`}
+          title={`Input monitoring: ${monitorMode} (click to cycle off→auto→on)`}
+          aria-label={`Input monitoring ${track.displayName}: ${monitorMode}`}
+        >
+          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round">
+            <path d="M2 7V6a4 4 0 018 0v1" />
+            <rect x="1" y="7" width="2.5" height="3" rx="0.5" fill={monitorMode !== 'off' ? 'currentColor' : 'none'} />
+            <rect x="8.5" y="7" width="2.5" height="3" rx="0.5" fill={monitorMode !== 'off' ? 'currentColor' : 'none'} />
           </svg>
         </button>
         {/* Automation toggle */}

--- a/src/store/__tests__/inputMonitoring.test.ts
+++ b/src/store/__tests__/inputMonitoring.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+// Mock projectStorage to prevent IndexedDB calls during testing
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('setInputMonitoring', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    useProjectStore.getState().addTrack('vocals');
+  });
+
+  it('sets input monitoring mode on a track and cycles correctly', () => {
+    const trackId = useProjectStore.getState().project!.tracks[0].id;
+
+    // Default should be undefined (treated as 'off' in the UI)
+    expect(useProjectStore.getState().project!.tracks[0].inputMonitoring).toBeUndefined();
+
+    useProjectStore.getState().setInputMonitoring(trackId, 'auto');
+    expect(useProjectStore.getState().project!.tracks[0].inputMonitoring).toBe('auto');
+
+    useProjectStore.getState().setInputMonitoring(trackId, 'on');
+    expect(useProjectStore.getState().project!.tracks[0].inputMonitoring).toBe('on');
+
+    useProjectStore.getState().setInputMonitoring(trackId, 'off');
+    expect(useProjectStore.getState().project!.tracks[0].inputMonitoring).toBe('off');
+  });
+
+  it('does not affect other tracks when setting input monitoring', () => {
+    useProjectStore.getState().addTrack('drums');
+    const tracks = useProjectStore.getState().project!.tracks;
+    const vocalsId = tracks[0].id;
+    const drumsId = tracks[1].id;
+
+    useProjectStore.getState().setInputMonitoring(vocalsId, 'on');
+
+    const updated = useProjectStore.getState().project!.tracks;
+    expect(updated.find((t) => t.id === vocalsId)!.inputMonitoring).toBe('on');
+    expect(updated.find((t) => t.id === drumsId)!.inputMonitoring).toBeUndefined();
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -8,6 +8,7 @@ import type {
   ClipVersion,
   TrackName,
   TrackType,
+  InputMonitoringMode,
   ClipGenerationStatus,
   AssetClip,
   SequencerPattern,
@@ -96,6 +97,7 @@ interface ProjectState {
   duplicateTrack: (trackId: string) => Track | undefined;
   updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'armed' | 'laneHeight' | 'trackType' | 'synthPreset' | 'drumKit' | 'color'>>) => void;
   renameTrack: (trackId: string, newName: string) => void;
+  setInputMonitoring: (trackId: string, mode: InputMonitoringMode) => void;
   reorderTrack: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
 
   addClip: (trackId: string, clip: Omit<Clip, 'id' | 'trackId' | 'generationStatus' | 'generationJobId' | 'cumulativeMixKey' | 'isolatedAudioKey' | 'waveformPeaks'>) => Clip;
@@ -537,6 +539,21 @@ export const useProjectStore = create<ProjectState>()(
         updatedAt: Date.now(),
         tracks: state.project.tracks.map((t) =>
           t.id === trackId ? { ...t, displayName: newName } : t,
+        ),
+      },
+    });
+  },
+
+  setInputMonitoring: (trackId, mode) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, inputMonitoring: mode } : t,
         ),
       },
     });

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -5,6 +5,7 @@ export type TrackName =
   | 'custom';
 
 export type TrackType = 'stems' | 'sample' | 'sequencer' | 'pianoRoll';
+export type InputMonitoringMode = 'off' | 'auto' | 'on';
 export type SynthPreset = 'piano' | 'strings' | 'pad' | 'lead' | 'bass' | 'organ';
 export type DrumKitName = '808' | 'acoustic' | 'electronic' | 'lofi';
 export type PianoRollGrid = '1/4' | '1/8' | '1/16' | '1/32';
@@ -182,6 +183,7 @@ export interface Track {
   muted: boolean;
   soloed: boolean;
   armed?: boolean;
+  inputMonitoring?: InputMonitoringMode;
   clips: Clip[];
   sequencerPattern?: SequencerPattern;
   synthPreset?: SynthPreset;


### PR DESCRIPTION
## Summary

Adds input monitoring support to recording tracks.

### Changes

- **`src/types/project.ts`** — New `InputMonitoringMode` type (`'off' | 'auto' | 'on'`) and optional `inputMonitoring` field on `Track`
- **`src/store/projectStore.ts`** — New `setInputMonitoring(trackId, mode)` action with undo/redo support
- **`src/components/tracks/TrackHeader.tsx`** — Small headphone icon button that cycles through off → auto → on modes with colour feedback (grey / dim-cyan / bright-cyan)
- **`src/store/__tests__/inputMonitoring.test.ts`** — 2 unit tests: cycling all modes, isolation to single track

### Test results

```
✓ src/store/__tests__/inputMonitoring.test.ts (2 tests) 3ms
```

Build: ✅ `vite build` succeeds (no TS errors)