### PR TITLE
feat: track color palette (closes #160)

### DIFF
--- a/src/constants/colorPalette.ts
+++ b/src/constants/colorPalette.ts
@@ -1,0 +1,25 @@
+export const TRACK_COLOR_PALETTE = [
+  '#ef4444',
+  '#f97316',
+  '#eab308',
+  '#22c55e',
+  '#14b8a6',
+  '#06b6d4',
+  '#3b82f6',
+  '#8b5cf6',
+  '#a855f7',
+  '#d946ef',
+  '#ec4899',
+  '#f43f5e',
+  '#71717a',
+  '#fbbf24',
+  '#34d399',
+  '#60a5fa',
+];
+
+export function getNextTrackColor(existingColors: string[]): string {
+  const unused = TRACK_COLOR_PALETTE.find(
+    (color) => !existingColors.includes(color),
+  );
+  return unused ?? TRACK_COLOR_PALETTE[0];
+}

--- a/tests/unit/colorPalette.test.ts
+++ b/tests/unit/colorPalette.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TRACK_COLOR_PALETTE,
+  getNextTrackColor,
+} from '../../src/constants/colorPalette';
+
+describe('getNextTrackColor', () => {
+  it('returns the first palette color when no colors are in use', () => {
+    expect(getNextTrackColor([])).toBe(TRACK_COLOR_PALETTE[0]);
+  });
+
+  it('returns the first unused color from the palette', () => {
+    const used = TRACK_COLOR_PALETTE.slice(0, 3);
+    expect(getNextTrackColor(used)).toBe(TRACK_COLOR_PALETTE[3]);
+  });
+
+  it('wraps to the first palette color when all colors are in use', () => {
+    expect(getNextTrackColor([...TRACK_COLOR_PALETTE])).toBe(
+      TRACK_COLOR_PALETTE[0],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `TRACK_COLOR_PALETTE` constant with 16 distinct track colors
- Add `getNextTrackColor(existingColors)` helper that returns the first unused palette color (wraps when exhausted)
- Include 3 unit tests covering empty, partial, and full-palette scenarios

## Test plan
- [x] `npm run build` passes
- [x] All 102 unit tests pass (`npx vitest run tests/unit/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)