### PR TITLE
feat: slip editing — move audio within clip boundaries

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -20,7 +20,7 @@ interface ClipBlockProps {
 const EDGE_HANDLE_PX = 6;
 const MIN_CLIP_DURATION = 0.5;
 
-type DragMode = 'move' | 'resize-left' | 'resize-right';
+type DragMode = 'move' | 'resize-left' | 'resize-right' | 'slip';
 
 interface DragGhostInfo {
   x: number;
@@ -91,6 +91,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     const relX = e.clientX - rect.left;
     if (relX <= EDGE_HANDLE_PX) return 'resize-left';
     if (relX >= rect.width - EDGE_HANDLE_PX) return 'resize-right';
+    if (e.altKey) return 'slip';
     return 'move';
   }, []);
 
@@ -216,6 +217,12 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
         const newDuration = origDuration + (origStart - newStart);
         updateClip(clip.id, { startTime: newStart, duration: newDuration, audioOffset: newAudioOffset });
+      } else if (mode === 'slip') {
+        const maxOffset = Math.max(0, origAudioDuration - origDuration);
+        if (maxOffset > 0) {
+          const newOffset = Math.max(0, Math.min(origAudioOffset + deltaSec, maxOffset));
+          updateClip(clip.id, { audioOffset: newOffset });
+        }
       } else {
         let newDuration = snapToGrid(origDuration + deltaSec, bpm, 1);
         newDuration = Math.max(MIN_CLIP_DURATION, newDuration);
@@ -293,7 +300,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     if (relX <= EDGE_HANDLE_PX || relX >= rect.width - EDGE_HANDLE_PX) {
       el.style.cursor = 'col-resize';
     } else {
-      el.style.cursor = 'grab';
+      el.style.cursor = e.altKey ? 'ew-resize' : 'grab';
     }
   }, []);
 

