### PR TITLE
feat: MIDI file import — drag .mid files onto timeline to create piano roll tracks

### DIFF
--- a/src/components/dialogs/InstrumentPicker.tsx
+++ b/src/components/dialogs/InstrumentPicker.tsx
@@ -140,8 +140,8 @@ export function InstrumentPicker() {
             >
               <span className="text-xl">📁</span>
               <div>
-                <div className="text-sm font-medium">Import Audio File</div>
-                <div className="text-[11px] text-zinc-400">Pick a file from your computer to create a track with audio</div>
+                <div className="text-sm font-medium">Import Audio or MIDI File</div>
+                <div className="text-[11px] text-zinc-400">Pick files from your computer to create sample or piano roll tracks</div>
               </div>
             </button>
           </div>
@@ -188,6 +188,17 @@ export function InstrumentPicker() {
               <div>
                 <div className="text-sm font-medium">Piano Roll Track</div>
                 <div className="text-[11px] text-zinc-400">MIDI clips with built-in synth presets and note editing.</div>
+              </div>
+            </button>
+            <button
+              onClick={() => { close(); openFilePicker(); }}
+              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-[#484848] transition-colors text-left"
+              style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.pianoRoll.color}` }}
+            >
+              <span className="text-xl">📥</span>
+              <div>
+                <div className="text-sm font-medium">Import MIDI File</div>
+                <div className="text-[11px] text-zinc-400">Load .mid files and create piano roll tracks from their note data.</div>
               </div>
             </button>
           </div>

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -138,7 +138,7 @@ export function Toolbar() {
         <button onClick={() => setShowExportDialog(true)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Export">
           Export
         </button>
-        <button onClick={openFilePicker} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Import Audio">
+        <button onClick={openFilePicker} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Import Audio or MIDI">
           Import
         </button>
       </div>

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -76,7 +76,7 @@ export function Timeline() {
   const [normalDrag, setNormalDrag] = useState<DragRect | null>(null);
   const [fileDragOver, setFileDragOver] = useState(false);
   const dragCounterRef = useRef(0);
-  const { importAudioBufferToTrack, importMultipleFiles, importLoopToTrack, importAssetToTrack } = useAudioImport();
+  const { importMultipleFiles, importLoopToTrack, importAssetToTrack } = useAudioImport();
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer.types;

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -87,7 +87,7 @@ export function TrackLane({ track }: TrackLaneProps) {
     startTime: number; duration: number;
   } | null>(null);
 
-  const { importAudioBufferToTrack, importAudioToTrack, importLoopToTrack, importAssetToTrack } = useAudioImport();
+  const { importAudioToTrack, importMidiFile, importLoopToTrack, importAssetToTrack } = useAudioImport();
   const [fileDragOver, setFileDragOver] = useState(false);
 
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
@@ -223,9 +223,11 @@ export function TrackLane({ track }: TrackLaneProps) {
     for (const file of Array.from(files)) {
       if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
         await importAudioToTrack(file, track.id, startTime);
+      } else if (/\.(mid|midi)$/i.test(file.name)) {
+        await importMidiFile(file, startTime);
       }
     }
-  }, [project, pixelsPerSecond, track.id, importAudioToTrack, importLoopToTrack, importAssetToTrack]);
+  }, [project, pixelsPerSecond, track.id, importAudioToTrack, importMidiFile, importLoopToTrack, importAssetToTrack]);
 
   const hasClips = track.clips.length > 0;
   const automationLanes = (project?.automationLanes ?? []).filter((l) => l.trackId === track.id);
@@ -245,7 +247,7 @@ export function TrackLane({ track }: TrackLaneProps) {
       >
         {fileDragOver && (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-30 border border-dashed border-blue-400/60 rounded-sm">
-            <span className="text-[10px] text-blue-300 bg-blue-950/80 px-2 py-0.5 rounded">Drop audio here</span>
+            <span className="text-[10px] text-blue-300 bg-blue-950/80 px-2 py-0.5 rounded">Drop audio or MIDI here</span>
           </div>
         )}
 

--- a/src/components/tracks/AddTrackButton.tsx
+++ b/src/components/tracks/AddTrackButton.tsx
@@ -16,7 +16,7 @@ export function AddTrackButton() {
       <button
         onClick={openFilePicker}
         className="flex items-center justify-center gap-1 h-7 px-2 text-[11px] font-medium text-zinc-400 hover:text-white bg-[#3a3a3a] hover:bg-[#484848] rounded transition-colors"
-        title="Import audio file"
+        title="Import audio or MIDI file"
       >
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
           <path d="M6 1v7M3 5l3 3 3-3" />

--- a/src/hooks/useAudioImport.ts
+++ b/src/hooks/useAudioImport.ts
@@ -4,7 +4,8 @@ import { getAudioEngine } from './useAudioEngine';
 import { saveAudioBlob, loadAudioBlobByKey } from '../services/audioFileManager';
 import { computeWaveformPeaks } from '../utils/waveformPeaks';
 import { audioBufferToWavBlob } from '../utils/wav';
-import { toastSuccess } from './useToast';
+import { parseMidiFile } from '../utils/midi';
+import { toastError, toastInfo, toastSuccess } from './useToast';
 import { LOOP_DEFINITIONS, loadLoop } from '../engine/LoopLibrary';
 
 function trimAudioBuffer(
@@ -35,7 +36,51 @@ function trimAudioBuffer(
 export function useAudioImport() {
   const addTrack = useProjectStore((s) => s.addTrack);
   const addClip = useProjectStore((s) => s.addClip);
+  const updateProject = useProjectStore((s) => s.updateProject);
+  const updateTrack = useProjectStore((s) => s.updateTrack);
   const updateClipStatus = useProjectStore((s) => s.updateClipStatus);
+
+  const maybeApplyImportedMidiMetadata = useCallback((fileName: string, bpm?: number, timeSignature?: number) => {
+    const project = useProjectStore.getState().project;
+    if (!project) return { bpm: 120, timeSignature: 4 };
+
+    const shouldPrompt = (
+      (bpm !== undefined && Math.round(project.bpm) !== Math.round(bpm))
+      || (timeSignature !== undefined && project.timeSignature !== timeSignature)
+    );
+
+    let effectiveBpm = project.bpm;
+    let effectiveTimeSignature = project.timeSignature;
+
+    if (shouldPrompt) {
+      const promptMessage = [
+        `${fileName} includes MIDI metadata.`,
+        bpm !== undefined ? `Tempo: ${Math.round(bpm * 100) / 100} BPM` : null,
+        timeSignature !== undefined ? `Time signature: ${timeSignature}/4` : null,
+        'Apply this to the project?',
+      ].filter(Boolean).join('\n');
+
+      const confirmed = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm(promptMessage)
+        : false;
+
+      if (confirmed) {
+        const updates: { bpm?: number; timeSignature?: number } = {};
+        if (bpm !== undefined) {
+          effectiveBpm = bpm;
+          updates.bpm = bpm;
+        }
+        if (timeSignature !== undefined) {
+          effectiveTimeSignature = timeSignature;
+          updates.timeSignature = timeSignature;
+        }
+        updateProject(updates);
+        toastInfo('Imported MIDI tempo and time signature applied');
+      }
+    }
+
+    return { bpm: effectiveBpm, timeSignature: effectiveTimeSignature };
+  }, [updateProject]);
 
   const importAudioBufferToTrack = useCallback(async (
     audioBuffer: AudioBuffer,
@@ -136,18 +181,70 @@ export function useAudioImport() {
     await importAudioBufferToTrack(audioBuffer, file.name, trackId, startTime);
   }, [importAudioBufferToTrack]);
 
+  const importMidiFile = useCallback(async (file: File, startTime: number = 0) => {
+    const project = useProjectStore.getState().project;
+    if (!project) return;
+
+    try {
+      const parsed = parseMidiFile(await file.arrayBuffer());
+      if (parsed.tracks.length === 0) {
+        toastError('No MIDI note data found in file');
+        return;
+      }
+
+      const applied = maybeApplyImportedMidiMetadata(
+        file.name,
+        parsed.bpm,
+        parsed.timeSignature?.denominator === 4 ? parsed.timeSignature.numerator : undefined,
+      );
+      const baseName = file.name.replace(/\.(mid|midi)$/i, '');
+
+      parsed.tracks.forEach((parsedTrack, index) => {
+        const track = addTrack('keyboard', 'pianoRoll');
+        updateTrack(track.id, {
+          displayName: parsedTrack.name || (parsed.tracks.length === 1 ? baseName : `${baseName} ${index + 1}`),
+        });
+
+        const clipBeats = parsedTrack.notes.reduce(
+          (max, note) => Math.max(max, note.startBeat + note.durationBeats),
+          applied.timeSignature,
+        );
+        const clipDurationSeconds = Math.max((clipBeats * 60) / applied.bpm, (applied.timeSignature * 60) / applied.bpm);
+
+        addClip(track.id, {
+          startTime,
+          duration: clipDurationSeconds,
+          prompt: `Imported MIDI: ${file.name}`,
+          lyrics: '',
+          source: 'uploaded',
+          midiData: {
+            notes: parsedTrack.notes.map((note) => ({ ...note, id: crypto.randomUUID() })),
+            grid: '1/16',
+          },
+        });
+      });
+
+      toastSuccess(`Imported MIDI into ${parsed.tracks.length} piano roll track${parsed.tracks.length === 1 ? '' : 's'}`);
+    } catch (error) {
+      console.error(error);
+      toastError(`Failed to import MIDI file: ${file.name}`);
+    }
+  }, [addClip, addTrack, maybeApplyImportedMidiMetadata, updateTrack]);
+
   const importMultipleFiles = useCallback(async (files: FileList | File[]) => {
     for (const file of Array.from(files)) {
       if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
         await importAudioFile(file);
+      } else if (/\.(mid|midi)$/i.test(file.name)) {
+        await importMidiFile(file);
       }
     }
-  }, [importAudioFile]);
+  }, [importAudioFile, importMidiFile]);
 
   const openFilePicker = useCallback(() => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = 'audio/*';
+    input.accept = 'audio/*,.mid,.midi';
     input.multiple = true;
     input.onchange = async () => {
       if (input.files && input.files.length > 0) {
@@ -235,6 +332,7 @@ export function useAudioImport() {
     importAudioFile,
     importAudioBufferToTrack,
     importAudioToTrack,
+    importMidiFile,
     importMultipleFiles,
     openFilePicker,
     importLoopToTrack,

--- a/src/utils/midi.ts
+++ b/src/utils/midi.ts
@@ -1,0 +1,252 @@
+import type { MidiNote, TimeSignatureEvent } from '../types/project';
+
+export interface ParsedMidiTrack {
+  name: string;
+  sourceTrackIndex: number;
+  channel: number;
+  notes: Array<Omit<MidiNote, 'id'>>;
+}
+
+export interface ParsedMidiFile {
+  format: number;
+  ticksPerQuarterNote: number;
+  tracks: ParsedMidiTrack[];
+  bpm?: number;
+  timeSignature?: TimeSignatureEvent;
+}
+
+interface ParsedTrackState {
+  name?: string;
+  notesByChannel: Map<number, Array<Omit<MidiNote, 'id'>>>;
+}
+
+interface ActiveNote {
+  startTick: number;
+  velocity: number;
+}
+
+function readUint32(view: DataView, offset: number) {
+  return view.getUint32(offset, false);
+}
+
+function readUint16(view: DataView, offset: number) {
+  return view.getUint16(offset, false);
+}
+
+function readVariableLength(data: Uint8Array, offset: number): { value: number; nextOffset: number } {
+  let value = 0;
+  let nextOffset = offset;
+
+  while (nextOffset < data.length) {
+    const byte = data[nextOffset++];
+    value = (value << 7) | (byte & 0x7f);
+    if ((byte & 0x80) === 0) {
+      return { value, nextOffset };
+    }
+  }
+
+  throw new Error('Unexpected end of MIDI data while reading variable-length value');
+}
+
+function decodeText(bytes: Uint8Array) {
+  return new TextDecoder('utf-8').decode(bytes).replace(/\0/g, '').trim();
+}
+
+function getOrCreateActiveNotes(
+  activeNotes: Map<number, Map<number, ActiveNote[]>>,
+  channel: number,
+  pitch: number,
+) {
+  let byPitch = activeNotes.get(channel);
+  if (!byPitch) {
+    byPitch = new Map<number, ActiveNote[]>();
+    activeNotes.set(channel, byPitch);
+  }
+
+  let stack = byPitch.get(pitch);
+  if (!stack) {
+    stack = [];
+    byPitch.set(pitch, stack);
+  }
+
+  return stack;
+}
+
+function pushCompletedNote(
+  notesByChannel: Map<number, Array<Omit<MidiNote, 'id'>>>,
+  channel: number,
+  pitch: number,
+  startTick: number,
+  endTick: number,
+  velocity: number,
+  ticksPerQuarterNote: number,
+) {
+  const durationTicks = endTick - startTick;
+  if (durationTicks <= 0) return;
+
+  const existing = notesByChannel.get(channel) ?? [];
+  existing.push({
+    pitch,
+    startBeat: startTick / ticksPerQuarterNote,
+    durationBeats: durationTicks / ticksPerQuarterNote,
+    velocity,
+  });
+  notesByChannel.set(channel, existing);
+}
+
+export function parseMidiFile(arrayBuffer: ArrayBuffer): ParsedMidiFile {
+  const view = new DataView(arrayBuffer);
+  const bytes = new Uint8Array(arrayBuffer);
+
+  if (bytes.length < 14 || decodeText(bytes.slice(0, 4)) !== 'MThd') {
+    throw new Error('Invalid MIDI header');
+  }
+
+  const headerLength = readUint32(view, 4);
+  if (headerLength < 6) {
+    throw new Error('Unsupported MIDI header length');
+  }
+
+  const format = readUint16(view, 8);
+  const trackCount = readUint16(view, 10);
+  const division = readUint16(view, 12);
+  if ((division & 0x8000) !== 0) {
+    throw new Error('SMPTE time division is not supported');
+  }
+
+  const ticksPerQuarterNote = division;
+  let offset = 8 + headerLength;
+  let firstTempoBpm: number | undefined;
+  let firstTimeSignature: TimeSignatureEvent | undefined;
+  const parsedTracks: ParsedTrackState[] = [];
+
+  for (let trackIndex = 0; trackIndex < trackCount; trackIndex++) {
+    if (offset + 8 > bytes.length || decodeText(bytes.slice(offset, offset + 4)) !== 'MTrk') {
+      throw new Error(`Invalid MIDI track header at track ${trackIndex + 1}`);
+    }
+
+    const trackLength = readUint32(view, offset + 4);
+    const trackStart = offset + 8;
+    const trackEnd = trackStart + trackLength;
+    if (trackEnd > bytes.length) {
+      throw new Error(`Track ${trackIndex + 1} exceeds file length`);
+    }
+
+    let cursor = trackStart;
+    let tick = 0;
+    let runningStatus: number | null = null;
+    const notesByChannel = new Map<number, Array<Omit<MidiNote, 'id'>>>();
+    const activeNotes = new Map<number, Map<number, ActiveNote[]>>();
+    let trackName: string | undefined;
+
+    while (cursor < trackEnd) {
+      const delta = readVariableLength(bytes, cursor);
+      tick += delta.value;
+      cursor = delta.nextOffset;
+      if (cursor >= trackEnd) break;
+
+      let statusByte = bytes[cursor++];
+      let firstDataByte: number | undefined;
+
+      if (statusByte < 0x80) {
+        if (runningStatus === null) {
+          throw new Error(`Running status encountered without previous status in track ${trackIndex + 1}`);
+        }
+        firstDataByte = statusByte;
+        statusByte = runningStatus;
+      } else if (statusByte < 0xf0) {
+        runningStatus = statusByte;
+      }
+
+      if (statusByte === 0xff) {
+        runningStatus = null;
+        if (cursor >= trackEnd) break;
+        const metaType = bytes[cursor++];
+        const metaLength = readVariableLength(bytes, cursor);
+        cursor = metaLength.nextOffset;
+        const metaData = bytes.slice(cursor, cursor + metaLength.value);
+        cursor += metaLength.value;
+
+        if (metaType === 0x03 && metaData.length > 0) {
+          trackName = decodeText(metaData);
+        } else if (metaType === 0x51 && metaData.length === 3 && firstTempoBpm === undefined) {
+          const microsPerQuarter = (metaData[0] << 16) | (metaData[1] << 8) | metaData[2];
+          if (microsPerQuarter > 0) {
+            firstTempoBpm = 60000000 / microsPerQuarter;
+          }
+        } else if (metaType === 0x58 && metaData.length >= 2 && firstTimeSignature === undefined) {
+          firstTimeSignature = {
+            bar: 1,
+            numerator: metaData[0],
+            denominator: 2 ** metaData[1],
+          };
+        }
+
+        continue;
+      }
+
+      if (statusByte === 0xf0 || statusByte === 0xf7) {
+        runningStatus = null;
+        const sysexLength = readVariableLength(bytes, cursor);
+        cursor = sysexLength.nextOffset + sysexLength.value;
+        continue;
+      }
+
+      const command = statusByte & 0xf0;
+      const channel = statusByte & 0x0f;
+      const needsOneDataByte = command === 0xc0 || command === 0xd0;
+      const data1 = firstDataByte ?? bytes[cursor++];
+      const data2 = needsOneDataByte ? undefined : bytes[cursor++];
+
+      if (command === 0x90 && data2 !== undefined && data2 > 0) {
+        getOrCreateActiveNotes(activeNotes, channel, data1).push({
+          startTick: tick,
+          velocity: data2 / 127,
+        });
+      } else if ((command === 0x80 && data2 !== undefined) || (command === 0x90 && data2 === 0)) {
+        const stack = getOrCreateActiveNotes(activeNotes, channel, data1);
+        const active = stack.shift();
+        if (active) {
+          pushCompletedNote(
+            notesByChannel,
+            channel,
+            data1,
+            active.startTick,
+            tick,
+            active.velocity,
+            ticksPerQuarterNote,
+          );
+        }
+      }
+    }
+
+    parsedTracks.push({ name: trackName, notesByChannel });
+    offset = trackEnd;
+  }
+
+  const flattenedTracks: ParsedMidiTrack[] = [];
+  parsedTracks.forEach((track, sourceTrackIndex) => {
+    const channels = [...track.notesByChannel.entries()]
+      .filter(([, notes]) => notes.length > 0)
+      .sort((a, b) => a[0] - b[0]);
+
+    const hasMultipleChannels = channels.length > 1;
+    channels.forEach(([channel, notes]) => {
+      const baseName = track.name || `MIDI Track ${sourceTrackIndex + 1}`;
+      flattenedTracks.push({
+        name: hasMultipleChannels ? `${baseName} Ch ${channel + 1}` : baseName,
+        sourceTrackIndex,
+        channel,
+        notes: [...notes].sort((a, b) => a.startBeat - b.startBeat || a.pitch - b.pitch),
+      });
+    });
+  });
+
+  return {
+    format,
+    ticksPerQuarterNote,
+    tracks: flattenedTracks,
+    bpm: firstTempoBpm !== undefined ? Math.round(firstTempoBpm * 100) / 100 : undefined,
+    timeSignature: firstTimeSignature,
+  };
+}

--- a/tests/unit/midi.test.ts
+++ b/tests/unit/midi.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { parseMidiFile } from '../../src/utils/midi';
+
+function textBytes(value: string) {
+  return [...new TextEncoder().encode(value)];
+}
+
+function vlq(value: number): number[] {
+  const buffer = [value & 0x7f];
+  let remaining = value >> 7;
+
+  while (remaining > 0) {
+    buffer.unshift((remaining & 0x7f) | 0x80);
+    remaining >>= 7;
+  }
+
+  return buffer;
+}
+
+function meta(delta: number, type: number, data: number[]) {
+  return [...vlq(delta), 0xff, type, ...vlq(data.length), ...data];
+}
+
+function midi(delta: number, status: number, data: number[]) {
+  return [...vlq(delta), status, ...data];
+}
+
+function trackChunk(events: number[]) {
+  const bytes = Uint8Array.from(events);
+  return [
+    ...textBytes('MTrk'),
+    (bytes.length >>> 24) & 0xff,
+    (bytes.length >>> 16) & 0xff,
+    (bytes.length >>> 8) & 0xff,
+    bytes.length & 0xff,
+    ...bytes,
+  ];
+}
+
+function midiFile(format: number, tracks: number[][], division: number = 480) {
+  const header = [
+    ...textBytes('MThd'),
+    0x00, 0x00, 0x00, 0x06,
+    0x00, format,
+    0x00, tracks.length,
+    (division >>> 8) & 0xff,
+    division & 0xff,
+  ];
+  return Uint8Array.from([
+    ...header,
+    ...tracks.flatMap((events) => trackChunk(events)),
+  ]).buffer;
+}
+
+describe('parseMidiFile', () => {
+  it('parses notes, tempo, time signature, and track names from a type 1 file', () => {
+    const tempoTrack = [
+      meta(0, 0x03, textBytes('Conductor')),
+      meta(0, 0x51, [0x07, 0xa1, 0x20]), // 120 BPM
+      meta(0, 0x58, [0x04, 0x02, 0x18, 0x08]), // 4/4
+      meta(0, 0x2f, []),
+    ].flat();
+
+    const pianoTrack = [
+      meta(0, 0x03, textBytes('Piano')),
+      midi(0, 0x90, [60, 100]),
+      midi(480, 0x80, [60, 0]),
+      midi(0, 0x90, [64, 80]),
+      midi(240, 0x80, [64, 0]),
+      meta(0, 0x2f, []),
+    ].flat();
+
+    const parsed = parseMidiFile(midiFile(1, [tempoTrack, pianoTrack]));
+
+    expect(parsed.bpm).toBe(120);
+    expect(parsed.timeSignature).toEqual({ bar: 1, numerator: 4, denominator: 4 });
+    expect(parsed.tracks).toHaveLength(1);
+    expect(parsed.tracks[0].name).toBe('Piano');
+    expect(parsed.tracks[0].notes).toEqual([
+      { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 100 / 127 },
+      { pitch: 64, startBeat: 1, durationBeats: 0.5, velocity: 80 / 127 },
+    ]);
+  });
+
+  it('splits a type 0 file into separate imported tracks by MIDI channel', () => {
+    const mergedTrack = [
+      meta(0, 0x03, textBytes('Merged')),
+      midi(0, 0x90, [60, 96]),
+      midi(0, 0x91, [67, 64]),
+      midi(480, 0x80, [60, 0]),
+      midi(0, 0x81, [67, 0]),
+      meta(0, 0x2f, []),
+    ].flat();
+
+    const parsed = parseMidiFile(midiFile(0, [mergedTrack]));
+
+    expect(parsed.tracks).toHaveLength(2);
+    expect(parsed.tracks.map((track) => track.name)).toEqual(['Merged Ch 1', 'Merged Ch 2']);
+    expect(parsed.tracks[0].channel).toBe(0);
+    expect(parsed.tracks[1].channel).toBe(1);
+    expect(parsed.tracks[0].notes[0]).toMatchObject({ pitch: 60, startBeat: 0, durationBeats: 1 });
+    expect(parsed.tracks[1].notes[0]).toMatchObject({ pitch: 67, startBeat: 0, durationBeats: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- add Standard MIDI file parsing for note data, track names, tempo, and time signature metadata
- import `.mid` and `.midi` files from drag-and-drop or the file picker into piano roll tracks
- add unit coverage for type 0 and type 1 MIDI parsing

## Verification
- `npm run build`
- `npx vitest run tests/unit/`

## Related
- Closes #231
