### PR TITLE
feat: sidechain compression with cross-track routing (closes #196)

### DIFF
--- a/src/store/__tests__/sidechainCompression.test.ts
+++ b/src/store/__tests__/sidechainCompression.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({ saveProject: vi.fn() }));
+
+describe('sidechain compression with cross-track routing', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject({ name: 'Test', bpm: 120 });
+  });
+
+  it('setSidechainSource sets the sidechain source trackId on a compressor effect', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('stems');
+    store.addTrack('stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+    const kickTrackId = tracks[0].id;
+    const bassTrackId = tracks[1].id;
+
+    const effectId = store.addTrackEffect(bassTrackId, 'compressor')!;
+    expect(effectId).toBeDefined();
+
+    useProjectStore.getState().setSidechainSource(bassTrackId, effectId, kickTrackId);
+
+    const updatedTrack = useProjectStore.getState().project!.tracks.find(t => t.id === bassTrackId)!;
+    const compressor = updatedTrack.effects.find(e => e.id === effectId)!;
+    expect(compressor.type).toBe('compressor');
+    expect((compressor.params as { sidechainSourceTrackId?: string }).sidechainSourceTrackId).toBe(kickTrackId);
+  });
+
+  it('setSidechainSource can clear the sidechain by passing undefined', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('stems');
+    store.addTrack('stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+    const kickTrackId = tracks[0].id;
+    const bassTrackId = tracks[1].id;
+
+    const effectId = store.addTrackEffect(bassTrackId, 'compressor')!;
+
+    useProjectStore.getState().setSidechainSource(bassTrackId, effectId, kickTrackId);
+    let compressor = useProjectStore.getState().project!.tracks.find(t => t.id === bassTrackId)!
+      .effects.find(e => e.id === effectId)!;
+    expect((compressor.params as { sidechainSourceTrackId?: string }).sidechainSourceTrackId).toBe(kickTrackId);
+
+    useProjectStore.getState().setSidechainSource(bassTrackId, effectId, undefined);
+    compressor = useProjectStore.getState().project!.tracks.find(t => t.id === bassTrackId)!
+      .effects.find(e => e.id === effectId)!;
+    expect((compressor.params as { sidechainSourceTrackId?: string }).sidechainSourceTrackId).toBeUndefined();
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -18,6 +18,7 @@ import type {
   PianoRollGrid,
   TrackEffect,
   TrackEffectType,
+  CompressorParams,
   AutomationParameter,
   AutomationPoint,
   AutomationLane,
@@ -165,6 +166,7 @@ interface ProjectState {
   updateTrackEffect: (trackId: string, effectId: string, updates: Partial<TrackEffect>) => void;
   removeTrackEffect: (trackId: string, effectId: string) => void;
   reorderTrackEffect: (trackId: string, fromIndex: number, toIndex: number) => void;
+  setSidechainSource: (trackId: string, effectId: string, sourceTrackId: string | undefined) => void;
 
   // Automation
   addAutomationPoint: (trackId: string, parameter: AutomationParameter, point: AutomationPoint) => void;
@@ -1994,6 +1996,34 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
+
+  setSidechainSource: (trackId, effectId, sourceTrackId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) => {
+          if (track.id !== trackId) return track;
+          return {
+            ...track,
+            effects: (track.effects ?? []).map((effect) => {
+              if (effect.id !== effectId || effect.type !== 'compressor') return effect;
+              const params = { ...effect.params } as CompressorParams;
+              if (sourceTrackId === undefined) {
+                delete params.sidechainSourceTrackId;
+              } else {
+                params.sidechainSourceTrackId = sourceTrackId;
+              }
+              return { ...effect, params } as TrackEffect;
+            }),
+          };
+        }),
+      },
+    });
+  },
   // ─── Automation ───────────────────────────────────────────────────────────
 
   addAutomationPoint: (trackId, parameter, point) => {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -47,6 +47,7 @@ export interface CompressorParams {
   attack: number;
   release: number;
   knee: number;
+  sidechainSourceTrackId?: string;
 }
 
 export interface ReverbParams {


### PR DESCRIPTION
## Summary
- Added optional `sidechainSourceTrackId` field to `CompressorParams` type for cross-track sidechain routing
- Added `setSidechainSource(trackId, effectId, sourceTrackId)` store action that sets/clears the sidechain source on compressor effects
- Includes 2 unit tests: setting a sidechain source and clearing it with `undefined`

## Test plan
- [x] `setSidechainSource` correctly sets `sidechainSourceTrackId` on a compressor effect
- [x] `setSidechainSource` can clear the sidechain by passing `undefined`
- [x] All 194 unit tests pass
- [x] `npx tsc --noEmit` — 0 type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)