### PR TITLE
feat: add AI stem separation flow

### DIFF
--- a/src/components/generation/StemSeparationModal.tsx
+++ b/src/components/generation/StemSeparationModal.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useUIStore } from '../../store/uiStore';
+import { useProjectStore } from '../../store/projectStore';
+import { useGenerationStore } from '../../store/generationStore';
+import { separateClipStems } from '../../services/stemSeparation';
+import type { StemCount } from '../../types/api';
+
+const STEM_OPTIONS: Array<{ count: StemCount; title: string; description: string }> = [
+  { count: 2, title: '2-Stem', description: 'Vocals + Instrumental' },
+  { count: 4, title: '4-Stem', description: 'Vocals, Drums, Bass, Other' },
+  { count: 6, title: '6-Stem', description: 'Adds Guitar + Piano isolation' },
+];
+
+export function StemSeparationModal() {
+  const clipId = useUIStore((s) => s.stemSeparationClipId);
+  const setStemSeparationModal = useUIStore((s) => s.setStemSeparationModal);
+  const project = useProjectStore((s) => s.project);
+  const getClipById = useProjectStore((s) => s.getClipById);
+  const isGenerating = useGenerationStore((s) => s.isGenerating);
+  const progress = useGenerationStore((s) => {
+    if (!clipId) return '';
+    return s.jobs.find((job) => job.clipId === clipId && job.status !== 'done')?.progress ?? '';
+  });
+
+  const clip = clipId ? getClipById(clipId) : null;
+  const track = project?.tracks.find((candidate) => candidate.clips.some((candidateClip) => candidateClip.id === clipId)) ?? null;
+  const [stemCount, setStemCount] = useState<StemCount>(4);
+
+  useEffect(() => {
+    setStemCount(4);
+  }, [clipId]);
+
+  const onClose = useCallback(() => setStemSeparationModal(null), [setStemSeparationModal]);
+
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  const handleSeparate = useCallback(async () => {
+    if (!clipId || isGenerating) return;
+    const succeeded = await separateClipStems(clipId, stemCount);
+    if (succeeded) {
+      onClose();
+    }
+  }, [clipId, isGenerating, onClose, stemCount]);
+
+  if (!clipId || !clip || !track) return null;
+
+  const hasAudio = !!(clip.isolatedAudioKey || clip.cumulativeMixKey);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={(event) => { if (event.target === event.currentTarget) onClose(); }}
+    >
+      <div className="w-[420px] rounded-lg border border-daw-border bg-daw-surface text-xs text-zinc-200 shadow-2xl">
+        <div className="flex items-center justify-between border-b border-daw-border px-4 py-3">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Separate Stems</h2>
+            <p className="text-[10px] text-zinc-500">{track.displayName} • {clip.duration.toFixed(1)}s</p>
+          </div>
+          <button onClick={onClose} className="text-zinc-500 transition-colors hover:text-zinc-200" aria-label="Close stem separation dialog">
+            ✕
+          </button>
+        </div>
+
+        <div className="space-y-3 px-4 py-4">
+          <div className="rounded border border-[#3a3a3a] bg-[#202020] px-3 py-2">
+            <p className="text-[9px] uppercase tracking-wide text-zinc-500">Source Clip</p>
+            <p className="truncate text-[11px] font-medium text-zinc-100">{clip.prompt || '(untitled audio clip)'}</p>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-[10px] font-medium uppercase tracking-wide text-zinc-400">Stem Count</p>
+            <div className="grid gap-2">
+              {STEM_OPTIONS.map((option) => {
+                const active = option.count === stemCount;
+                return (
+                  <button
+                    key={option.count}
+                    type="button"
+                    aria-label={`Choose ${option.title} separation`}
+                    onClick={() => setStemCount(option.count)}
+                    className={`rounded border px-3 py-2 text-left transition-colors ${active ? 'border-cyan-500 bg-cyan-500/12 text-cyan-100' : 'border-[#3a3a3a] bg-[#202020] text-zinc-200 hover:border-zinc-500'}`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-[11px] font-medium">{option.title}</span>
+                      <span className="text-[9px] uppercase tracking-wide text-zinc-500">{option.count} tracks</span>
+                    </div>
+                    <p className="mt-1 text-[10px] text-zinc-400">{option.description}</p>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {progress && (
+            <div className="rounded border border-cyan-900/50 bg-cyan-950/20 px-3 py-2 text-[10px] text-cyan-200">
+              {progress}
+            </div>
+          )}
+
+          {!hasAudio && (
+            <div className="rounded border border-amber-900/50 bg-amber-950/20 px-3 py-2 text-[10px] text-amber-300">
+              Generate or import audio first. Stem separation requires an existing audio clip.
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-daw-border px-4 py-3">
+          <button onClick={onClose} className="rounded border border-[#3a3a3a] px-3 py-1.5 text-[11px] text-zinc-300 hover:border-zinc-500">
+            Cancel
+          </button>
+          <button
+            onClick={handleSeparate}
+            disabled={!hasAudio || isGenerating}
+            aria-label="Start stem separation"
+            className="rounded bg-cyan-600 px-3 py-1.5 text-[11px] font-medium text-white transition-colors hover:bg-cyan-500 disabled:cursor-not-allowed disabled:bg-zinc-700 disabled:text-zinc-400"
+          >
+            {isGenerating ? 'Separating…' : 'Separate'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { CoverModal } from '../generation/CoverModal';
 import { RepaintModal } from '../generation/RepaintModal';
 import { Vocal2BGMModal } from '../generation/Vocal2BGMModal';
 import { AudioAnalysisPanel } from '../generation/AudioAnalysisPanel';
+import { StemSeparationModal } from '../generation/StemSeparationModal';
 import { NewProjectDialog } from '../dialogs/NewProjectDialog';
 import { InstrumentPicker } from '../dialogs/InstrumentPicker';
 import { ExportDialog } from '../dialogs/ExportDialog';
@@ -100,6 +101,7 @@ export function AppShell() {
       <RepaintModal />
       <Vocal2BGMModal />
       <AudioAnalysisPanel />
+      <StemSeparationModal />
     </div>
   );
 }

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -45,6 +45,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const setRepaintModal = useUIStore((s) => s.setRepaintModal);
   const setVocal2BGMModal = useUIStore((s) => s.setVocal2BGMModal);
   const setAnalysisPanel = useUIStore((s) => s.setAnalysisPanel);
+  const setStemSeparationModal = useUIStore((s) => s.setStemSeparationModal);
 
   const generatingProgress = useGenerationStore((s) => {
     const job = s.jobs.find(
@@ -446,11 +447,16 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
             closeCtxMenu();
             setAnalysisPanel(clip.id);
           }}
+          onSeparateStems={() => {
+            closeCtxMenu();
+            setStemSeparationModal(clip.id);
+          }}
           onClose={closeCtxMenu}
           hasPrompt={!!clip.prompt}
           isReady={clip.generationStatus === 'ready'}
           isMidiClip={isMidiClip}
           isVocalTrack={track.trackName === 'vocals' || track.trackName === 'backing_vocals'}
+          hasAudio={Boolean(clip.isolatedAudioKey || clip.cumulativeMixKey)}
         />
       )}
 

--- a/src/components/timeline/ClipContextMenu.tsx
+++ b/src/components/timeline/ClipContextMenu.tsx
@@ -12,11 +12,13 @@ interface ClipContextMenuProps {
   onRepaint: () => void;
   onVocal2BGM: () => void;
   onAnalyze: () => void;
+  onSeparateStems: () => void;
   onClose: () => void;
   hasPrompt: boolean;
   isReady: boolean;
   isMidiClip: boolean;
   isVocalTrack: boolean;
+  hasAudio: boolean;
 }
 
 export function ClipContextMenu({
@@ -33,11 +35,13 @@ export function ClipContextMenu({
   onRepaint,
   onVocal2BGM,
   onAnalyze,
+  onSeparateStems,
   onClose,
   hasPrompt,
   isReady,
   isMidiClip,
   isVocalTrack,
+  hasAudio,
 }: ClipContextMenuProps) {
   const clampedX = Math.min(x, window.innerWidth - 210);
   const clampedY = Math.min(y, window.innerHeight - 300);
@@ -82,6 +86,11 @@ export function ClipContextMenu({
             <button onClick={onAnalyze} className="w-full text-left px-3 py-1.5 text-[11px] text-cyan-300 hover:bg-daw-accent hover:text-white transition-colors">
               Analyze Audio…
             </button>
+            {hasAudio && (
+              <button onClick={onSeparateStems} className="w-full text-left px-3 py-1.5 text-[11px] text-sky-300 hover:bg-daw-accent hover:text-white transition-colors">
+                Separate Stems…
+              </button>
+            )}
           </>
         )}
 

--- a/src/services/aceStepApi.ts
+++ b/src/services/aceStepApi.ts
@@ -2,6 +2,7 @@ import type {
   LegoTaskParams,
   CoverTaskParams,
   RepaintTaskParams,
+  StemSeparationTaskParams,
   ApiEnvelope,
   ReleaseTaskResponse,
   TaskResultEntry,
@@ -11,7 +12,7 @@ import type {
   InitModelResponse,
 } from '../types/api';
 
-export type AceStepTaskParams = LegoTaskParams | CoverTaskParams | RepaintTaskParams;
+export type AceStepTaskParams = LegoTaskParams | CoverTaskParams | RepaintTaskParams | StemSeparationTaskParams;
 import { downsampleWavBlob } from '../utils/audioDownsample';
 
 const BACKEND_URL_KEY = 'ace-step-daw-backend-url';

--- a/src/services/stemSeparation.ts
+++ b/src/services/stemSeparation.ts
@@ -1,0 +1,178 @@
+import { v4 as uuidv4 } from 'uuid';
+import { useProjectStore } from '../store/projectStore';
+import { useGenerationStore } from '../store/generationStore';
+import { loadAudioBlobByKey, saveAudioBlob } from './audioFileManager';
+import * as api from './aceStepApi';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+import { computeWaveformPeaks } from '../utils/waveformPeaks';
+import { MAX_POLL_DURATION_MS, POLL_INTERVAL_MS } from '../constants/defaults';
+import type { StemCount, TaskResultItem } from '../types/api';
+import type { TrackName } from '../types/project';
+import { toastError, toastInfo, toastSuccess } from '../hooks/useToast';
+
+const STEM_LAYOUTS: Record<StemCount, Array<{ stemKey: string; displayName: string; trackName?: TrackName; color: string }>> = {
+  2: [
+    { stemKey: 'vocals', displayName: 'Vocals', trackName: 'vocals', color: '#f43f5e' },
+    { stemKey: 'instrumental', displayName: 'Instrumental', trackName: 'custom', color: '#64748b' },
+  ],
+  4: [
+    { stemKey: 'vocals', displayName: 'Vocals', trackName: 'vocals', color: '#f43f5e' },
+    { stemKey: 'drums', displayName: 'Drums', trackName: 'drums', color: '#ef4444' },
+    { stemKey: 'bass', displayName: 'Bass', trackName: 'bass', color: '#f97316' },
+    { stemKey: 'other', displayName: 'Other', trackName: 'custom', color: '#64748b' },
+  ],
+  6: [
+    { stemKey: 'vocals', displayName: 'Vocals', trackName: 'vocals', color: '#f43f5e' },
+    { stemKey: 'drums', displayName: 'Drums', trackName: 'drums', color: '#ef4444' },
+    { stemKey: 'bass', displayName: 'Bass', trackName: 'bass', color: '#f97316' },
+    { stemKey: 'guitar', displayName: 'Guitar', trackName: 'guitar', color: '#eab308' },
+    { stemKey: 'piano', displayName: 'Piano', trackName: 'keyboard', color: '#22c55e' },
+    { stemKey: 'other', displayName: 'Other', trackName: 'custom', color: '#64748b' },
+  ],
+};
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeStemKey(value: string | undefined): string {
+  return (value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function inferStemKey(item: TaskResultItem, fallbackStemKey: string): string {
+  const candidates = [
+    item.stage,
+    item.prompt,
+    item.generation_info,
+    item.file,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeStemKey(candidate);
+    if (!normalized) continue;
+    if (normalized.includes('backing_vocal')) return 'backing_vocals';
+    if (normalized.includes('vocal')) return 'vocals';
+    if (normalized.includes('drum')) return 'drums';
+    if (normalized.includes('bass')) return 'bass';
+    if (normalized.includes('guitar')) return 'guitar';
+    if (normalized.includes('piano') || normalized.includes('keys') || normalized.includes('keyboard')) return 'piano';
+    if (normalized.includes('instrumental')) return 'instrumental';
+    if (normalized.includes('other')) return 'other';
+  }
+
+  return fallbackStemKey;
+}
+
+export async function separateClipStems(clipId: string, stemCount: StemCount): Promise<boolean> {
+  const genStore = useGenerationStore.getState();
+  if (genStore.isGenerating) return false;
+
+  const store = useProjectStore.getState();
+  const project = store.project;
+  const clip = store.getClipById(clipId);
+  if (!project || !clip) return false;
+
+  let sourceAudioBlob: Blob | null = null;
+  if (clip.isolatedAudioKey) {
+    sourceAudioBlob = (await loadAudioBlobByKey(clip.isolatedAudioKey)) ?? null;
+  }
+  if (!sourceAudioBlob && clip.cumulativeMixKey) {
+    sourceAudioBlob = (await loadAudioBlobByKey(clip.cumulativeMixKey)) ?? null;
+  }
+  if (!sourceAudioBlob) {
+    toastError('No audio available for stem separation');
+    return false;
+  }
+
+  const jobId = uuidv4();
+  const track = store.getTrackForClip(clipId);
+  genStore.addJob({
+    id: jobId,
+    clipId,
+    trackName: track?.displayName ?? 'Stem separation',
+    status: 'queued',
+    progress: `Queued ${stemCount}-stem separation`,
+  });
+
+  toastInfo(`Stem separation started (${stemCount} stems)`);
+  genStore.setIsGenerating(true);
+
+  try {
+    genStore.updateJob(jobId, { status: 'generating', progress: 'Submitting...' });
+    const releaseResp = await api.releaseLegoTask(sourceAudioBlob, {
+      task_type: 'separate_stems',
+      stem_count: stemCount,
+      audio_duration: clip.audioDuration ?? clip.duration,
+      audio_format: 'wav',
+    });
+
+    const taskId = releaseResp.task_id;
+    const startTime = Date.now();
+    let resultItems: TaskResultItem[] | null = null;
+
+    while (Date.now() - startTime < MAX_POLL_DURATION_MS) {
+      await sleep(POLL_INTERVAL_MS);
+      const entries = await api.queryResult([taskId]);
+      const entry = entries?.[0];
+      if (!entry) continue;
+
+      genStore.updateJob(jobId, {
+        progress: entry.progress_text || 'Separating stems...',
+      });
+
+      if (entry.status === 1) {
+        resultItems = JSON.parse(entry.result) as TaskResultItem[];
+        break;
+      }
+      if (entry.status === 2) {
+        throw new Error(`Stem separation failed: ${entry.result}`);
+      }
+    }
+
+    if (!resultItems?.length) {
+      throw new Error('Stem separation timed out');
+    }
+
+    genStore.updateJob(jobId, { status: 'processing', progress: 'Downloading stems...' });
+
+    const engine = getAudioEngine();
+    const layout = STEM_LAYOUTS[stemCount];
+    const preparedStems = await Promise.all(
+      resultItems.slice(0, layout.length).map(async (item, index) => {
+        const blob = await api.downloadAudio(item.file);
+        const buffer = await engine.decodeAudioData(blob);
+        const peaks = computeWaveformPeaks(buffer, 200);
+        const layoutEntry = layout[index];
+        const inferredStemKey = inferStemKey(item, layoutEntry.stemKey);
+        const matchedLayout = layout.find((candidate) => candidate.stemKey === inferredStemKey) ?? layoutEntry;
+        const isolatedAudioKey = await saveAudioBlob(project.id, `${clipId}-${matchedLayout.stemKey}-${index}`, 'isolated', blob);
+
+        return {
+          stemKey: matchedLayout.stemKey,
+          displayName: matchedLayout.displayName,
+          trackName: matchedLayout.trackName,
+          color: matchedLayout.color,
+          isolatedAudioKey,
+          waveformPeaks: peaks,
+          duration: buffer.duration,
+          prompt: `Stem separation: ${matchedLayout.displayName}`,
+        };
+      }),
+    );
+
+    store.separateStems(clipId, preparedStems);
+    genStore.updateJob(jobId, { status: 'done', progress: 'Done' });
+    toastSuccess(`Created ${preparedStems.length} separated stem tracks`);
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Stem separation failed';
+    genStore.updateJob(jobId, { status: 'error', progress: message, error: message });
+    toastError(message);
+    return false;
+  } finally {
+    genStore.setIsGenerating(false);
+  }
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -123,6 +123,19 @@ interface ProjectState {
   reorderTrack: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
 
   addClip: (trackId: string, clip: Omit<Clip, 'id' | 'trackId' | 'generationStatus' | 'generationJobId' | 'cumulativeMixKey' | 'isolatedAudioKey' | 'waveformPeaks'>) => Clip;
+  separateStems: (
+    sourceClipId: string,
+    stems: Array<{
+      stemKey: string;
+      displayName: string;
+      trackName?: TrackName;
+      color?: string;
+      isolatedAudioKey: string;
+      waveformPeaks: number[];
+      duration?: number;
+      prompt?: string;
+    }>,
+  ) => Track[];
   ensureMidiClip: (trackId: string, startTime?: number, duration?: number) => Clip;
   updateClip: (clipId: string, updates: Partial<Clip>) => void;
   removeClip: (clipId: string) => void;
@@ -349,6 +362,42 @@ function ensureTrackDefaults(track: Track): Track {
           }
         : undefined,
     })),
+  };
+}
+
+function createTrackRecord(
+  trackName: TrackName,
+  trackType: TrackType,
+  existingTracks: Track[],
+  overrides?: Partial<Track>,
+): Track {
+  const info = TRACK_CATALOG[trackName] ?? TRACK_CATALOG.custom;
+  const existingOrders = existingTracks.map((t) => t.order);
+  const maxOrder = existingOrders.length > 0 ? Math.max(...existingOrders) : 0;
+  const sameNameCount = existingTracks.filter((t) => t.trackName === trackName).length;
+  const displayName = sameNameCount === 0 ? info.displayName : `${info.displayName} ${sameNameCount + 1}`;
+
+  return {
+    id: uuidv4(),
+    trackType,
+    trackName,
+    displayName,
+    color: info.color,
+    order: maxOrder + 1,
+    volume: 0.8,
+    muted: false,
+    soloed: false,
+    clips: [],
+    laneHeight: trackType === 'sequencer' ? 80 : trackType === 'pianoRoll' ? 88 : undefined,
+    synthPreset:
+      trackName === 'bass' ? 'bass'
+        : trackName === 'strings' ? 'strings'
+          : trackName === 'synth' ? 'lead'
+            : trackName === 'keyboard' ? 'organ'
+              : 'piano',
+    effects: [],
+    drumKit: trackName === 'drums' || trackType === 'sequencer' ? '808' : undefined,
+    ...overrides,
   };
 }
 
@@ -594,34 +643,7 @@ export const useProjectStore = create<ProjectState>()(
     _pushHistory(state.project);
 
     const resolvedType: TrackType = trackType ?? (trackName === 'custom' ? 'sample' : 'stems');
-    const info = TRACK_CATALOG[trackName] ?? TRACK_CATALOG['custom'];
-    const existingOrders = state.project.tracks.map((t) => t.order);
-    const maxOrder = existingOrders.length > 0 ? Math.max(...existingOrders) : 0;
-
-    const sameNameCount = state.project.tracks.filter((t) => t.trackName === trackName).length;
-    const displayName = sameNameCount === 0 ? info.displayName : `${info.displayName} ${sameNameCount + 1}`;
-
-    const track: Track = {
-      id: uuidv4(),
-      trackType: resolvedType,
-      trackName,
-      displayName,
-      color: info.color,
-      order: maxOrder + 1,
-      volume: 0.8,
-      muted: false,
-      soloed: false,
-      clips: [],
-      laneHeight: resolvedType === 'sequencer' ? 80 : resolvedType === 'pianoRoll' ? 88 : undefined,
-      synthPreset:
-        trackName === 'bass' ? 'bass'
-          : trackName === 'strings' ? 'strings'
-            : trackName === 'synth' ? 'lead'
-              : trackName === 'keyboard' ? 'organ'
-                : 'piano',
-      effects: [],
-      drumKit: trackName === 'drums' || resolvedType === 'sequencer' ? '808' : undefined,
-    };
+    const track = createTrackRecord(trackName, resolvedType, state.project.tracks);
 
     // Auto-initialize sequencer pattern for sequencer tracks
     if (resolvedType === 'sequencer') {
@@ -658,6 +680,73 @@ export const useProjectStore = create<ProjectState>()(
     });
 
     return track;
+  },
+
+  separateStems: (sourceClipId, stems) => {
+    const state = get();
+    if (!state.project || stems.length === 0) return [];
+
+    let sourceClip: Clip | undefined;
+    for (const track of state.project.tracks) {
+      const clip = track.clips.find((candidate) => candidate.id === sourceClipId);
+      if (clip) {
+        sourceClip = clip;
+        break;
+      }
+    }
+    if (!sourceClip) return [];
+
+    _pushHistory(state.project);
+
+    const tracksToAppend: Track[] = [];
+    let workingTracks = [...state.project.tracks];
+
+    for (const stem of stems) {
+      const stemTrackName = stem.trackName ?? 'custom';
+      const track = createTrackRecord(stemTrackName, 'sample', workingTracks, {
+        displayName: stem.displayName,
+        color: stem.color ?? (TRACK_CATALOG[stemTrackName] ?? TRACK_CATALOG.custom).color,
+        synthPreset: undefined,
+        drumKit: undefined,
+      });
+
+      const clip: Clip = {
+        id: uuidv4(),
+        trackId: track.id,
+        startTime: sourceClip.startTime,
+        duration: stem.duration ?? sourceClip.duration,
+        prompt: stem.prompt ?? `Separated: ${stem.displayName}`,
+        globalCaption: sourceClip.globalCaption || '',
+        lyrics: '',
+        generationStatus: 'ready',
+        generationJobId: null,
+        cumulativeMixKey: null,
+        isolatedAudioKey: stem.isolatedAudioKey,
+        waveformPeaks: stem.waveformPeaks,
+        bpm: sourceClip.bpm ?? null,
+        keyScale: sourceClip.keyScale ?? null,
+        timeSignature: sourceClip.timeSignature ?? null,
+        audioDuration: stem.duration ?? sourceClip.duration,
+        audioOffset: 0,
+        source: 'uploaded',
+      };
+
+      track.clips = [clip];
+      tracksToAppend.push(track);
+      workingTracks = [...workingTracks, track];
+    }
+
+    const newTracks = [...state.project.tracks, ...tracksToAppend];
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        tracks: newTracks,
+      },
+    });
+
+    return tracksToAppend;
   },
 
   removeTrack: (trackId) => {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -60,6 +60,7 @@ interface UIState {
   // Vocal2BGM / Audio Analysis
   vocal2bgmClipId: string | null;
   analysisClipId: string | null;
+  stemSeparationClipId: string | null;
 
   setPixelsPerSecond: (pps: number) => void;
   toggleSnap: () => void;
@@ -114,6 +115,7 @@ interface UIState {
   // Vocal2BGM / Audio Analysis
   setVocal2BGMModal: (clipId: string | null) => void;
   setAnalysisPanel: (clipId: string | null) => void;
+  setStemSeparationModal: (clipId: string | null) => void;
 }
 
 const ZOOM_LEVELS = [10, 25, 50, 100, 200, 500];
@@ -168,6 +170,7 @@ export const useUIStore = create<UIState>()(
 
   vocal2bgmClipId: null,
   analysisClipId: null,
+  stemSeparationClipId: null,
 
   setPixelsPerSecond: (pps) => set({ pixelsPerSecond: pps }),
   toggleSnap: () => set((s) => ({ snapEnabled: !s.snapEnabled })),
@@ -256,6 +259,7 @@ export const useUIStore = create<UIState>()(
 
   setVocal2BGMModal: (clipId) => set({ vocal2bgmClipId: clipId }),
   setAnalysisPanel: (clipId) => set({ analysisClipId: clipId }),
+  setStemSeparationModal: (clipId) => set({ stemSeparationClipId: clipId }),
 }),
     {
       name: 'ace-step-daw-ui',

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,3 +1,12 @@
+export type StemCount = 2 | 4 | 6;
+
+export interface StemSeparationTaskParams {
+  task_type: 'separate_stems';
+  stem_count: StemCount;
+  audio_duration: number;
+  audio_format: 'wav';
+}
+
 /** Parameters for cover generation — transforms source audio into a new style */
 export interface CoverTaskParams {
   task_type: 'cover';

--- a/tests/unit/projectStore.test.ts
+++ b/tests/unit/projectStore.test.ts
@@ -103,6 +103,79 @@ describe('projectStore', () => {
     });
   });
 
+  describe('separateStems', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject();
+    });
+
+    it('creates aligned sample tracks for separated stems', () => {
+      const sourceTrack = useProjectStore.getState().addTrack('custom', 'sample');
+      const sourceClip = useProjectStore.getState().addClip(sourceTrack.id, {
+        startTime: 12,
+        duration: 8,
+        prompt: 'Imported: reference mix',
+        lyrics: '',
+        source: 'uploaded',
+      });
+      useProjectStore.getState().updateClipStatus(sourceClip.id, 'ready', {
+        isolatedAudioKey: 'source-audio',
+        waveformPeaks: [0.1, 0.5],
+        audioDuration: 8,
+      });
+
+      const createdTracks = useProjectStore.getState().separateStems(sourceClip.id, [
+        {
+          stemKey: 'vocals',
+          displayName: 'Vocals',
+          trackName: 'vocals',
+          color: '#f43f5e',
+          isolatedAudioKey: 'vocals-key',
+          waveformPeaks: [0.2, 0.3],
+          duration: 8,
+        },
+        {
+          stemKey: 'drums',
+          displayName: 'Drums',
+          trackName: 'drums',
+          color: '#ef4444',
+          isolatedAudioKey: 'drums-key',
+          waveformPeaks: [0.6, 0.4],
+          duration: 8,
+        },
+      ]);
+
+      expect(createdTracks).toHaveLength(2);
+      expect(createdTracks.map((track) => track.displayName)).toEqual(['Vocals', 'Drums']);
+
+      const project = useProjectStore.getState().project!;
+      expect(project.tracks).toHaveLength(3);
+
+      const vocalsTrack = project.tracks.find((track) => track.displayName === 'Vocals');
+      const drumsTrack = project.tracks.find((track) => track.displayName === 'Drums');
+
+      expect(vocalsTrack).toBeDefined();
+      expect(drumsTrack).toBeDefined();
+      expect(vocalsTrack?.trackType).toBe('sample');
+      expect(drumsTrack?.trackType).toBe('sample');
+      expect(vocalsTrack?.clips[0]).toMatchObject({
+        startTime: 12,
+        duration: 8,
+        generationStatus: 'ready',
+        isolatedAudioKey: 'vocals-key',
+        prompt: 'Separated: Vocals',
+        source: 'uploaded',
+      });
+      expect(drumsTrack?.clips[0]).toMatchObject({
+        startTime: 12,
+        duration: 8,
+        generationStatus: 'ready',
+        isolatedAudioKey: 'drums-key',
+        prompt: 'Separated: Drums',
+        source: 'uploaded',
+      });
+    });
+  });
+
   describe('automation lane operations', () => {
     const parameter = { type: 'mixer', param: 'volume' } as const;
 


### PR DESCRIPTION
## Summary
- add clip-context stem separation entry and modal with 2/4/6 stem options
- add async stem separation service using backend polling and job progress updates
- add store support for creating aligned sample tracks/clips from separated stems with unit coverage

## Testing
- npm run build
- npx vitest run tests/unit/

Closes #230