### PR TITLE
feat: arrangement markers — intro/verse/chorus/bridge sections

### DIFF
--- a/src/components/timeline/ArrangementMarkers.tsx
+++ b/src/components/timeline/ArrangementMarkers.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import { useTransport } from '../../hooks/useTransport';
+import { computeSections } from '../../utils/arrangementSections';
+
+/** Preset colors for common arrangement sections. */
+const SECTION_COLORS: Record<string, string> = {
+  intro: '#6366f1',   // indigo
+  verse: '#22c55e',   // green
+  chorus: '#f59e0b',  // amber
+  bridge: '#8b5cf6',  // violet
+  outro: '#ef4444',   // red
+  hook: '#ec4899',    // pink
+  'pre-chorus': '#14b8a6', // teal
+  solo: '#f97316',    // orange
+  breakdown: '#64748b', // slate
+};
+
+function getSectionColor(name: string, fallback: string): string {
+  const key = name.toLowerCase().trim();
+  return SECTION_COLORS[key] ?? fallback;
+}
+
+const MARKER_HEIGHT = 20;
+
+export function ArrangementMarkers() {
+  const project = useProjectStore((s) => s.project);
+  const addMarker = useProjectStore((s) => s.addMarker);
+  const removeMarker = useProjectStore((s) => s.removeMarker);
+  const updateMarker = useProjectStore((s) => s.updateMarker);
+  const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
+  const { seek } = useTransport();
+
+  const markers = project?.markers ?? [];
+  const totalDuration = project?.totalDuration ?? 0;
+
+  const sections = useMemo(
+    () => computeSections(markers, totalDuration),
+    [markers, totalDuration],
+  );
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = useCallback(
+    (time: number) => {
+      seek(time);
+    },
+    [seek],
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!project) return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const time = Math.max(0, x / pixelsPerSecond);
+      addMarker(time, 'New Section');
+    },
+    [project, pixelsPerSecond, addMarker],
+  );
+
+  const handleRightClick = useCallback(
+    (e: React.MouseEvent, markerId: string) => {
+      e.preventDefault();
+      removeMarker(markerId);
+    },
+    [removeMarker],
+  );
+
+  const startEditing = useCallback((id: string) => {
+    setEditingId(id);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, []);
+
+  const commitEdit = useCallback(
+    (id: string, newName: string) => {
+      const trimmed = newName.trim();
+      if (trimmed) {
+        const color = getSectionColor(trimmed, '');
+        updateMarker(id, color ? { name: trimmed, color } : { name: trimmed });
+      }
+      setEditingId(null);
+    },
+    [updateMarker],
+  );
+
+  if (!project || sections.length === 0) return null;
+
+  const totalWidth = totalDuration * pixelsPerSecond;
+
+  return (
+    <div
+      className="relative select-none"
+      style={{ width: totalWidth, height: MARKER_HEIGHT }}
+      onDoubleClick={handleDoubleClick}
+      data-testid="arrangement-markers"
+    >
+      {sections.map(({ marker, startTime, endTime }) => {
+        const left = startTime * pixelsPerSecond;
+        const width = (endTime - startTime) * pixelsPerSecond;
+        const color = getSectionColor(marker.name, marker.color);
+        const isEditing = editingId === marker.id;
+
+        return (
+          <div
+            key={marker.id}
+            className="absolute top-0 h-full flex items-center overflow-hidden cursor-pointer"
+            style={{
+              left,
+              width: Math.max(width, 2),
+              backgroundColor: `${color}33`,
+              borderLeft: `2px solid ${color}`,
+            }}
+            data-marker-id={marker.id}
+            onClick={() => handleClick(startTime)}
+            onContextMenu={(e) => handleRightClick(e, marker.id)}
+            onDoubleClick={(e) => {
+              e.stopPropagation();
+              startEditing(marker.id);
+            }}
+          >
+            {isEditing ? (
+              <input
+                ref={inputRef}
+                className="bg-transparent text-white text-[10px] font-semibold px-1 w-full outline-none border-b border-white/40"
+                defaultValue={marker.name}
+                onBlur={(e) => commitEdit(marker.id, e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitEdit(marker.id, (e.target as HTMLInputElement).value);
+                  if (e.key === 'Escape') setEditingId(null);
+                }}
+              />
+            ) : (
+              <span
+                className="text-[10px] font-semibold px-1.5 truncate"
+                style={{ color }}
+              >
+                {marker.name}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -10,6 +10,7 @@ import { MultiTrackGenerateModal } from '../generation/MultiTrackGenerateModal';
 import { useAudioImport } from '../../hooks/useAudioImport';
 import { Minimap } from './Minimap';
 import { TempoLane } from './TempoLane';
+import { ArrangementMarkers } from './ArrangementMarkers';
 
 /** @deprecated Inspector is now a modal; kept for potential future use */
 export const TRACK_INSPECTOR_HEIGHT = 220;
@@ -343,6 +344,7 @@ export function Timeline() {
         )}
         <div className="relative" style={{ width: totalWidth, minWidth: '100%' }}>
           <TimeRuler />
+          <ArrangementMarkers />
           {showTempoLane && <TempoLane />}
 
           <div ref={trackAreaRef} className="relative">

--- a/src/utils/__tests__/arrangementSections.test.ts
+++ b/src/utils/__tests__/arrangementSections.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { computeSections } from '../arrangementSections';
+import type { Marker } from '../../types/project';
+
+function mkMarker(time: number, name: string, color = '#facc15'): Marker {
+  return { id: `m-${time}`, time, name, color };
+}
+
+describe('computeSections', () => {
+  it('returns empty array when no markers', () => {
+    expect(computeSections([], 60)).toEqual([]);
+  });
+
+  it('creates sections from markers sorted by time', () => {
+    const markers = [mkMarker(20, 'Chorus'), mkMarker(0, 'Intro'), mkMarker(10, 'Verse')];
+    const sections = computeSections(markers, 60);
+    expect(sections).toEqual([
+      { marker: expect.objectContaining({ name: 'Intro' }), startTime: 0, endTime: 10 },
+      { marker: expect.objectContaining({ name: 'Verse' }), startTime: 10, endTime: 20 },
+      { marker: expect.objectContaining({ name: 'Chorus' }), startTime: 20, endTime: 60 },
+    ]);
+  });
+
+  it('single marker spans to totalDuration', () => {
+    const sections = computeSections([mkMarker(5, 'Bridge')], 30);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].startTime).toBe(5);
+    expect(sections[0].endTime).toBe(30);
+  });
+
+  it('handles markers at same time (stable order by id)', () => {
+    const markers = [
+      { id: 'b', time: 0, name: 'B', color: '#ff0000' },
+      { id: 'a', time: 0, name: 'A', color: '#00ff00' },
+    ];
+    const sections = computeSections(markers, 10);
+    expect(sections[0].marker.name).toBe('B');
+    expect(sections[1].marker.name).toBe('A');
+  });
+});

--- a/src/utils/arrangementSections.ts
+++ b/src/utils/arrangementSections.ts
@@ -1,0 +1,24 @@
+import type { Marker } from '../types/project';
+
+export interface ArrangementSection {
+  marker: Marker;
+  startTime: number;
+  endTime: number;
+}
+
+/**
+ * Compute contiguous sections from markers.
+ * Each marker defines the start of a section; it ends where the next marker begins
+ * (or at totalDuration for the last one).
+ */
+export function computeSections(markers: Marker[], totalDuration: number): ArrangementSection[] {
+  if (markers.length === 0) return [];
+
+  const sorted = [...markers].sort((a, b) => a.time - b.time);
+
+  return sorted.map((marker, i) => ({
+    marker,
+    startTime: marker.time,
+    endTime: i < sorted.length - 1 ? sorted[i + 1].time : totalDuration,
+  }));
+}


### PR DESCRIPTION
## Summary
- Add **ArrangementMarkers** component that renders named, colored section bands (intro, verse, chorus, bridge, etc.) on the timeline ruler between TimeRuler and TempoLane
- **Click** any section to navigate (seek) to its start time
- **Double-click** empty area to add a new marker, **right-click** to remove, **double-click label** to rename inline
- Auto-assigns preset colors per section name (intro=indigo, verse=green, chorus=amber, bridge=violet, outro=red, etc.)
- `computeSections()` pure utility sorts markers by time and creates contiguous sections
- 4 unit tests for section computation logic

Closes #211

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — all tests pass (4 new tests for `computeSections`)
- [x] `npm run build` — succeeds
- [ ] Manual: add markers via store API (`window.__store.getState().addMarker(0, 'Intro')`) and verify colored sections appear on timeline
- [ ] Manual: click section to verify seek, double-click to add, right-click to remove
- [ ] Manual: double-click label to rename; verify color auto-updates for known section names

🤖 Generated with [Claude Code](https://claude.com/claude-code)