### PR TITLE
feat: #235 — MIDI quantize with strength control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ace-step-daw",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "idb-keyval": "^6.2.0",
         "react": "^19.0.0",

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -90,6 +90,7 @@ const SECTIONS: Section[] = [
       { keys: ['⇧', '↑'],               description: 'Transpose selected notes up 1 semitone' },
       { keys: ['⇧', '↓'],               description: 'Transpose selected notes down 1 semitone' },
       { keys: ['Q'],                    description: 'Quantize selected notes to the current grid' },
+      { keys: [`${mod}`, 'Q'],          description: 'Quantize with options (strength, swing, scope)' },
       { keys: [`${mod}`, 'A'],          description: 'Select all notes in the current clip' },
     ],
   },

--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -4,6 +4,7 @@ import { useUIStore } from '../../store/uiStore';
 import type { PianoRollGrid } from '../../types/project';
 import { PianoRollCanvas } from './PianoRollCanvas';
 import { PianoRollEmptyState } from './PianoRollEmptyState';
+import { QuantizeDialog } from './QuantizeDialog';
 
 export function PianoRoll() {
   const [drawMode, setDrawMode] = useState(false);
@@ -175,6 +176,7 @@ export function PianoRoll() {
       ) : (
         <PianoRollEmptyState />
       )}
+      <QuantizeDialog />
     </div>
   );
 }

--- a/src/components/pianoroll/PianoRollCanvas.tsx
+++ b/src/components/pianoroll/PianoRollCanvas.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { synthEngine } from '../../engine/SynthEngine';
 import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
 import { useTransportStore } from '../../store/transportStore';
 import type { Clip, MidiNote, PianoRollGrid, Track } from '../../types/project';
 import { drawPianoRollKeyboard } from './PianoRollKeyboard';
