### PR TITLE
fix: add missing MIDI effect store methods — unblock all PR CI

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -184,6 +184,9 @@ interface ProjectState {
   // MIDI effects
   addMidiEffect: (trackId: string, type: MidiEffectType) => string | undefined;
   removeMidiEffect: (trackId: string, effectId: string) => void;
+  updateMidiEffect: (trackId: string, effectId: string, updates: Partial<MidiEffect>) => void;
+  toggleMidiEffect: (trackId: string, effectId: string) => void;
+  reorderMidiEffect: (trackId: string, fromIndex: number, toIndex: number) => void;
 
   // Automation
   addAutomationPoint: (trackId: string, parameter: AutomationParameter, point: AutomationPoint) => void;
@@ -2201,6 +2204,69 @@ export const useProjectStore = create<ProjectState>()(
             ? { ...track, midiEffects: (track.midiEffects ?? []).filter((e) => e.id !== effectId) }
             : track,
         ),
+      },
+    });
+  },
+
+  updateMidiEffect: (trackId, effectId, updates) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) =>
+          track.id === trackId
+            ? {
+                ...track,
+                midiEffects: (track.midiEffects ?? []).map((e) =>
+                  e.id === effectId ? { ...e, ...updates } as MidiEffect : e,
+                ),
+              }
+            : track,
+        ),
+      },
+    });
+  },
+
+  toggleMidiEffect: (trackId, effectId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) =>
+          track.id === trackId
+            ? {
+                ...track,
+                midiEffects: (track.midiEffects ?? []).map((e) =>
+                  e.id === effectId ? { ...e, enabled: !e.enabled } : e,
+                ),
+              }
+            : track,
+        ),
+      },
+    });
+  },
+
+  reorderMidiEffect: (trackId, fromIndex, toIndex) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) => {
+          if (track.id !== trackId) return track;
+          const effects = [...(track.midiEffects ?? [])];
+          const [moved] = effects.splice(fromIndex, 1);
+          if (moved) effects.splice(toIndex, 0, moved);
+          return { ...track, midiEffects: effects };
+        }),
       },
     });
   },

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -34,6 +34,7 @@ interface UIState {
   openPianoRollTrackId: string | null;
   openPianoRollClipId: string | null;
   openEffectChainTrackId: string | null;
+  openMidiEffectChainTrackId: string | null;
   sequencerEditorHeight: number;
   pianoRollHeight: number;
   effectChainHeight: number;
@@ -89,6 +90,7 @@ interface UIState {
   setOpenSequencerTrackId: (id: string | null) => void;
   setOpenPianoRoll: (trackId: string | null, clipId?: string | null) => void;
   setOpenEffectChainTrackId: (id: string | null) => void;
+  setOpenMidiEffectChainTrackId: (id: string | null) => void;
   setSequencerEditorHeight: (v: number) => void;
   setPianoRollHeight: (v: number) => void;
   setEffectChainHeight: (v: number) => void;
@@ -145,6 +147,7 @@ export const useUIStore = create<UIState>()(
   openPianoRollTrackId: null,
   openPianoRollClipId: null,
   openEffectChainTrackId: null,
+  openMidiEffectChainTrackId: null,
   sequencerEditorHeight: 320,
   pianoRollHeight: 360,
   effectChainHeight: 320,
@@ -229,6 +232,9 @@ export const useUIStore = create<UIState>()(
   setOpenEffectChainTrackId: (id) => set({
     openEffectChainTrackId: id,
     activeBottomPanel: id ? 'effects' : null,
+  }),
+  setOpenMidiEffectChainTrackId: (id) => set({
+    openMidiEffectChainTrackId: id,
   }),
   setSequencerEditorHeight: (v) => set({ sequencerEditorHeight: Math.min(600, Math.max(200, v)) }),
   setPianoRollHeight: (v) => set({ pianoRollHeight: Math.min(700, Math.max(220, v)) }),


### PR DESCRIPTION
## Summary
- PR #203 added `MidiEffectChain.tsx` but omitted store action implementations
- This caused `type-check` to fail for **all** open PRs
- Adds `updateMidiEffect`, `toggleMidiEffect`, `reorderMidiEffect` to projectStore
- Adds `openMidiEffectChainTrackId` / `setOpenMidiEffectChainTrackId` to uiStore

## Test plan
- [x] `npx tsc --noEmit` — 0 errors  
- [x] `npx vitest run` — 311 tests pass
- [ ] All blocked PRs should pass CI after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)