### PR TITLE
fix: widen BPM input field in Settings dialog

### DIFF
--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -245,7 +245,7 @@ export function SettingsDialog() {
                   onChange={(e) => setBpm(parseInt(e.target.value) || 120)}
                   min={40}
                   max={300}
-                  className="flex-1 min-w-0 px-3 py-1.5 text-sm text-zinc-200 bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
+                  className="flex-1 min-w-[3.5rem] px-2 py-1.5 text-sm text-zinc-200 bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
                 />
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- Fixes #184: BPM input field in Settings dialog was too narrow when sharing space with the TAP button
- Changed `min-w-0` to `min-w-[3.5rem]` so the input maintains a usable minimum width within the flex layout

## Test plan
- [ ] Open Settings dialog and verify BPM input is wide enough to display 3-digit values
- [ ] Verify TAP button still renders alongside the input without overflow
- [ ] Confirm no layout shifts in the Project settings grid row

🤖 Generated with [Claude Code](https://claude.com/claude-code)