### PR TITLE
feat: click-free mute — fade mute/unmute to avoid pops

### DIFF
--- a/src/engine/TrackNode.ts
+++ b/src/engine/TrackNode.ts
@@ -117,14 +117,22 @@ export class TrackNode {
 
   set soloActive(v: boolean) { this._soloActive = v; this._applyGain(); }
 
+  /** Fade duration in seconds to avoid audio clicks on mute/unmute. */
+  static readonly MUTE_FADE_SEC = 0.005;
+
   private _applyGain() {
+    let target: number;
     if (this._muted) {
-      this.volumeGain.gain.value = 0;
+      target = 0;
     } else if (this._soloActive && !this._soloed) {
-      this.volumeGain.gain.value = 0;
+      target = 0;
     } else {
-      this.volumeGain.gain.value = this._volume;
+      target = this._volume;
     }
+    const now = this.ctx.currentTime;
+    this.volumeGain.gain.cancelScheduledValues(now);
+    this.volumeGain.gain.setValueAtTime(this.volumeGain.gain.value, now);
+    this.volumeGain.gain.linearRampToValueAtTime(target, now + TrackNode.MUTE_FADE_SEC);
   }
 
   // -----------------------------------------------------------------------

--- a/src/engine/__tests__/TrackNode.test.ts
+++ b/src/engine/__tests__/TrackNode.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TrackNode } from '../TrackNode';
+
+/** Minimal AudioParam stub that records ramp calls */
+function makeAudioParam(initial = 0) {
+  let _value = initial;
+  const rampCalls: { value: number; endTime: number }[] = [];
+  const cancelCalls: number[] = [];
+  return {
+    get value() { return _value; },
+    set value(v: number) { _value = v; },
+    linearRampToValueAtTime(value: number, endTime: number) {
+      rampCalls.push({ value, endTime });
+      _value = value;
+      return this;
+    },
+    setValueAtTime(value: number, _time: number) {
+      _value = value;
+      return this;
+    },
+    cancelScheduledValues(_time: number) {
+      cancelCalls.push(_time);
+      return this;
+    },
+    rampCalls,
+    cancelCalls,
+  };
+}
+
+/** Minimal AudioNode / AudioContext stubs */
+function makeNode(overrides: Record<string, unknown> = {}) {
+  return {
+    connect: vi.fn().mockReturnThis(),
+    disconnect: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeAudioContext(): AudioContext {
+  let _currentTime = 0;
+  return {
+    get currentTime() { return _currentTime; },
+    set currentTime(v: number) { _currentTime = v; },
+    sampleRate: 44100,
+    createGain() {
+      return makeNode({ gain: makeAudioParam(1) });
+    },
+    createStereoPanner() {
+      return makeNode({ pan: makeAudioParam(0) });
+    },
+    createBiquadFilter() {
+      return makeNode({
+        type: 'lowshelf',
+        frequency: makeAudioParam(1000),
+        Q: makeAudioParam(1),
+        gain: makeAudioParam(0),
+      });
+    },
+    createDynamicsCompressor() {
+      return makeNode({
+        threshold: makeAudioParam(0),
+        ratio: makeAudioParam(1),
+        attack: makeAudioParam(0.003),
+        release: makeAudioParam(0.25),
+        knee: makeAudioParam(30),
+      });
+    },
+    createConvolver() {
+      return makeNode({ buffer: null });
+    },
+    createAnalyser() {
+      return makeNode({
+        fftSize: 256,
+        smoothingTimeConstant: 0.6,
+        frequencyBinCount: 128,
+        getByteFrequencyData: vi.fn(),
+      });
+    },
+    createBuffer(_channels: number, length: number, sampleRate: number) {
+      const data = new Float32Array(length);
+      return {
+        getChannelData: () => data,
+        sampleRate,
+        length,
+        numberOfChannels: _channels,
+        duration: length / sampleRate,
+      };
+    },
+  } as unknown as AudioContext;
+}
+
+describe('TrackNode', () => {
+  let ctx: AudioContext;
+  let destination: ReturnType<typeof makeNode>;
+  let node: TrackNode;
+
+  beforeEach(() => {
+    ctx = makeAudioContext();
+    destination = makeNode();
+    node = new TrackNode(ctx, destination as unknown as AudioNode);
+  });
+
+  describe('click-free mute/unmute', () => {
+    function getGainParam() {
+      return node.volumeGain.gain as unknown as ReturnType<typeof makeAudioParam>;
+    }
+
+    it('uses linearRampToValueAtTime when muting', () => {
+      const param = getGainParam();
+      param.rampCalls.length = 0;
+
+      node.muted = true;
+
+      expect(param.rampCalls.length).toBeGreaterThanOrEqual(1);
+      const lastRamp = param.rampCalls[param.rampCalls.length - 1];
+      expect(lastRamp.value).toBe(0);
+    });
+
+    it('uses linearRampToValueAtTime when unmuting', () => {
+      node.muted = true;
+
+      const param = getGainParam();
+      param.rampCalls.length = 0;
+
+      node.muted = false;
+
+      expect(param.rampCalls.length).toBeGreaterThanOrEqual(1);
+      const lastRamp = param.rampCalls[param.rampCalls.length - 1];
+      expect(lastRamp.value).toBe(0.8); // default volume
+    });
+
+    it('ramps to 0 when solo is active on another track', () => {
+      const param = getGainParam();
+      param.rampCalls.length = 0;
+
+      node.soloActive = true;
+
+      expect(param.rampCalls.length).toBeGreaterThanOrEqual(1);
+      const lastRamp = param.rampCalls[param.rampCalls.length - 1];
+      expect(lastRamp.value).toBe(0);
+    });
+
+    it('fade duration is approximately 5ms', () => {
+      const param = getGainParam();
+      param.rampCalls.length = 0;
+
+      node.muted = true;
+
+      const lastRamp = param.rampCalls[param.rampCalls.length - 1];
+      expect(lastRamp.endTime).toBeCloseTo(ctx.currentTime + 0.005, 3);
+    });
+
+    it('ramps volume back when unmuting after solo-implied mute', () => {
+      node.soloActive = true;
+      const param = getGainParam();
+      param.rampCalls.length = 0;
+
+      node.soloed = true;
+
+      expect(param.rampCalls.length).toBeGreaterThanOrEqual(1);
+      const lastRamp = param.rampCalls[param.rampCalls.length - 1];
+      expect(lastRamp.value).toBe(0.8);
+    });
+
+    it('cancels scheduled values before ramping (prevents stacking)', () => {
+      const param = getGainParam();
+      param.cancelCalls.length = 0;
+
+      node.muted = true;
+
+      expect(param.cancelCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace direct `volumeGain.gain.value` assignment with 5ms `linearRampToValueAtTime` in `TrackNode._applyGain()` to eliminate audio clicks/pops on mute, unmute, and solo toggle
- Applies to all gain transitions: mute, unmute, solo-active implied mute, and solo restore
- Adds `TrackNode.MUTE_FADE_SEC` static constant (0.005s) for the fade duration

Closes #209

## Test plan
- [x] 6 new unit tests for click-free mute behavior (`src/engine/__tests__/TrackNode.test.ts`)
- [ ] Manual test: toggle mute rapidly during playback — no clicks/pops
- [ ] Manual test: toggle solo on/off during playback — smooth transitions
- [ ] Verify existing tests still pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)