### PR TITLE
feat: tempo automation and time signature changes (closes #198)

### DIFF
--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -69,6 +69,7 @@ const SECTIONS: Section[] = [
       { keys: ['X'],                    description: 'Toggle Mixer' },
       { keys: ['B'],                    description: 'Toggle Smart Controls' },
       { keys: ['O'],                    description: 'Toggle Loop Browser' },
+      { keys: ['T'],                    description: 'Toggle Tempo Lane' },
     ],
   },
   {

--- a/src/components/timeline/TempoLane.tsx
+++ b/src/components/timeline/TempoLane.tsx
@@ -1,0 +1,221 @@
+import { useRef, useCallback, useMemo } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import { MIN_BPM, MAX_BPM } from '../../constants/defaults';
+import { beatToTime } from '../../utils/tempoMap';
+import type { TempoEvent } from '../../types/project';
+
+const LANE_HEIGHT = 60;
+const POINT_RADIUS = 5;
+const COLOR = '#f59e0b'; // amber for tempo
+
+/**
+ * Tempo lane displayed above the timeline track area.
+ * Shows discrete tempo change points and optional linear ramps.
+ * Double-click to add a tempo event, right-click a point to remove it.
+ */
+export function TempoLane() {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const project = useProjectStore((s) => s.project);
+  const addTempoEvent = useProjectStore((s) => s.addTempoEvent);
+  const updateTempoEvent = useProjectStore((s) => s.updateTempoEvent);
+  const removeTempoEvent = useProjectStore((s) => s.removeTempoEvent);
+  const beginDrag = useProjectStore((s) => s.beginDrag);
+  const endDrag = useProjectStore((s) => s.endDrag);
+  const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
+
+  const bpm = project?.bpm ?? 120;
+  const tempoMap = project?.tempoMap;
+  const totalDuration = project?.totalDuration ?? 30;
+  const width = totalDuration * pixelsPerSecond;
+
+  const beatToX = useCallback(
+    (beat: number) => beatToTime(beat, tempoMap, bpm) * pixelsPerSecond,
+    [tempoMap, bpm, pixelsPerSecond],
+  );
+
+  const xToBeat = useCallback(
+    (x: number) => {
+      const time = x / pixelsPerSecond;
+      if (!tempoMap || tempoMap.length === 0) {
+        return (time / 60) * bpm;
+      }
+      let lo = 0;
+      let hi = bpm * (totalDuration / 60) * 2;
+      for (let i = 0; i < 40; i++) {
+        const mid = (lo + hi) / 2;
+        const t = beatToTime(mid, tempoMap, bpm);
+        if (t < time) lo = mid;
+        else hi = mid;
+      }
+      return (lo + hi) / 2;
+    },
+    [tempoMap, bpm, pixelsPerSecond, totalDuration],
+  );
+
+  const bpmToY = useCallback(
+    (v: number) => {
+      const ratio = (v - MIN_BPM) / (MAX_BPM - MIN_BPM);
+      return LANE_HEIGHT - ratio * LANE_HEIGHT;
+    },
+    [],
+  );
+
+  const yToBpm = useCallback(
+    (y: number) => {
+      const ratio = Math.max(0, Math.min(1, (LANE_HEIGHT - y) / LANE_HEIGHT));
+      return Math.round(MIN_BPM + ratio * (MAX_BPM - MIN_BPM));
+    },
+    [],
+  );
+
+  const renderPoints = useMemo(() => {
+    const events = tempoMap ?? [];
+    if (events.length === 0) {
+      return [
+        { x: 0, y: bpmToY(bpm), bpm, beat: 0 },
+        { x: width, y: bpmToY(bpm), bpm, beat: -1 },
+      ];
+    }
+    const pts: { x: number; y: number; bpm: number; beat: number }[] = [];
+
+    if (events[0].beat > 0) {
+      pts.push({ x: 0, y: bpmToY(bpm), bpm, beat: -1 });
+      if (!events[0].ramp) {
+        pts.push({ x: beatToX(events[0].beat), y: bpmToY(bpm), bpm, beat: -1 });
+      }
+    }
+
+    for (const ev of events) {
+      pts.push({ x: beatToX(ev.beat), y: bpmToY(ev.bpm), bpm: ev.bpm, beat: ev.beat });
+    }
+
+    const lastEv = events[events.length - 1];
+    pts.push({ x: width, y: bpmToY(lastEv.bpm), bpm: lastEv.bpm, beat: -1 });
+
+    return pts;
+  }, [tempoMap, bpm, bpmToY, beatToX, width]);
+
+  const pathD = useMemo(() => {
+    if (renderPoints.length === 0) return '';
+    let d = `M ${renderPoints[0].x} ${renderPoints[0].y}`;
+    for (let i = 1; i < renderPoints.length; i++) {
+      d += ` L ${renderPoints[i].x} ${renderPoints[i].y}`;
+    }
+    return d;
+  }, [renderPoints]);
+
+  const fillD = useMemo(() => {
+    if (renderPoints.length === 0) return '';
+    let d = `M ${renderPoints[0].x} ${LANE_HEIGHT}`;
+    d += ` L ${renderPoints[0].x} ${renderPoints[0].y}`;
+    for (let i = 1; i < renderPoints.length; i++) {
+      d += ` L ${renderPoints[i].x} ${renderPoints[i].y}`;
+    }
+    d += ` L ${renderPoints[renderPoints.length - 1].x} ${LANE_HEIGHT} Z`;
+    return d;
+  }, [renderPoints]);
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      const svg = svgRef.current;
+      if (!svg) return;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const beat = Math.max(0, Math.round(xToBeat(x)));
+      const newBpm = Math.max(MIN_BPM, Math.min(MAX_BPM, yToBpm(y)));
+      addTempoEvent({ beat, bpm: newBpm });
+    },
+    [xToBeat, yToBpm, addTempoEvent],
+  );
+
+  const handlePointMouseDown = useCallback(
+    (ev: TempoEvent, e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const svg = svgRef.current;
+      if (!svg) return;
+      const rect = svg.getBoundingClientRect();
+      beginDrag();
+
+      const onMove = (me: MouseEvent) => {
+        const y = me.clientY - rect.top;
+        const newBpm = Math.max(MIN_BPM, Math.min(MAX_BPM, yToBpm(y)));
+        updateTempoEvent(ev.beat, { bpm: newBpm });
+      };
+      const onUp = () => {
+        endDrag();
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    },
+    [yToBpm, updateTempoEvent, beginDrag, endDrag],
+  );
+
+  const handlePointContextMenu = useCallback(
+    (ev: TempoEvent, e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      removeTempoEvent(ev.beat);
+    },
+    [removeTempoEvent],
+  );
+
+  const events = tempoMap ?? [];
+
+  return (
+    <div
+      className="relative border-b border-white/10"
+      style={{ height: LANE_HEIGHT, background: 'rgba(245, 158, 11, 0.03)' }}
+      data-tempo-lane
+    >
+      <div className="absolute left-1 top-0.5 text-[9px] font-mono select-none pointer-events-none z-10 text-amber-400/60">
+        Tempo
+      </div>
+
+      <div className="absolute right-1 top-0 text-[8px] font-mono text-amber-400/30 pointer-events-none select-none">
+        {MAX_BPM}
+      </div>
+      <div className="absolute right-1 bottom-0 text-[8px] font-mono text-amber-400/30 pointer-events-none select-none">
+        {MIN_BPM}
+      </div>
+
+      <svg
+        ref={svgRef}
+        width={width}
+        height={LANE_HEIGHT}
+        className="absolute left-0 top-0"
+        onDoubleClick={handleDoubleClick}
+        style={{ cursor: 'crosshair' }}
+      >
+        {fillD && <path d={fillD} fill={COLOR} opacity={0.06} />}
+        {pathD && <path d={pathD} fill="none" stroke={COLOR} strokeWidth={1.5} opacity={0.6} />}
+        {events.map((ev: TempoEvent) => (
+          <circle
+            key={ev.beat}
+            cx={beatToX(ev.beat)}
+            cy={bpmToY(ev.bpm)}
+            r={POINT_RADIUS}
+            fill={COLOR}
+            stroke="white"
+            strokeWidth={1}
+            style={{ cursor: 'grab' }}
+            onMouseDown={(e) => handlePointMouseDown(ev, e)}
+            onContextMenu={(e) => handlePointContextMenu(ev, e)}
+          >
+            <title>{`${ev.bpm} BPM @ beat ${ev.beat}${ev.ramp ? ' (ramp)' : ''}`}</title>
+          </circle>
+        ))}
+      </svg>
+
+      <div className="absolute inset-0 pointer-events-none">
+        <div className="absolute w-full" style={{ top: 0, height: 1, background: 'rgba(245,158,11,0.08)' }} />
+        <div className="absolute w-full" style={{ top: LANE_HEIGHT / 2, height: 1, background: 'rgba(245,158,11,0.05)' }} />
+        <div className="absolute w-full" style={{ top: LANE_HEIGHT - 1, height: 1, background: 'rgba(245,158,11,0.08)' }} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -9,6 +9,7 @@ import { snapToGrid } from '../../utils/time';
 import { MultiTrackGenerateModal } from '../generation/MultiTrackGenerateModal';
 import { useAudioImport } from '../../hooks/useAudioImport';
 import { Minimap } from './Minimap';
+import { TempoLane } from './TempoLane';
 
 /** @deprecated Inspector is now a modal; kept for potential future use */
 export const TRACK_INSPECTOR_HEIGHT = 220;
@@ -59,6 +60,7 @@ export function Timeline() {
   const updateTrack = useProjectStore((s) => s.updateTrack);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const setPixelsPerSecond = useUIStore((s) => s.setPixelsPerSecond);
+  const showTempoLane = useUIStore((s) => s.showTempoLane);
   const contextWindow = useUIStore((s) => s.contextWindow);
   const setContextWindow = useUIStore((s) => s.setContextWindow);
   const selectWindow = useUIStore((s) => s.selectWindow);
@@ -341,6 +343,7 @@ export function Timeline() {
         )}
         <div className="relative" style={{ width: totalWidth, minWidth: '100%' }}>
           <TimeRuler />
+          {showTempoLane && <TempoLane />}
 
           <div ref={trackAreaRef} className="relative">
             <GridOverlay />

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -332,6 +332,12 @@ export function useKeyboardShortcuts() {
           ui.setShowLibrary(!ui.showLibrary);
           break;
 
+        // Tempo lane toggle (T)
+        case 'KeyT':
+          e.preventDefault();
+          ui.toggleTempoLane();
+          break;
+
         // Help
         case 'Slash':
           // ? key (Shift+/ on most keyboards)

--- a/src/store/__tests__/tempoMap.test.ts
+++ b/src/store/__tests__/tempoMap.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('tempoMap store actions', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject({ bpm: 120 });
+  });
+
+  describe('addTempoEvent', () => {
+    it('adds a tempo event to an empty map', () => {
+      useProjectStore.getState().addTempoEvent({ beat: 0, bpm: 100 });
+      const map = useProjectStore.getState().project!.tempoMap!;
+      expect(map).toHaveLength(1);
+      expect(map[0]).toEqual({ beat: 0, bpm: 100 });
+    });
+
+    it('keeps events sorted by beat', () => {
+      useProjectStore.getState().addTempoEvent({ beat: 8, bpm: 140 });
+      useProjectStore.getState().addTempoEvent({ beat: 0, bpm: 100 });
+      const map = useProjectStore.getState().project!.tempoMap!;
+      expect(map).toHaveLength(2);
+      expect(map[0].beat).toBe(0);
+      expect(map[1].beat).toBe(8);
+    });
+
+    it('replaces an event at the same beat', () => {
+      useProjectStore.getState().addTempoEvent({ beat: 4, bpm: 100 });
+      useProjectStore.getState().addTempoEvent({ beat: 4, bpm: 160 });
+      const map = useProjectStore.getState().project!.tempoMap!;
+      expect(map).toHaveLength(1);
+      expect(map[0].bpm).toBe(160);
+    });
+
+    it('supports ramp flag', () => {
+      useProjectStore.getState().addTempoEvent({ beat: 0, bpm: 100 });
+      useProjectStore.getState().addTempoEvent({ beat: 8, bpm: 140, ramp: true });
+      const map = useProjectStore.getState().project!.tempoMap!;
+      expect(map[1].ramp).toBe(true);
+    });
+  });
+
+  describe('removeTempoEvent', () => {
+    it('removes an event by beat', () => {
+      useProjectStore.getState().addTempoEvent({ beat: 0, bpm: 100 });
+      useProjectStore.getState().addTempoEvent({ beat: 8, bpm: 140 });
+      useProjectStore.getState().removeTempoEvent(0);
+      const map = useProjectStore.getState().project!.tempoMap!;
+      expect(map).toHaveLength(1);
+      expect(map[0].beat).toBe(8);
+    });
+  });
+
+  describe('updateTempoEvent', () => {
+    it('updates BPM of an existing event', () => {
+      useProjectStore.getState().addTempoEvent({ beat: 4, bpm: 100 });
+      useProjectStore.getState().updateTempoEvent(4, { bpm: 180 });
+      const map = useProjectStore.getState().project!.tempoMap!;
+      expect(map[0].bpm).toBe(180);
+      expect(map[0].beat).toBe(4);
+    });
+  });
+
+  describe('clearTempoMap', () => {
+    it('removes all tempo events', () => {
+      useProjectStore.getState().addTempoEvent({ beat: 0, bpm: 100 });
+      useProjectStore.getState().addTempoEvent({ beat: 8, bpm: 140 });
+      useProjectStore.getState().clearTempoMap();
+      expect(useProjectStore.getState().project!.tempoMap).toEqual([]);
+    });
+  });
+});
+
+describe('timeSignatureMap store actions', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+  });
+
+  describe('addTimeSignatureEvent', () => {
+    it('adds a time signature event', () => {
+      useProjectStore.getState().addTimeSignatureEvent({ bar: 1, numerator: 3, denominator: 4 });
+      const map = useProjectStore.getState().project!.timeSignatureMap!;
+      expect(map).toHaveLength(1);
+      expect(map[0]).toEqual({ bar: 1, numerator: 3, denominator: 4 });
+    });
+
+    it('keeps events sorted by bar', () => {
+      useProjectStore.getState().addTimeSignatureEvent({ bar: 5, numerator: 3, denominator: 4 });
+      useProjectStore.getState().addTimeSignatureEvent({ bar: 1, numerator: 4, denominator: 4 });
+      const map = useProjectStore.getState().project!.timeSignatureMap!;
+      expect(map[0].bar).toBe(1);
+      expect(map[1].bar).toBe(5);
+    });
+
+    it('replaces an event at the same bar', () => {
+      useProjectStore.getState().addTimeSignatureEvent({ bar: 1, numerator: 4, denominator: 4 });
+      useProjectStore.getState().addTimeSignatureEvent({ bar: 1, numerator: 6, denominator: 8 });
+      const map = useProjectStore.getState().project!.timeSignatureMap!;
+      expect(map).toHaveLength(1);
+      expect(map[0].numerator).toBe(6);
+    });
+  });
+
+  describe('removeTimeSignatureEvent', () => {
+    it('removes event by bar', () => {
+      useProjectStore.getState().addTimeSignatureEvent({ bar: 1, numerator: 4, denominator: 4 });
+      useProjectStore.getState().addTimeSignatureEvent({ bar: 5, numerator: 3, denominator: 4 });
+      useProjectStore.getState().removeTimeSignatureEvent(1);
+      const map = useProjectStore.getState().project!.timeSignatureMap!;
+      expect(map).toHaveLength(1);
+      expect(map[0].bar).toBe(5);
+    });
+  });
+
+  describe('clearTimeSignatureMap', () => {
+    it('removes all time signature events', () => {
+      useProjectStore.getState().addTimeSignatureEvent({ bar: 1, numerator: 4, denominator: 4 });
+      useProjectStore.getState().clearTimeSignatureMap();
+      expect(useProjectStore.getState().project!.timeSignatureMap).toEqual([]);
+    });
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -25,6 +25,8 @@ import type {
   ReturnTrack,
   Take,
   Marker,
+  TempoEvent,
+  TimeSignatureEvent,
 } from '../types/project';
 import { automationParamEquals } from '../types/project';
 import { TRACK_CATALOG, DEFAULT_DRUM_KIT } from '../constants/tracks';
@@ -185,6 +187,18 @@ interface ProjectState {
   moveTrackToGroup: (trackId: string, groupId: string | null) => void;
   toggleGroupCollapse: (groupId: string) => void;
   getGroupVolume: (groupId: string) => number;
+
+  // Tempo map
+  addTempoEvent: (event: TempoEvent) => void;
+  removeTempoEvent: (beat: number) => void;
+  updateTempoEvent: (beat: number, updates: Partial<TempoEvent>) => void;
+  clearTempoMap: () => void;
+
+  // Time signature map
+  addTimeSignatureEvent: (event: TimeSignatureEvent) => void;
+  removeTimeSignatureEvent: (bar: number) => void;
+  updateTimeSignatureEvent: (bar: number, updates: Partial<TimeSignatureEvent>) => void;
+  clearTimeSignatureMap: () => void;
 
   // Markers
   addMarker: (time: number, name: string) => void;
@@ -2232,6 +2246,92 @@ export const useProjectStore = create<ProjectState>()(
         }),
       },
     });
