### PR TITLE
feat: sidechain compression with cross-track routing (#196)

### DIFF
--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -152,13 +152,20 @@ export function EQCurve({ low, mid, high }: { low: number; mid: number; high: nu
 
 export function CompressorCard({ effect, trackId }: { effect: TrackEffect & { type: 'compressor' }; trackId: string }) {
   const updateTrackEffect = useProjectStore((s) => s.updateTrackEffect);
+  const setSidechainSource = useProjectStore((s) => s.setSidechainSource);
+  const tracks = useProjectStore((s) => s.project?.tracks ?? []);
   const p = effect.params;
   const [reduction, setReduction] = useState(0);
+  const [scReduction, setScReduction] = useState(0);
   const animRef = useRef<number>(0);
+
+  const hasSidechain = !!p.sidechainSourceTrackId;
+  const otherTracks = tracks.filter((t) => t.id !== trackId);
 
   useEffect(() => {
     const tick = () => {
       setReduction(effectsEngine.getCompressorReduction(trackId, effect.id));
+      setScReduction(effectsEngine.getSidechainReduction(trackId, effect.id));
       animRef.current = requestAnimationFrame(tick);
     };
     animRef.current = requestAnimationFrame(tick);
@@ -171,6 +178,11 @@ export function CompressorCard({ effect, trackId }: { effect: TrackEffect & { ty
     effectsEngine.updateEffectParams(trackId, effect.id, newParams, 'compressor');
   };
 
+  const handleSidechainChange = (sourceTrackId: string) => {
+    const value = sourceTrackId === '' ? undefined : sourceTrackId;
+    setSidechainSource(trackId, effect.id, value);
+  };
+
   return (
     <div className="flex flex-col gap-2 p-2">
       <div className="flex gap-2 justify-center">
@@ -180,6 +192,28 @@ export function CompressorCard({ effect, trackId }: { effect: TrackEffect & { ty
         <Knob value={p.release} onChange={(v) => update({ release: v })} min={0.01} max={1} defaultValue={0.2} label="Release" size={28} step={0.01} />
       </div>
       <Knob value={p.knee} onChange={(v) => update({ knee: v })} min={0} max={40} defaultValue={6} label="Knee" size={24} step={1} />
+
+      {/* Sidechain source dropdown */}
+      <div className="border-t border-white/5 pt-1.5 mt-0.5">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[7px] text-white/30 uppercase w-6">SC</span>
+          <select
+            data-testid="sidechain-source-select"
+            className="flex-1 text-[9px] bg-white/5 border border-white/10 rounded px-1 py-0.5 text-white/70 outline-none focus:border-amber-500/50"
+            value={p.sidechainSourceTrackId ?? ''}
+            onChange={(e) => handleSidechainChange(e.target.value)}
+          >
+            <option value="">None</option>
+            {otherTracks.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.displayName || `Track ${tracks.indexOf(t) + 1}`}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Compressor GR meter */}
       <div className="flex items-center gap-1.5">
         <span className="text-[7px] text-white/30 w-6">GR</span>
         <div className="flex-1 h-3 bg-white/5 rounded-full overflow-hidden relative">
@@ -190,6 +224,20 @@ export function CompressorCard({ effect, trackId }: { effect: TrackEffect & { ty
         </div>
         <span className="text-[8px] text-white/40 font-mono w-10 text-right">{reduction.toFixed(1)} dB</span>
       </div>
+
+      {/* Sidechain GR meter (only shown when sidechain is active) */}
+      {hasSidechain && (
+        <div className="flex items-center gap-1.5">
+          <span className="text-[7px] text-amber-400/50 w-6">SC</span>
+          <div className="flex-1 h-3 bg-white/5 rounded-full overflow-hidden relative">
+            <div
+              className="absolute right-0 top-0 bottom-0 bg-amber-400/40 rounded-full transition-all"
+              style={{ width: `${Math.min(100, Math.abs(scReduction) * 100 / 30)}%` }}
+            />
+          </div>
+          <span className="text-[8px] text-amber-400/40 font-mono w-10 text-right">{scReduction.toFixed(1)} dB</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -9,6 +9,7 @@ import type {
   DistortionParams,
   FilterParams,
 } from '../types/project';
+import { SidechainFollower } from './sidechainFollower';
 
 type EffectNode = {
   id: string;
@@ -86,8 +87,13 @@ function createNode(effect: TrackEffect): EffectNode {
   }
 }
 
+function scKey(trackId: string, effectId: string): string {
+  return `${trackId}:${effectId}`;
+}
+
 class EffectsEngine {
   private chains = new Map<string, EffectNode[]>();
+  private sidechains = new Map<string, SidechainFollower>();
 
   rebuildChain(trackId: string, effects: TrackEffect[]) {
     this.disposeChain(trackId);
@@ -99,9 +105,6 @@ class EffectsEngine {
     this.chains.set(trackId, nodes);
   }
 
-  /**
-   * Update a single effect's parameters in real-time (no full rebuild needed for most effects).
-   */
   updateEffectParams(
     trackId: string,
     effectId: string,
@@ -132,6 +135,7 @@ class EffectsEngine {
         comp.attack.value = p.attack;
         comp.release.value = p.release;
         comp.knee.value = p.knee;
+        this.updateSidechainParams(trackId, effectId, p);
         break;
       }
       case 'reverb': {
@@ -198,14 +202,82 @@ class EffectsEngine {
     return (effectNode.node as Tone.Compressor).reduction;
   }
 
+  /** Get sidechain gain reduction in dB for metering. */
+  getSidechainReduction(trackId: string, effectId: string): number {
+    const follower = this.sidechains.get(scKey(trackId, effectId));
+    return follower ? follower.reduction : 0;
+  }
+
+  /**
+   * Connect a sidechain source to a compressor on a target track.
+   * Inserts SidechainFollower.gainNode after the compressor in the chain.
+   */
+  connectSidechain(
+    targetTrackId: string,
+    effectId: string,
+    sourceOutput: AudioNode,
+    params: CompressorParams,
+  ) {
+    const key = scKey(targetTrackId, effectId);
+    this.disconnectSidechain(targetTrackId, effectId);
+
+    const ctx = sourceOutput.context as AudioContext;
+    const follower = new SidechainFollower(ctx, sourceOutput, {
+      threshold: params.threshold,
+      ratio: params.ratio,
+      attack: params.attack,
+      release: params.release,
+      knee: params.knee,
+    });
+    this.sidechains.set(key, follower);
+
+    // Insert the gainNode into the chain after the compressor
+    const nodes = this.chains.get(targetTrackId);
+    if (!nodes) return;
+    const compIdx = nodes.findIndex((n) => n.id === effectId && n.type === 'compressor');
+    if (compIdx < 0) return;
+
+    const compNode = nodes[compIdx];
+    const nextNode = nodes[compIdx + 1];
+
+    if (nextNode) {
+      try { compNode.node.disconnect(nextNode.node); } catch { /* ok */ }
+      const nextInput = (nextNode.node as unknown as { input?: AudioNode }).input
+        ?? (nextNode.node as unknown as AudioNode);
+      compNode.node.connect(follower.gainNode as unknown as AudioNode);
+      (follower.gainNode as unknown as AudioNode).connect(nextInput);
+    } else {
+      compNode.node.connect(follower.gainNode as unknown as AudioNode);
+    }
+  }
+
+  disconnectSidechain(targetTrackId: string, effectId: string) {
+    const key = scKey(targetTrackId, effectId);
+    const follower = this.sidechains.get(key);
+    if (follower) {
+      follower.dispose();
+      this.sidechains.delete(key);
+    }
+  }
+
+  updateSidechainParams(targetTrackId: string, effectId: string, params: CompressorParams) {
+    const key = scKey(targetTrackId, effectId);
+    const follower = this.sidechains.get(key);
+    if (follower) {
+      follower.updateParams({
+        threshold: params.threshold,
+        ratio: params.ratio,
+        attack: params.attack,
+        release: params.release,
+        knee: params.knee,
+      });
+    }
+  }
+
   getChain(trackId: string): EffectNode[] {
     return this.chains.get(trackId) ?? [];
   }
 
-  /**
-   * Returns the native AudioNode input of this track's effect chain, or null if empty.
-   * Tone.js ToneAudioNode exposes `.input` which is a native AudioNode suitable for connect().
-   */
   getInputNode(trackId: string): AudioNode | null {
     const nodes = this.chains.get(trackId);
     if (!nodes?.length) return null;
@@ -213,18 +285,29 @@ class EffectsEngine {
     return toneNode.input ?? null;
   }
 
-  /**
-   * Returns the native AudioNode output of this track's effect chain, or null if empty.
-   * Tone.js ToneAudioNode exposes `.output` which is a native AudioNode suitable for connect().
-   */
   getOutputNode(trackId: string): AudioNode | null {
     const nodes = this.chains.get(trackId);
     if (!nodes?.length) return null;
-    const toneNode = nodes[nodes.length - 1].node as unknown as { output?: AudioNode };
+
+    // If the last node is a compressor with sidechain, return the follower's gainNode
+    const lastNode = nodes[nodes.length - 1];
+    if (lastNode.type === 'compressor') {
+      const follower = this.sidechains.get(scKey(trackId, lastNode.id));
+      if (follower) return follower.gainNode;
+    }
+
+    const toneNode = lastNode.node as unknown as { output?: AudioNode };
     return toneNode.output ?? null;
   }
 
   disposeChain(trackId: string) {
+    // Dispose all sidechains for this track
+    for (const [key, follower] of this.sidechains) {
+      if (key.startsWith(`${trackId}:`)) {
+        follower.dispose();
+        this.sidechains.delete(key);
+      }
+    }
     const nodes = this.chains.get(trackId);
     if (!nodes) return;
     for (const node of nodes) {
@@ -235,6 +318,10 @@ class EffectsEngine {
   }
 
   dispose() {
+    for (const follower of this.sidechains.values()) {
+      follower.dispose();
+    }
+    this.sidechains.clear();
     for (const trackId of this.chains.keys()) {
       this.disposeChain(trackId);
     }

--- a/src/engine/__tests__/sidechainFollower.test.ts
+++ b/src/engine/__tests__/sidechainFollower.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { computeGainReduction, smoothGain } from '../sidechainFollower';
+
+describe('sidechain follower — pure computation', () => {
+  describe('computeGainReduction', () => {
+    it('returns 0 dB reduction when signal is below threshold', () => {
+      expect(computeGainReduction(-30, -20, 4, 0)).toBe(0);
+    });
+
+    it('applies compression ratio when signal exceeds threshold', () => {
+      // 10 dB over threshold at 4:1 → 7.5 dB reduction
+      expect(computeGainReduction(-10, -20, 4, 0)).toBeCloseTo(7.5);
+    });
+
+    it('returns full reduction at infinite ratio (limiter)', () => {
+      expect(computeGainReduction(-10, -20, Infinity, 0)).toBeCloseTo(10);
+    });
+
+    it('applies soft knee when knee > 0', () => {
+      const reductionAtThreshold = computeGainReduction(-20, -20, 4, 6);
+      expect(reductionAtThreshold).toBeGreaterThan(0);
+      expect(reductionAtThreshold).toBeLessThan(computeGainReduction(-17, -20, 4, 0));
+    });
+
+    it('returns 0 reduction at ratio 1:1', () => {
+      expect(computeGainReduction(-10, -20, 1, 0)).toBe(0);
+    });
+
+    it('returns 0 when signal is well below soft knee range', () => {
+      expect(computeGainReduction(-30, -20, 4, 6)).toBe(0);
+    });
+
+    it('matches hard knee beyond the knee region', () => {
+      const hardKnee = computeGainReduction(0, -20, 4, 0);
+      const softKnee = computeGainReduction(0, -20, 4, 6);
+      expect(softKnee).toBeCloseTo(hardKnee, 1);
+    });
+  });
+
+  describe('smoothGain', () => {
+    it('approaches target gain using attack coefficient (ducking)', () => {
+      const result = smoothGain(1.0, 0.5, 0.01, 0.1, 1 / 60);
+      expect(result).toBeLessThan(1.0);
+      expect(result).toBeGreaterThan(0.5);
+    });
+
+    it('approaches target gain using release coefficient (recovering)', () => {
+      const result = smoothGain(0.5, 1.0, 0.01, 0.1, 1 / 60);
+      expect(result).toBeGreaterThan(0.5);
+      expect(result).toBeLessThan(1.0);
+    });
+
+    it('reaches target faster with shorter attack time', () => {
+      const fast = smoothGain(1.0, 0.5, 0.001, 0.1, 1 / 60);
+      const slow = smoothGain(1.0, 0.5, 0.05, 0.1, 1 / 60);
+      expect(fast).toBeLessThan(slow);
+    });
+
+    it('returns value near target with large dt', () => {
+      const result = smoothGain(1.0, 0.5, 0.01, 0.1, 10);
+      expect(result).toBeCloseTo(0.5, 2);
+    });
+
+    it('returns current gain when dt is 0', () => {
+      const result = smoothGain(0.8, 0.5, 0.01, 0.1, 0);
+      expect(result).toBeCloseTo(0.8, 5);
+    });
+  });
+});

--- a/src/engine/sidechainFollower.ts
+++ b/src/engine/sidechainFollower.ts
@@ -1,0 +1,164 @@
+/**
+ * Sidechain compression envelope follower.
+ *
+ * Pure computation functions (testable without Web Audio) +
+ * SidechainFollower class that wires source track → envelope → gain ducking.
+ */
+
+/**
+ * Compute gain reduction in dB given the source signal level.
+ *
+ * @param inputDb   - RMS level of the sidechain source in dB
+ * @param threshold - Compressor threshold in dB
+ * @param ratio     - Compression ratio (e.g. 4 = 4:1)
+ * @param knee      - Soft knee width in dB (0 = hard knee)
+ * @returns Gain reduction in dB (always >= 0)
+ */
+export function computeGainReduction(
+  inputDb: number,
+  threshold: number,
+  ratio: number,
+  knee: number,
+): number {
+  if (ratio <= 1) return 0;
+
+  const slope = 1 - 1 / ratio;
+
+  if (knee <= 0) {
+    const overshoot = inputDb - threshold;
+    if (overshoot <= 0) return 0;
+    return overshoot * slope;
+  }
+
+  // Soft knee
+  const halfKnee = knee / 2;
+  const overshoot = inputDb - threshold;
+
+  if (overshoot <= -halfKnee) {
+    return 0;
+  } else if (overshoot >= halfKnee) {
+    return overshoot * slope;
+  } else {
+    // Quadratic transition in the knee region
+    const x = overshoot + halfKnee;
+    return (slope * x * x) / (2 * knee);
+  }
+}
+
+/**
+ * One-pole smoothing for gain envelope (attack/release).
+ *
+ * @param currentGain - Current linear gain value
+ * @param targetGain  - Target linear gain value
+ * @param attackSec   - Attack time in seconds
+ * @param releaseSec  - Release time in seconds
+ * @param dt          - Time step in seconds (e.g. 1/60 for 60fps)
+ * @returns Smoothed linear gain value
+ */
+export function smoothGain(
+  currentGain: number,
+  targetGain: number,
+  attackSec: number,
+  releaseSec: number,
+  dt: number,
+): number {
+  const timeSec = targetGain < currentGain ? attackSec : releaseSec;
+  const alpha = 1 - Math.exp(-dt / Math.max(timeSec, 0.0001));
+  return currentGain + alpha * (targetGain - currentGain);
+}
+
+export interface SidechainParams {
+  threshold: number;
+  ratio: number;
+  attack: number;
+  release: number;
+  knee: number;
+}
+
+/**
+ * SidechainFollower — connects a source track's audio to an envelope follower
+ * and applies gain reduction to the target track via a GainNode.
+ */
+export class SidechainFollower {
+  readonly gainNode: GainNode;
+  private analyser: AnalyserNode;
+  private analyserBuffer: Float32Array<ArrayBuffer>;
+  private rafId = 0;
+  private params: SidechainParams;
+  private currentGainLinear = 1;
+  private lastTime = 0;
+  private disposed = false;
+  /** Latest gain reduction in dB (for metering). */
+  reduction = 0;
+
+  constructor(
+    ctx: AudioContext,
+    sourceOutput: AudioNode,
+    params: SidechainParams,
+  ) {
+    this.params = { ...params };
+    this.analyser = ctx.createAnalyser();
+    this.analyser.fftSize = 256;
+    this.analyserBuffer = new Float32Array(this.analyser.fftSize) as Float32Array<ArrayBuffer>;
+    this.gainNode = ctx.createGain();
+
+    // Tap the source track's output (does not interrupt source routing)
+    sourceOutput.connect(this.analyser);
+
+    this.lastTime = performance.now() / 1000;
+    this.tick = this.tick.bind(this);
+    this.rafId = requestAnimationFrame(this.tick);
+  }
+
+  updateParams(p: SidechainParams) {
+    this.params = { ...p };
+  }
+
+  private tick() {
+    if (this.disposed) return;
+
+    const now = performance.now() / 1000;
+    const dt = Math.min(now - this.lastTime, 0.1);
+    this.lastTime = now;
+
+    // Read RMS from source
+    this.analyser.getFloatTimeDomainData(this.analyserBuffer);
+    let sum = 0;
+    for (let i = 0; i < this.analyserBuffer.length; i++) {
+      const s = this.analyserBuffer[i];
+      sum += s * s;
+    }
+    const rms = Math.sqrt(sum / this.analyserBuffer.length);
+    const inputDb = 20 * Math.log10(Math.max(rms, 1e-8));
+
+    // Compute target gain reduction
+    const reductionDb = computeGainReduction(
+      inputDb,
+      this.params.threshold,
+      this.params.ratio,
+      this.params.knee,
+    );
+    this.reduction = reductionDb;
+    const targetGain = Math.pow(10, -reductionDb / 20);
+
+    // Smooth
+    this.currentGainLinear = smoothGain(
+      this.currentGainLinear,
+      targetGain,
+      this.params.attack,
+      this.params.release,
+      dt,
+    );
+
+    // Apply
+    this.gainNode.gain.value = this.currentGainLinear;
+    this.rafId = requestAnimationFrame(this.tick);
+  }
+
+  dispose() {
+    this.disposed = true;
+    cancelAnimationFrame(this.rafId);
+    try { this.analyser.disconnect(); } catch { /* ok */ }
+    try { this.gainNode.disconnect(); } catch { /* ok */ }
+  }
+}

--- a/src/hooks/useEffectsSync.ts
+++ b/src/hooks/useEffectsSync.ts
@@ -1,14 +1,14 @@
 /**
  * useEffectsSync.ts — Keeps the audio effect chain in sync with track store state.
  *
- * Previously, effects were only wired when the EffectChain panel was open.
- * This hook runs at the app level and ensures effects are always applied,
- * regardless of whether the Mixer/EffectChain UI is visible.
+ * Runs at the app level so effects are always applied regardless of UI visibility.
+ * Also wires sidechain compression when a compressor has sidechainSourceTrackId.
  */
 import { useEffect } from 'react';
 import { useProjectStore } from '../store/projectStore';
 import { effectsEngine } from '../engine/EffectsEngine';
 import { getAudioEngine } from './useAudioEngine';
+import type { CompressorParams } from '../types/project';
 
 export function useEffectsSync() {
   const tracks = useProjectStore((s) => s.project?.tracks);
@@ -18,17 +18,43 @@ export function useEffectsSync() {
 
     const engine = getAudioEngine();
 
+    // First pass: rebuild all effect chains
     for (const track of tracks) {
       const effects = track.effects ?? [];
-      // Build the Tone.js chain for this track
       effectsEngine.rebuildChain(track.id, effects);
-      // Splice into the Web Audio signal path
       const trackNode = engine.getOrCreateTrackNode(track.id);
       if (trackNode) {
         trackNode.spliceEffects(
           effectsEngine.getInputNode(track.id),
           effectsEngine.getOutputNode(track.id),
         );
+      }
+    }
+
+    // Second pass: wire sidechain connections (all chains must exist first)
+    for (const track of tracks) {
+      for (const effect of track.effects ?? []) {
+        if (effect.type !== 'compressor') continue;
+        const params = effect.params as CompressorParams;
+        if (!params.sidechainSourceTrackId) continue;
+
+        const sourceTrackNode = engine.getOrCreateTrackNode(params.sidechainSourceTrackId);
+        if (!sourceTrackNode) continue;
+
+        effectsEngine.connectSidechain(
+          track.id,
+          effect.id,
+          sourceTrackNode.volumeGain,
+          params,
+        );
+        // Re-splice output since sidechain may have changed the output node
+        const targetTrackNode = engine.getOrCreateTrackNode(track.id);
+        if (targetTrackNode) {
+          targetTrackNode.spliceEffects(
+            effectsEngine.getInputNode(track.id),
+            effectsEngine.getOutputNode(track.id),
+          );
+        }
       }
     }
   }, [tracks]);

--- a/src/store/__tests__/sidechainCompression.test.ts
+++ b/src/store/__tests__/sidechainCompression.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useProjectStore } from '../projectStore';
+import type { CompressorParams } from '../../types/project';
 
 vi.mock('../../services/projectStorage', () => ({ saveProject: vi.fn() }));
 
@@ -25,7 +26,7 @@ describe('sidechain compression with cross-track routing', () => {
     const updatedTrack = useProjectStore.getState().project!.tracks.find(t => t.id === bassTrackId)!;
     const compressor = updatedTrack.effects.find(e => e.id === effectId)!;
     expect(compressor.type).toBe('compressor');
-    expect((compressor.params as { sidechainSourceTrackId?: string }).sidechainSourceTrackId).toBe(kickTrackId);
+    expect((compressor.params as CompressorParams).sidechainSourceTrackId).toBe(kickTrackId);
   });
 
   it('setSidechainSource can clear the sidechain by passing undefined', () => {
@@ -41,11 +42,64 @@ describe('sidechain compression with cross-track routing', () => {
     useProjectStore.getState().setSidechainSource(bassTrackId, effectId, kickTrackId);
     let compressor = useProjectStore.getState().project!.tracks.find(t => t.id === bassTrackId)!
       .effects.find(e => e.id === effectId)!;
-    expect((compressor.params as { sidechainSourceTrackId?: string }).sidechainSourceTrackId).toBe(kickTrackId);
+    expect((compressor.params as CompressorParams).sidechainSourceTrackId).toBe(kickTrackId);
 
     useProjectStore.getState().setSidechainSource(bassTrackId, effectId, undefined);
     compressor = useProjectStore.getState().project!.tracks.find(t => t.id === bassTrackId)!
       .effects.find(e => e.id === effectId)!;
-    expect((compressor.params as { sidechainSourceTrackId?: string }).sidechainSourceTrackId).toBeUndefined();
+    expect((compressor.params as CompressorParams).sidechainSourceTrackId).toBeUndefined();
+  });
+
+  it('setSidechainSource ignores non-compressor effects', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('stems');
+    store.addTrack('stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+    const kickTrackId = tracks[0].id;
+    const bassTrackId = tracks[1].id;
+
+    const reverbId = store.addTrackEffect(bassTrackId, 'reverb')!;
+
+    // Should not crash or modify the reverb effect
+    useProjectStore.getState().setSidechainSource(bassTrackId, reverbId, kickTrackId);
+    const updatedTrack = useProjectStore.getState().project!.tracks.find(t => t.id === bassTrackId)!;
+    const reverb = updatedTrack.effects.find(e => e.id === reverbId)!;
+    expect(reverb.type).toBe('reverb');
+    expect((reverb.params as Record<string, unknown>).sidechainSourceTrackId).toBeUndefined();
+  });
+
+  it('compressor default params do not include sidechainSourceTrackId', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+
+    const effectId = store.addTrackEffect(tracks[0].id, 'compressor')!;
+    const track = useProjectStore.getState().project!.tracks[0];
+    const compressor = track.effects.find(e => e.id === effectId)!;
+    const params = compressor.params as CompressorParams;
+
+    expect(params.sidechainSourceTrackId).toBeUndefined();
+    expect(params.threshold).toBe(-24);
+    expect(params.ratio).toBe(4);
+  });
+
+  it('setSidechainSource supports undo', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('stems');
+    store.addTrack('stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+
+    const effectId = store.addTrackEffect(tracks[1].id, 'compressor')!;
+
+    useProjectStore.getState().setSidechainSource(tracks[1].id, effectId, tracks[0].id);
+    const params = useProjectStore.getState().project!.tracks.find(t => t.id === tracks[1].id)!
+      .effects.find(e => e.id === effectId)!.params as CompressorParams;
+    expect(params.sidechainSourceTrackId).toBe(tracks[0].id);
+
+    // Undo should revert the sidechain source
+    useProjectStore.getState().undo();
+    const undoneParams = useProjectStore.getState().project!.tracks.find(t => t.id === tracks[1].id)!
+      .effects.find(e => e.id === effectId)!.params as CompressorParams;
+    expect(undoneParams.sidechainSourceTrackId).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- **Envelope follower**: `SidechainFollower` class reads source track RMS via AnalyserNode, computes gain reduction with soft knee support, smooths via one-pole attack/release filter, applies ducking via GainNode
- **EffectsEngine**: `connectSidechain` / `disconnectSidechain` / `getSidechainReduction` / `updateSidechainParams`
- **useEffectsSync**: Two-pass wiring — rebuild chains first, then wire sidechain routes
- **CompressorCard UI**: Sidechain source dropdown + SC gain reduction meter
- **Pure computation functions**: `computeGainReduction` (hard/soft knee) and `smoothGain` — fully unit tested

## Test plan
- [x] `computeGainReduction` — below/above threshold, soft knee, infinite ratio, ratio 1:1
- [x] `smoothGain` — attack/release behavior, convergence rates
- [x] `setSidechainSource` — set, clear, non-compressor ignored, default params clean
- [x] Undo support — sidechain source reverts on undo
- [x] All 253 tests pass, tsc clean, build succeeds

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)