@@ -70,6 +71,7 @@ export function PianoRollCanvas({
   const [prScrollX, setPrScrollX] = useState(0);
   const [prScrollY, setPrScrollY] = useState(780);
   const [selectedNoteIds, setSelectedNoteIds] = useState<Set<string>>(new Set());
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
 
   const addMidiNote = useProjectStore((s) => s.addMidiNote);
   const removeMidiNote = useProjectStore((s) => s.removeMidiNote);
@@ -77,6 +79,7 @@ export function PianoRollCanvas({
   const quantizeMidiNotes = useProjectStore((s) => s.quantizeMidiNotes);
   const beginDrag = useProjectStore((s) => s.beginDrag);
   const endDrag = useProjectStore((s) => s.endDrag);
+  const openQuantizeDialog = useUIStore((s) => s.openQuantizeDialog);
 
   const notes: MidiNote[] = clip.midiData?.notes ?? [];
   const bpm = useProjectStore((s) => s.project?.bpm ?? 120);
@@ -750,9 +753,15 @@ export function PianoRollCanvas({
         return;
       }
 
-      if (key === 'q' && !e.metaKey && !e.ctrlKey && selectedNoteIds.size > 0) {
+      if (key === 'q' && selectedNoteIds.size > 0) {
         e.preventDefault();
-        quantizeMidiNotes(clip.id, Array.from(selectedNoteIds), gridBeats);
+        if (e.ctrlKey || e.metaKey) {
+          // Ctrl/Cmd+Q: open quantize dialog with options
+          openQuantizeDialog(clip.id, Array.from(selectedNoteIds));
+        } else {
+          // Q: quick quantize to current grid
+          quantizeMidiNotes(clip.id, Array.from(selectedNoteIds), gridBeats);
+        }
         return;
       }
 
@@ -840,7 +849,28 @@ export function PianoRollCanvas({
     selectedNoteIds,
     snapBeat,
     updateMidiNote,
+    openQuantizeDialog,
   ]);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (selectedNoteIds.size > 0) {
+        setContextMenu({ x: e.clientX, y: e.clientY });
+      }
+    },
+    [selectedNoteIds],
+  );
+
+  const handleContextMenuQuantize = useCallback(() => {
+    setContextMenu(null);
+    openQuantizeDialog(clip.id, Array.from(selectedNoteIds));
+  }, [clip.id, selectedNoteIds, openQuantizeDialog]);
+
+  const handleContextMenuQuickQuantize = useCallback(() => {
+    setContextMenu(null);
+    quantizeMidiNotes(clip.id, Array.from(selectedNoteIds), gridBeats);
+  }, [clip.id, selectedNoteIds, quantizeMidiNotes, gridBeats]);
 
   return (
     <div ref={containerRef} className="flex-1 relative overflow-hidden">
@@ -852,7 +882,37 @@ export function PianoRollCanvas({
         onMouseDown={handleMouseDown}
         onDoubleClick={handleDoubleClick}
         onWheel={handleWheel}
+        onContextMenu={handleContextMenu}
       />
+      {contextMenu && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setContextMenu(null)}
+            onContextMenu={(e) => { e.preventDefault(); setContextMenu(null); }}
+          />
+          <div
+            className="fixed z-50 bg-[#1a1a2e] border border-[#333] rounded shadow-xl py-1 min-w-[160px]"
+            style={{
+              left: Math.min(contextMenu.x, window.innerWidth - 180),
+              top: Math.min(contextMenu.y, window.innerHeight - 120),
+            }}
+          >
+            <button
+              className="w-full text-left px-3 py-1.5 text-xs text-zinc-300 hover:bg-violet-600/30 hover:text-white transition-colors"
+              onClick={handleContextMenuQuickQuantize}
+            >
+              Quantize (Q)
+            </button>
+            <button
+              className="w-full text-left px-3 py-1.5 text-xs text-zinc-300 hover:bg-violet-600/30 hover:text-white transition-colors"
+              onClick={handleContextMenuQuantize}
+            >
+              Quantize with options... ({navigator.platform?.includes('Mac') ? '\u2318' : 'Ctrl'}+Q)
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/pianoroll/QuantizeDialog.tsx
+++ b/src/components/pianoroll/QuantizeDialog.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useState } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import type { PianoRollGrid } from '../../types/project';
+import type { QuantizeOptions } from '../../utils/midiQuantize';
+import { gridSizeToBeats } from './PianoRollConstants';
+
+const GRID_OPTIONS: { label: string; value: PianoRollGrid }[] = [
+  { label: '1/4', value: '1/4' },
+  { label: '1/8', value: '1/8' },
+  { label: '1/16', value: '1/16' },
+  { label: '1/32', value: '1/32' },
+];
+
+const SCOPE_OPTIONS: { label: string; value: QuantizeOptions['scope'] }[] = [
+  { label: 'Start only', value: 'start' },
+  { label: 'Start + End', value: 'startEnd' },
+  { label: 'Preserve duration', value: 'preserveDuration' },
+];
+
+export function QuantizeDialog() {
+  const show = useUIStore((s) => s.showQuantizeDialog);
+  const target = useUIStore((s) => s.quantizeTarget);
+  const setShow = useUIStore((s) => s.setShowQuantizeDialog);
+  const quantizeMidiNotes = useProjectStore((s) => s.quantizeMidiNotes);
+
+  const [gridSize, setGridSize] = useState<PianoRollGrid>('1/8');
+  const [strength, setStrength] = useState(100);
+  const [swing, setSwing] = useState(0);
+  const [scope, setScope] = useState<QuantizeOptions['scope']>('start');
+
+  const handleApply = useCallback(() => {
+    if (!target) return;
+    const options: QuantizeOptions = {
+      gridBeats: gridSizeToBeats(gridSize),
+      strength,
+      swing,
+      scope,
+    };
+    quantizeMidiNotes(target.clipId, target.noteIds, options);
+    setShow(false);
+  }, [target, gridSize, strength, swing, scope, quantizeMidiNotes, setShow]);
+
+  const handleCancel = useCallback(() => {
+    setShow(false);
+  }, [setShow]);
+
+  if (!show || !target) return null;
+
+  const noteCount = target.noteIds.length;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onMouseDown={(e) => e.target === e.currentTarget && handleCancel()}
+    >
+      <div
+        className="w-[360px] bg-daw-surface rounded-lg border border-daw-border shadow-2xl flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') { e.preventDefault(); handleApply(); }
+          if (e.key === 'Escape') handleCancel();
+        }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-daw-border">
+          <h2 className="text-sm font-semibold text-zinc-100">
+            Quantize {noteCount} note{noteCount !== 1 ? 's' : ''}
+          </h2>
+          <button
+            onClick={handleCancel}
+            className="text-zinc-500 hover:text-zinc-200 transition-colors text-lg leading-none"
+          >
+            x
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-4 py-4 space-y-4">
+          {/* Grid size */}
+          <div className="flex items-center justify-between">
+            <label className="text-xs text-zinc-400">Grid size</label>
+            <select
+              value={gridSize}
+              onChange={(e) => setGridSize(e.target.value as PianoRollGrid)}
+              className="bg-[#111] border border-[#333] rounded px-2 py-1 text-[11px] text-zinc-300 w-24"
+            >
+              {GRID_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Strength */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-xs text-zinc-400">Strength</label>
+              <span className="text-[11px] text-zinc-300 tabular-nums w-10 text-right">{strength}%</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={strength}
+              onChange={(e) => setStrength(Number(e.target.value))}
+              className="w-full h-1.5 bg-zinc-700 rounded-full appearance-none cursor-pointer accent-violet-500"
+            />
+          </div>
+
+          {/* Swing */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-xs text-zinc-400">Swing</label>
+              <span className="text-[11px] text-zinc-300 tabular-nums w-10 text-right">{swing}%</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={swing}
+              onChange={(e) => setSwing(Number(e.target.value))}
+              className="w-full h-1.5 bg-zinc-700 rounded-full appearance-none cursor-pointer accent-violet-500"
+            />
+          </div>
+
+          {/* Scope */}
+          <div className="flex items-center justify-between">
+            <label className="text-xs text-zinc-400">Scope</label>
+            <select
+              value={scope}
+              onChange={(e) => setScope(e.target.value as QuantizeOptions['scope'])}
+              className="bg-[#111] border border-[#333] rounded px-2 py-1 text-[11px] text-zinc-300 w-40"
+            >
+              {SCOPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-daw-border">
+          <button
+            onClick={handleCancel}
+            className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 bg-white/5 hover:bg-white/10 rounded transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleApply}
+            className="px-3 py-1.5 text-xs text-white bg-violet-600 hover:bg-violet-500 rounded transition-colors"
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -34,6 +34,7 @@ import type {
   StretchMode,
 } from '../types/project';
 import { automationParamEquals } from '../types/project';
+import { quantizeNotes as applyQuantize, type QuantizeOptions } from '../utils/midiQuantize';
 import { TRACK_CATALOG, DEFAULT_DRUM_KIT } from '../constants/tracks';
 import {
   DEFAULT_BPM,
@@ -173,7 +174,7 @@ interface ProjectState {
   addMidiNote: (clipId: string, note: Omit<MidiNote, 'id'> & { id?: string }) => string | undefined;
   updateMidiNote: (clipId: string, noteId: string, updates: Partial<MidiNote>) => void;
   removeMidiNote: (clipId: string, noteId: string) => void;
-  quantizeMidiNotes: (clipId: string, noteIds: string[], gridBeats: number) => void;
+  quantizeMidiNotes: (clipId: string, noteIds: string[], gridBeatsOrOptions: number | QuantizeOptions) => void;
   stampChord: (clipId: string, rootPitch: number, intervals: number[], startBeat: number, durationBeats: number, velocity?: number) => string[];
   setMidiGrid: (clipId: string, grid: PianoRollGrid) => void;
   addTrackEffect: (trackId: string, type: TrackEffectType) => string | undefined;
@@ -1962,9 +1963,13 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
-  quantizeMidiNotes: (clipId, noteIds, gridBeats) => {
+  quantizeMidiNotes: (clipId, noteIds, gridBeatsOrOptions) => {
     const state = get();
-    if (!state.project || gridBeats <= 0) return;
+    const options: QuantizeOptions =
+      typeof gridBeatsOrOptions === 'number'
+        ? { gridBeats: gridBeatsOrOptions, strength: 100, swing: 0, scope: 'start' }
+        : gridBeatsOrOptions;
+    if (!state.project || options.gridBeats <= 0) return;
     _pushHistory(state.project);
     const noteIdSet = new Set(noteIds);
     set({
@@ -1979,11 +1984,7 @@ export const useProjectStore = create<ProjectState>()(
                   ...clip,
                   midiData: {
                     ...clip.midiData,
-                    notes: clip.midiData.notes.map((note) =>
-                      noteIdSet.has(note.id)
-                        ? { ...note, startBeat: Math.round(note.startBeat / gridBeats) * gridBeats }
-                        : note,
-                    ),
+                    notes: applyQuantize(clip.midiData.notes, noteIdSet, options),
                   },
                 }
               : clip,

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -61,6 +61,11 @@ interface UIState {
   vocal2bgmClipId: string | null;
   analysisClipId: string | null;
 
+  // Quantize dialog
+  showQuantizeDialog: boolean;
+  /** Clip ID + selected note IDs passed from the piano roll to the quantize dialog. */
+  quantizeTarget: { clipId: string; noteIds: string[] } | null;
+
   setPixelsPerSecond: (pps: number) => void;
   toggleSnap: () => void;
   zoomIn: () => void;
@@ -114,6 +119,11 @@ interface UIState {
   // Vocal2BGM / Audio Analysis
   setVocal2BGMModal: (clipId: string | null) => void;
   setAnalysisPanel: (clipId: string | null) => void;
+
+  // Quantize dialog
+  setShowQuantizeDialog: (v: boolean) => void;
+  setQuantizeTarget: (target: { clipId: string; noteIds: string[] } | null) => void;
+  openQuantizeDialog: (clipId: string, noteIds: string[]) => void;
 }
 
 const ZOOM_LEVELS = [10, 25, 50, 100, 200, 500];
@@ -168,6 +178,9 @@ export const useUIStore = create<UIState>()(
 
   vocal2bgmClipId: null,
   analysisClipId: null,
+
+  showQuantizeDialog: false,
+  quantizeTarget: null,
 
   setPixelsPerSecond: (pps) => set({ pixelsPerSecond: pps }),
   toggleSnap: () => set((s) => ({ snapEnabled: !s.snapEnabled })),
@@ -256,6 +269,10 @@ export const useUIStore = create<UIState>()(
 
   setVocal2BGMModal: (clipId) => set({ vocal2bgmClipId: clipId }),
   setAnalysisPanel: (clipId) => set({ analysisClipId: clipId }),
+
+  setShowQuantizeDialog: (v) => set(v ? { showQuantizeDialog: v } : { showQuantizeDialog: false, quantizeTarget: null }),
+  setQuantizeTarget: (target) => set({ quantizeTarget: target }),
+  openQuantizeDialog: (clipId, noteIds) => set({ showQuantizeDialog: true, quantizeTarget: { clipId, noteIds } }),
 }),
     {
       name: 'ace-step-daw-ui',

--- a/src/utils/midiQuantize.ts
+++ b/src/utils/midiQuantize.ts
@@ -1,0 +1,71 @@
+import type { MidiNote } from '../types/project';
+
+export interface QuantizeOptions {
+  /** Grid size in beats (e.g. 1 = quarter, 0.5 = eighth). */
+  gridBeats: number;
+  /** 0–100: 0 = no change, 100 = snap to grid. */
+  strength: number;
+  /** 0–100: offsets every other grid line for swing feel. */
+  swing: number;
+  /** What to quantize: 'start' | 'startEnd' | 'preserveDuration'. */
+  scope: 'start' | 'startEnd' | 'preserveDuration';
+}
+
+/**
+ * Compute the quantized position of a beat value to the nearest grid line,
+ * taking swing into account. Swing offsets every odd grid position.
+ */
+export function quantizedBeat(beat: number, gridBeats: number, swing: number): number {
+  const gridIndex = Math.round(beat / gridBeats);
+  let snapped = gridIndex * gridBeats;
+  // Apply swing: shift odd grid positions forward by up to half a grid
+  if (swing > 0 && gridIndex % 2 !== 0) {
+    snapped += (swing / 100) * gridBeats * 0.5;
+  }
+  return snapped;
+}
+
+/**
+ * Quantize a single MIDI note, returning a new note object (never mutates).
+ */
+export function quantizeNote(note: MidiNote, options: QuantizeOptions): MidiNote {
+  const { gridBeats, strength, swing, scope } = options;
+  if (strength === 0 || gridBeats <= 0) return note;
+
+  const factor = strength / 100;
+  const targetStart = quantizedBeat(note.startBeat, gridBeats, swing);
+  const newStart = note.startBeat + (targetStart - note.startBeat) * factor;
+
+  if (scope === 'start' || scope === 'preserveDuration') {
+    return {
+      ...note,
+      startBeat: newStart,
+      durationBeats: scope === 'preserveDuration' ? note.durationBeats : note.durationBeats,
+    };
+  }
+
+  // scope === 'startEnd': quantize both start and end independently
+  const endBeat = note.startBeat + note.durationBeats;
+  const targetEnd = quantizedBeat(endBeat, gridBeats, swing);
+  const newEnd = endBeat + (targetEnd - endBeat) * factor;
+  const newDuration = Math.max(gridBeats * 0.25, newEnd - newStart); // minimum duration
+
+  return {
+    ...note,
+    startBeat: newStart,
+    durationBeats: newDuration,
+  };
+}
+
+/**
+ * Quantize an array of MIDI notes. Returns new array with quantized notes.
+ */
+export function quantizeNotes(
+  notes: MidiNote[],
+  noteIds: Set<string>,
+  options: QuantizeOptions,
+): MidiNote[] {
+  return notes.map((note) =>
+    noteIds.has(note.id) ? quantizeNote(note, options) : note,
+  );
+}

--- a/tests/unit/midiQuantize.test.ts
+++ b/tests/unit/midiQuantize.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+  quantizedBeat,
+  quantizeNote,
+  quantizeNotes,
+  type QuantizeOptions,
+} from '../../src/utils/midiQuantize';
+import type { MidiNote } from '../../src/types/project';
+
+function makeNote(overrides: Partial<MidiNote> = {}): MidiNote {
+  return {
+    id: 'n1',
+    pitch: 60,
+    startBeat: 0,
+    durationBeats: 1,
+    velocity: 100,
+    ...overrides,
+  };
+}
+
+const defaultOptions: QuantizeOptions = {
+  gridBeats: 0.5, // 1/8 notes
+  strength: 100,
+  swing: 0,
+  scope: 'start',
+};
+
+describe('quantizedBeat', () => {
+  it('snaps to nearest grid line', () => {
+    expect(quantizedBeat(0.3, 0.5, 0)).toBe(0.5);
+    expect(quantizedBeat(0.2, 0.5, 0)).toBe(0);
+    expect(quantizedBeat(1.0, 0.5, 0)).toBe(1.0);
+  });
+
+  it('applies swing to odd grid positions', () => {
+    // grid index 1 (odd) at gridBeats=0.5 → 0.5 + swing offset
+    const result = quantizedBeat(0.5, 0.5, 100);
+    // swing 100% shifts odd positions by gridBeats * 0.5 = 0.25
+    expect(result).toBeCloseTo(0.75);
+  });
+
+  it('does not apply swing to even grid positions', () => {
+    const result = quantizedBeat(1.0, 0.5, 100);
+    // grid index 2 (even) — no swing
+    expect(result).toBe(1.0);
+  });
+
+  it('partial swing applies proportionally', () => {
+    // 50% swing on odd position
+    const result = quantizedBeat(0.5, 0.5, 50);
+    expect(result).toBeCloseTo(0.625);
+  });
+});
+
+describe('quantizeNote', () => {
+  it('100% strength snaps start to grid', () => {
+    const note = makeNote({ startBeat: 0.3 });
+    const result = quantizeNote(note, { ...defaultOptions, strength: 100 });
+    expect(result.startBeat).toBe(0.5);
+  });
+
+  it('50% strength moves halfway to grid', () => {
+    const note = makeNote({ startBeat: 0.3 });
+    const result = quantizeNote(note, { ...defaultOptions, strength: 50 });
+    // target = 0.5, distance = 0.2, half = 0.1 → 0.4
+    expect(result.startBeat).toBeCloseTo(0.4);
+  });
+
+  it('0% strength does not move note', () => {
+    const note = makeNote({ startBeat: 0.3 });
+    const result = quantizeNote(note, { ...defaultOptions, strength: 0 });
+    expect(result.startBeat).toBe(0.3);
+  });
+
+  it('preserves duration in start scope', () => {
+    const note = makeNote({ startBeat: 0.3, durationBeats: 0.7 });
+    const result = quantizeNote(note, { ...defaultOptions, scope: 'start' });
+    expect(result.durationBeats).toBe(0.7);
+  });
+
+  it('preserves duration in preserveDuration scope', () => {
+    const note = makeNote({ startBeat: 0.3, durationBeats: 0.7 });
+    const result = quantizeNote(note, { ...defaultOptions, scope: 'preserveDuration' });
+    expect(result.durationBeats).toBe(0.7);
+    expect(result.startBeat).toBe(0.5); // snapped
+  });
+
+  it('quantizes both start and end in startEnd scope', () => {
+    const note = makeNote({ startBeat: 0.3, durationBeats: 0.6 });
+    // start → 0.5, end 0.9 → 1.0, duration = 0.5
+    const result = quantizeNote(note, { ...defaultOptions, scope: 'startEnd' });
+    expect(result.startBeat).toBe(0.5);
+    expect(result.durationBeats).toBeCloseTo(0.5);
+  });
+
+  it('enforces minimum duration in startEnd scope', () => {
+    // Note where start and end snap to same grid line
+    const note = makeNote({ startBeat: 0.45, durationBeats: 0.1 });
+    // start → 0.5, end 0.55 → 0.5, would be 0 duration
+    const result = quantizeNote(note, { ...defaultOptions, scope: 'startEnd' });
+    expect(result.durationBeats).toBeGreaterThan(0);
+  });
+
+  it('does not mutate original note', () => {
+    const note = makeNote({ startBeat: 0.3 });
+    const original = { ...note };
+    quantizeNote(note, defaultOptions);
+    expect(note).toEqual(original);
+  });
+
+  it('handles gridBeats <= 0 gracefully', () => {
+    const note = makeNote({ startBeat: 0.3 });
+    const result = quantizeNote(note, { ...defaultOptions, gridBeats: 0 });
+    expect(result).toEqual(note);
+  });
+
+  it('applies swing with partial strength', () => {
+    const note = makeNote({ startBeat: 0.45 });
+    const result = quantizeNote(note, {
+      gridBeats: 0.5,
+      strength: 100,
+      swing: 100,
+      scope: 'start',
+    });
+    // nearest grid is index 1 (0.5), swing shifts to 0.75
+    expect(result.startBeat).toBeCloseTo(0.75);
+  });
+});
+
+describe('quantizeNotes', () => {
+  it('only quantizes notes in the noteIds set', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0.3 }),
+      makeNote({ id: 'b', startBeat: 0.7 }),
+    ];
+    const result = quantizeNotes(notes, new Set(['a']), defaultOptions);
+    expect(result[0].startBeat).toBe(0.5); // quantized
+    expect(result[1].startBeat).toBe(0.7); // untouched
+  });
+
+  it('returns new array (no mutation)', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 0.3 })];
+    const result = quantizeNotes(notes, new Set(['a']), defaultOptions);
+    expect(result).not.toBe(notes);
+    expect(result[0]).not.toBe(notes[0]);
+  });
+
+  it('handles empty noteIds set', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 0.3 })];
+    const result = quantizeNotes(notes, new Set(), defaultOptions);
+    expect(result[0].startBeat).toBe(0.3);
+  });
+});


### PR DESCRIPTION
## Summary
- Add pure quantize algorithm (`src/utils/midiQuantize.ts`) with strength (0-100%), swing, and scope (start only / start+end / preserve duration)
- Quantize dialog accessible via **Ctrl/Cmd+Q** and right-click context menu on selected notes
- **Q** key still performs quick quantize to current grid (backward compatible)
- Store action `quantizeMidiNotes` now accepts `QuantizeOptions` object (or raw `gridBeats` number for backward compat)
- 17 unit tests covering algorithm edge cases

## Test plan
- [x] `npm run build` passes (0 type errors)
- [x] `npx vitest run tests/unit/` — 131 tests pass (17 new)
- [ ] Manual: select MIDI notes → Ctrl+Q → adjust strength slider → Apply → verify notes move proportionally
- [ ] Manual: right-click selected notes → "Quantize with options..." → dialog opens
- [ ] Manual: undo after quantize restores original positions

Closes #235