+  },
+
+  // ── Tempo Map ──────────────────────────────────────────────────────────────
+
+  addTempoEvent: (event: TempoEvent) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const map = [...(state.project.tempoMap ?? [])];
+    const existingIdx = map.findIndex((e: TempoEvent) => e.beat === event.beat);
+    if (existingIdx >= 0) {
+      map[existingIdx] = event;
+    } else {
+      map.push(event);
+      map.sort((a: TempoEvent, b: TempoEvent) => a.beat - b.beat);
+    }
+    set({ project: { ...state.project, updatedAt: Date.now(), tempoMap: map } });
+  },
+
+  removeTempoEvent: (beat: number) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const map = (state.project.tempoMap ?? []).filter((e: TempoEvent) => e.beat !== beat);
+    set({ project: { ...state.project, updatedAt: Date.now(), tempoMap: map } });
+  },
+
+  updateTempoEvent: (beat: number, updates: Partial<TempoEvent>) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const map = (state.project.tempoMap ?? []).map((e: TempoEvent) =>
+      e.beat === beat ? { ...e, ...updates } : e,
+    );
+    if ('beat' in updates) map.sort((a: TempoEvent, b: TempoEvent) => a.beat - b.beat);
+    set({ project: { ...state.project, updatedAt: Date.now(), tempoMap: map } });
+  },
+
+  clearTempoMap: () => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({ project: { ...state.project, updatedAt: Date.now(), tempoMap: [] } });
+  },
+
+  // ── Time Signature Map ────────────────────────────────────────────────────
+
+  addTimeSignatureEvent: (event: TimeSignatureEvent) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const map = [...(state.project.timeSignatureMap ?? [])];
+    const existingIdx = map.findIndex((e: TimeSignatureEvent) => e.bar === event.bar);
+    if (existingIdx >= 0) {
+      map[existingIdx] = event;
+    } else {
+      map.push(event);
+      map.sort((a: TimeSignatureEvent, b: TimeSignatureEvent) => a.bar - b.bar);
+    }
+    set({ project: { ...state.project, updatedAt: Date.now(), timeSignatureMap: map } });
+  },
+
+  removeTimeSignatureEvent: (bar: number) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const map = (state.project.timeSignatureMap ?? []).filter((e: TimeSignatureEvent) => e.bar !== bar);
+    set({ project: { ...state.project, updatedAt: Date.now(), timeSignatureMap: map } });
+  },
+
+  updateTimeSignatureEvent: (bar: number, updates: Partial<TimeSignatureEvent>) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const map = (state.project.timeSignatureMap ?? []).map((e: TimeSignatureEvent) =>
+      e.bar === bar ? { ...e, ...updates } : e,
+    );
+    if ('bar' in updates) map.sort((a: TimeSignatureEvent, b: TimeSignatureEvent) => a.bar - b.bar);
+    set({ project: { ...state.project, updatedAt: Date.now(), timeSignatureMap: map } });
+  },
+
+  clearTimeSignatureMap: () => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({ project: { ...state.project, updatedAt: Date.now(), timeSignatureMap: [] } });
   },
 
   // ── Markers ────────────────────────────────────────────────────────────────

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -42,6 +42,9 @@ interface UIState {
   /** Which bottom editor is visible: null = none, 'smart' = smart controls, 'editor' = region editor */
   activeBottomPanel: 'smart' | 'editor' | 'pianoRoll' | 'effects' | null;
 
+  // Tempo lane
+  showTempoLane: boolean;
+
   // Loop Browser
   loopBrowserOpen: boolean;
   loopBrowserCategory: 'All' | 'Drums' | 'Bass' | 'Keys' | 'Synth';
@@ -92,6 +95,9 @@ interface UIState {
   setShowSmartControls: (v: boolean) => void;
   setShowLibrary: (v: boolean) => void;
   setActiveBottomPanel: (v: 'smart' | 'editor' | 'pianoRoll' | 'effects' | null) => void;
+
+  // Tempo lane
+  toggleTempoLane: () => void;
 
   // Loop Browser
   toggleLoopBrowser: () => void;
@@ -145,6 +151,8 @@ export const useUIStore = create<UIState>()(
   showSmartControls: false,
   showLibrary: false,
   activeBottomPanel: null,
+
+  showTempoLane: false,
 
   loopBrowserOpen: false,
   loopBrowserCategory: 'All',
@@ -228,6 +236,8 @@ export const useUIStore = create<UIState>()(
   setShowSmartControls: (v) => set({ showSmartControls: v }),
   setShowLibrary: (v) => set({ showLibrary: v }),
   setActiveBottomPanel: (v) => set({ activeBottomPanel: v }),
+
+  toggleTempoLane: () => set((s) => ({ showTempoLane: !s.showTempoLane })),
 
   toggleLoopBrowser: () => set((s) => ({ loopBrowserOpen: !s.loopBrowserOpen })),
   setLoopBrowserCategory: (v) => set({ loopBrowserCategory: v }),

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -311,6 +311,32 @@ export interface Project {
   returnTracks?: ReturnTrack[];
   /** Timeline markers (sorted by time). */
   markers?: Marker[];
+  /** Tempo map: discrete tempo changes sorted by beat. Empty = use project.bpm everywhere. */
+  tempoMap?: TempoEvent[];
+  /** Time signature map: changes sorted by bar. Empty = use project.timeSignature everywhere. */
+  timeSignatureMap?: TimeSignatureEvent[];
+}
+
+// ─── Tempo & Time Signature Map Types ────────────────────────────────────────
+
+/** A discrete tempo change at a specific beat position. */
+export interface TempoEvent {
+  /** Beat position (0-indexed) where the tempo change occurs. */
+  beat: number;
+  /** BPM value at this point. */
+  bpm: number;
+  /** Optional: if set, linearly ramp from previous BPM to this BPM over the beat range. */
+  ramp?: boolean;
+}
+
+/** A time signature change at a specific bar position. */
+export interface TimeSignatureEvent {
+  /** Bar number (1-indexed) where the time signature change occurs. */
+  bar: number;
+  /** Numerator (beats per bar). */
+  numerator: number;
+  /** Denominator (beat unit, e.g. 4 = quarter note). */
+  denominator: number;
 }
 
 // ─── Automation Types ────────────────────────────────────────────────────────

--- a/src/utils/__tests__/tempoMap.test.ts
+++ b/src/utils/__tests__/tempoMap.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getTempoAtBeat,
+  beatToTime,
+  timeToBeat,
+  getTimeSignatureAtBar,
+  getBarAtBeat,
+  getBeatAtBar,
+} from '../tempoMap';
+import type { TempoEvent, TimeSignatureEvent } from '../../types/project';
+
+describe('tempoMap utilities', () => {
+  describe('getTempoAtBeat', () => {
+    it('returns fallback BPM when tempoMap is empty', () => {
+      expect(getTempoAtBeat([], 0, 120)).toBe(120);
+      expect(getTempoAtBeat([], 10, 140)).toBe(140);
+    });
+
+    it('returns fallback BPM when tempoMap is undefined', () => {
+      expect(getTempoAtBeat(undefined, 5, 120)).toBe(120);
+    });
+
+    it('returns first event BPM at beat 0', () => {
+      const map: TempoEvent[] = [{ beat: 0, bpm: 100 }];
+      expect(getTempoAtBeat(map, 0, 120)).toBe(100);
+    });
+
+    it('returns correct BPM after a tempo change', () => {
+      const map: TempoEvent[] = [
+        { beat: 0, bpm: 100 },
+        { beat: 8, bpm: 140 },
+      ];
+      expect(getTempoAtBeat(map, 0, 120)).toBe(100);
+      expect(getTempoAtBeat(map, 4, 120)).toBe(100);
+      expect(getTempoAtBeat(map, 8, 120)).toBe(140);
+      expect(getTempoAtBeat(map, 16, 120)).toBe(140);
+    });
+
+    it('returns fallback BPM before the first event', () => {
+      const map: TempoEvent[] = [{ beat: 4, bpm: 160 }];
+      expect(getTempoAtBeat(map, 0, 120)).toBe(120);
+      expect(getTempoAtBeat(map, 3.99, 120)).toBe(120);
+      expect(getTempoAtBeat(map, 4, 120)).toBe(160);
+    });
+
+    it('interpolates BPM during a ramp', () => {
+      const map: TempoEvent[] = [
+        { beat: 0, bpm: 100 },
+        { beat: 8, bpm: 140, ramp: true },
+      ];
+      expect(getTempoAtBeat(map, 4, 120)).toBe(120);
+      expect(getTempoAtBeat(map, 0, 120)).toBe(100);
+      expect(getTempoAtBeat(map, 8, 120)).toBe(140);
+    });
+  });
+
+  describe('beatToTime', () => {
+    it('converts beats to seconds with constant tempo', () => {
+      expect(beatToTime(4, [], 120)).toBeCloseTo(2.0);
+      expect(beatToTime(0, [], 120)).toBe(0);
+    });
+
+    it('converts beats with a single tempo change', () => {
+      const map: TempoEvent[] = [
+        { beat: 0, bpm: 120 },
+        { beat: 4, bpm: 60 },
+      ];
+      expect(beatToTime(4, map, 120)).toBeCloseTo(2.0);
+      expect(beatToTime(8, map, 120)).toBeCloseTo(6.0);
+    });
+
+    it('converts beats with tempo ramp', () => {
+      const map: TempoEvent[] = [
+        { beat: 0, bpm: 60 },
+        { beat: 4, bpm: 120, ramp: true },
+      ];
+      expect(beatToTime(4, map, 120)).toBeCloseTo(2.6667, 3);
+    });
+
+    it('handles empty tempoMap', () => {
+      expect(beatToTime(8, undefined, 120)).toBeCloseTo(4.0);
+    });
+  });
+
+  describe('timeToBeat', () => {
+    it('converts time to beats with constant tempo', () => {
+      expect(timeToBeat(2.0, [], 120)).toBeCloseTo(4);
+    });
+
+    it('inverts beatToTime with tempo changes', () => {
+      const map: TempoEvent[] = [
+        { beat: 0, bpm: 120 },
+        { beat: 4, bpm: 60 },
+      ];
+      expect(timeToBeat(6.0, map, 120)).toBeCloseTo(8);
+      expect(timeToBeat(2.0, map, 120)).toBeCloseTo(4);
+    });
+
+    it('handles empty tempoMap', () => {
+      expect(timeToBeat(4.0, undefined, 120)).toBeCloseTo(8);
+    });
+  });
+
+  describe('getTimeSignatureAtBar', () => {
+    it('returns default when map is empty', () => {
+      const result = getTimeSignatureAtBar([], 1, 4, 4);
+      expect(result).toEqual({ numerator: 4, denominator: 4 });
+    });
+
+    it('returns changed time signature at the correct bar', () => {
+      const map: TimeSignatureEvent[] = [
+        { bar: 1, numerator: 4, denominator: 4 },
+        { bar: 5, numerator: 3, denominator: 4 },
+      ];
+      expect(getTimeSignatureAtBar(map, 1, 4, 4)).toEqual({ numerator: 4, denominator: 4 });
+      expect(getTimeSignatureAtBar(map, 4, 4, 4)).toEqual({ numerator: 4, denominator: 4 });
+      expect(getTimeSignatureAtBar(map, 5, 4, 4)).toEqual({ numerator: 3, denominator: 4 });
+      expect(getTimeSignatureAtBar(map, 10, 4, 4)).toEqual({ numerator: 3, denominator: 4 });
+    });
+  });
+
+  describe('getBarAtBeat / getBeatAtBar', () => {
+    it('returns correct bar for constant time signature', () => {
+      expect(getBarAtBeat(0, [], 4)).toBe(1);
+      expect(getBarAtBeat(3, [], 4)).toBe(1);
+      expect(getBarAtBeat(4, [], 4)).toBe(2);
+      expect(getBarAtBeat(7, [], 4)).toBe(2);
+    });
+
+    it('returns correct beat for a given bar with constant time signature', () => {
+      expect(getBeatAtBar(1, [], 4)).toBe(0);
+      expect(getBeatAtBar(2, [], 4)).toBe(4);
+      expect(getBeatAtBar(3, [], 4)).toBe(8);
+    });
+
+    it('handles time signature changes', () => {
+      const map: TimeSignatureEvent[] = [
+        { bar: 1, numerator: 4, denominator: 4 },
+        { bar: 3, numerator: 3, denominator: 4 },
+      ];
+      expect(getBeatAtBar(1, map, 4)).toBe(0);
+      expect(getBeatAtBar(2, map, 4)).toBe(4);
+      expect(getBeatAtBar(3, map, 4)).toBe(8);
+      expect(getBeatAtBar(4, map, 4)).toBe(11);
+
+      expect(getBarAtBeat(0, map, 4)).toBe(1);
+      expect(getBarAtBeat(7, map, 4)).toBe(2);
+      expect(getBarAtBeat(8, map, 4)).toBe(3);
+      expect(getBarAtBeat(10, map, 4)).toBe(3);
+      expect(getBarAtBeat(11, map, 4)).toBe(4);
+    });
+  });
+});

--- a/src/utils/tempoMap.ts
+++ b/src/utils/tempoMap.ts
@@ -1,0 +1,225 @@
+import type { TempoEvent, TimeSignatureEvent } from '../types/project';
+
+/**
+ * Get the BPM at a specific beat position.
+ * If a ramp is active, interpolates linearly between the previous and current event BPMs.
+ */
+export function getTempoAtBeat(
+  tempoMap: TempoEvent[] | undefined,
+  beat: number,
+  fallbackBpm: number,
+): number {
+  if (!tempoMap || tempoMap.length === 0) return fallbackBpm;
+
+  let prevBpm = fallbackBpm;
+  let prevBeat = 0;
+
+  for (let i = 0; i < tempoMap.length; i++) {
+    const ev = tempoMap[i];
+    if (ev.beat > beat) {
+      if (ev.ramp) {
+        const range = ev.beat - prevBeat;
+        if (range <= 0) return ev.bpm;
+        const t = (beat - prevBeat) / range;
+        return prevBpm + (ev.bpm - prevBpm) * t;
+      }
+      return prevBpm;
+    }
+    prevBpm = ev.bpm;
+    prevBeat = ev.beat;
+  }
+
+  return prevBpm;
+}
+
+/**
+ * Convert a beat position to absolute time (seconds), accounting for tempo changes and ramps.
+ */
+export function beatToTime(
+  beat: number,
+  tempoMap: TempoEvent[] | undefined,
+  fallbackBpm: number,
+): number {
+  if (!tempoMap || tempoMap.length === 0) {
+    return (beat / fallbackBpm) * 60;
+  }
+
+  let time = 0;
+  let currentBeat = 0;
+  let currentBpm = fallbackBpm;
+
+  for (const ev of tempoMap) {
+    if (ev.beat >= beat) {
+      if (ev.ramp && ev.beat > currentBeat) {
+        const segBeats = beat - currentBeat;
+        const fullSegBeats = ev.beat - currentBeat;
+        const t = segBeats / fullSegBeats;
+        const startBpm = currentBpm;
+        const endBpm = currentBpm + (ev.bpm - currentBpm) * t;
+        const avgBpm = (startBpm + endBpm) / 2;
+        time += (segBeats / avgBpm) * 60;
+      } else {
+        time += ((beat - currentBeat) / currentBpm) * 60;
+      }
+      return time;
+    }
+
+    const segBeats = ev.beat - currentBeat;
+    if (segBeats > 0) {
+      if (ev.ramp) {
+        const avgBpm = (currentBpm + ev.bpm) / 2;
+        time += (segBeats / avgBpm) * 60;
+      } else {
+        time += (segBeats / currentBpm) * 60;
+      }
+    }
+    currentBeat = ev.beat;
+    currentBpm = ev.bpm;
+  }
+
+  time += ((beat - currentBeat) / currentBpm) * 60;
+  return time;
+}
+
+/**
+ * Convert absolute time (seconds) to beat position, accounting for tempo changes and ramps.
+ */
+export function timeToBeat(
+  targetTime: number,
+  tempoMap: TempoEvent[] | undefined,
+  fallbackBpm: number,
+): number {
+  if (!tempoMap || tempoMap.length === 0) {
+    return (targetTime / 60) * fallbackBpm;
+  }
+
+  let time = 0;
+  let currentBeat = 0;
+  let currentBpm = fallbackBpm;
+
+  for (const ev of tempoMap) {
+    const segBeats = ev.beat - currentBeat;
+    if (segBeats > 0) {
+      let segTime: number;
+      if (ev.ramp) {
+        const avgBpm = (currentBpm + ev.bpm) / 2;
+        segTime = (segBeats / avgBpm) * 60;
+      } else {
+        segTime = (segBeats / currentBpm) * 60;
+      }
+
+      if (time + segTime >= targetTime) {
+        const remaining = targetTime - time;
+        if (ev.ramp) {
+          const bpmRate = (ev.bpm - currentBpm) / segBeats;
+          let b = remaining * currentBpm / 60;
+          for (let iter = 0; iter < 10; iter++) {
+            const endBpm = currentBpm + bpmRate * b;
+            const avgBpm = (currentBpm + endBpm) / 2;
+            const actualTime = (b / avgBpm) * 60;
+            const error = remaining - actualTime;
+            if (Math.abs(error) < 1e-9) break;
+            b += error * currentBpm / 60;
+          }
+          return currentBeat + Math.max(0, b);
+        } else {
+          return currentBeat + (remaining / 60) * currentBpm;
+        }
+      }
+      time += segTime;
+    }
+    currentBeat = ev.beat;
+    currentBpm = ev.bpm;
+  }
+
+  const remaining = targetTime - time;
+  return currentBeat + (remaining / 60) * currentBpm;
+}
+
+/**
+ * Get the time signature at a specific bar (1-indexed).
+ */
+export function getTimeSignatureAtBar(
+  tsMap: TimeSignatureEvent[] | undefined,
+  bar: number,
+  fallbackNumerator: number,
+  fallbackDenominator: number,
+): { numerator: number; denominator: number } {
+  if (!tsMap || tsMap.length === 0) {
+    return { numerator: fallbackNumerator, denominator: fallbackDenominator };
+  }
+
+  let numerator = fallbackNumerator;
+  let denominator = fallbackDenominator;
+
+  for (const ev of tsMap) {
+    if (ev.bar > bar) break;
+    numerator = ev.numerator;
+    denominator = ev.denominator;
+  }
+
+  return { numerator, denominator };
+}
+
+/**
+ * Get the bar number (1-indexed) at a given beat position.
+ */
+export function getBarAtBeat(
+  beat: number,
+  tsMap: TimeSignatureEvent[] | undefined,
+  fallbackNumerator: number,
+): number {
+  if (!tsMap || tsMap.length === 0) {
+    return Math.floor(beat / fallbackNumerator) + 1;
+  }
+
+  let currentBeat = 0;
+  let currentBar = 1;
+  let currentNum = fallbackNumerator;
+
+  for (const ev of tsMap) {
+    const barsToEvent = ev.bar - currentBar;
+    const beatsToEvent = barsToEvent * currentNum;
+    const eventBeat = currentBeat + beatsToEvent;
+
+    if (beat < eventBeat) {
+      const beatsIntoSection = beat - currentBeat;
+      return currentBar + Math.floor(beatsIntoSection / currentNum);
+    }
+
+    currentBeat = eventBeat;
+    currentBar = ev.bar;
+    currentNum = ev.numerator;
+  }
+
+  const beatsIntoSection = beat - currentBeat;
+  return currentBar + Math.floor(beatsIntoSection / currentNum);
+}
+
+/**
+ * Get the beat position at the start of a given bar (1-indexed).
+ */
+export function getBeatAtBar(
+  bar: number,
+  tsMap: TimeSignatureEvent[] | undefined,
+  fallbackNumerator: number,
+): number {
+  if (!tsMap || tsMap.length === 0) {
+    return (bar - 1) * fallbackNumerator;
+  }
+
+  let currentBeat = 0;
+  let currentBar = 1;
+  let currentNum = fallbackNumerator;
+
+  for (const ev of tsMap) {
+    if (ev.bar > bar) break;
+    const barsToEvent = ev.bar - currentBar;
+    currentBeat += barsToEvent * currentNum;
+    currentBar = ev.bar;
+    currentNum = ev.numerator;
+  }
+
+  const remainingBars = bar - currentBar;
+  return currentBeat + remainingBars * currentNum;
+}


### PR DESCRIPTION
## Summary
- Add `TempoEvent` and `TimeSignatureEvent` types with linear ramp support for smooth tempo transitions
- Add `tempoMap` and `timeSignatureMap` fields to `Project` interface
- Create `src/utils/tempoMap.ts` with 6 utility functions: `getTempoAtBeat`, `beatToTime`, `timeToBeat`, `getTimeSignatureAtBar`, `getBarAtBeat`, `getBeatAtBar`
- Add 8 store actions for CRUD operations on both maps (add/remove/update/clear)
- Create `TempoLane` SVG component above the timeline (amber-colored, 60px height)
  - Double-click to add tempo points, drag to adjust BPM, right-click to delete
  - BPM scale from 30–300, with visual ramp lines
- Toggle via `T` keyboard shortcut, persisted in UI store
- 30 new unit tests (18 utility + 12 store) — all passing

## v1 Scope (this PR)
- Discrete tempo changes per bar position
- Linear tempo ramps between events
- Time signature changes at bar boundaries

## v2 (future)
- Engine integration: replace static `bpm` reads with `getTempoAtBeat()`
- Metronome/sequencer scheduling with variable tempo
- TimeRuler/GridOverlay rendering with non-uniform bar widths

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run` — 224 tests passing (30 files, 0 failures)
- [x] `npm run build` — succeeds
- [ ] Manual: press `T` to toggle tempo lane visibility
- [ ] Manual: double-click in tempo lane to add points, drag to adjust
- [ ] Manual: verify undo/redo works for tempo map changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)