--- a/src/store/__tests__/slipClip.test.ts
+++ b/src/store/__tests__/slipClip.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('slipClip', () => {
+  let clipId: string;
+
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('stems');
+    const clip = useProjectStore.getState().addClip(track.id, {
+      startTime: 5, duration: 4, prompt: 'test', lyrics: '',
+    });
+    clipId = clip.id;
+    useProjectStore.getState().updateClip(clipId, {
+      audioDuration: 10, audioOffset: 2, generationStatus: 'ready',
+    });
+  });
+
+  it('adjusts audioOffset without changing startTime or duration', () => {
+    useProjectStore.getState().slipClip(clipId, 1);
+    const c = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(c.audioOffset).toBe(3);
+    expect(c.startTime).toBe(5);
+    expect(c.duration).toBe(4);
+  });
+
+  it('clamps audioOffset to 0', () => {
+    useProjectStore.getState().slipClip(clipId, -10);
+    const c = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(c.audioOffset).toBe(0);
+  });
+
+  it('clamps audioOffset so clip does not exceed audio end', () => {
+    useProjectStore.getState().slipClip(clipId, 20);
+    const c = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(c.audioOffset).toBe(6);
+  });
+
+  it('does nothing for a clip without audioDuration', () => {
+    useProjectStore.getState().updateClip(clipId, { audioDuration: undefined, audioOffset: undefined });
+    useProjectStore.getState().slipClip(clipId, 2);
+    const c = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(c.audioOffset).toBeUndefined();
+  });
+
+  it('is undoable', () => {
+    useProjectStore.getState().slipClip(clipId, 2);
+    expect(useProjectStore.getState().project!.tracks[0].clips[0].audioOffset).toBe(4);
+    useProjectStore.getState().undo();
+    expect(useProjectStore.getState().project!.tracks[0].clips[0].audioOffset).toBe(2);
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -129,6 +129,8 @@ interface ProjectState {
   setClipTimeStretch: (clipId: string, rate: number) => void;
   setClipPitchShift: (clipId: string, semitones: number) => void;
 
+  /** Slip-edit: shift audioOffset by deltaSeconds without changing startTime/duration. */
+  slipClip: (clipId: string, deltaSeconds: number) => void;
   splitClip: (clipId: string, splitTime: number) => void;
   toggleClipStar: (clipId: string) => void;
   moveClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => void;
@@ -903,6 +905,22 @@ export const useProjectStore = create<ProjectState>()(
 
   setClipPitchShift: (clipId, semitones) => {
     get().updateClip(clipId, { pitchShift: semitones });
+  },
+
+  slipClip: (clipId, deltaSeconds) => {
+    const state = get();
+    if (!state.project) return;
+    for (const track of state.project.tracks) {
+      const clip = track.clips.find((c) => c.id === clipId);
+      if (!clip) continue;
+      const audioDuration = clip.audioDuration;
+      if (audioDuration == null) return;
+      const origOffset = clip.audioOffset ?? 0;
+      const maxOffset = Math.max(0, audioDuration - clip.duration);
+      const newOffset = Math.max(0, Math.min(origOffset + deltaSeconds, maxOffset));
+      get().updateClip(clipId, { audioOffset: newOffset });
+      return;
+    }
   },
 
   splitClip: (clipId, splitTime) => {

--- a/src/utils/__tests__/dragMath.test.ts
+++ b/src/utils/__tests__/dragMath.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { calcClipSlip } from '../dragMath';
+
+describe('calcClipSlip', () => {
+  const pps = 100;
+  const audioDuration = 10;
+
+  it('shifts audioOffset right when dragging right (positive deltaPx)', () => {
+    expect(calcClipSlip(2, 100, pps, audioDuration, 4)).toBe(3);
+  });
+
+  it('shifts audioOffset left when dragging left (negative deltaPx)', () => {
+    expect(calcClipSlip(3, -200, pps, audioDuration, 4)).toBe(1);
+  });
+
+  it('clamps audioOffset to 0', () => {
+    expect(calcClipSlip(1, -500, pps, audioDuration, 4)).toBe(0);
+  });
+
+  it('clamps audioOffset so clip does not extend past audio end', () => {
+    expect(calcClipSlip(5, 500, pps, audioDuration, 4)).toBe(6);
+  });
+
+  it('returns origAudioOffset when audioDuration <= clipDuration', () => {
+    expect(calcClipSlip(0, 100, pps, 4, 4)).toBe(0);
+  });
+
+  it('handles zero deltaPx', () => {
+    expect(calcClipSlip(2, 0, pps, audioDuration, 4)).toBe(2);
+  });
+});

--- a/src/utils/dragMath.ts
+++ b/src/utils/dragMath.ts
@@ -72,6 +72,25 @@ export function calcClipResizeLeft(
 /**
  * Convert pixel X to time (seconds) on the timeline.
  */
+/**
+ * Calculate new audioOffset after a slip-edit drag.
+ * Slip editing moves the audio content within clip boundaries
+ * without changing clip startTime or duration.
+ */
+export function calcClipSlip(
+  origAudioOffset: number,
+  deltaPx: number,
+  pixelsPerSecond: number,
+  audioDuration: number,
+  clipDuration: number,
+): number {
+  const maxOffset = Math.max(0, audioDuration - clipDuration);
+  if (maxOffset <= 0) return origAudioOffset;
+  const deltaSec = deltaPx / pixelsPerSecond;
+  const raw = origAudioOffset + deltaSec;
+  return Math.max(0, Math.min(raw, maxOffset));
+}
+
 export function pxToTime(px: number, pixelsPerSecond: number): number {
   return px / pixelsPerSecond;
 }


### PR DESCRIPTION
## Summary
- **Alt+drag** on a clip slides the audio content (audioOffset) within the clip's boundaries without changing clip position or duration
- Added `slipClip(clipId, deltaSeconds)` store action for programmatic/agent access
- Added `calcClipSlip()` pure function in dragMath.ts for testable slip offset calculation
- Cursor changes to `ew-resize` when Alt is held over a clip to indicate slip mode

## Test plan
- [x] `calcClipSlip` unit tests: 6 tests covering positive/negative/zero delta, clamping both ends, no-room-to-slip
- [x] `slipClip` store tests: 5 tests covering offset adjustment, clamping, no-audioDuration, undo
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run` — all 213 tests pass (32 files)
- [x] `npm run build` — succeeds

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)