### PR TITLE
fix: track header icon bar cleanup — remove duplicate headphone icons (closes #267)

### DIFF
--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -292,78 +292,83 @@ export function TrackHeader({
             <circle cx="6" cy="6" r="3.25" fill={isArmed ? 'currentColor' : 'none'} />
           </svg>
         </button>
-        {/* Input monitoring — cycles off → auto → on */}
-        <button
-          onClick={cycleMonitor}
-          className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
-            monitorMode === 'on'
-              ? 'bg-cyan-600/90 text-white'
-              : monitorMode === 'auto'
-                ? 'bg-cyan-600/50 text-cyan-200'
-                : 'text-zinc-500 hover:text-cyan-400 hover:bg-[#444]'
-          }`}
-          title={`Input monitoring: ${monitorMode} (click to cycle off→auto→on)`}
-          aria-label={`Input monitoring ${track.displayName}: ${monitorMode}`}
-        >
-          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round">
-            <path d="M2 7V6a4 4 0 018 0v1" />
-            <rect x="1" y="7" width="2.5" height="3" rx="0.5" fill={monitorMode !== 'off' ? 'currentColor' : 'none'} />
-            <rect x="8.5" y="7" width="2.5" height="3" rx="0.5" fill={monitorMode !== 'off' ? 'currentColor' : 'none'} />
-          </svg>
-        </button>
-        {/* Freeze toggle */}
-        <button
-          onClick={handleFreeze}
-          disabled={isFreezing}
-          className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
-            track.frozen
-              ? 'bg-cyan-600/90 text-white'
-              : isFreezing
-                ? 'text-cyan-400 animate-pulse'
-                : 'text-zinc-500 hover:text-cyan-400 hover:bg-[#444]'
-          }`}
-          title={track.frozen ? 'Unfreeze Track' : 'Freeze Track'}
-          aria-label={`${track.frozen ? 'Unfreeze' : 'Freeze'} ${track.displayName}`}
-        >
-          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
-            <path d="M6 1v10M1 6h10M3 3l6 6M9 3L3 9" />
-          </svg>
-        </button>
-        {/* Automation toggle */}
-        <button
-          onClick={() => {
-            const project = useProjectStore.getState().project;
-            if (!project) return;
-            const hasLane = (project.automationLanes ?? []).some((l) => l.trackId === track.id);
-            if (!hasLane) {
-              // Create a default volume automation lane with 2 points
-              useProjectStore.getState().addAutomationPoint(
-                track.id,
-                { type: 'mixer', param: 'volume' },
-                { time: 0, value: track.volume },
-              );
-              useProjectStore.getState().addAutomationPoint(
-                track.id,
-                { type: 'mixer', param: 'volume' },
-                { time: project.totalDuration, value: track.volume },
-              );
-            } else {
-              // Clear all automation for this track
-              for (const lane of (project.automationLanes ?? []).filter((l) => l.trackId === track.id)) {
-                useProjectStore.getState().clearAutomationLane(track.id, lane.parameter);
+        {/* Secondary buttons — visible on hover or when active */}
+        <div className={`flex items-center gap-px transition-opacity ${
+          monitorMode !== 'off' || track.frozen || isFreezing || (useProjectStore.getState().project?.automationLanes ?? []).some((l) => l.trackId === track.id)
+            ? 'opacity-100'
+            : 'opacity-0 group-hover:opacity-100'
+        }`}>
+          {/* Input monitoring — microphone icon, cycles off → auto → on */}
+          <button
+            onClick={cycleMonitor}
+            className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
+              monitorMode === 'on'
+                ? 'bg-cyan-600/90 text-white'
+                : monitorMode === 'auto'
+                  ? 'bg-cyan-600/50 text-cyan-200'
+                  : 'text-zinc-500 hover:text-cyan-400 hover:bg-[#444]'
+            }`}
+            title={`Input monitoring: ${monitorMode} (click to cycle off→auto→on)`}
+            aria-label={`Input monitoring ${track.displayName}: ${monitorMode}`}
+          >
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round">
+              <rect x="4" y="1" width="4" height="6" rx="2" fill={monitorMode !== 'off' ? 'currentColor' : 'none'} />
+              <path d="M3 7a3 3 0 006 0" />
+              <path d="M6 10v1.5M4.5 11.5h3" />
+            </svg>
+          </button>
+          {/* Freeze toggle */}
+          <button
+            onClick={handleFreeze}
+            disabled={isFreezing}
+            className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
+              track.frozen
+                ? 'bg-cyan-600/90 text-white'
+                : isFreezing
+                  ? 'text-cyan-400 animate-pulse'
+                  : 'text-zinc-500 hover:text-cyan-400 hover:bg-[#444]'
+            }`}
+            title={track.frozen ? 'Unfreeze Track' : 'Freeze Track'}
+            aria-label={`${track.frozen ? 'Unfreeze' : 'Freeze'} ${track.displayName}`}
+          >
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
+              <path d="M6 1v10M1 6h10M3 3l6 6M9 3L3 9" />
+            </svg>
+          </button>
+          {/* Automation toggle */}
+          <button
+            onClick={() => {
+              const project = useProjectStore.getState().project;
+              if (!project) return;
+              const hasLane = (project.automationLanes ?? []).some((l) => l.trackId === track.id);
+              if (!hasLane) {
+                useProjectStore.getState().addAutomationPoint(
+                  track.id,
+                  { type: 'mixer', param: 'volume' },
+                  { time: 0, value: track.volume },
+                );
+                useProjectStore.getState().addAutomationPoint(
+                  track.id,
+                  { type: 'mixer', param: 'volume' },
+                  { time: project.totalDuration, value: track.volume },
+                );
+              } else {
+                for (const lane of (project.automationLanes ?? []).filter((l) => l.trackId === track.id)) {
+                  useProjectStore.getState().clearAutomationLane(track.id, lane.parameter);
+                }
               }
-            }
-          }}
-          className={`w-5 h-5 flex items-center justify-center rounded text-[9px] font-bold transition-colors ${
-            (useProjectStore.getState().project?.automationLanes ?? []).some((l) => l.trackId === track.id)
-              ? 'bg-amber-600/80 text-white'
-              : 'text-zinc-500 hover:text-amber-400 hover:bg-[#444]'
-          }`}
-          title="Toggle automation lane (A)"
-          aria-label={`Toggle automation ${track.displayName}`}
-        >
-          A
-        </button>
+            }}
+            className={`w-5 h-5 flex items-center justify-center rounded text-[9px] font-bold transition-colors ${
+              (useProjectStore.getState().project?.automationLanes ?? []).some((l) => l.trackId === track.id)
+                ? 'bg-amber-600/80 text-white'
+                : 'text-zinc-500 hover:text-amber-400 hover:bg-[#444]'
+            }`}
+            title="Toggle automation lane (A)"
+            aria-label={`Toggle automation ${track.displayName}`}
+          >
+            A
+          </button>
+        </div>
         {/* Delete - hidden by default, visible on hover */}
         <button
           onClick={() => removeTrack(track.id)}

