### PR TITLE
feat: track height presets — small/medium/large/auto (closes #210)

### DIFF
--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -31,6 +31,8 @@ export function TrackHeader({
   const renameTrack = useProjectStore((s) => s.renameTrack);
   const removeTrack = useProjectStore((s) => s.removeTrack);
   const duplicateTrack = useProjectStore((s) => s.duplicateTrack);
+  const setTrackHeightPreset = useProjectStore((s) => s.setTrackHeightPreset);
+  const setAllTracksHeightPreset = useProjectStore((s) => s.setAllTracksHeightPreset);
   const setInputMonitoring = useProjectStore((s) => s.setInputMonitoring);
   const unfreezeTrack = useProjectStore((s) => s.unfreezeTrack);
 
@@ -44,6 +46,7 @@ export function TrackHeader({
 
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
+  const [heightSubmenu, setHeightSubmenu] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [isFreezing, setIsFreezing] = useState(false);
 
@@ -419,6 +422,42 @@ export function TrackHeader({
           >
             Track Settings...
           </button>
+          {/* Track Height submenu */}
+          <div
+            className="relative"
+            onMouseEnter={() => setHeightSubmenu(true)}
+            onMouseLeave={() => setHeightSubmenu(false)}
+          >
+            <button
+              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors flex items-center justify-between"
+            >
+              Track Height
+              <span className="text-zinc-500 text-[9px] ml-2">&#8250;</span>
+            </button>
+            {heightSubmenu && (
+              <div className="absolute left-full top-0 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[130px] z-50">
+                {(['small', 'medium', 'large', 'auto'] as const).map((preset) => (
+                  <button
+                    key={preset}
+                    onClick={() => { setCtxMenu(null); setHeightSubmenu(false); setTrackHeightPreset(track.id, preset); }}
+                    className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors capitalize"
+                  >
+                    {preset}
+                  </button>
+                ))}
+                <div className="my-1 border-t border-[#555]" />
+                {(['small', 'medium', 'large', 'auto'] as const).map((preset) => (
+                  <button
+                    key={`all-${preset}`}
+                    onClick={() => { setCtxMenu(null); setHeightSubmenu(false); setAllTracksHeightPreset(preset); }}
+                    className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-400 hover:bg-daw-accent hover:text-white transition-colors capitalize"
+                  >
+                    All Tracks {preset}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
           <button
             onClick={() => { setCtxMenu(null); duplicateTrack(track.id); }}
             className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"

--- a/src/constants/trackHeight.ts
+++ b/src/constants/trackHeight.ts
@@ -1,0 +1,27 @@
+import type { TrackType } from '../types/project';
+
+export type TrackHeightPreset = 'small' | 'medium' | 'large' | 'auto';
+
+/** Fixed pixel heights for non-auto presets. */
+export const TRACK_HEIGHT_PRESETS: Record<string, number> = {
+  small: 48,
+  medium: 80,
+  large: 140,
+};
+
+/** Default lane heights per track type (used for 'auto' preset). */
+const AUTO_DEFAULTS: Record<TrackType, number> = {
+  stems: 64,
+  sample: 64,
+  sequencer: 80,
+  pianoRoll: 88,
+};
+
+/** Resolve a preset to a pixel height, considering track type for 'auto'. */
+export function getTrackHeightForPreset(
+  preset: TrackHeightPreset,
+  trackType: TrackType,
+): number {
+  if (preset === 'auto') return AUTO_DEFAULTS[trackType] ?? 64;
+  return TRACK_HEIGHT_PRESETS[preset];
+}

--- a/src/store/__tests__/trackHeightPresets.test.ts
+++ b/src/store/__tests__/trackHeightPresets.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+import {
+  TRACK_HEIGHT_PRESETS,
+  getTrackHeightForPreset,
+} from '../../constants/trackHeight';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('track height presets', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+  });
+
+  describe('TRACK_HEIGHT_PRESETS', () => {
+    it('defines small, medium, large, and auto presets', () => {
+      expect(TRACK_HEIGHT_PRESETS.small).toBeDefined();
+      expect(TRACK_HEIGHT_PRESETS.medium).toBeDefined();
+      expect(TRACK_HEIGHT_PRESETS.large).toBeDefined();
+      expect(TRACK_HEIGHT_PRESETS.auto).toBeUndefined();
+    });
+
+    it('small < medium < large', () => {
+      expect(TRACK_HEIGHT_PRESETS.small).toBeLessThan(TRACK_HEIGHT_PRESETS.medium);
+      expect(TRACK_HEIGHT_PRESETS.medium).toBeLessThan(TRACK_HEIGHT_PRESETS.large);
+    });
+  });
+
+  describe('getTrackHeightForPreset', () => {
+    it('returns fixed height for small/medium/large', () => {
+      expect(getTrackHeightForPreset('small', 'stems')).toBe(TRACK_HEIGHT_PRESETS.small);
+      expect(getTrackHeightForPreset('medium', 'stems')).toBe(TRACK_HEIGHT_PRESETS.medium);
+      expect(getTrackHeightForPreset('large', 'stems')).toBe(TRACK_HEIGHT_PRESETS.large);
+    });
+
+    it('returns track-type default for auto preset', () => {
+      expect(getTrackHeightForPreset('auto', 'stems')).toBe(64);
+      expect(getTrackHeightForPreset('auto', 'sample')).toBe(64);
+      expect(getTrackHeightForPreset('auto', 'sequencer')).toBe(80);
+      expect(getTrackHeightForPreset('auto', 'pianoRoll')).toBe(88);
+    });
+  });
+
+  describe('setTrackHeightPreset (single track)', () => {
+    it('sets a single track to a preset height', () => {
+      const track = useProjectStore.getState().addTrack('stems');
+      useProjectStore.getState().setTrackHeightPreset(track.id, 'small');
+      const updated = useProjectStore.getState().project!.tracks[0];
+      expect(updated.laneHeight).toBe(TRACK_HEIGHT_PRESETS.small);
+    });
+
+    it('sets auto preset to track-type default', () => {
+      const track = useProjectStore.getState().addTrack('stems', 'sequencer');
+      useProjectStore.getState().setTrackHeightPreset(track.id, 'auto');
+      const updated = useProjectStore.getState().project!.tracks[0];
+      expect(updated.laneHeight).toBe(80);
+    });
+
+    it('pushes to undo history', () => {
+      const track = useProjectStore.getState().addTrack('stems');
+      useProjectStore.getState().setTrackHeightPreset(track.id, 'large');
+      useProjectStore.getState().undo();
+      const after = useProjectStore.getState().project!.tracks[0];
+      expect(after.laneHeight).not.toBe(TRACK_HEIGHT_PRESETS.large);
+    });
+  });
+
+  describe('setAllTracksHeightPreset', () => {
+    it('sets all tracks to the given preset', () => {
+      useProjectStore.getState().addTrack('stems');
+      useProjectStore.getState().addTrack('stems', 'sequencer');
+      useProjectStore.getState().addTrack('stems', 'pianoRoll');
+      useProjectStore.getState().setAllTracksHeightPreset('small');
+      const tracks = useProjectStore.getState().project!.tracks;
+      expect(tracks).toHaveLength(3);
+      for (const t of tracks) {
+        expect(t.laneHeight).toBe(TRACK_HEIGHT_PRESETS.small);
+      }
+    });
+
+    it('auto preset uses track-type defaults', () => {
+      useProjectStore.getState().addTrack('stems');
+      useProjectStore.getState().addTrack('stems', 'sequencer');
+      useProjectStore.getState().addTrack('stems', 'pianoRoll');
+      useProjectStore.getState().setAllTracksHeightPreset('auto');
+      const tracks = useProjectStore.getState().project!.tracks;
+      expect(tracks[0].laneHeight).toBe(64);
+      expect(tracks[1].laneHeight).toBe(80);
+      expect(tracks[2].laneHeight).toBe(88);
+    });
+
+    it('pushes a single undo snapshot for all tracks', () => {
+      useProjectStore.getState().addTrack('stems');
+      useProjectStore.getState().addTrack('stems');
+      useProjectStore.getState().setAllTracksHeightPreset('large');
+      useProjectStore.getState().undo();
+      const tracks = useProjectStore.getState().project!.tracks;
+      for (const t of tracks) {
+        expect(t.laneHeight).not.toBe(TRACK_HEIGHT_PRESETS.large);
+      }
+    });
+
+    it('does nothing when no project exists', () => {
+      useProjectStore.setState({ project: null });
+      useProjectStore.getState().setAllTracksHeightPreset('small');
+    });
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
+import { type TrackHeightPreset, getTrackHeightForPreset } from '../constants/trackHeight';
 import type {
   Project,
   Track,
@@ -115,6 +116,8 @@ interface ProjectState {
   updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'armed' | 'laneHeight' | 'trackType' | 'synthPreset' | 'drumKit' | 'color'>>) => void;
   renameTrack: (trackId: string, newName: string) => void;
   setInputMonitoring: (trackId: string, mode: InputMonitoringMode) => void;
+  setTrackHeightPreset: (trackId: string, preset: TrackHeightPreset) => void;
+  setAllTracksHeightPreset: (preset: TrackHeightPreset) => void;
   reorderTrack: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
 
   addClip: (trackId: string, clip: Omit<Clip, 'id' | 'trackId' | 'generationStatus' | 'generationJobId' | 'cumulativeMixKey' | 'isolatedAudioKey' | 'waveformPeaks'>) => Clip;
@@ -706,6 +709,41 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
+
+  setTrackHeightPreset: (trackId, preset) => {
+    const state = get();
+    if (!state.project) return;
+    const track = state.project.tracks.find((t) => t.id === trackId);
+    if (!track) return;
+    const trackType = track.trackType ?? 'stems';
+    const laneHeight = getTrackHeightForPreset(preset, trackType);
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, laneHeight } : t,
+        ),
+      },
+    });
+  },
+
+  setAllTracksHeightPreset: (preset) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => ({
+          ...t,
+          laneHeight: getTrackHeightForPreset(preset, t.trackType ?? 'stems'),
+        })),
+      },
+    });
+  },
   renameTrack: (trackId, newName) => {
     const state = get();
     if (!state.project) return;


### PR DESCRIPTION
## Summary
- Adds `TrackHeightPreset` type (`small` 48px / `medium` 80px / `large` 140px / `auto` track-type defaults) in `src/constants/trackHeight.ts`
- Adds `setTrackHeightPreset` and `setAllTracksHeightPreset` store actions with full undo support
- Adds "Track Height" flyout submenu to the track header right-click context menu with per-track and all-tracks options

## Test plan
- [x] 11 unit tests covering preset constants, single-track preset, all-tracks preset, auto mode, and undo
- [ ] Manual: right-click track header → Track Height → select preset → verify height changes
- [ ] Manual: right-click → Track Height → All Tracks small → verify all tracks resize
- [ ] Manual: Cmd+Z after preset change → verify undo restores previous heights

🤖 Generated with [Claude Code](https://claude.com/claude-code)