### PR TITLE
fix: add missing MIDI effect store implementations

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -2205,6 +2205,69 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
+  updateMidiEffect: (trackId, effectId, updates) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) =>
+          track.id === trackId
+            ? {
+                ...track,
+                midiEffects: (track.midiEffects ?? []).map((e) =>
+                  e.id === effectId ? { ...e, ...updates } : e,
+                ),
+              }
+            : track,
+        ),
+      },
+    });
+  },
+
+  toggleMidiEffect: (trackId, effectId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) =>
+          track.id === trackId
+            ? {
+                ...track,
+                midiEffects: (track.midiEffects ?? []).map((e) =>
+                  e.id === effectId ? { ...e, enabled: !e.enabled } : e,
+                ),
+              }
+            : track,
+        ),
+      },
+    });
+  },
+
+  reorderMidiEffect: (trackId, fromIndex, toIndex) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) => {
+          if (track.id !== trackId) return track;
+          const effects = [...(track.midiEffects ?? [])];
+          const [moved] = effects.splice(fromIndex, 1);
+          if (moved) effects.splice(toIndex, 0, moved);
+          return { ...track, midiEffects: effects };
+        }),
+      },
+    });
+  },
+
   // ─── Automation ───────────────────────────────────────────────────────────
 
   addAutomationPoint: (trackId, parameter, point) => {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -34,6 +34,7 @@ interface UIState {
   openPianoRollTrackId: string | null;
   openPianoRollClipId: string | null;
   openEffectChainTrackId: string | null;
+  openMidiEffectChainTrackId: string | null;
   sequencerEditorHeight: number;
   pianoRollHeight: number;
   effectChainHeight: number;
@@ -89,6 +90,7 @@ interface UIState {
   setOpenSequencerTrackId: (id: string | null) => void;
   setOpenPianoRoll: (trackId: string | null, clipId?: string | null) => void;
   setOpenEffectChainTrackId: (id: string | null) => void;
+  setOpenMidiEffectChainTrackId: (id: string | null) => void;
   setSequencerEditorHeight: (v: number) => void;
   setPianoRollHeight: (v: number) => void;
   setEffectChainHeight: (v: number) => void;
@@ -145,6 +147,7 @@ export const useUIStore = create<UIState>()(
   openPianoRollTrackId: null,
   openPianoRollClipId: null,
   openEffectChainTrackId: null,
+  openMidiEffectChainTrackId: null,
   sequencerEditorHeight: 320,
   pianoRollHeight: 360,
   effectChainHeight: 320,
@@ -228,6 +231,10 @@ export const useUIStore = create<UIState>()(
   }),
   setOpenEffectChainTrackId: (id) => set({
     openEffectChainTrackId: id,
+    activeBottomPanel: id ? 'effects' : null,
+  }),
+  setOpenMidiEffectChainTrackId: (id) => set({
+    openMidiEffectChainTrackId: id,
     activeBottomPanel: id ? 'effects' : null,
   }),
   setSequencerEditorHeight: (v) => set({ sequencerEditorHeight: Math.min(600, Math.max(200, v)) }),


### PR DESCRIPTION
## Summary
- Add `updateMidiEffect`, `toggleMidiEffect`, `reorderMidiEffect` implementations to projectStore
- Add `openMidiEffectChainTrackId` field + `setOpenMidiEffectChainTrackId` setter to uiStore

PR #203 added `MidiEffectChain.tsx` referencing these store actions, but only declared them in the interface without implementing them. This broke `npx tsc --noEmit` on main (7 type errors).

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 311 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)