### PR TITLE
feat: #237 — MIDI transform tools — humanize, transpose, invert, legato, scale correct

### DIFF
--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -5,12 +5,14 @@ import type { PianoRollGrid } from '../../types/project';
 import { PianoRollCanvas } from './PianoRollCanvas';
 import { PianoRollEmptyState } from './PianoRollEmptyState';
 import { QuantizeDialog } from './QuantizeDialog';
+import { TransformMenu } from './TransformMenu';
 
 export function PianoRoll() {
   const [drawMode, setDrawMode] = useState(false);
   const [showGhostNotes, setShowGhostNotes] = useState(false);
   const [gridSize, setGridSize] = useState<PianoRollGrid>('1/16');
   const [prZoomX, setPrZoomX] = useState(1);
+  const [selectedNoteIds, setSelectedNoteIds] = useState<Set<string>>(new Set());
 
   const project = useProjectStore((s) => s.project);
   const updateTrack = useProjectStore((s) => s.updateTrack);
@@ -136,6 +138,8 @@ export function PianoRoll() {
           <option value="organ">Organ</option>
         </select>
 
+        {clip && <TransformMenu clipId={clip.id} selectedNoteIds={selectedNoteIds} />}
+
         {clip && <span className="text-[10px] text-zinc-500 ml-1 truncate max-w-[200px]">{clip.prompt}</span>}
 
         <div className="ml-auto flex items-center gap-2">
@@ -172,6 +176,8 @@ export function PianoRoll() {
           prZoomX={prZoomX}
           onZoomXChange={setPrZoomX}
           ghostNotes={ghostNotes}
+          selectedNoteIds={selectedNoteIds}
+          onSelectedNoteIdsChange={setSelectedNoteIds}
         />
       ) : (
         <PianoRollEmptyState />

--- a/src/components/pianoroll/PianoRollCanvas.tsx
+++ b/src/components/pianoroll/PianoRollCanvas.tsx
@@ -49,6 +49,8 @@ interface PianoRollCanvasProps {
   prZoomX: number;
   onZoomXChange: React.Dispatch<React.SetStateAction<number>>;
   ghostNotes?: GhostNote[];
+  selectedNoteIds: Set<string>;
+  onSelectedNoteIdsChange: React.Dispatch<React.SetStateAction<Set<string>>>;
 }
 
 export function PianoRollCanvas({
@@ -59,6 +61,8 @@ export function PianoRollCanvas({
   prZoomX,
   onZoomXChange,
   ghostNotes = [],
+  selectedNoteIds,
+  onSelectedNoteIdsChange: setSelectedNoteIds,
 }: PianoRollCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -70,7 +74,6 @@ export function PianoRollCanvas({
   const [prZoomY, setPrZoomY] = useState(1);
   const [prScrollX, setPrScrollX] = useState(0);
   const [prScrollY, setPrScrollY] = useState(780);
-  const [selectedNoteIds, setSelectedNoteIds] = useState<Set<string>>(new Set());
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
 
   const addMidiNote = useProjectStore((s) => s.addMidiNote);

--- a/src/components/pianoroll/TransformMenu.tsx
+++ b/src/components/pianoroll/TransformMenu.tsx
@@ -1,0 +1,285 @@
+import { useCallback, useRef, useState } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { SCALES, type TransformOptions } from '../../utils/midiTransforms';
+
+interface TransformMenuProps {
+  clipId: string;
+  selectedNoteIds: Set<string>;
+}
+
+type TransformType = TransformOptions['type'];
+
+const TRANSFORM_LABELS: Record<TransformType, string> = {
+  humanize: 'Humanize',
+  transpose: 'Transpose',
+  invert: 'Invert',
+  retrograde: 'Retrograde',
+  legato: 'Legato',
+  scaleCorrect: 'Scale Correct',
+  velocityScale: 'Velocity Scale',
+};
+
+export function TransformMenu({ clipId, selectedNoteIds }: TransformMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [activeTransform, setActiveTransform] = useState<TransformType | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const transformMidiNotes = useProjectStore((s) => s.transformMidiNotes);
+
+  // Parameter states
+  const [transposeSemitones, setTransposeSemitones] = useState(0);
+  const [humanizeTiming, setHumanizeTiming] = useState(0.05);
+  const [humanizeVelocity, setHumanizeVelocity] = useState(10);
+  const [invertAxis, setInvertAxis] = useState<string>('');
+  const [legatoOverlap, setLegatoOverlap] = useState(0);
+  const [scaleRoot, setScaleRoot] = useState(0);
+  const [scaleName, setScaleName] = useState('major');
+  const [velMin, setVelMin] = useState(20);
+  const [velMax, setVelMax] = useState(120);
+
+  const noteIdArray = useCallback(() => Array.from(selectedNoteIds), [selectedNoteIds]);
+
+  const apply = useCallback(
+    (opts: TransformOptions) => {
+      transformMidiNotes(clipId, noteIdArray(), opts);
+      setActiveTransform(null);
+      setOpen(false);
+    },
+    [clipId, noteIdArray, transformMidiNotes],
+  );
+
+  const disabled = selectedNoteIds.size === 0;
+
+  const handleSelect = (type: TransformType) => {
+    // Immediate-apply transforms (no params needed)
+    if (type === 'retrograde') {
+      apply({ type: 'retrograde' });
+      return;
+    }
+    setActiveTransform(type);
+  };
+
+  const renderParams = () => {
+    switch (activeTransform) {
+      case 'transpose':
+        return (
+          <div className="flex flex-col gap-1.5 p-2">
+            <label className="text-[10px] text-zinc-400">Semitones</label>
+            <input
+              type="number"
+              value={transposeSemitones}
+              onChange={(e) => setTransposeSemitones(Number(e.target.value))}
+              className="bg-[#111] border border-[#444] rounded px-2 py-0.5 text-[11px] text-zinc-200 w-20"
+              min={-48}
+              max={48}
+            />
+            <button
+              className="mt-1 px-2 py-1 bg-violet-600 hover:bg-violet-500 rounded text-[10px] text-white"
+              onClick={() => apply({ type: 'transpose', semitones: transposeSemitones })}
+            >
+              Apply
+            </button>
+          </div>
+        );
+
+      case 'humanize':
+        return (
+          <div className="flex flex-col gap-1.5 p-2">
+            <label className="text-[10px] text-zinc-400">Timing (beats)</label>
+            <input
+              type="number"
+              value={humanizeTiming}
+              onChange={(e) => setHumanizeTiming(Number(e.target.value))}
+              className="bg-[#111] border border-[#444] rounded px-2 py-0.5 text-[11px] text-zinc-200 w-20"
+              min={0}
+              max={1}
+              step={0.01}
+            />
+            <label className="text-[10px] text-zinc-400">Velocity</label>
+            <input
+              type="number"
+              value={humanizeVelocity}
+              onChange={(e) => setHumanizeVelocity(Number(e.target.value))}
+              className="bg-[#111] border border-[#444] rounded px-2 py-0.5 text-[11px] text-zinc-200 w-20"
+              min={0}
+              max={64}
+            />
+            <button
+              className="mt-1 px-2 py-1 bg-violet-600 hover:bg-violet-500 rounded text-[10px] text-white"
+              onClick={() =>
+                apply({ type: 'humanize', timingAmount: humanizeTiming, velocityAmount: humanizeVelocity })
+              }
+            >
+              Apply
+            </button>
+          </div>
+        );
+
+      case 'invert':
+        return (
+          <div className="flex flex-col gap-1.5 p-2">
+            <label className="text-[10px] text-zinc-400">Axis (pitch, blank=auto)</label>
+            <input
+              type="number"
+              value={invertAxis}
+              onChange={(e) => setInvertAxis(e.target.value)}
+              className="bg-[#111] border border-[#444] rounded px-2 py-0.5 text-[11px] text-zinc-200 w-20"
+              min={0}
+              max={127}
+              placeholder="auto"
+            />
+            <button
+              className="mt-1 px-2 py-1 bg-violet-600 hover:bg-violet-500 rounded text-[10px] text-white"
+              onClick={() =>
+                apply({ type: 'invert', axis: invertAxis !== '' ? Number(invertAxis) : undefined })
+              }
+            >
+              Apply
+            </button>
+          </div>
+        );
+
+      case 'legato':
+        return (
+          <div className="flex flex-col gap-1.5 p-2">
+            <label className="text-[10px] text-zinc-400">Overlap (beats)</label>
+            <input
+              type="number"
+              value={legatoOverlap}
+              onChange={(e) => setLegatoOverlap(Number(e.target.value))}
+              className="bg-[#111] border border-[#444] rounded px-2 py-0.5 text-[11px] text-zinc-200 w-20"
+              min={-1}
+              max={1}
+              step={0.05}
+            />
+            <button
+              className="mt-1 px-2 py-1 bg-violet-600 hover:bg-violet-500 rounded text-[10px] text-white"
+              onClick={() => apply({ type: 'legato', overlapBeats: legatoOverlap })}
+            >
+              Apply
+            </button>
+          </div>
+        );
+
+      case 'scaleCorrect':
+        return (
+          <div className="flex flex-col gap-1.5 p-2">
+            <label className="text-[10px] text-zinc-400">Root</label>
+            <select
+              value={scaleRoot}
+              onChange={(e) => setScaleRoot(Number(e.target.value))}
+              className="bg-[#111] border border-[#444] rounded px-2 py-0.5 text-[11px] text-zinc-200"
+            >
+              {['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'].map((n, i) => (
+                <option key={i} value={i}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            <label className="text-[10px] text-zinc-400">Scale</label>
+            <select
+              value={scaleName}
+              onChange={(e) => setScaleName(e.target.value)}
+              className="bg-[#111] border border-[#444] rounded px-2 py-0.5 text-[11px] text-zinc-200"
+            >
+              {Object.keys(SCALES).map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+            <button
+              className="mt-1 px-2 py-1 bg-violet-600 hover:bg-violet-500 rounded text-[10px] text-white"
+              onClick={() => apply({ type: 'scaleCorrect', root: scaleRoot, scale: scaleName })}
+            >
+              Apply
+            </button>
+          </div>
+        );
+
+      case 'velocityScale':
+        return (
+          <div className="flex flex-col gap-1.5 p-2">
+            <label className="text-[10px] text-zinc-400">Min velocity</label>
+            <input
+              type="number"
+              value={velMin}
+              onChange={(e) => setVelMin(Number(e.target.value))}
+              className="bg-[#111] border border-[#444] rounded px-2 py-0.5 text-[11px] text-zinc-200 w-20"
+              min={1}
+              max={127}
+            />
+            <label className="text-[10px] text-zinc-400">Max velocity</label>
+            <input
+              type="number"
+              value={velMax}
+              onChange={(e) => setVelMax(Number(e.target.value))}
+              className="bg-[#111] border border-[#444] rounded px-2 py-0.5 text-[11px] text-zinc-200 w-20"
+              min={1}
+              max={127}
+            />
+            <button
+              className="mt-1 px-2 py-1 bg-violet-600 hover:bg-violet-500 rounded text-[10px] text-white"
+              onClick={() => apply({ type: 'velocityScale', min: velMin, max: velMax })}
+            >
+              Apply
+            </button>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        aria-label="MIDI transform tools"
+        className={`px-2 py-1 rounded text-[10px] transition-colors ${
+          disabled
+            ? 'bg-white/5 text-zinc-600 cursor-not-allowed'
+            : 'bg-white/5 text-zinc-400 hover:bg-white/10 hover:text-zinc-200'
+        }`}
+        disabled={disabled}
+        onClick={() => {
+          setOpen(!open);
+          setActiveTransform(null);
+        }}
+        title="Transform selected notes"
+      >
+        Transform
+      </button>
+
+      {open && !disabled && (
+        <div className="absolute top-full left-0 mt-1 z-50 bg-[#1a1a2e] border border-[#333] rounded shadow-lg min-w-[140px]">
+          {activeTransform ? (
+            <div>
+              <button
+                className="w-full text-left px-2 py-1 text-[10px] text-zinc-500 hover:text-zinc-300 border-b border-[#333]"
+                onClick={() => setActiveTransform(null)}
+              >
+                ← Back
+              </button>
+              <div className="text-[11px] text-zinc-200 px-2 pt-1 font-medium">
+                {TRANSFORM_LABELS[activeTransform]}
+              </div>
+              {renderParams()}
+            </div>
+          ) : (
+            <div className="py-1">
+              {(Object.keys(TRANSFORM_LABELS) as TransformType[]).map((type) => (
+                <button
+                  key={type}
+                  className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-300 hover:bg-violet-600/30 hover:text-white transition-colors"
+                  onClick={() => handleSelect(type)}
+                >
+                  {TRANSFORM_LABELS[type]}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -46,6 +46,7 @@ import {
 } from '../constants/defaults';
 import { saveProject as saveProjectToIDB } from '../services/projectStorage';
 import { exportStemToWav, type ExportClip } from '../engine/exportMix';
+import { applyTransform, type TransformOptions } from '../utils/midiTransforms';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { getAudioEngine } from '../hooks/useAudioEngine';
 import { renderMidiTrackOffline, renderSequencerTrackOffline } from '../engine/offlineRender';
@@ -178,6 +179,7 @@ interface ProjectState {
   quantizeMidiNotes: (clipId: string, noteIds: string[], gridBeatsOrOptions: number | QuantizeOptions) => void;
   stampChord: (clipId: string, rootPitch: number, intervals: number[], startBeat: number, durationBeats: number, velocity?: number) => string[];
   setMidiGrid: (clipId: string, grid: PianoRollGrid) => void;
+  transformMidiNotes: (clipId: string, noteIds: string[], transform: TransformOptions) => void;
   addTrackEffect: (trackId: string, type: TrackEffectType) => string | undefined;
   updateTrackEffect: (trackId: string, effectId: string, updates: Partial<TrackEffect>) => void;
   removeTrackEffect: (trackId: string, effectId: string) => void;
@@ -2063,6 +2065,32 @@ export const useProjectStore = create<ProjectState>()(
                 }
               : clip,
           ),
+        })),
+      },
+    });
+  },
+
+  transformMidiNotes: (clipId, noteIds, transform) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const noteIdSet = new Set(noteIds);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) => ({
+          ...track,
+          clips: track.clips.map((clip) => {
+            if (clip.id !== clipId || !clip.midiData) return clip;
+            const selected = clip.midiData.notes.filter((n) => noteIdSet.has(n.id));
+            const unselected = clip.midiData.notes.filter((n) => !noteIdSet.has(n.id));
+            const transformed = applyTransform(selected, transform);
+            return {
+              ...clip,
+              midiData: { ...clip.midiData, notes: [...unselected, ...transformed] },
+            };
+          }),
         })),
       },
     });

--- a/src/utils/midiTransforms.ts
+++ b/src/utils/midiTransforms.ts
@@ -1,0 +1,192 @@
+import type { MidiNote } from '../types/project';
+
+// ── Scale definitions (semitone offsets from root) ──────────────────────
+export const SCALES: Record<string, number[]> = {
+  major:            [0, 2, 4, 5, 7, 9, 11],
+  minor:            [0, 2, 3, 5, 7, 8, 10],
+  dorian:           [0, 2, 3, 5, 7, 9, 10],
+  mixolydian:       [0, 2, 4, 5, 7, 9, 10],
+  pentatonic:       [0, 2, 4, 7, 9],
+  'minor-pentatonic': [0, 3, 5, 7, 10],
+  blues:            [0, 3, 5, 6, 7, 10],
+  chromatic:        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+};
+
+// ── Transform option types ──────────────────────────────────────────────
+
+export interface HumanizeOptions {
+  type: 'humanize';
+  timingAmount: number;   // max ± beats to randomize timing
+  velocityAmount: number; // max ± to randomize velocity (0-127 range)
+  seed?: number;          // optional seed for deterministic tests
+}
+
+export interface TransposeOptions {
+  type: 'transpose';
+  semitones: number;
+}
+
+export interface InvertOptions {
+  type: 'invert';
+  axis?: number; // pitch axis; defaults to midpoint of selected notes
+}
+
+export interface RetrogradeOptions {
+  type: 'retrograde';
+}
+
+export interface LegatoOptions {
+  type: 'legato';
+  overlapBeats?: number; // optional overlap (default 0 = exactly touching)
+}
+
+export interface ScaleCorrectOptions {
+  type: 'scaleCorrect';
+  root: number;          // 0-11 (C=0, C#=1, …)
+  scale: string;         // key into SCALES
+}
+
+export interface VelocityScaleOptions {
+  type: 'velocityScale';
+  min: number; // target minimum velocity (0-127)
+  max: number; // target maximum velocity (0-127)
+}
+
+export type TransformOptions =
+  | HumanizeOptions
+  | TransposeOptions
+  | InvertOptions
+  | RetrogradeOptions
+  | LegatoOptions
+  | ScaleCorrectOptions
+  | VelocityScaleOptions;
+
+// ── Seeded random (simple mulberry32) ───────────────────────────────────
+
+function seededRandom(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ── Individual transform functions ──────────────────────────────────────
+
+export function humanize(notes: MidiNote[], opts: HumanizeOptions): MidiNote[] {
+  const rand = opts.seed != null ? seededRandom(opts.seed) : Math.random;
+  return notes.map((note) => {
+    const timingShift = (rand() * 2 - 1) * opts.timingAmount;
+    const velocityShift = Math.round((rand() * 2 - 1) * opts.velocityAmount);
+    return {
+      ...note,
+      startBeat: Math.max(0, note.startBeat + timingShift),
+      velocity: Math.max(1, Math.min(127, note.velocity + velocityShift)),
+    };
+  });
+}
+
+export function transpose(notes: MidiNote[], opts: TransposeOptions): MidiNote[] {
+  return notes.map((note) => ({
+    ...note,
+    pitch: Math.max(0, Math.min(127, note.pitch + opts.semitones)),
+  }));
+}
+
+export function invert(notes: MidiNote[], opts: InvertOptions): MidiNote[] {
+  if (notes.length === 0) return notes;
+  const axis =
+    opts.axis ??
+    Math.round(
+      (Math.min(...notes.map((n) => n.pitch)) + Math.max(...notes.map((n) => n.pitch))) / 2,
+    );
+  return notes.map((note) => ({
+    ...note,
+    pitch: Math.max(0, Math.min(127, 2 * axis - note.pitch)),
+  }));
+}
+
+export function retrograde(notes: MidiNote[]): MidiNote[] {
+  if (notes.length === 0) return notes;
+  const sorted = [...notes].sort((a, b) => a.startBeat - b.startBeat);
+  const minStart = sorted[0].startBeat;
+  const maxEnd = Math.max(...sorted.map((n) => n.startBeat + n.durationBeats));
+  return sorted.map((note) => ({
+    ...note,
+    startBeat: maxEnd - (note.startBeat - minStart) - note.durationBeats,
+  }));
+}
+
+export function legato(notes: MidiNote[], opts: LegatoOptions): MidiNote[] {
+  if (notes.length <= 1) return notes;
+  const overlap = opts.overlapBeats ?? 0;
+  const sorted = [...notes].sort((a, b) => a.startBeat - b.startBeat);
+  const result: MidiNote[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    if (i < sorted.length - 1) {
+      const gap = sorted[i + 1].startBeat - sorted[i].startBeat;
+      result.push({ ...sorted[i], durationBeats: gap + overlap });
+    } else {
+      result.push({ ...sorted[i] });
+    }
+  }
+  return result;
+}
+
+export function scaleCorrect(notes: MidiNote[], opts: ScaleCorrectOptions): MidiNote[] {
+  const scaleIntervals = SCALES[opts.scale];
+  if (!scaleIntervals) return notes;
+
+  // Build a set of all valid pitches in 0-127
+  const validPitches = new Set<number>();
+  for (let octave = -1; octave <= 10; octave++) {
+    for (const interval of scaleIntervals) {
+      const pitch = (octave + 1) * 12 + opts.root + interval;
+      if (pitch >= 0 && pitch <= 127) validPitches.add(pitch);
+    }
+  }
+
+  function snapToScale(pitch: number): number {
+    if (validPitches.has(pitch)) return pitch;
+    for (let offset = 1; offset <= 6; offset++) {
+      if (validPitches.has(pitch - offset)) return pitch - offset;
+      if (validPitches.has(pitch + offset)) return pitch + offset;
+    }
+    return pitch;
+  }
+
+  return notes.map((note) => ({
+    ...note,
+    pitch: snapToScale(note.pitch),
+  }));
+}
+
+export function velocityScale(notes: MidiNote[], opts: VelocityScaleOptions): MidiNote[] {
+  if (notes.length === 0) return notes;
+  const velocities = notes.map((n) => n.velocity);
+  const srcMin = Math.min(...velocities);
+  const srcMax = Math.max(...velocities);
+  const srcRange = srcMax - srcMin;
+
+  return notes.map((note) => {
+    const normalized = srcRange === 0 ? 0.5 : (note.velocity - srcMin) / srcRange;
+    const newVel = Math.round(opts.min + normalized * (opts.max - opts.min));
+    return { ...note, velocity: Math.max(1, Math.min(127, newVel)) };
+  });
+}
+
+// ── Dispatcher ──────────────────────────────────────────────────────────
+
+export function applyTransform(notes: MidiNote[], opts: TransformOptions): MidiNote[] {
+  switch (opts.type) {
+    case 'humanize':     return humanize(notes, opts);
+    case 'transpose':    return transpose(notes, opts);
+    case 'invert':       return invert(notes, opts);
+    case 'retrograde':   return retrograde(notes);
+    case 'legato':       return legato(notes, opts);
+    case 'scaleCorrect': return scaleCorrect(notes, opts);
+    case 'velocityScale': return velocityScale(notes, opts);
+  }
+}

--- a/tests/unit/midiTransforms.test.ts
+++ b/tests/unit/midiTransforms.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest';
+import type { MidiNote } from '../../src/types/project';
+import {
+  humanize,
+  transpose,
+  invert,
+  retrograde,
+  legato,
+  scaleCorrect,
+  velocityScale,
+  applyTransform,
+} from '../../src/utils/midiTransforms';
+
+function makeNote(overrides: Partial<MidiNote> & { id: string }): MidiNote {
+  return { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 100, ...overrides };
+}
+
+// ── Humanize ────────────────────────────────────────────────────────────
+
+describe('humanize', () => {
+  it('randomizes timing and velocity within bounds', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 2, velocity: 80 })];
+    const result = humanize(notes, { type: 'humanize', timingAmount: 0.1, velocityAmount: 10, seed: 42 });
+    expect(result).toHaveLength(1);
+    expect(result[0].startBeat).not.toBe(2);
+    expect(Math.abs(result[0].startBeat - 2)).toBeLessThanOrEqual(0.1);
+    expect(Math.abs(result[0].velocity - 80)).toBeLessThanOrEqual(10);
+  });
+
+  it('clamps startBeat to >= 0', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 0, velocity: 100 })];
+    const result = humanize(notes, { type: 'humanize', timingAmount: 10, velocityAmount: 0, seed: 1 });
+    expect(result[0].startBeat).toBeGreaterThanOrEqual(0);
+  });
+
+  it('clamps velocity to 1-127', () => {
+    const notes = [makeNote({ id: 'a', velocity: 1 })];
+    const result = humanize(notes, { type: 'humanize', timingAmount: 0, velocityAmount: 100, seed: 999 });
+    expect(result[0].velocity).toBeGreaterThanOrEqual(1);
+    expect(result[0].velocity).toBeLessThanOrEqual(127);
+  });
+
+  it('is deterministic with same seed', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 4, velocity: 64 })];
+    const r1 = humanize(notes, { type: 'humanize', timingAmount: 0.5, velocityAmount: 20, seed: 7 });
+    const r2 = humanize(notes, { type: 'humanize', timingAmount: 0.5, velocityAmount: 20, seed: 7 });
+    expect(r1).toEqual(r2);
+  });
+});
+
+// ── Transpose ───────────────────────────────────────────────────────────
+
+describe('transpose', () => {
+  it('shifts pitch by semitones', () => {
+    const notes = [makeNote({ id: 'a', pitch: 60 }), makeNote({ id: 'b', pitch: 64 })];
+    const result = transpose(notes, { type: 'transpose', semitones: 7 });
+    expect(result.map((n) => n.pitch)).toEqual([67, 71]);
+  });
+
+  it('clamps pitch to 0-127', () => {
+    const notes = [makeNote({ id: 'a', pitch: 125 })];
+    expect(transpose(notes, { type: 'transpose', semitones: 5 })[0].pitch).toBe(127);
+    expect(transpose(notes, { type: 'transpose', semitones: -200 })[0].pitch).toBe(0);
+  });
+
+  it('supports negative (downward) transposition', () => {
+    const notes = [makeNote({ id: 'a', pitch: 60 })];
+    expect(transpose(notes, { type: 'transpose', semitones: -12 })[0].pitch).toBe(48);
+  });
+});
+
+// ── Invert ──────────────────────────────────────────────────────────────
+
+describe('invert', () => {
+  it('mirrors notes around the midpoint by default', () => {
+    const notes = [
+      makeNote({ id: 'a', pitch: 60 }),
+      makeNote({ id: 'b', pitch: 64 }),
+      makeNote({ id: 'c', pitch: 67 }),
+    ];
+    // midpoint = round((60+67)/2) = 64 (63.5 → 64)
+    const result = invert(notes, { type: 'invert' });
+    expect(result.map((n) => n.pitch)).toEqual([68, 64, 61]);
+  });
+
+  it('mirrors around a specified axis', () => {
+    const notes = [makeNote({ id: 'a', pitch: 60 })];
+    const result = invert(notes, { type: 'invert', axis: 64 });
+    expect(result[0].pitch).toBe(68);
+  });
+
+  it('clamps to MIDI range', () => {
+    const notes = [makeNote({ id: 'a', pitch: 5 })];
+    const result = invert(notes, { type: 'invert', axis: 0 });
+    expect(result[0].pitch).toBe(0); // 2*0-5 = -5 → clamped to 0
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(invert([], { type: 'invert' })).toEqual([]);
+  });
+});
+
+// ── Retrograde ──────────────────────────────────────────────────────────
+
+describe('retrograde', () => {
+  it('reverses note order in time', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0, durationBeats: 1 }),
+      makeNote({ id: 'b', startBeat: 1, durationBeats: 2 }),
+      makeNote({ id: 'c', startBeat: 3, durationBeats: 1 }),
+    ];
+    const result = retrograde(notes);
+    // total span: 0 to 4
+    // note a (start 0, dur 1): new start = 4 - 0 - 1 = 3
+    // note b (start 1, dur 2): new start = 4 - 1 - 2 = 1
+    // note c (start 3, dur 1): new start = 4 - 3 - 1 = 0
+    expect(result.map((n) => ({ id: n.id, s: n.startBeat }))).toEqual([
+      { id: 'a', s: 3 },
+      { id: 'b', s: 1 },
+      { id: 'c', s: 0 },
+    ]);
+  });
+
+  it('preserves durations', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0, durationBeats: 2 }),
+      makeNote({ id: 'b', startBeat: 2, durationBeats: 3 }),
+    ];
+    const result = retrograde(notes);
+    expect(result.map((n) => n.durationBeats)).toEqual([2, 3]);
+  });
+
+  it('handles empty array', () => {
+    expect(retrograde([])).toEqual([]);
+  });
+});
+
+// ── Legato ──────────────────────────────────────────────────────────────
+
+describe('legato', () => {
+  it('extends each note to touch the next', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0, durationBeats: 0.5 }),
+      makeNote({ id: 'b', startBeat: 2, durationBeats: 0.5 }),
+      makeNote({ id: 'c', startBeat: 4, durationBeats: 1 }),
+    ];
+    const result = legato(notes, { type: 'legato' });
+    expect(result.map((n) => n.durationBeats)).toEqual([2, 2, 1]);
+  });
+
+  it('supports overlap', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0, durationBeats: 0.5 }),
+      makeNote({ id: 'b', startBeat: 2, durationBeats: 0.5 }),
+    ];
+    const result = legato(notes, { type: 'legato', overlapBeats: 0.25 });
+    expect(result[0].durationBeats).toBe(2.25);
+  });
+
+  it('returns single note unchanged', () => {
+    const notes = [makeNote({ id: 'a' })];
+    const result = legato(notes, { type: 'legato' });
+    expect(result).toEqual(notes);
+  });
+});
+
+// ── Scale Correct ───────────────────────────────────────────────────────
+
+describe('scaleCorrect', () => {
+  it('snaps notes to C major scale', () => {
+    // C major = C D E F G A B
+    // C#(61) → C(60), D#(63) → D(62), F#(66) → F(65) or G(67)
+    const notes = [
+      makeNote({ id: 'a', pitch: 61 }), // C# → C (snap down)
+      makeNote({ id: 'b', pitch: 63 }), // D# → D (snap down)
+      makeNote({ id: 'c', pitch: 60 }), // C stays C
+    ];
+    const result = scaleCorrect(notes, { type: 'scaleCorrect', root: 0, scale: 'major' });
+    expect(result[0].pitch).toBe(60); // C# → C
+    expect(result[1].pitch).toBe(62); // D# → D
+    expect(result[2].pitch).toBe(60); // C stays
+  });
+
+  it('snaps to A minor pentatonic', () => {
+    // A minor pentatonic: A C D E G = 9 0 2 4 7 (relative to A=root)
+    const notes = [makeNote({ id: 'a', pitch: 70 })]; // A#4
+    const result = scaleCorrect(notes, { type: 'scaleCorrect', root: 9, scale: 'minor-pentatonic' });
+    // A#=70 is not in A minor pent. Nearest: A(69) or C(72)? Offset from root: 70%12=10, root=9, so semitone=1
+    // Valid intervals from root 9: 9,0,2,4,7 → pitches near 70: 69(A), 72(C)
+    // snap down preference: 69
+    expect(result[0].pitch).toBe(69);
+  });
+
+  it('returns notes unchanged for unknown scale', () => {
+    const notes = [makeNote({ id: 'a', pitch: 61 })];
+    const result = scaleCorrect(notes, { type: 'scaleCorrect', root: 0, scale: 'nonexistent' });
+    expect(result[0].pitch).toBe(61);
+  });
+});
+
+// ── Velocity Scale ──────────────────────────────────────────────────────
+
+describe('velocityScale', () => {
+  it('maps velocity range to new min/max', () => {
+    const notes = [
+      makeNote({ id: 'a', velocity: 50 }),
+      makeNote({ id: 'b', velocity: 100 }),
+    ];
+    const result = velocityScale(notes, { type: 'velocityScale', min: 20, max: 120 });
+    expect(result[0].velocity).toBe(20);
+    expect(result[1].velocity).toBe(120);
+  });
+
+  it('handles all same velocity', () => {
+    const notes = [
+      makeNote({ id: 'a', velocity: 80 }),
+      makeNote({ id: 'b', velocity: 80 }),
+    ];
+    const result = velocityScale(notes, { type: 'velocityScale', min: 40, max: 100 });
+    // normalized = 0.5 when range=0, so mapped to midpoint
+    expect(result[0].velocity).toBe(70);
+  });
+
+  it('clamps to 1-127', () => {
+    const notes = [makeNote({ id: 'a', velocity: 50 }), makeNote({ id: 'b', velocity: 100 })];
+    const result = velocityScale(notes, { type: 'velocityScale', min: 0, max: 200 });
+    expect(result[0].velocity).toBeGreaterThanOrEqual(1);
+    expect(result[1].velocity).toBeLessThanOrEqual(127);
+  });
+});
+
+// ── applyTransform dispatcher ───────────────────────────────────────────
+
+describe('applyTransform', () => {
+  const notes = [makeNote({ id: 'a', pitch: 60, startBeat: 0 })];
+
+  it('dispatches transpose', () => {
+    const result = applyTransform(notes, { type: 'transpose', semitones: 12 });
+    expect(result[0].pitch).toBe(72);
+  });
+
+  it('dispatches retrograde', () => {
+    const twoNotes = [
+      makeNote({ id: 'a', startBeat: 0, durationBeats: 1 }),
+      makeNote({ id: 'b', startBeat: 1, durationBeats: 1 }),
+    ];
+    const result = applyTransform(twoNotes, { type: 'retrograde' });
+    expect(result[0].startBeat).toBe(1);
+    expect(result[1].startBeat).toBe(0);
+  });
+
+  it('dispatches humanize', () => {
+    const result = applyTransform(notes, { type: 'humanize', timingAmount: 0.01, velocityAmount: 1, seed: 1 });
+    expect(result).toHaveLength(1);
+  });
+
+  it('dispatches legato', () => {
+    const twoNotes = [
+      makeNote({ id: 'a', startBeat: 0, durationBeats: 0.5 }),
+      makeNote({ id: 'b', startBeat: 2, durationBeats: 0.5 }),
+    ];
+    const result = applyTransform(twoNotes, { type: 'legato' });
+    expect(result[0].durationBeats).toBe(2);
+  });
+
+  it('dispatches scaleCorrect', () => {
+    const result = applyTransform(
+      [makeNote({ id: 'a', pitch: 61 })],
+      { type: 'scaleCorrect', root: 0, scale: 'major' },
+    );
+    expect(result[0].pitch).toBe(60);
+  });
+
+  it('dispatches velocityScale', () => {
+    const result = applyTransform(
+      [makeNote({ id: 'a', velocity: 50 }), makeNote({ id: 'b', velocity: 100 })],
+      { type: 'velocityScale', min: 10, max: 110 },
+    );
+    expect(result[0].velocity).toBe(10);
+    expect(result[1].velocity).toBe(110);
+  });
+
+  it('dispatches invert', () => {
+    const result = applyTransform(
+      [makeNote({ id: 'a', pitch: 60 }), makeNote({ id: 'b', pitch: 64 })],
+      { type: 'invert', axis: 62 },
+    );
+    expect(result[0].pitch).toBe(64);
+    expect(result[1].pitch).toBe(60);
+  });
+});

