### PR TITLE
fix: BPM input clamps on blur, not every keystroke

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ace-step-daw",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "idb-keyval": "^6.2.0",
         "react": "^19.0.0",

--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -18,6 +18,7 @@ export function NewProjectDialog() {
 
   const [name, setName] = useState(DEFAULT_PROJECT_NAME);
   const [bpm, setBpm] = useState(DEFAULT_BPM);
+  const [bpmText, setBpmText] = useState(String(DEFAULT_BPM));
   const [keyScale, setKeyScale] = useState(DEFAULT_KEY_SCALE);
   const [timeSignature, setTimeSignature] = useState(DEFAULT_TIME_SIGNATURE);
 
@@ -26,6 +27,7 @@ export function NewProjectDialog() {
     if (show) {
       setName(DEFAULT_PROJECT_NAME);
       setBpm(DEFAULT_BPM);
+      setBpmText(String(DEFAULT_BPM));
       setKeyScale(DEFAULT_KEY_SCALE);
       setTimeSignature(DEFAULT_TIME_SIGNATURE);
     }
@@ -66,8 +68,14 @@ export function NewProjectDialog() {
             <label className="block text-xs text-zinc-400 mb-1">BPM</label>
             <input
               type="number"
-              value={bpm}
-              onChange={(e) => setBpm(Math.min(MAX_BPM, Math.max(MIN_BPM, parseInt(e.target.value) || MIN_BPM)))}
+              value={bpmText}
+              onChange={(e) => setBpmText(e.target.value)}
+              onBlur={() => {
+                const parsed = parseInt(bpmText);
+                const valid = isNaN(parsed) ? DEFAULT_BPM : Math.min(MAX_BPM, Math.max(MIN_BPM, parsed));
+                setBpm(valid);
+                setBpmText(String(valid));
+              }}
               min={MIN_BPM}
               max={MAX_BPM}
               className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -15,6 +15,7 @@ export function SettingsDialog() {
   const project = useProjectStore((s) => s.project);
 
   const [bpm, setBpm] = useState(120);
+  const [bpmText, setBpmText] = useState('120');
   const tapTimesRef = useRef<number[]>([]);
   const tapResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -41,7 +42,9 @@ export function SettingsDialog() {
       }
       const avgInterval = intervals.reduce((a, b) => a + b, 0) / intervals.length;
       const calculatedBpm = Math.round(60000 / avgInterval);
-      setBpm(Math.min(300, Math.max(40, calculatedBpm)));
+      const clamped = Math.min(300, Math.max(40, calculatedBpm));
+      setBpm(clamped);
+      setBpmText(String(clamped));
     }
   }, []);
 
@@ -119,7 +122,9 @@ export function SettingsDialog() {
   useEffect(() => {
     if (show && !prevShow.current) {
       const gen = project?.generationDefaults ?? DEFAULT_GENERATION;
-      setBpm(project?.bpm ?? 120);
+      const projectBpm = project?.bpm ?? 120;
+      setBpm(projectBpm);
+      setBpmText(String(projectBpm));
       setKeyScale(project?.keyScale ?? '');
       setTimeSignature(project?.timeSignature ?? 4);
       setMeasures(project?.measures ?? DEFAULT_MEASURES);
@@ -241,8 +246,14 @@ export function SettingsDialog() {
               <div className="flex gap-1.5">
                 <input
                   type="number"
-                  value={bpm}
-                  onChange={(e) => setBpm(parseInt(e.target.value) || 120)}
+                  value={bpmText}
+                  onChange={(e) => setBpmText(e.target.value)}
+                  onBlur={() => {
+                    const parsed = parseInt(bpmText);
+                    const valid = isNaN(parsed) ? 120 : Math.min(300, Math.max(30, parsed));
+                    setBpm(valid);
+                    setBpmText(String(valid));
+                  }}
                   min={40}
                   max={300}
                   className="flex-1 min-w-[3.5rem] px-2 py-1.5 text-sm text-zinc-200 bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"

--- a/tests/unit/bpmInput.test.tsx
+++ b/tests/unit/bpmInput.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { NewProjectDialog } from '../../src/components/dialogs/NewProjectDialog';
+import { SettingsDialog } from '../../src/components/dialogs/SettingsDialog';
+import { useUIStore } from '../../src/store/uiStore';
+
+vi.mock('../../src/services/aceStepApi', () => ({
+  listModels: vi.fn().mockResolvedValue([]),
+  initModel: vi.fn().mockResolvedValue({}),
+  getBackendUrl: vi.fn().mockReturnValue('http://localhost:8001'),
+  setBackendUrl: vi.fn(),
+}));
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('BPM input — clamp on blur, not keystroke', () => {
+  beforeEach(() => {
+    // Open dialogs via store
+    useUIStore.getState().setShowNewProjectDialog(true);
+    useUIStore.getState().setShowSettingsDialog(true);
+  });
+
+  function getBpmInput(container: HTMLElement): HTMLInputElement {
+    return container.querySelector('input[type="number"]') as HTMLInputElement;
+  }
+
+  describe('NewProjectDialog', () => {
+    it('allows typing intermediate values below MIN_BPM without clamping', () => {
+      const { container } = render(<NewProjectDialog />);
+      const input = getBpmInput(container);
+
+      // Clear and type "1" — should NOT be clamped to 30
+      fireEvent.change(input, { target: { value: '1' } });
+      expect(input.value).toBe('1');
+
+      // Continue typing "12" — should NOT be clamped
+      fireEvent.change(input, { target: { value: '12' } });
+      expect(input.value).toBe('12');
+
+      // Finish typing "120"
+      fireEvent.change(input, { target: { value: '120' } });
+      expect(input.value).toBe('120');
+    });
+
+    it('clamps to MIN_BPM on blur when value is too low', () => {
+      const { container } = render(<NewProjectDialog />);
+      const input = getBpmInput(container);
+
+      fireEvent.change(input, { target: { value: '5' } });
+      fireEvent.blur(input);
+      expect(input.value).toBe('30');
+    });
+
+    it('clamps to MAX_BPM on blur when value is too high', () => {
+      const { container } = render(<NewProjectDialog />);
+      const input = getBpmInput(container);
+
+      fireEvent.change(input, { target: { value: '999' } });
+      fireEvent.blur(input);
+      expect(input.value).toBe('300');
+    });
+
+    it('defaults to 120 on blur when field is empty', () => {
+      const { container } = render(<NewProjectDialog />);
+      const input = getBpmInput(container);
+
+      fireEvent.change(input, { target: { value: '' } });
+      fireEvent.blur(input);
+      expect(input.value).toBe('120');
+    });
+  });
+
+  describe('SettingsDialog', () => {
+    function getSettingsBpmInput(container: HTMLElement): HTMLInputElement {
+      // Settings dialog has multiple number inputs; BPM is the one with min=40
+      const inputs = container.querySelectorAll('input[type="number"]');
+      for (const inp of inputs) {
+        if (inp.getAttribute('min') === '40') return inp as HTMLInputElement;
+      }
+      return inputs[0] as HTMLInputElement;
+    }
+
+    it('allows typing intermediate values without resetting', () => {
+      const { container } = render(<SettingsDialog />);
+      const input = getSettingsBpmInput(container);
+
+      // Clear and type "1" — should NOT reset to 120
+      fireEvent.change(input, { target: { value: '1' } });
+      expect(input.value).toBe('1');
+
+      fireEvent.change(input, { target: { value: '14' } });
+      expect(input.value).toBe('14');
+
+      fireEvent.change(input, { target: { value: '140' } });
+      expect(input.value).toBe('140');
+    });
+
+    it('allows clearing the field without resetting to 120', () => {
+      const { container } = render(<SettingsDialog />);
+      const input = getSettingsBpmInput(container);
+
+      fireEvent.change(input, { target: { value: '' } });
+      expect(input.value).toBe('');
+    });
+
+    it('clamps on blur for out-of-range values', () => {
+      const { container } = render(<SettingsDialog />);
+      const input = getSettingsBpmInput(container);
+
+      fireEvent.change(input, { target: { value: '5' } });
+      fireEvent.blur(input);
+      // Should clamp to min (30)
+      expect(Number(input.value)).toBeGreaterThanOrEqual(30);
+    });
+  });
+});


### PR DESCRIPTION
Closes #206

## Summary
- BPM inputs in NewProjectDialog and SettingsDialog now use a string-based intermediate state (`bpmText`) so users can freely type multi-digit values
- Validation/clamping (MIN_BPM–MAX_BPM) only fires on blur, not on every keystroke
- Empty/invalid values default to 120 on blur

## Test plan
- [x] Added 7 regression tests in `tests/unit/bpmInput.test.tsx`
- [x] All 303 unit tests pass
- [x] Type errors are pre-existing (`MidiEffectChain.tsx`), not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)