### PR TITLE
feat: clip gain envelope — per-clip volume automation (closes #207)

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -10,6 +10,7 @@ import { AddLayerModal } from '../generation/AddLayerModal';
 import { regenerateClip } from '../../services/generationPipeline';
 import { ClipContextMenu } from './ClipContextMenu';
 import { ClipWaveform, ClipMidiThumbnail } from './ClipWaveform';
+import { ClipGainEnvelope } from './ClipGainEnvelope';
 import { ClipStatusOverlay } from './ClipStatusOverlay';
 
 interface ClipBlockProps {
@@ -355,6 +356,16 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           width={width}
           color={track.color}
         />
+
+        {clip.gainEnvelope && clip.gainEnvelope.length > 0 && (
+          <ClipGainEnvelope
+            clipId={clip.id}
+            clipDuration={clip.duration}
+            width={width}
+            gainEnvelope={clip.gainEnvelope}
+            color={track.color}
+          />
+        )}
 
         {isMidiClip && clip.midiData && (
           <ClipMidiThumbnail

--- a/src/components/timeline/ClipGainEnvelope.tsx
+++ b/src/components/timeline/ClipGainEnvelope.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useRef } from 'react';
+import type { GainEnvelopePoint } from '../../types/project';
+import { useProjectStore } from '../../store/projectStore';
+
+interface ClipGainEnvelopeProps {
+  clipId: string;
+  clipDuration: number;
+  width: number;
+  gainEnvelope: GainEnvelopePoint[];
+  color: string;
+}
+
+const POINT_RADIUS = 4;
+const MAX_GAIN = 2;
+
+export function ClipGainEnvelope({
+  clipId,
+  clipDuration,
+  width,
+  gainEnvelope,
+  color,
+}: ClipGainEnvelopeProps) {
+  const addClipGainPoint = useProjectStore((s) => s.addClipGainPoint);
+  const removeClipGainPoint = useProjectStore((s) => s.removeClipGainPoint);
+  const updateClipGainPoint = useProjectStore((s) => s.updateClipGainPoint);
+  const beginDrag = useProjectStore((s) => s.beginDrag);
+  const endDrag = useProjectStore((s) => s.endDrag);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const timeToX = useCallback((time: number) => (time / clipDuration) * width, [clipDuration, width]);
+  const gainToY = useCallback((gain: number) => (1 - gain / MAX_GAIN) * 100, []);
+  const xToTime = useCallback((x: number) => Math.max(0, Math.min(clipDuration, (x / width) * clipDuration)), [clipDuration, width]);
+  const yToGain = useCallback((y: number, height: number) => Math.max(0, Math.min(MAX_GAIN, (1 - y / height) * MAX_GAIN)), []);
+
+  const handleSvgDoubleClick = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
+    e.stopPropagation();
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const time = xToTime(x);
+    const gain = yToGain(y, rect.height);
+    addClipGainPoint(clipId, { time, gain: Math.round(gain * 100) / 100 });
+  }, [clipId, xToTime, yToGain, addClipGainPoint]);
+
+  const handlePointMouseDown = useCallback((e: React.MouseEvent, pointIndex: number) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (e.altKey) {
+      removeClipGainPoint(clipId, pointIndex);
+      return;
+    }
+
+    const svg = svgRef.current;
+    if (!svg) return;
+
+    beginDrag();
+    const rect = svg.getBoundingClientRect();
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const x = ev.clientX - rect.left;
+      const y = ev.clientY - rect.top;
+      const time = xToTime(x);
+      const gain = yToGain(y, rect.height);
+      updateClipGainPoint(clipId, pointIndex, {
+        time: Math.round(time * 1000) / 1000,
+        gain: Math.round(gain * 100) / 100,
+      });
+    };
+
+    const onMouseUp = () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+      endDrag();
+    };
+
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+  }, [clipId, xToTime, yToGain, updateClipGainPoint, removeClipGainPoint, beginDrag, endDrag]);
+
+  if (gainEnvelope.length === 0) return null;
+
+  // Build SVG path
+  const sorted = [...gainEnvelope].sort((a, b) => a.time - b.time);
+  const viewBox = `0 0 ${width} 100`;
+
+  // Build polyline points
+  const pathPoints: string[] = [];
+  pathPoints.push(`0,${gainToY(sorted[0].gain)}`);
+  for (const pt of sorted) {
+    pathPoints.push(`${timeToX(pt.time)},${gainToY(pt.gain)}`);
+  }
+  pathPoints.push(`${width},${gainToY(sorted[sorted.length - 1].gain)}`);
+
+  // Fill area
+  const fillPath = `M0,${gainToY(sorted[0].gain)} ${sorted.map(pt => `L${timeToX(pt.time)},${gainToY(pt.gain)}`).join(' ')} L${width},${gainToY(sorted[sorted.length - 1].gain)} L${width},100 L0,100 Z`;
+
+  return (
+    <svg
+      ref={svgRef}
+      className="absolute inset-0 z-[5] pointer-events-auto"
+      viewBox={viewBox}
+      preserveAspectRatio="none"
+      onDoubleClick={handleSvgDoubleClick}
+      data-testid={`gain-envelope-${clipId}`}
+    >
+      <path d={fillPath} fill={color} opacity={0.08} />
+
+      <polyline
+        points={pathPoints.join(' ')}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        opacity={0.7}
+        vectorEffect="non-scaling-stroke"
+      />
+
+      <line
+        x1={0}
+        y1={gainToY(1)}
+        x2={width}
+        y2={gainToY(1)}
+        stroke="white"
+        strokeWidth="0.5"
+        opacity={0.2}
+        strokeDasharray="4 4"
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {sorted.map((pt, i) => (
+        <circle
+          key={i}
+          cx={timeToX(pt.time)}
+          cy={gainToY(pt.gain)}
+          r={POINT_RADIUS}
+          fill="white"
+          stroke={color}
+          strokeWidth="1.5"
+          opacity={0.9}
+          className="cursor-grab hover:opacity-100"
+          style={{ pointerEvents: 'auto' }}
+          vectorEffect="non-scaling-stroke"
+          onMouseDown={(e) => handlePointMouseDown(e, i)}
+          data-testid={`gain-point-${i}`}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -1,6 +1,6 @@
 import * as Tone from 'tone';
 import { TrackNode } from './TrackNode';
-import type { SequencerPattern } from '../types/project';
+import type { GainEnvelopePoint, SequencerPattern } from '../types/project';
 
 export interface ScheduledSource {
   source: AudioBufferSourceNode;
@@ -24,6 +24,7 @@ export interface ClipScheduleInfo {
   audioOffset: number;   // offset into the buffer (crop start)
   clipDuration: number;  // how long to play (crop length)
   timeStretchRate?: number; // playback rate (1 = normal, 0.5 = half speed, 2 = double)
+  gainEnvelope?: GainEnvelopePoint[]; // per-clip volume automation
 }
 
 /**
@@ -124,7 +125,17 @@ export class AudioEngine {
       const trackNode = this.getOrCreateTrackNode(clip.trackId);
       const source = this.ctx.createBufferSource();
       source.buffer = clip.buffer;
-      source.connect(trackNode.inputGain);
+
+      // Insert per-clip gain envelope node if envelope exists
+      const envelope = clip.gainEnvelope;
+      if (envelope && envelope.length > 0) {
+        const gainNode = this.ctx.createGain();
+        source.connect(gainNode);
+        gainNode.connect(trackNode.inputGain);
+        this._scheduleGainEnvelope(gainNode, envelope, clip, fromTime);
+      } else {
+        source.connect(trackNode.inputGain);
+      }
 
       // Apply time-stretch via playback rate
       const rate = clip.timeStretchRate ?? 1;
@@ -252,6 +263,53 @@ export class AudioEngine {
 
   clearMidiEvents() {
     this._midiEvents = [];
+  }
+
+
+  /**
+   * Schedule Web Audio gain automation for a clip's gain envelope.
+   * Uses linearRampToValueAtTime between envelope points.
+   */
+  private _scheduleGainEnvelope(
+    gainNode: GainNode,
+    points: GainEnvelopePoint[],
+    clip: ClipScheduleInfo,
+    fromTime: number,
+  ) {
+    const contextNow = this.ctx.currentTime;
+    const clipStart = clip.startTime;
+    const seekOffset = Math.max(0, fromTime - clipStart);
+    const delay = Math.max(0, clipStart - fromTime);
+    const sorted = [...points].sort((a, b) => a.time - b.time);
+
+    const clamp = (v: number) => Math.max(0, Math.min(2, v));
+
+    // Compute initial gain at seek position
+    let initialGain = 1;
+    if (sorted.length === 1) {
+      initialGain = clamp(sorted[0].gain);
+    } else if (seekOffset <= sorted[0].time) {
+      initialGain = clamp(sorted[0].gain);
+    } else if (seekOffset >= sorted[sorted.length - 1].time) {
+      initialGain = clamp(sorted[sorted.length - 1].gain);
+    } else {
+      for (let i = 0; i < sorted.length - 1; i++) {
+        if (seekOffset >= sorted[i].time && seekOffset <= sorted[i + 1].time) {
+          const t = (seekOffset - sorted[i].time) / (sorted[i + 1].time - sorted[i].time);
+          initialGain = clamp(sorted[i].gain + t * (sorted[i + 1].gain - sorted[i].gain));
+          break;
+        }
+      }
+    }
+
+    gainNode.gain.setValueAtTime(initialGain, contextNow + delay);
+
+    // Schedule ramps for each point after the seek position
+    for (const pt of sorted) {
+      const ptContextTime = contextNow + delay + (pt.time - seekOffset);
+      if (ptContextTime <= contextNow + delay) continue;
+      gainNode.gain.linearRampToValueAtTime(clamp(pt.gain), ptContextTime);
+    }
   }
 
   private _startTimeUpdate(totalDuration: number) {

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -85,6 +85,7 @@ export function useTransport() {
       audioOffset: number;
       clipDuration: number;
       timeStretchRate?: number;
+      gainEnvelope?: import('../types/project').GainEnvelopePoint[];
     }
     const clipBuffers: ScheduleEntry[] = [];
 
@@ -151,6 +152,7 @@ export function useTransport() {
           audioOffset: clip.audioOffset ?? 0,
           clipDuration: clip.duration,
           timeStretchRate: clip.timeStretchRate,
+          gainEnvelope: clip.gainEnvelope,
         });
       }
     }

--- a/src/store/__tests__/clipGainEnvelope.test.ts
+++ b/src/store/__tests__/clipGainEnvelope.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('clip gain envelope store actions', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('vocals');
+    useProjectStore.getState().addClip(track.id, {
+      startTime: 0,
+      duration: 10,
+      prompt: 'test',
+      lyrics: '',
+    });
+  });
+
+  function getClip() {
+    return useProjectStore.getState().project!.tracks[0].clips[0];
+  }
+
+  describe('setClipGainEnvelope', () => {
+    it('sets the full gain envelope on a clip', () => {
+      const clip = getClip();
+      const envelope = [
+        { time: 0, gain: 1.0 },
+        { time: 5, gain: 0.5 },
+      ];
+      useProjectStore.getState().setClipGainEnvelope(clip.id, envelope);
+      expect(getClip().gainEnvelope).toEqual(envelope);
+    });
+
+    it('replaces existing envelope', () => {
+      const clip = getClip();
+      useProjectStore.getState().setClipGainEnvelope(clip.id, [{ time: 0, gain: 1 }]);
+      useProjectStore.getState().setClipGainEnvelope(clip.id, [{ time: 1, gain: 0.5 }]);
+      expect(getClip().gainEnvelope).toEqual([{ time: 1, gain: 0.5 }]);
+    });
+
+    it('clears envelope when set to empty array', () => {
+      const clip = getClip();
+      useProjectStore.getState().setClipGainEnvelope(clip.id, [{ time: 0, gain: 1 }]);
+      useProjectStore.getState().setClipGainEnvelope(clip.id, []);
+      expect(getClip().gainEnvelope).toEqual([]);
+    });
+  });
+
+  describe('addClipGainPoint', () => {
+    it('adds a point and keeps envelope sorted by time', () => {
+      const clip = getClip();
+      useProjectStore.getState().setClipGainEnvelope(clip.id, [
+        { time: 0, gain: 1 },
+        { time: 4, gain: 0.5 },
+      ]);
+      useProjectStore.getState().addClipGainPoint(clip.id, { time: 2, gain: 0.8 });
+      expect(getClip().gainEnvelope).toEqual([
+        { time: 0, gain: 1 },
+        { time: 2, gain: 0.8 },
+        { time: 4, gain: 0.5 },
+      ]);
+    });
+
+    it('creates envelope if none exists', () => {
+      const clip = getClip();
+      useProjectStore.getState().addClipGainPoint(clip.id, { time: 1, gain: 0.7 });
+      expect(getClip().gainEnvelope).toEqual([{ time: 1, gain: 0.7 }]);
+    });
+  });
+
+  describe('removeClipGainPoint', () => {
+    it('removes a point by index', () => {
+      const clip = getClip();
+      useProjectStore.getState().setClipGainEnvelope(clip.id, [
+        { time: 0, gain: 1 },
+        { time: 2, gain: 0.5 },
+        { time: 4, gain: 0.8 },
+      ]);
+      useProjectStore.getState().removeClipGainPoint(clip.id, 1);
+      expect(getClip().gainEnvelope).toEqual([
+        { time: 0, gain: 1 },
+        { time: 4, gain: 0.8 },
+      ]);
+    });
+
+    it('no-ops for out-of-range index', () => {
+      const clip = getClip();
+      useProjectStore.getState().setClipGainEnvelope(clip.id, [{ time: 0, gain: 1 }]);
+      useProjectStore.getState().removeClipGainPoint(clip.id, 5);
+      expect(getClip().gainEnvelope).toEqual([{ time: 0, gain: 1 }]);
+    });
+  });
+
+  describe('updateClipGainPoint', () => {
+    it('updates a point and re-sorts by time', () => {
+      const clip = getClip();
+      useProjectStore.getState().setClipGainEnvelope(clip.id, [
+        { time: 0, gain: 1 },
+        { time: 2, gain: 0.5 },
+        { time: 4, gain: 0.8 },
+      ]);
+      useProjectStore.getState().updateClipGainPoint(clip.id, 1, { gain: 0.3 });
+      expect(getClip().gainEnvelope![1]).toEqual({ time: 2, gain: 0.3 });
+    });
+
+    it('re-sorts when time changes', () => {
+      const clip = getClip();
+      useProjectStore.getState().setClipGainEnvelope(clip.id, [
+        { time: 0, gain: 1 },
+        { time: 2, gain: 0.5 },
+        { time: 4, gain: 0.8 },
+      ]);
+      useProjectStore.getState().updateClipGainPoint(clip.id, 0, { time: 5 });
+      expect(getClip().gainEnvelope).toEqual([
+        { time: 2, gain: 0.5 },
+        { time: 4, gain: 0.8 },
+        { time: 5, gain: 1 },
+      ]);
+    });
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -32,6 +32,7 @@ import type {
   TimeSignatureEvent,
   AudioWarpMarker,
   StretchMode,
+  GainEnvelopePoint,
 } from '../types/project';
 import { automationParamEquals } from '../types/project';
 import { TRACK_CATALOG, DEFAULT_DRUM_KIT } from '../constants/tracks';
@@ -137,6 +138,10 @@ interface ProjectState {
   setClipPitchShift: (clipId: string, semitones: number) => void;
   quantizeAudioClip: (clipId: string, warpMarkers: AudioWarpMarker[]) => void;
   clearAudioQuantize: (clipId: string) => void;
+  setClipGainEnvelope: (clipId: string, points: GainEnvelopePoint[]) => void;
+  addClipGainPoint: (clipId: string, point: GainEnvelopePoint) => void;
+  removeClipGainPoint: (clipId: string, pointIndex: number) => void;
+  updateClipGainPoint: (clipId: string, pointIndex: number, updates: Partial<GainEnvelopePoint>) => void;
 
   /** Slip-edit: shift audioOffset by deltaSeconds without changing startTime/duration. */
   slipClip: (clipId: string, deltaSeconds: number) => void;
@@ -988,6 +993,37 @@ export const useProjectStore = create<ProjectState>()(
       get().updateClip(clipId, { audioOffset: newOffset });
       return;
     }
+  },
+
+  setClipGainEnvelope: (clipId, points) => {
+    get().updateClip(clipId, { gainEnvelope: [...points] });
+  },
+
+  addClipGainPoint: (clipId, point) => {
+    const clip = get().getClipById(clipId);
+    if (!clip) return;
+    const envelope = [...(clip.gainEnvelope ?? []), point];
+    envelope.sort((a, b) => a.time - b.time);
+    get().updateClip(clipId, { gainEnvelope: envelope });
+  },
+
+  removeClipGainPoint: (clipId, pointIndex) => {
+    const clip = get().getClipById(clipId);
+    if (!clip || !clip.gainEnvelope) return;
+    if (pointIndex < 0 || pointIndex >= clip.gainEnvelope.length) return;
+    const envelope = clip.gainEnvelope.filter((_, i) => i !== pointIndex);
+    get().updateClip(clipId, { gainEnvelope: envelope });
+  },
+
+  updateClipGainPoint: (clipId, pointIndex, updates) => {
+    const clip = get().getClipById(clipId);
+    if (!clip || !clip.gainEnvelope) return;
+    if (pointIndex < 0 || pointIndex >= clip.gainEnvelope.length) return;
+    const envelope = clip.gainEnvelope.map((p, i) =>
+      i === pointIndex ? { ...p, ...updates } : p,
+    );
+    envelope.sort((a, b) => a.time - b.time);
+    get().updateClip(clipId, { gainEnvelope: envelope });
   },
 
   splitClip: (clipId, splitTime) => {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -141,6 +141,12 @@ export interface Take {
   selected: boolean;
 }
 
+/** A point in a clip-level gain envelope (non-destructive volume automation). */
+export interface GainEnvelopePoint {
+  time: number;   // seconds relative to clip start
+  gain: number;   // 0–2 (1 = unity, >1 = boost)
+}
+
 export interface Clip {
   id: string;
   trackId: string;
@@ -197,6 +203,8 @@ export interface Clip {
   takes?: Take[];
   /** Warp markers for audio quantize (transient-to-grid alignment). */
   warpMarkers?: AudioWarpMarker[];
+  /** Per-clip gain envelope for non-destructive volume automation. */
+  gainEnvelope?: GainEnvelopePoint[];
 }
 
 /** A warp marker on a clip mapping an original transient time to a grid-snapped position. */

--- a/src/utils/__tests__/gainEnvelope.test.ts
+++ b/src/utils/__tests__/gainEnvelope.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { interpolateGainEnvelope } from '../gainEnvelope';
+import type { GainEnvelopePoint } from '../../types/project';
+
+describe('interpolateGainEnvelope', () => {
+  it('returns 1.0 when envelope is empty', () => {
+    expect(interpolateGainEnvelope([], 0)).toBe(1);
+    expect(interpolateGainEnvelope([], 5)).toBe(1);
+  });
+
+  it('returns the single point value for any time when there is one point', () => {
+    const points: GainEnvelopePoint[] = [{ time: 1, gain: 0.5 }];
+    expect(interpolateGainEnvelope(points, 0)).toBe(0.5);
+    expect(interpolateGainEnvelope(points, 1)).toBe(0.5);
+    expect(interpolateGainEnvelope(points, 10)).toBe(0.5);
+  });
+
+  it('holds first point value before the first point', () => {
+    const points: GainEnvelopePoint[] = [
+      { time: 2, gain: 0.8 },
+      { time: 5, gain: 0.2 },
+    ];
+    expect(interpolateGainEnvelope(points, 0)).toBe(0.8);
+    expect(interpolateGainEnvelope(points, 1)).toBe(0.8);
+  });
+
+  it('holds last point value after the last point', () => {
+    const points: GainEnvelopePoint[] = [
+      { time: 0, gain: 1.0 },
+      { time: 3, gain: 0.5 },
+    ];
+    expect(interpolateGainEnvelope(points, 3)).toBe(0.5);
+    expect(interpolateGainEnvelope(points, 10)).toBe(0.5);
+  });
+
+  it('linearly interpolates between two points', () => {
+    const points: GainEnvelopePoint[] = [
+      { time: 0, gain: 1.0 },
+      { time: 4, gain: 0.0 },
+    ];
+    expect(interpolateGainEnvelope(points, 1)).toBeCloseTo(0.75);
+    expect(interpolateGainEnvelope(points, 2)).toBeCloseTo(0.5);
+    expect(interpolateGainEnvelope(points, 3)).toBeCloseTo(0.25);
+  });
+
+  it('interpolates across multiple segments', () => {
+    const points: GainEnvelopePoint[] = [
+      { time: 0, gain: 0 },
+      { time: 2, gain: 1.0 },
+      { time: 4, gain: 0.5 },
+    ];
+    expect(interpolateGainEnvelope(points, 1)).toBeCloseTo(0.5);
+    expect(interpolateGainEnvelope(points, 3)).toBeCloseTo(0.75);
+  });
+
+  it('clamps gain values to 0-2 range', () => {
+    const points: GainEnvelopePoint[] = [
+      { time: 0, gain: -0.5 },
+      { time: 1, gain: 3.0 },
+    ];
+    expect(interpolateGainEnvelope(points, 0)).toBe(0);
+    expect(interpolateGainEnvelope(points, 1)).toBe(2);
+  });
+});

--- a/src/utils/gainEnvelope.ts
+++ b/src/utils/gainEnvelope.ts
@@ -1,0 +1,36 @@
+import type { GainEnvelopePoint } from '../types/project';
+
+/**
+ * Interpolate gain value at a given time from a sorted envelope.
+ * Returns 1.0 (unity gain) if envelope is empty.
+ * Holds first/last value outside the envelope range.
+ * Linearly interpolates between adjacent points.
+ */
+export function interpolateGainEnvelope(
+  points: GainEnvelopePoint[],
+  time: number,
+): number {
+  if (points.length === 0) return 1;
+
+  const clamp = (v: number) => Math.max(0, Math.min(2, v));
+
+  if (points.length === 1) return clamp(points[0].gain);
+
+  // Before first point: hold
+  if (time <= points[0].time) return clamp(points[0].gain);
+
+  // After last point: hold
+  if (time >= points[points.length - 1].time) return clamp(points[points.length - 1].gain);
+
+  // Find segment
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i];
+    const b = points[i + 1];
+    if (time >= a.time && time <= b.time) {
+      const t = (time - a.time) / (b.time - a.time);
+      return clamp(a.gain + t * (b.gain - a.gain));
+    }
+  }
+
+  return 1;
+}


### PR DESCRIPTION
## Summary
- Add `GainEnvelopePoint` type and `gainEnvelope` field to `Clip` for non-destructive per-clip volume automation
- Store CRUD actions: `setClipGainEnvelope`, `addClipGainPoint`, `removeClipGainPoint`, `updateClipGainPoint` with auto-sort by time
- `interpolateGainEnvelope` utility for computing gain at any time position
- AudioEngine applies gain envelope via Web Audio API `linearRampToValueAtTime` with proper seek handling
- `ClipGainEnvelope` SVG overlay component: double-click to add points, drag to move, Alt+click to remove
- 16 new unit tests covering interpolation and store actions

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 254 tests pass (16 new)
- [x] `npm run build` — succeeds
- [ ] Manual: create clip, use `window.__store.getState().setClipGainEnvelope(clipId, [{time:0,gain:1},{time:5,gain:0.2}])` to draw envelope
- [ ] Manual: verify gain envelope renders as SVG overlay on clip
- [ ] Manual: verify playback applies volume automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)