--- a/tests/unit/transformMidiNotes.test.ts
+++ b/tests/unit/transformMidiNotes.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useProjectStore } from '../../src/store/projectStore';
+
+describe('projectStore.transformMidiNotes', () => {
+  let clipId: string;
+  const noteIds: string[] = [];
+
+  beforeEach(() => {
+    useProjectStore.getState().createProject({ name: 'Test', bpm: 120 });
+    const track = useProjectStore.getState().addTrack('synth', 'pianoRoll');
+    const clip = useProjectStore.getState().ensureMidiClip(track.id);
+    clipId = clip.id;
+    noteIds.length = 0;
+    noteIds.push(
+      useProjectStore.getState().addMidiNote(clipId, { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 100 })!,
+      useProjectStore.getState().addMidiNote(clipId, { pitch: 64, startBeat: 1, durationBeats: 1, velocity: 80 })!,
+      useProjectStore.getState().addMidiNote(clipId, { pitch: 67, startBeat: 2, durationBeats: 1, velocity: 60 })!,
+    );
+  });
+
+  function getNotes() {
+    const project = useProjectStore.getState().project!;
+    for (const track of project.tracks) {
+      for (const clip of track.clips) {
+        if (clip.id === clipId && clip.midiData) return clip.midiData.notes;
+      }
+    }
+    return [];
+  }
+
+  it('transposes selected notes only', () => {
+    useProjectStore.getState().transformMidiNotes(clipId, [noteIds[0], noteIds[1]], {
+      type: 'transpose',
+      semitones: 12,
+    });
+    const notes = getNotes();
+    const byId = Object.fromEntries(notes.map((n) => [n.id, n]));
+    expect(byId[noteIds[0]].pitch).toBe(72);
+    expect(byId[noteIds[1]].pitch).toBe(76);
+    expect(byId[noteIds[2]].pitch).toBe(67); // unchanged
+  });
+
+  it('supports undo after transform', () => {
+    const beforePitch = getNotes().find((n) => n.id === noteIds[0])!.pitch;
+    useProjectStore.getState().transformMidiNotes(clipId, [noteIds[0]], {
+      type: 'transpose',
+      semitones: 5,
+    });
+    expect(getNotes().find((n) => n.id === noteIds[0])!.pitch).toBe(beforePitch + 5);
+    useProjectStore.getState().undo();
+    expect(getNotes().find((n) => n.id === noteIds[0])!.pitch).toBe(beforePitch);
+  });
+
+  it('applies legato transform', () => {
+    useProjectStore.getState().transformMidiNotes(clipId, noteIds, { type: 'legato' });
+    const notes = getNotes();
+    const sorted = [...notes].sort((a, b) => a.startBeat - b.startBeat);
+    expect(sorted[0].durationBeats).toBe(1); // gap to next = 1
+    expect(sorted[1].durationBeats).toBe(1); // gap to next = 1
+    expect(sorted[2].durationBeats).toBe(1); // last note unchanged
+  });
+
+  it('applies velocity scale transform', () => {
+    useProjectStore.getState().transformMidiNotes(clipId, noteIds, {
+      type: 'velocityScale',
+      min: 20,
+      max: 120,
+    });
+    const notes = getNotes();
+    const velocities = notes.map((n) => n.velocity).sort((a, b) => a - b);
+    expect(velocities[0]).toBe(20);
+    expect(velocities[2]).toBe(120);
+  });
+
+  it('does nothing for non-existent clip', () => {
+    // Should not throw or modify notes for a non-existent clip
+    useProjectStore.getState().transformMidiNotes('nonexistent-clip', noteIds, { type: 'transpose', semitones: 1 });
+    const notes = getNotes();
+    expect(notes.find((n) => n.id === noteIds[0])!.pitch).toBe(60); // unchanged
+  });
+});


### PR DESCRIPTION
Closes #237

## Summary
- **7 MIDI transform types** implemented as pure functions in `src/utils/midiTransforms.ts`: humanize, transpose, invert, retrograde, legato, scale correct, velocity scale
- **Store action** `transformMidiNotes(clipId, noteIds, transform)` applies transforms to selected notes only, with full undo support via `_pushHistory()`
- **Transform dropdown menu** in piano roll toolbar with configurable parameters per transform type
- Lifted `selectedNoteIds` state from `PianoRollCanvas` to `PianoRoll` so the toolbar can access selection

## Test plan
- [x] 30 unit tests for all 7 transform functions (edge cases, clamping, determinism)
- [x] 5 store integration tests (selective transform, undo, non-existent clip)
- [x] Full suite: 149/149 tests pass
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)