### PR TITLE
feat: add AI master bus chain

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -102,18 +102,184 @@ interface MasterStripProps { faderHeight: number; }
 function MasterStrip({ faderHeight }: MasterStripProps) {
   const project = useProjectStore((s) => s.project);
   const updateProject = useProjectStore((s) => s.updateProject);
+  const setMasteringEnabled = useProjectStore((s) => s.setMasteringEnabled);
+  const setMasteringPreset = useProjectStore((s) => s.setMasteringPreset);
+  const setMasteringTargetLufs = useProjectStore((s) => s.setMasteringTargetLufs);
+  const setMasteringPreviewBypassed = useProjectStore((s) => s.setMasteringPreviewBypassed);
+  const runMasteringAnalysis = useProjectStore((s) => s.runMasteringAnalysis);
   if (!project) return null;
   const masterVol = project.masterVolume ?? 1.0;
+  const mastering = project.mastering;
+  const analysis = mastering?.analysis;
   const handleChange = (v: number) => { updateProject({ masterVolume: v }); getAudioEngine().masterVolume = v; };
+  const handleAnalyze = async () => {
+    await runMasteringAnalysis();
+    getAudioEngine().applyMastering(useProjectStore.getState().project?.mastering);
+  };
+  const handleMasteringToggle = async () => {
+    if (!mastering?.enabled) {
+      await handleAnalyze();
+      return;
+    }
+    setMasteringEnabled(false);
+    getAudioEngine().applyMastering({
+      ...mastering,
+      enabled: false,
+      previewBypassed: false,
+    });
+  };
+  const beforeMeterWidth = `${Math.min(100, Math.max(8, ((analysis?.inputLufs ?? -18) + 30) * 4))}%`;
+  const afterMeterWidth = `${Math.min(100, Math.max(8, ((analysis?.outputLufs ?? -14) + 30) * 4))}%`;
+  const tonalBars = [
+    { label: 'Lo', value: analysis?.lowBalance ?? 0.33, color: '#f59e0b' },
+    { label: 'Mid', value: analysis?.midBalance ?? 0.34, color: '#38bdf8' },
+    { label: 'Hi', value: analysis?.highBalance ?? 0.33, color: '#e879f9' },
+  ];
 
   return (
-    <div className="flex flex-col items-center gap-1.5 px-4 py-2 bg-[#252525] border-l-2 border-[#555] min-w-[120px]">
+    <div className="flex flex-col items-center gap-2 px-4 py-2 bg-[#252525] border-l-2 border-[#555] min-w-[220px]">
       <span className="text-xs font-bold text-zinc-300 uppercase tracking-widest">Master</span>
+      <div className="w-full rounded-lg border border-[#3f3f3f] bg-[#202020] p-2">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            aria-label={mastering?.enabled ? 'Disable AI mastering' : 'Enable AI mastering'}
+            onClick={() => { void handleMasteringToggle(); }}
+            className={`flex-1 rounded-md px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide transition-colors ${
+              mastering?.enabled
+                ? 'bg-emerald-500 text-black'
+                : 'bg-daw-accent text-white hover:bg-[#5fa6ec]'
+            }`}
+          >
+            {mastering?.enabled ? 'AI Master On' : 'AI Master'}
+          </button>
+          <button
+            type="button"
+            aria-label="Run AI mastering analysis"
+            onClick={() => { void handleAnalyze(); }}
+            className="rounded-md border border-[#4a4a4a] px-2 py-1.5 text-[10px] font-medium text-zinc-300 hover:border-[#6a6a6a]"
+          >
+            Analyze
+          </button>
+        </div>
+
+        <div className="mt-2">
+          {analysis?.status === 'analyzing' ? (
+            <div className="space-y-1.5" aria-label="AI mastering analysis in progress">
+              <div className="text-[10px] uppercase tracking-widest text-zinc-400">Analyzing Mix</div>
+              <div className="h-1.5 overflow-hidden rounded-full bg-[#101010]">
+                <div className="h-full w-2/3 animate-pulse rounded-full bg-daw-accent" />
+              </div>
+              <div className="text-[10px] text-zinc-500">
+                Scanning balance, loudness, and dynamics...
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <div className="flex gap-2">
+                <label className="flex-1">
+                  <span className="mb-1 block text-[9px] uppercase tracking-widest text-zinc-500">Preset</span>
+                  <select
+                    aria-label="Mastering preset"
+                    value={mastering?.preset ?? 'balanced'}
+                    onChange={(e) => setMasteringPreset(e.target.value as 'balanced' | 'loud' | 'warm' | 'bright')}
+                    className="w-full rounded-md border border-[#404040] bg-[#171717] px-2 py-1 text-[11px] text-zinc-200"
+                  >
+                    <option value="balanced">Balanced</option>
+                    <option value="loud">Loud</option>
+                    <option value="warm">Warm</option>
+                    <option value="bright">Bright</option>
+                  </select>
+                </label>
+                <label className="w-[78px]">
+                  <span className="mb-1 block text-[9px] uppercase tracking-widest text-zinc-500">Target</span>
+                  <select
+                    aria-label="Mastering loudness target"
+                    value={String(mastering?.targetLufs ?? -14)}
+                    onChange={(e) => setMasteringTargetLufs(Number(e.target.value) as -14 | -11 | -8)}
+                    className="w-full rounded-md border border-[#404040] bg-[#171717] px-2 py-1 text-[11px] text-zinc-200"
+                  >
+                    <option value="-14">-14</option>
+                    <option value="-11">-11</option>
+                    <option value="-8">-8</option>
+                  </select>
+                </label>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2 text-[10px]">
+                <div className="rounded-md bg-[#171717] px-2 py-1.5">
+                  <div className="uppercase tracking-widest text-zinc-500">Before</div>
+                  <div className="font-mono text-zinc-200">{(analysis?.inputLufs ?? -18).toFixed(1)} LUFS</div>
+                  <div className="mt-1 h-1 rounded-full bg-[#101010]">
+                    <div className="h-full rounded-full bg-amber-400" style={{ width: beforeMeterWidth }} />
+                  </div>
+                </div>
+                <div className="rounded-md bg-[#171717] px-2 py-1.5">
+                  <div className="uppercase tracking-widest text-zinc-500">After</div>
+                  <div className="font-mono text-zinc-200">{(analysis?.outputLufs ?? -14).toFixed(1)} LUFS</div>
+                  <div className="mt-1 h-1 rounded-full bg-[#101010]">
+                    <div className="h-full rounded-full bg-emerald-400" style={{ width: afterMeterWidth }} />
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-md bg-[#171717] px-2 py-1.5">
+                <div className="mb-1 flex items-center justify-between text-[9px] uppercase tracking-widest text-zinc-500">
+                  <span>Tonal Balance</span>
+                  <span>{analysis?.recommendedPreset ?? 'balanced'}</span>
+                </div>
+                <div className="space-y-1">
+                  {tonalBars.map((bar) => (
+                    <div key={bar.label} className="flex items-center gap-2 text-[9px] text-zinc-400">
+                      <span className="w-6 uppercase">{bar.label}</span>
+                      <div className="h-1 flex-1 rounded-full bg-[#101010]">
+                        <div
+                          className="h-full rounded-full"
+                          style={{ width: `${Math.round(bar.value * 100)}%`, backgroundColor: bar.color }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2 text-[10px] text-zinc-400">
+                <div className="rounded-md bg-[#171717] px-2 py-1.5">
+                  <div className="uppercase tracking-widest text-zinc-500">Dynamics</div>
+                  <div className="font-mono text-zinc-200">{(analysis?.dynamicRange ?? 10).toFixed(1)} dB</div>
+                </div>
+                <div className="rounded-md bg-[#171717] px-2 py-1.5">
+                  <div className="uppercase tracking-widest text-zinc-500">Stereo</div>
+                  <div className="font-mono text-zinc-200">{Math.round((analysis?.stereoWidth ?? 0.5) * 100)}%</div>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                aria-label={mastering?.previewBypassed ? 'Switch to mastered preview' : 'Switch to original preview'}
+                onClick={() => setMasteringPreviewBypassed(!(mastering?.previewBypassed ?? false))}
+                className={`w-full rounded-md px-2 py-1.5 text-[10px] font-semibold uppercase tracking-widest ${
+                  mastering?.previewBypassed
+                    ? 'bg-[#3b2a1a] text-amber-300'
+                    : 'bg-[#16221b] text-emerald-300'
+                }`}
+              >
+                {mastering?.previewBypassed ? 'A/B: Original' : 'A/B: Mastered'}
+              </button>
+
+              <div className="text-[10px] text-zinc-500">
+                {analysis?.summary ?? 'Run analysis to generate a non-destructive mastering chain.'}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
       <div className="flex-1 flex flex-col items-center justify-end gap-1 w-full">
         <div className="relative flex justify-center" style={{ height: faderHeight }}>
           <input
             type="range" min={0} max={1.5} step={0.01} value={masterVol}
             onChange={(e) => handleChange(parseFloat(e.target.value))}
+            aria-label="Master volume fader"
             className="appearance-none bg-transparent cursor-pointer"
             style={{ writingMode: 'vertical-lr', direction: 'rtl', width: 32, height: faderHeight, accentColor: '#4a90d9' }}
           />

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -1,6 +1,7 @@
 import * as Tone from 'tone';
 import { TrackNode } from './TrackNode';
-import type { SequencerPattern } from '../types/project';
+import type { MasteringSettings, SequencerPattern } from '../types/project';
+import { createDefaultMasteringSettings } from '../utils/mastering';
 
 export interface ScheduledSource {
   source: AudioBufferSourceNode;
@@ -30,9 +31,21 @@ export interface ClipScheduleInfo {
  */
 export class AudioEngine {
   ctx: AudioContext;
+  masterInput: GainNode;
   masterGain: GainNode;
   trackNodes: Map<string, TrackNode> = new Map();
   scheduledSources: ScheduledSource[] = [];
+
+  private readonly masterDryGain: GainNode;
+  private readonly masterWetGain: GainNode;
+  private readonly masterLowShelf: BiquadFilterNode;
+  private readonly masterPresence: BiquadFilterNode;
+  private readonly masterHighShelf: BiquadFilterNode;
+  private readonly masterBusCompressor: DynamicsCompressorNode;
+  private readonly masterLimiterDrive: GainNode;
+  private readonly masterLimiter: WaveShaperNode;
+  private readonly masterAnalysisNode: AnalyserNode;
+  private readonly masterAnalysisData: Float32Array<ArrayBuffer>;
 
   private _playing = false;
   private _startedAt = 0;
@@ -56,11 +69,49 @@ export class AudioEngine {
     this.ctx = new AudioContext({ sampleRate: 48000 });
     // Share our AudioContext with Tone.js so EffectsEngine nodes live on the same graph
     Tone.setContext(this.ctx as unknown as Tone.BaseContext);
+    this.masterInput = this.ctx.createGain();
+    this.masterDryGain = this.ctx.createGain();
+    this.masterWetGain = this.ctx.createGain();
+    this.masterLowShelf = this.ctx.createBiquadFilter();
+    this.masterPresence = this.ctx.createBiquadFilter();
+    this.masterHighShelf = this.ctx.createBiquadFilter();
+    this.masterBusCompressor = this.ctx.createDynamicsCompressor();
+    this.masterLimiterDrive = this.ctx.createGain();
+    this.masterLimiter = this.ctx.createWaveShaper();
     this.masterGain = this.ctx.createGain();
-    this.masterGain.connect(this.ctx.destination);
+    this.masterAnalysisNode = this.ctx.createAnalyser();
+    this.masterAnalysisNode.fftSize = 2048;
+    this.masterAnalysisNode.smoothingTimeConstant = 0.75;
+    this.masterAnalysisData = new Float32Array(this.masterAnalysisNode.fftSize);
+    this.masterGain.connect(this.masterAnalysisNode);
+    this.masterAnalysisNode.connect(this.ctx.destination);
     this._metronomeGain = this.ctx.createGain();
     this._metronomeGain.gain.value = 0.35;
     this._metronomeGain.connect(this.ctx.destination);
+
+    this.masterLowShelf.type = 'lowshelf';
+    this.masterLowShelf.frequency.value = 110;
+    this.masterPresence.type = 'peaking';
+    this.masterPresence.frequency.value = 2400;
+    this.masterPresence.Q.value = 0.8;
+    this.masterHighShelf.type = 'highshelf';
+    this.masterHighShelf.frequency.value = 7200;
+    this.masterLimiter.curve = this.buildSoftClipCurve();
+    this.masterLimiter.oversample = '4x';
+
+    this.masterInput.connect(this.masterDryGain);
+    this.masterDryGain.connect(this.masterGain);
+
+    this.masterInput.connect(this.masterLowShelf);
+    this.masterLowShelf.connect(this.masterPresence);
+    this.masterPresence.connect(this.masterHighShelf);
+    this.masterHighShelf.connect(this.masterBusCompressor);
+    this.masterBusCompressor.connect(this.masterLimiterDrive);
+    this.masterLimiterDrive.connect(this.masterLimiter);
+    this.masterLimiter.connect(this.masterWetGain);
+    this.masterWetGain.connect(this.masterGain);
+
+    this.applyMastering(createDefaultMasteringSettings());
   }
 
   async resume() {
@@ -80,7 +131,7 @@ export class AudioEngine {
   getOrCreateTrackNode(trackId: string): TrackNode {
     let node = this.trackNodes.get(trackId);
     if (!node) {
-      node = new TrackNode(this.ctx, this.masterGain);
+      node = new TrackNode(this.ctx, this.masterInput);
       this.trackNodes.set(trackId, node);
     }
     return node;
@@ -97,8 +148,91 @@ export class AudioEngine {
   get masterVolume() { return this.masterGain.gain.value; }
   set masterVolume(v: number) { this.masterGain.gain.value = Math.max(0, Math.min(2, v)); }
 
+  applyMastering(settings?: MasteringSettings) {
+    const mastering = settings ?? createDefaultMasteringSettings();
+    const active = mastering.enabled && !mastering.previewBypassed;
+
+    this.masterDryGain.gain.value = active ? 0 : 1;
+    this.masterWetGain.gain.value = active ? 1 : 0;
+
+    if (!active) {
+      this.masterLowShelf.gain.value = 0;
+      this.masterPresence.gain.value = 0;
+      this.masterHighShelf.gain.value = 0;
+      this.masterBusCompressor.threshold.value = 0;
+      this.masterBusCompressor.ratio.value = 1;
+      this.masterBusCompressor.attack.value = 0.003;
+      this.masterBusCompressor.release.value = 0.25;
+      this.masterBusCompressor.knee.value = 30;
+      this.masterLimiterDrive.gain.value = 1;
+      return;
+    }
+
+    const targetBoost =
+      mastering.targetLufs === -8 ? 1.28 :
+      mastering.targetLufs === -11 ? 1.18 :
+      1.08;
+
+    switch (mastering.preset) {
+      case 'loud':
+        this.masterLowShelf.gain.value = 1.4;
+        this.masterPresence.gain.value = 0.9;
+        this.masterHighShelf.gain.value = 1.25;
+        this.masterBusCompressor.threshold.value = -24;
+        this.masterBusCompressor.ratio.value = 3;
+        this.masterBusCompressor.attack.value = 0.006;
+        this.masterBusCompressor.release.value = 0.12;
+        this.masterBusCompressor.knee.value = 8;
+        this.masterLimiterDrive.gain.value = targetBoost * 1.08;
+        break;
+      case 'warm':
+        this.masterLowShelf.gain.value = 2.2;
+        this.masterPresence.gain.value = -0.5;
+        this.masterHighShelf.gain.value = -0.2;
+        this.masterBusCompressor.threshold.value = -20;
+        this.masterBusCompressor.ratio.value = 2.2;
+        this.masterBusCompressor.attack.value = 0.018;
+        this.masterBusCompressor.release.value = 0.2;
+        this.masterBusCompressor.knee.value = 12;
+        this.masterLimiterDrive.gain.value = targetBoost * 1.02;
+        break;
+      case 'bright':
+        this.masterLowShelf.gain.value = -0.5;
+        this.masterPresence.gain.value = 1.1;
+        this.masterHighShelf.gain.value = 2.1;
+        this.masterBusCompressor.threshold.value = -18;
+        this.masterBusCompressor.ratio.value = 2;
+        this.masterBusCompressor.attack.value = 0.014;
+        this.masterBusCompressor.release.value = 0.16;
+        this.masterBusCompressor.knee.value = 10;
+        this.masterLimiterDrive.gain.value = targetBoost;
+        break;
+      case 'balanced':
+      default:
+        this.masterLowShelf.gain.value = 0.8;
+        this.masterPresence.gain.value = 0.45;
+        this.masterHighShelf.gain.value = 0.9;
+        this.masterBusCompressor.threshold.value = -18;
+        this.masterBusCompressor.ratio.value = 1.8;
+        this.masterBusCompressor.attack.value = 0.012;
+        this.masterBusCompressor.release.value = 0.18;
+        this.masterBusCompressor.knee.value = 10;
+        this.masterLimiterDrive.gain.value = targetBoost;
+        break;
+    }
+  }
+
   getTrackLevel(trackId: string): number {
     return this.trackNodes.get(trackId)?.getLevel() ?? 0;
+  }
+
+  getMasterLevel(): number {
+    this.masterAnalysisNode.getFloatTimeDomainData(this.masterAnalysisData);
+    let peak = 0;
+    for (let i = 0; i < this.masterAnalysisData.length; i++) {
+      peak = Math.max(peak, Math.abs(this.masterAnalysisData[i]));
+    }
+    return peak;
   }
 
   updateSoloState() {
@@ -292,6 +426,16 @@ export class AudioEngine {
       s.source.disconnect();
     }
     this.scheduledSources = [];
+  }
+
+  private buildSoftClipCurve() {
+    const samples = 4096;
+    const curve = new Float32Array(samples);
+    for (let i = 0; i < samples; i++) {
+      const x = (i / (samples - 1)) * 2 - 1;
+      curve[i] = Math.tanh(x * 2.6) / Math.tanh(2.6);
+    }
+    return curve;
   }
 
   get playing() { return this._playing; }

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -76,6 +76,7 @@ export function useTransport() {
 
     // Sync master volume
     engine.masterVolume = proj.masterVolume ?? 1.0;
+    engine.applyMastering(proj.mastering);
 
     interface ScheduleEntry {
       clipId: string;
@@ -335,6 +336,7 @@ export function useTransport() {
     if (!project || !isPlaying) return;
     const engine = getAudioEngine();
     engine.masterVolume = project.masterVolume ?? 1.0;
+    engine.applyMastering(project.mastering);
     for (const track of project.tracks) {
       const trackNode = engine.trackNodes.get(track.id);
       if (trackNode) {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -30,6 +30,8 @@ import type {
   Marker,
   TempoEvent,
   TimeSignatureEvent,
+  MasteringPreset,
+  MasteringLoudnessTarget,
 } from '../types/project';
 import { automationParamEquals } from '../types/project';
 import { TRACK_CATALOG, DEFAULT_DRUM_KIT } from '../constants/tracks';
@@ -46,6 +48,11 @@ import { exportStemToWav, type ExportClip } from '../engine/exportMix';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { getAudioEngine } from '../hooks/useAudioEngine';
 import { renderMidiTrackOffline, renderSequencerTrackOffline } from '../engine/offlineRender';
+import {
+  analyzeProjectForMastering,
+  createDefaultMasteringAnalysis,
+  createDefaultMasteringSettings,
+} from '../utils/mastering';
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
   return (60 / bpm) * timeSig;
@@ -101,6 +108,11 @@ interface ProjectState {
   endDrag: () => void;
 
   updateProject: (updates: Partial<Pick<Project, 'globalCaption' | 'bpm' | 'keyScale' | 'timeSignature' | 'name' | 'masterVolume' | 'measures'>>) => void;
+  setMasteringEnabled: (enabled: boolean) => void;
+  setMasteringPreset: (preset: MasteringPreset) => void;
+  setMasteringTargetLufs: (targetLufs: MasteringLoudnessTarget) => void;
+  setMasteringPreviewBypassed: (previewBypassed: boolean) => void;
+  runMasteringAnalysis: () => Promise<void>;
   updateTrackMixer: (trackId: string, updates: Partial<Pick<Track, 'pan' | 'eqLowGain' | 'eqMidGain' | 'eqHighGain' | 'compressorEnabled' | 'compressorThreshold' | 'compressorRatio'>>) => void;
   setPanMode: (trackId: string, mode: 'stereo' | 'dual-mono') => void;
   setDualMonoPan: (trackId: string, left: number, right: number) => void;
@@ -345,6 +357,23 @@ function ensureTrackDefaults(track: Track): Track {
   };
 }
 
+function ensureProjectDefaults(project: Project): Project {
+  return {
+    ...project,
+    masterVolume: project.masterVolume ?? 1.0,
+    mastering: project.mastering
+      ? {
+          ...createDefaultMasteringSettings(),
+          ...project.mastering,
+          analysis: {
+            ...createDefaultMasteringAnalysis(),
+            ...project.mastering.analysis,
+          },
+        }
+      : createDefaultMasteringSettings(),
+  };
+}
+
 export const useProjectStore = create<ProjectState>()(
   persist(
     (set, get) => ({
@@ -355,7 +384,7 @@ export const useProjectStore = create<ProjectState>()(
     _future.length = 0;
     // Migration: backfill trackType for projects created before the field existed
     const migrated: Project = {
-      ...project,
+      ...ensureProjectDefaults(project),
       tracks: project.tracks.map((t) => {
         if (t.trackType) return t;
         const inferred: TrackType =
@@ -412,6 +441,8 @@ export const useProjectStore = create<ProjectState>()(
       tracks: [],
       generationDefaults: { ...DEFAULT_GENERATION },
       globalCaption: '',
+      masterVolume: 1.0,
+      mastering: createDefaultMasteringSettings(),
     };
     set({ project });
   },
@@ -431,6 +462,124 @@ export const useProjectStore = create<ProjectState>()(
       );
     }
     set({ project: merged });
+  },
+
+  setMasteringEnabled: (enabled) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const mastering = {
+      ...(state.project.mastering ?? createDefaultMasteringSettings()),
+      enabled,
+      previewBypassed: enabled ? state.project.mastering?.previewBypassed ?? false : false,
+    };
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        mastering,
+      },
+    });
+  },
+
+  setMasteringPreset: (preset) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const mastering = {
+      ...(state.project.mastering ?? createDefaultMasteringSettings()),
+      preset,
+    };
+    const analysis =
+      mastering.analysis.status === 'ready'
+        ? analyzeProjectForMastering(state.project, preset, mastering.targetLufs)
+        : mastering.analysis;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        mastering: { ...mastering, analysis },
+      },
+    });
+  },
+
+  setMasteringTargetLufs: (targetLufs) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    const mastering = {
+      ...(state.project.mastering ?? createDefaultMasteringSettings()),
+      targetLufs,
+    };
+    const analysis =
+      mastering.analysis.status === 'ready'
+        ? analyzeProjectForMastering(state.project, mastering.preset, targetLufs)
+        : mastering.analysis;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        mastering: { ...mastering, analysis },
+      },
+    });
+  },
+
+  setMasteringPreviewBypassed: (previewBypassed) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        mastering: {
+          ...(state.project.mastering ?? createDefaultMasteringSettings()),
+          previewBypassed,
+        },
+      },
+    });
+  },
+
+  runMasteringAnalysis: async () => {
+    const state = get();
+    if (!state.project) return;
+    const startedAt = Date.now();
+    const currentSettings = state.project.mastering ?? createDefaultMasteringSettings();
+    set({
+      project: {
+        ...state.project,
+        updatedAt: startedAt,
+        mastering: {
+          ...currentSettings,
+          analysis: {
+            ...currentSettings.analysis,
+            status: 'analyzing',
+          },
+        },
+      },
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 900));
+
+    const nextState = get();
+    if (!nextState.project) return;
+    const nextSettings = nextState.project.mastering ?? createDefaultMasteringSettings();
+    const analysis = analyzeProjectForMastering(
+      nextState.project,
+      nextSettings.preset,
+      nextSettings.targetLufs,
+    );
+    set({
+      project: {
+        ...nextState.project,
+        updatedAt: Date.now(),
+        mastering: {
+          ...nextSettings,
+          enabled: true,
+          analysis,
+        },
+      },
+    });
   },
 
   updateTrackMixer: (trackId, updates) => {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -312,6 +312,32 @@ export interface Marker {
   color: string;
 }
 
+export type MasteringPreset = 'balanced' | 'loud' | 'warm' | 'bright';
+export type MasteringLoudnessTarget = -14 | -11 | -8;
+export type MasteringAnalysisStatus = 'idle' | 'analyzing' | 'ready';
+
+export interface MasteringAnalysis {
+  status: MasteringAnalysisStatus;
+  analyzedAt?: number;
+  recommendedPreset?: MasteringPreset;
+  inputLufs: number;
+  outputLufs: number;
+  dynamicRange: number;
+  stereoWidth: number;
+  lowBalance: number;
+  midBalance: number;
+  highBalance: number;
+  summary: string;
+}
+
+export interface MasteringSettings {
+  enabled: boolean;
+  previewBypassed: boolean;
+  preset: MasteringPreset;
+  targetLufs: MasteringLoudnessTarget;
+  analysis: MasteringAnalysis;
+}
+
 export interface Project {
   id: string;
   name: string;
@@ -329,6 +355,8 @@ export interface Project {
   globalCaption?: string;
   /** Master output fader level (0–1), default 1.0 */
   masterVolume?: number;
+  /** AI mastering chain settings for the master bus. */
+  mastering?: MasteringSettings;
   /** Persistent asset clips — survives clip/track removal. */
   assets?: AssetClip[];
   /** Per-track automation lanes. */

--- a/src/utils/mastering.ts
+++ b/src/utils/mastering.ts
@@ -1,0 +1,107 @@
+import type {
+  MasteringAnalysis,
+  MasteringLoudnessTarget,
+  MasteringPreset,
+  MasteringSettings,
+  Project,
+} from '../types/project';
+
+const PRESET_SUMMARIES: Record<MasteringPreset, string> = {
+  balanced: 'Balanced keeps the mix controlled with light tonal correction.',
+  loud: 'Loud pushes density and output for more aggressive streaming level.',
+  warm: 'Warm adds low-mid weight and softer top-end for a rounder master.',
+  bright: 'Bright adds clarity and air to lift darker arrangements.',
+};
+
+export function createDefaultMasteringAnalysis(): MasteringAnalysis {
+  return {
+    status: 'idle',
+    inputLufs: -18,
+    outputLufs: -14,
+    dynamicRange: 10,
+    stereoWidth: 0.5,
+    lowBalance: 0.33,
+    midBalance: 0.34,
+    highBalance: 0.33,
+    summary: PRESET_SUMMARIES.balanced,
+  };
+}
+
+export function createDefaultMasteringSettings(): MasteringSettings {
+  return {
+    enabled: false,
+    previewBypassed: false,
+    preset: 'balanced',
+    targetLufs: -14,
+    analysis: createDefaultMasteringAnalysis(),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function analyzeProjectForMastering(
+  project: Project,
+  preset: MasteringPreset,
+  targetLufs: MasteringLoudnessTarget,
+): MasteringAnalysis {
+  const tracks = project.tracks ?? [];
+  const activeTracks = tracks.filter((track) => !track.muted);
+  const activeTrackCount = Math.max(activeTracks.length, 1);
+  const readyClipCount = tracks.reduce(
+    (sum, track) => sum + track.clips.filter((clip) => clip.generationStatus === 'ready').length,
+    0,
+  );
+  const averageVolume =
+    activeTracks.reduce((sum, track) => sum + track.volume, 0) / activeTrackCount;
+  const lowEnergy =
+    tracks.filter((track) => ['bass', 'drums', 'percussion'].includes(track.trackName)).length * 1.35;
+  const highEnergy =
+    tracks.filter((track) => ['synth', 'strings', 'keyboard', 'fx'].includes(track.trackName)).length * 1.15;
+  const eqTilt = tracks.reduce(
+    (sum, track) => sum + (track.eqHighGain ?? 0) - (track.eqLowGain ?? 0),
+    0,
+  ) / activeTrackCount;
+
+  const rawInputLufs = -24 + activeTrackCount * 1.15 + averageVolume * 5.5 + readyClipCount * 0.2;
+  const inputLufs = Number(clamp(rawInputLufs, -26, -10).toFixed(1));
+  const density = clamp((activeTrackCount + readyClipCount * 0.35) / 12, 0.2, 1);
+
+  let recommendedPreset: MasteringPreset = 'balanced';
+  if (lowEnergy - highEnergy > 1.25 || eqTilt < -1.5) {
+    recommendedPreset = 'bright';
+  } else if (highEnergy - lowEnergy > 1.25 || eqTilt > 1.5) {
+    recommendedPreset = 'warm';
+  } else if (density > 0.72) {
+    recommendedPreset = 'loud';
+  }
+
+  const lowBalance = clamp(0.28 + lowEnergy * 0.045 - eqTilt * 0.01, 0.15, 0.6);
+  const highBalance = clamp(0.25 + highEnergy * 0.04 + eqTilt * 0.012, 0.15, 0.6);
+  const midBalance = clamp(1 - lowBalance - highBalance, 0.15, 0.7);
+  const normalizedTotal = lowBalance + midBalance + highBalance;
+
+  const presetLift =
+    preset === 'loud' ? 2.8 :
+    preset === 'warm' ? 1.8 :
+    preset === 'bright' ? 1.7 :
+    1.2;
+  const outputLufs = Number(Math.max(targetLufs, inputLufs + presetLift).toFixed(1));
+  const dynamicRange = Number(clamp(13 - density * 4.5 - (preset === 'loud' ? 1.2 : 0), 5, 14).toFixed(1));
+  const stereoWidth = Number(clamp(0.42 + highEnergy * 0.05 + (preset === 'bright' ? 0.08 : 0), 0.2, 0.95).toFixed(2));
+
+  return {
+    status: 'ready',
+    analyzedAt: Date.now(),
+    recommendedPreset,
+    inputLufs,
+    outputLufs,
+    dynamicRange,
+    stereoWidth,
+    lowBalance: Number((lowBalance / normalizedTotal).toFixed(2)),
+    midBalance: Number((midBalance / normalizedTotal).toFixed(2)),
+    highBalance: Number((highBalance / normalizedTotal).toFixed(2)),
+    summary: PRESET_SUMMARIES[preset],
+  };
+}

--- a/tests/unit/projectStore.test.ts
+++ b/tests/unit/projectStore.test.ts
@@ -43,7 +43,63 @@ describe('projectStore', () => {
 
       useProjectStore.getState().setProject(project);
 
-      expect(useProjectStore.getState().project).toEqual(project);
+      expect(useProjectStore.getState().project).toMatchObject(project);
+      expect(useProjectStore.getState().project?.mastering).toBeDefined();
+    });
+  });
+
+  describe('AI mastering', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject();
+      useProjectStore.getState().addTrack('drums');
+      useProjectStore.getState().addTrack('bass');
+    });
+
+    it('creates projects with mastering defaults', () => {
+      const mastering = useProjectStore.getState().project?.mastering;
+      expect(mastering).toBeDefined();
+      expect(mastering?.enabled).toBe(false);
+      expect(mastering?.preset).toBe('balanced');
+      expect(mastering?.targetLufs).toBe(-14);
+      expect(mastering?.analysis.status).toBe('idle');
+    });
+
+    it('updates mastering controls without destroying the preset state', () => {
+      const store = useProjectStore.getState();
+      store.setMasteringPreset('warm');
+      store.setMasteringTargetLufs(-11);
+      store.setMasteringPreviewBypassed(true);
+
+      expect(useProjectStore.getState().project?.mastering).toMatchObject({
+        preset: 'warm',
+        targetLufs: -11,
+        previewBypassed: true,
+      });
+
+      store.setMasteringEnabled(false);
+      expect(useProjectStore.getState().project?.mastering).toMatchObject({
+        preset: 'warm',
+        targetLufs: -11,
+      });
+    });
+
+    it('runs mastering analysis and enables the master bus chain', async () => {
+      vi.useFakeTimers();
+      try {
+        const analysisPromise = useProjectStore.getState().runMasteringAnalysis();
+        expect(useProjectStore.getState().project?.mastering?.analysis.status).toBe('analyzing');
+
+        await vi.advanceTimersByTimeAsync(900);
+        await analysisPromise;
+
+        const mastering = useProjectStore.getState().project?.mastering;
+        expect(mastering?.enabled).toBe(true);
+        expect(mastering?.analysis.status).toBe('ready');
+        expect(mastering?.analysis.outputLufs).toBeGreaterThanOrEqual(mastering?.targetLufs ?? -14);
+        expect(mastering?.analysis.recommendedPreset).toBeDefined();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary\n- add persisted AI mastering settings and heuristic mix analysis to the project store\n- route playback through a non-destructive master bus processing chain with preset and loudness target support\n- add master-strip controls for AI Master, analysis feedback, A/B preview, and before/after loudness readouts\n\n## Verification\n- npm run build\n- npx vitest run tests/unit/\n\nCloses #232