--- a/tests/unit/trackHeader.test.tsx
+++ b/tests/unit/trackHeader.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TrackHeader } from '../../src/components/tracks/TrackHeader';
+import type { Track } from '../../src/types/project';
+
+vi.mock('../../src/services/aceStepApi', () => ({
+  listModels: vi.fn().mockResolvedValue([]),
+  initModel: vi.fn().mockResolvedValue({}),
+  getBackendUrl: vi.fn().mockReturnValue('http://localhost:8001'),
+  setBackendUrl: vi.fn(),
+}));
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../src/services/freezeTrack', () => ({
+  freezeTrackToAudio: vi.fn().mockResolvedValue(undefined),
+  flattenTrackToAudio: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/hooks/useRecording', () => ({
+  useRecording: () => ({
+    armedTrackIds: [],
+    toggleArmTrack: vi.fn(),
+  }),
+}));
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: 'track-1',
+    trackType: 'stems',
+    trackName: 'drums',
+    displayName: 'Drums',
+    color: '#ef4444',
+    order: 0,
+    volume: 0.8,
+    muted: false,
+    soloed: false,
+    clips: [],
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+function renderHeader(trackOverrides: Partial<Track> = {}) {
+  const track = makeTrack(trackOverrides);
+  return render(
+    <TrackHeader
+      track={track}
+      onDragStart={noop}
+      onDragOver={noop as any}
+      onDrop={noop as any}
+      isDragOver={false}
+      dragOverPosition={null}
+    />,
+  );
+}
+
+describe('TrackHeader — icon bar cleanup (#267)', () => {
+  describe('icon differentiation', () => {
+    it('renders Solo button with headphone icon (arc path)', () => {
+      renderHeader();
+      const soloBtn = screen.getByTitle('Solo (S)');
+      expect(soloBtn).toBeInTheDocument();
+      // Headphone icon has the arc "a4 4 0 018 0" in its SVG path
+      const svg = soloBtn.querySelector('svg');
+      expect(svg).toBeTruthy();
+      const paths = svg!.querySelectorAll('path');
+      const hasHeadphoneArc = Array.from(paths).some((p) =>
+        p.getAttribute('d')?.includes('a4 4 0 018 0'),
+      );
+      expect(hasHeadphoneArc).toBe(true);
+    });
+
+    it('renders Input Monitoring button with microphone icon (rect element)', () => {
+      renderHeader();
+      const monitorBtn = screen.getByTitle(/Input monitoring/);
+      expect(monitorBtn).toBeInTheDocument();
+      const svg = monitorBtn.querySelector('svg');
+      expect(svg).toBeTruthy();
+      // Microphone icon uses a <rect> for the mic body, not a headphone arc
+      const rects = svg!.querySelectorAll('rect');
+      expect(rects.length).toBeGreaterThan(0);
+      // Should NOT contain headphone-style arc path
+      const paths = svg!.querySelectorAll('path');
+      const hasHeadphoneArc = Array.from(paths).some((p) =>
+        p.getAttribute('d')?.includes('a4 4 0 018 0'),
+      );
+      expect(hasHeadphoneArc).toBe(false);
+    });
+
+    it('Solo and Input Monitoring use visually distinct SVG shapes', () => {
+      renderHeader();
+      const soloSvg = screen.getByTitle('Solo (S)').querySelector('svg')!;
+      const monitorSvg = screen.getByTitle(/Input monitoring/).querySelector('svg')!;
+      // They must not be identical
+      expect(soloSvg.innerHTML).not.toBe(monitorSvg.innerHTML);
+    });
+  });
+
+  describe('progressive disclosure', () => {
+    it('primary buttons (Mute, Solo, Record arm) are always visible', () => {
+      renderHeader();
+      const muteBtn = screen.getByTitle('Mute (M)');
+      const soloBtn = screen.getByTitle('Solo (S)');
+      const armBtn = screen.getByTitle('Record arm');
+      // These should not be inside a hidden container
+      expect(muteBtn.closest('.opacity-0')).toBeNull();
+      expect(soloBtn.closest('.opacity-0')).toBeNull();
+      expect(armBtn.closest('.opacity-0')).toBeNull();
+    });
+
+    it('secondary buttons (Monitor, Freeze, Automation) are in a hover-reveal container when inactive', () => {
+      renderHeader({ inputMonitoring: 'off', frozen: false });
+      const monitorBtn = screen.getByTitle(/Input monitoring/);
+      const freezeBtn = screen.getByTitle(/Freeze Track/);
+      const autoBtn = screen.getByTitle(/automation/i);
+      // All three should share a common parent with opacity-0 class
+      const container = monitorBtn.parentElement!;
+      expect(container.classList.contains('opacity-0')).toBe(true);
+      expect(container.classList.contains('group-hover:opacity-100')).toBe(true);
+      expect(freezeBtn.parentElement).toBe(container);
+      expect(autoBtn.parentElement).toBe(container);
+    });
+
+    it('secondary buttons become visible when input monitoring is active', () => {
+      renderHeader({ inputMonitoring: 'on' });
+      const monitorBtn = screen.getByTitle(/Input monitoring/);
+      const container = monitorBtn.parentElement!;
+      expect(container.classList.contains('opacity-100')).toBe(true);
+      expect(container.classList.contains('opacity-0')).toBe(false);
+    });
+
+    it('secondary buttons become visible when track is frozen', () => {
+      renderHeader({ frozen: true });
+      const freezeBtn = screen.getByTitle(/Unfreeze Track/);
+      const container = freezeBtn.parentElement!;
+      expect(container.classList.contains('opacity-100')).toBe(true);
+      expect(container.classList.contains('opacity-0')).toBe(false);
+    });
+  });
+
+  describe('button tooltips', () => {
+    it('all icon buttons have descriptive titles', () => {
+      renderHeader();
+      expect(screen.getByTitle('Mute (M)')).toBeInTheDocument();
+      expect(screen.getByTitle('Solo (S)')).toBeInTheDocument();
+      expect(screen.getByTitle('Record arm')).toBeInTheDocument();
+      expect(screen.getByTitle(/Input monitoring/)).toBeInTheDocument();
+      expect(screen.getByTitle(/Freeze Track/)).toBeInTheDocument();
+      expect(screen.getByTitle(/automation/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Icon differentiation**: Replaced Input Monitoring's headphone icon with a microphone SVG, so Solo (headphone) and Input Monitoring (microphone) are visually distinct
- **Progressive disclosure**: Secondary buttons (Input Monitoring, Freeze, Automation) are now hidden by default and revealed on hover — or always visible when any is active
- **Tests**: Added 8 unit tests covering icon shape differentiation, progressive disclosure visibility logic, and tooltip labels

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run` — 451/451 tests pass (including 8 new)
- [x] `npm run build` — succeeds
- [ ] Manual: hover over track header to verify secondary buttons appear/hide
- [ ] Manual: verify Solo shows headphone icon, Input Monitoring shows microphone icon

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)