### PR TITLE
feat: add parametric EQ with spectrum analyzer (closes #233)

### DIFF
--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -6,16 +6,35 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Knob } from '../ui/Knob';
 import { useProjectStore } from '../../store/projectStore';
 import { effectsEngine } from '../../engine/EffectsEngine';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
 import type {
   TrackEffect,
   TrackEffectType,
   EQ3Params,
+  ParametricEQParams,
+  ParametricEQBand,
+  ParametricEQBandType,
   CompressorParams,
   ReverbParams,
   DelayParams,
   DistortionParams,
   FilterParams,
 } from '../../types/project';
+import {
+  PARAMETRIC_EQ_MAX_GAIN,
+  PARAMETRIC_EQ_MAX_Q,
+  PARAMETRIC_EQ_MIN_GAIN,
+  PARAMETRIC_EQ_MIN_Q,
+  clampParametricEqFrequency,
+  clampParametricEqGain,
+  clampParametricEqQ,
+  createDefaultParametricEqBands,
+  createSimpleParametricEqBands,
+  frequencyToRatio,
+  getBandControlLabel,
+  getEqResponseAtFrequency,
+  ratioToFrequency,
+} from '../../utils/parametricEq';
 
 interface HSliderProps {
   value: number;
@@ -148,6 +167,316 @@ export function EQCurve({ low, mid, high }: { low: number; mid: number; high: nu
   }, [low, mid, high]);
 
   return <canvas ref={canvasRef} className="rounded" style={{ width: 150, height: 40 }} />;
+}
+
+const PARAMETRIC_EQ_CANVAS_WIDTH = 220;
+const PARAMETRIC_EQ_CANVAS_HEIGHT = 108;
+const PARAMETRIC_EQ_BAND_TYPES: ParametricEQBandType[] = [
+  'peaking',
+  'lowshelf',
+  'highshelf',
+  'notch',
+  'highpass',
+  'lowpass',
+];
+
+function gainToCanvasY(gain: number, height: number): number {
+  const norm = (clampParametricEqGain(gain) - PARAMETRIC_EQ_MIN_GAIN) / (PARAMETRIC_EQ_MAX_GAIN - PARAMETRIC_EQ_MIN_GAIN);
+  return height - norm * height;
+}
+
+function canvasYToGain(y: number, height: number): number {
+  const norm = 1 - Math.max(0, Math.min(1, y / height));
+  return clampParametricEqGain(PARAMETRIC_EQ_MIN_GAIN + norm * (PARAMETRIC_EQ_MAX_GAIN - PARAMETRIC_EQ_MIN_GAIN));
+}
+
+function getSimpleBandsFromParametricBands(bands: ParametricEQBand[]) {
+  return {
+    low: bands[0]?.gain ?? 0,
+    mid: bands[1]?.gain ?? 0,
+    high: bands[2]?.gain ?? 0,
+    lowFrequency: bands[0]?.frequency ?? 250,
+    highFrequency: bands[2]?.frequency ?? 4000,
+  };
+}
+
+export function ParametricEQCard({
+  effect,
+  trackId,
+}: {
+  effect: TrackEffect & { type: 'parametricEq' };
+  trackId: string;
+}) {
+  const updateTrackEffect = useProjectStore((s) => s.updateTrackEffect);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const bands = effect.params.bands;
+  const [selectedBandId, setSelectedBandId] = useState<string>(bands[0]?.id ?? '');
+  const [spectrum, setSpectrum] = useState<Float32Array<ArrayBuffer> | null>(null);
+
+  useEffect(() => {
+    if (!bands.some((band) => band.id === selectedBandId)) {
+      setSelectedBandId(bands[0]?.id ?? '');
+    }
+  }, [bands, selectedBandId]);
+
+  useEffect(() => {
+    let frame = 0;
+    const tick = () => {
+      const nextSpectrum = getAudioEngine().getTrackSpectrum(trackId);
+      setSpectrum(nextSpectrum);
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [trackId]);
+
+  const commitParams = useCallback((nextParams: ParametricEQParams) => {
+    updateTrackEffect(trackId, effect.id, { params: nextParams } as Partial<TrackEffect>);
+    effectsEngine.updateEffectParams(trackId, effect.id, nextParams, 'parametricEq');
+  }, [effect.id, trackId, updateTrackEffect]);
+
+  const updateBand = useCallback((bandId: string, updates: Partial<ParametricEQBand>) => {
+    const nextParams: ParametricEQParams = {
+      ...effect.params,
+      bands: effect.params.bands.map((band) => (
+        band.id === bandId
+          ? {
+              ...band,
+              ...updates,
+              frequency: clampParametricEqFrequency(updates.frequency ?? band.frequency),
+              gain: clampParametricEqGain(updates.gain ?? band.gain),
+              q: clampParametricEqQ(updates.q ?? band.q),
+            }
+          : band
+      )),
+    };
+    commitParams(nextParams);
+  }, [commitParams, effect.params]);
+
+  const switchMode = useCallback((mode: ParametricEQParams['mode']) => {
+    commitParams({
+      mode,
+      bands: mode === 'simple'
+        ? createSimpleParametricEqBands()
+        : createDefaultParametricEqBands(),
+    });
+  }, [commitParams]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const width = PARAMETRIC_EQ_CANVAS_WIDTH;
+    const height = PARAMETRIC_EQ_CANVAS_HEIGHT;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+
+    ctx.fillStyle = 'rgba(8, 12, 24, 0.95)';
+    ctx.fillRect(0, 0, width, height);
+
+    ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+    ctx.lineWidth = 1;
+    const gridFrequencies = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000];
+    for (const frequency of gridFrequencies) {
+      const x = frequencyToRatio(frequency) * width;
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.stroke();
+    }
+    for (const gain of [-18, -9, 0, 9, 18]) {
+      const y = gainToCanvasY(gain, height);
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.strokeStyle = gain === 0 ? 'rgba(120, 180, 255, 0.24)' : 'rgba(255,255,255,0.08)';
+      ctx.stroke();
+    }
+
+    if (spectrum && spectrum.length > 0) {
+      ctx.beginPath();
+      ctx.lineWidth = 1.5;
+      ctx.strokeStyle = 'rgba(34,197,94,0.35)';
+      for (let i = 0; i < spectrum.length; i++) {
+        const x = (i / Math.max(1, spectrum.length - 1)) * width;
+        const normalized = Math.max(0, Math.min(1, (spectrum[i] + 120) / 90));
+        const y = height - normalized * height;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+    }
+
+    ctx.beginPath();
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = 'rgba(96,165,250,0.95)';
+    for (let x = 0; x <= width; x++) {
+      const frequency = ratioToFrequency(x / width);
+      const response = getEqResponseAtFrequency(bands, frequency);
+      const y = gainToCanvasY(response, height);
+      if (x === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+
+    bands.forEach((band, index) => {
+      const x = frequencyToRatio(band.frequency) * width;
+      const y = gainToCanvasY(band.gain, height);
+      ctx.beginPath();
+      ctx.arc(x, y, selectedBandId === band.id ? 6 : 4.5, 0, Math.PI * 2);
+      ctx.fillStyle = band.enabled ? '#f8fafc' : 'rgba(248,250,252,0.25)';
+      ctx.fill();
+      ctx.lineWidth = selectedBandId === band.id ? 2.5 : 1.5;
+      ctx.strokeStyle = band.enabled ? '#60a5fa' : 'rgba(96,165,250,0.35)';
+      ctx.stroke();
+      ctx.fillStyle = 'rgba(255,255,255,0.7)';
+      ctx.font = '9px monospace';
+      ctx.fillText(String(index + 1), x - 3, y - 10);
+    });
+  }, [bands, selectedBandId, spectrum]);
+
+  const handleCanvasMouseDown = useCallback((event: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const pointerX = event.clientX - rect.left;
+    const pointerY = event.clientY - rect.top;
+    const width = rect.width;
+    const height = rect.height;
+
+    let activeBand = effect.params.bands.reduce<ParametricEQBand | null>((closest, band) => {
+      const x = frequencyToRatio(band.frequency) * width;
+      const y = gainToCanvasY(band.gain, height);
+      const distance = Math.hypot(pointerX - x, pointerY - y);
+      if (!closest) return distance <= 18 ? band : null;
+      const closestDistance = Math.hypot(
+        pointerX - frequencyToRatio(closest.frequency) * width,
+        pointerY - gainToCanvasY(closest.gain, height),
+      );
+      return distance < closestDistance ? band : closest;
+    }, null);
+
+    if (!activeBand) {
+      activeBand = effect.params.bands[0] ?? null;
+    }
+    if (!activeBand) return;
+    setSelectedBandId(activeBand.id);
+
+    const updateFromPointer = (clientX: number, clientY: number) => {
+      const nextX = clientX - rect.left;
+      const nextY = clientY - rect.top;
+      updateBand(activeBand.id, {
+        enabled: true,
+        frequency: ratioToFrequency(nextX / width),
+        gain: canvasYToGain(nextY, height),
+      });
+    };
+
+    updateFromPointer(event.clientX, event.clientY);
+    const onMove = (moveEvent: MouseEvent) => updateFromPointer(moveEvent.clientX, moveEvent.clientY);
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }, [effect.params.bands, updateBand]);
+
+  const selectedBand = bands.find((band) => band.id === selectedBandId) ?? bands[0];
+  const simpleBands = getSimpleBandsFromParametricBands(bands);
+
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex gap-1">
+          <button
+            className={`px-2 py-0.5 rounded text-[8px] uppercase ${effect.params.mode === 'simple' ? 'bg-blue-500/30 text-blue-200' : 'text-white/40 hover:bg-white/5'}`}
+            onClick={() => switchMode('simple')}
+            aria-label="Parametric EQ simple mode"
+          >
+            Simple
+          </button>
+          <button
+            className={`px-2 py-0.5 rounded text-[8px] uppercase ${effect.params.mode === 'parametric' ? 'bg-blue-500/30 text-blue-200' : 'text-white/40 hover:bg-white/5'}`}
+            onClick={() => switchMode('parametric')}
+            aria-label="Parametric EQ parametric mode"
+          >
+            Parametric
+          </button>
+        </div>
+        <span className="text-[8px] text-white/35">Spectrum + response</span>
+      </div>
+
+      <canvas
+        ref={canvasRef}
+        className="rounded-md border border-white/10 cursor-crosshair"
+        onMouseDown={handleCanvasMouseDown}
+        aria-label="Parametric EQ frequency display"
+      />
+
+      {effect.params.mode === 'simple' ? (
+        <>
+          <div className="flex gap-3 justify-center">
+            <Knob value={simpleBands.low} onChange={(v) => commitParams({ mode: 'simple', bands: createSimpleParametricEqBands(v, simpleBands.mid, simpleBands.high, simpleBands.lowFrequency, simpleBands.highFrequency) })} min={-12} max={12} defaultValue={0} label="Low" unit="dB" size={30} step={0.5} />
+            <Knob value={simpleBands.mid} onChange={(v) => commitParams({ mode: 'simple', bands: createSimpleParametricEqBands(simpleBands.low, v, simpleBands.high, simpleBands.lowFrequency, simpleBands.highFrequency) })} min={-12} max={12} defaultValue={0} label="Mid" unit="dB" size={30} step={0.5} />
+            <Knob value={simpleBands.high} onChange={(v) => commitParams({ mode: 'simple', bands: createSimpleParametricEqBands(simpleBands.low, simpleBands.mid, v, simpleBands.lowFrequency, simpleBands.highFrequency) })} min={-12} max={12} defaultValue={0} label="High" unit="dB" size={30} step={0.5} />
+          </div>
+          <div className="flex gap-2">
+            <HSlider value={simpleBands.lowFrequency} onChange={(v) => commitParams({ mode: 'simple', bands: createSimpleParametricEqBands(simpleBands.low, simpleBands.mid, simpleBands.high, v, simpleBands.highFrequency) })} min={100} max={1000} label="Low Freq" displayValue={`${Math.round(simpleBands.lowFrequency)} Hz`} color="#22c55e" width={100} />
+            <HSlider value={simpleBands.highFrequency} onChange={(v) => commitParams({ mode: 'simple', bands: createSimpleParametricEqBands(simpleBands.low, simpleBands.mid, simpleBands.high, simpleBands.lowFrequency, v) })} min={1000} max={8000} label="High Freq" displayValue={`${Math.round(simpleBands.highFrequency)} Hz`} color="#ef4444" width={100} />
+          </div>
+        </>
+      ) : selectedBand ? (
+        <>
+          <div className="grid grid-cols-4 gap-1">
+            {bands.map((band, index) => (
+              <button
+                key={band.id}
+                className={`px-1.5 py-1 rounded text-[8px] ${selectedBand.id === band.id ? 'bg-blue-500/25 text-blue-100 border border-blue-400/30' : 'bg-white/5 text-white/50 border border-transparent hover:bg-white/8'}`}
+                onClick={() => setSelectedBandId(band.id)}
+                aria-label={`Select EQ band ${index + 1}`}
+              >
+                B{index + 1} {band.enabled ? '' : 'Off'}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <button
+              className={`px-2 py-0.5 rounded text-[8px] ${selectedBand.enabled ? 'bg-green-500/25 text-green-200' : 'text-white/40 hover:bg-white/5'}`}
+              onClick={() => updateBand(selectedBand.id, { enabled: !selectedBand.enabled })}
+              aria-label="Toggle selected EQ band"
+            >
+              {selectedBand.enabled ? 'Band On' : 'Band Off'}
+            </button>
+            <select
+              className="bg-white/5 border border-white/10 rounded px-1.5 py-1 text-[9px] text-white/70"
+              value={selectedBand.type}
+              onChange={(e) => updateBand(selectedBand.id, { type: e.target.value as ParametricEQBandType })}
+              aria-label="Selected EQ band type"
+            >
+              {PARAMETRIC_EQ_BAND_TYPES.map((type) => (
+                <option key={type} value={type} className="bg-[#0e0e24]">
+                  {getBandControlLabel(type)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex gap-2 justify-center">
+            <Knob value={selectedBand.frequency} onChange={(v) => updateBand(selectedBand.id, { frequency: v })} min={20} max={20000} defaultValue={1000} label="Freq" unit="Hz" size={34} step={10} />
+            <Knob value={selectedBand.gain} onChange={(v) => updateBand(selectedBand.id, { gain: v })} min={-18} max={18} defaultValue={0} label="Gain" unit="dB" size={34} step={0.5} />
+            <Knob value={selectedBand.q} onChange={(v) => updateBand(selectedBand.id, { q: v })} min={PARAMETRIC_EQ_MIN_Q} max={PARAMETRIC_EQ_MAX_Q} defaultValue={1} label="Q" size={34} step={0.1} />
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
 }
 
 export function CompressorCard({ effect, trackId }: { effect: TrackEffect & { type: 'compressor' }; trackId: string }) {
@@ -368,6 +697,7 @@ export function FilterCard({ effect, trackId }: { effect: TrackEffect & { type: 
 
 export const EFFECT_COLORS: Record<TrackEffectType, string> = {
   eq3: '#22c55e',
+  parametricEq: '#60a5fa',
   compressor: '#f59e0b',
   reverb: '#8b5cf6',
   delay: '#f59e0b',

--- a/src/components/mixer/EffectChain.tsx
+++ b/src/components/mixer/EffectChain.tsx
@@ -29,6 +29,7 @@ import type {
   TrackEffect,
   TrackEffectType,
   EQ3Params,
+  ParametricEQParams,
   CompressorParams,
   ReverbParams,
   DelayParams,
@@ -50,6 +51,44 @@ const EFFECT_PRESETS: Record<TrackEffectType, EffectPreset[]> = {
     { name: 'Bass Boost', params: { low: 6, mid: 0, high: 0, lowFrequency: 250, highFrequency: 4000 } as EQ3Params },
     { name: 'Presence', params: { low: 0, mid: 3, high: 4, lowFrequency: 250, highFrequency: 4000 } as EQ3Params },
     { name: 'Warmth', params: { low: 3, mid: -1, high: -2, lowFrequency: 350, highFrequency: 5000 } as EQ3Params },
+  ],
+  parametricEq: [
+    {
+      name: 'Simple',
+      params: {
+        mode: 'simple',
+        bands: [
+          { id: 'simple-low', enabled: true, type: 'lowshelf', frequency: 250, gain: 0, q: 0.7 },
+          { id: 'simple-mid', enabled: true, type: 'peaking', frequency: 1000, gain: 0, q: 1 },
+          { id: 'simple-high', enabled: true, type: 'highshelf', frequency: 4000, gain: 0, q: 0.7 },
+          { id: 'simple-extra', enabled: false, type: 'highpass', frequency: 20, gain: 0, q: 0.7 },
+        ],
+      } as ParametricEQParams,
+    },
+    {
+      name: 'Vocal Air',
+      params: {
+        mode: 'parametric',
+        bands: [
+          { id: 'vocal-cut', enabled: true, type: 'highpass', frequency: 90, gain: 0, q: 0.7 },
+          { id: 'vocal-box', enabled: true, type: 'peaking', frequency: 320, gain: -3, q: 1.2 },
+          { id: 'vocal-pres', enabled: true, type: 'peaking', frequency: 3500, gain: 2.5, q: 1.1 },
+          { id: 'vocal-air', enabled: true, type: 'highshelf', frequency: 10000, gain: 4, q: 0.7 },
+        ],
+      } as ParametricEQParams,
+    },
+    {
+      name: 'Bass Tight',
+      params: {
+        mode: 'parametric',
+        bands: [
+          { id: 'bass-rumble', enabled: true, type: 'highpass', frequency: 35, gain: 0, q: 0.8 },
+          { id: 'bass-weight', enabled: true, type: 'peaking', frequency: 90, gain: 3, q: 1.1 },
+          { id: 'bass-mud', enabled: true, type: 'peaking', frequency: 260, gain: -2.5, q: 1.4 },
+          { id: 'bass-top', enabled: true, type: 'lowpass', frequency: 9000, gain: 0, q: 0.8 },
+        ],
+      } as ParametricEQParams,
+    },
   ],
   compressor: [
     { name: 'Gentle', params: { threshold: -24, ratio: 2, attack: 0.02, release: 0.2, knee: 10 } as CompressorParams },
@@ -93,7 +132,16 @@ interface HSliderProps {
   width?: number;
 }
 
-import { EQ3Card, CompressorCard, ReverbCard, DelayCard, DistortionCard, FilterCard, EFFECT_COLORS } from './EffectCards';
+import {
+  EQ3Card,
+  ParametricEQCard,
+  CompressorCard,
+  ReverbCard,
+  DelayCard,
+  DistortionCard,
+  FilterCard,
+  EFFECT_COLORS,
+} from './EffectCards';
 
 
 function EffectDevice({
@@ -194,6 +242,7 @@ function EffectDevice({
       {!collapsed && (
         <div className="overflow-y-auto max-h-[220px]">
           {effect.type === 'eq3' && <EQ3Card effect={effect} trackId={track.id} />}
+          {effect.type === 'parametricEq' && <ParametricEQCard effect={effect} trackId={track.id} />}
           {effect.type === 'compressor' && <CompressorCard effect={effect} trackId={track.id} />}
           {effect.type === 'reverb' && <ReverbCard effect={effect} trackId={track.id} />}
           {effect.type === 'delay' && <DelayCard effect={effect} trackId={track.id} />}
@@ -212,6 +261,7 @@ function AddEffectButton({ trackId }: { trackId: string }) {
   const [open, setOpen] = useState(false);
 
   const effectTypes: { type: TrackEffectType; label: string; icon: string }[] = [
+    { type: 'parametricEq', label: 'Parametric EQ', icon: '🎚️' },
     { type: 'eq3', label: 'EQ Three', icon: '📊' },
     { type: 'compressor', label: 'Compressor', icon: '🔧' },
     { type: 'reverb', label: 'Reverb', icon: '🌊' },

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -102,6 +102,10 @@ export class AudioEngine {
     return this.trackNodes.get(trackId)?.getLevel() ?? 0;
   }
 
+  getTrackSpectrum(trackId: string): Float32Array<ArrayBuffer> | null {
+    return this.trackNodes.get(trackId)?.getSpectrumData() ?? null;
+  }
+
   updateSoloState() {
     const anySoloed = Array.from(this.trackNodes.values()).some((n) => n.soloed);
     for (const node of this.trackNodes.values()) {

--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -3,6 +3,7 @@ import type {
   TrackEffect,
   TrackEffectType,
   EQ3Params,
+  ParametricEQParams,
   CompressorParams,
   ReverbParams,
   DelayParams,
@@ -15,8 +16,53 @@ type EffectNode = {
   id: string;
   type: TrackEffectType;
   node: Tone.ToneAudioNode;
+  inputNode?: AudioNode;
+  outputNode?: AudioNode;
   lfo?: Tone.LFO;
+  parametricEqRuntime?: {
+    input: Tone.Gain;
+    output: Tone.Gain;
+    filters: Tone.Filter[];
+  };
+  dispose?: () => void;
 };
+
+function applyParametricEqFilters(
+  input: Tone.Gain,
+  output: Tone.Gain,
+  filters: Tone.Filter[],
+  params: ParametricEQParams,
+) {
+  try { input.disconnect(); } catch {}
+  for (const filter of filters) {
+    try { filter.disconnect(); } catch {}
+  }
+
+  params.bands.forEach((band, index) => {
+    const filter = filters[index];
+    if (!filter) return;
+    filter.type = band.type;
+    filter.frequency.value = band.frequency;
+    filter.Q.value = band.q;
+    filter.gain.value = band.gain;
+  });
+
+  const enabledFilters = filters.filter((_, index) => params.bands[index]?.enabled !== false);
+  let previous: Tone.ToneAudioNode = input;
+  for (const filter of enabledFilters) {
+    previous.connect(filter);
+    previous = filter;
+  }
+  previous.connect(output);
+}
+
+function getEffectInput(effectNode: EffectNode): AudioNode {
+  return effectNode.inputNode ?? (effectNode.node as unknown as { input: AudioNode }).input;
+}
+
+function getEffectOutput(effectNode: EffectNode): AudioNode {
+  return effectNode.outputNode ?? (effectNode.node as unknown as { output: AudioNode }).output;
+}
 
 function createNode(effect: TrackEffect): EffectNode {
   switch (effect.type) {
@@ -39,6 +85,26 @@ function createNode(effect: TrackEffect): EffectNode {
           release: p.release,
           knee: p.knee,
         }),
+      };
+    }
+    case 'parametricEq': {
+      const p = effect.params as ParametricEQParams;
+      const input = new Tone.Gain();
+      const output = new Tone.Gain();
+      const filters = p.bands.map(() => new Tone.Filter({ type: 'peaking', frequency: 1000, Q: 1 }));
+      applyParametricEqFilters(input, output, filters, p);
+      return {
+        id: effect.id,
+        type: effect.type,
+        node: input,
+        inputNode: (input as unknown as { input?: AudioNode }).input,
+        outputNode: (output as unknown as { output?: AudioNode }).output,
+        parametricEqRuntime: { input, output, filters },
+        dispose: () => {
+          input.dispose();
+          output.dispose();
+          filters.forEach((filter) => filter.dispose());
+        },
       };
     }
     case 'reverb': {
@@ -100,7 +166,7 @@ class EffectsEngine {
     const activeEffects = effects.filter((e) => e.enabled);
     const nodes = activeEffects.map(createNode);
     for (let i = 0; i < nodes.length - 1; i++) {
-      nodes[i].node.connect(nodes[i + 1].node);
+      getEffectOutput(nodes[i]).connect(getEffectInput(nodes[i + 1]));
     }
     this.chains.set(trackId, nodes);
   }
@@ -125,6 +191,13 @@ class EffectsEngine {
         eq.high.value = p.high;
         eq.lowFrequency.value = p.lowFrequency;
         eq.highFrequency.value = p.highFrequency;
+        break;
+      }
+      case 'parametricEq': {
+        const p = params as ParametricEQParams;
+        const runtime = effectNode.parametricEqRuntime;
+        if (!runtime) break;
+        applyParametricEqFilters(runtime.input, runtime.output, runtime.filters, p);
         break;
       }
       case 'compressor': {
@@ -281,8 +354,7 @@ class EffectsEngine {
   getInputNode(trackId: string): AudioNode | null {
     const nodes = this.chains.get(trackId);
     if (!nodes?.length) return null;
-    const toneNode = nodes[0].node as unknown as { input?: AudioNode };
-    return toneNode.input ?? null;
+    return getEffectInput(nodes[0]) ?? null;
   }
 
   getOutputNode(trackId: string): AudioNode | null {
@@ -296,8 +368,7 @@ class EffectsEngine {
       if (follower) return follower.gainNode;
     }
 
-    const toneNode = lastNode.node as unknown as { output?: AudioNode };
-    return toneNode.output ?? null;
+    return getEffectOutput(lastNode) ?? null;
   }
 
   disposeChain(trackId: string) {
@@ -312,7 +383,8 @@ class EffectsEngine {
     if (!nodes) return;
     for (const node of nodes) {
       if (node.lfo) { node.lfo.stop(); node.lfo.dispose(); }
-      node.node.dispose();
+      if (node.dispose) node.dispose();
+      else node.node.dispose();
     }
     this.chains.delete(trackId);
   }

--- a/src/engine/TrackNode.ts
+++ b/src/engine/TrackNode.ts
@@ -21,6 +21,7 @@ export class TrackNode {
   readonly volumeGain: GainNode;
   private readonly analyserNode: AnalyserNode;
   private readonly analyserData: Uint8Array<ArrayBuffer>;
+  private readonly analyserFloatData: Float32Array<ArrayBuffer>;
 
   private _volume = 0.8;
   private _muted = false;
@@ -44,9 +45,10 @@ export class TrackNode {
     this.compressor = ctx.createDynamicsCompressor();
     this.volumeGain = ctx.createGain();
     this.analyserNode = ctx.createAnalyser();
-    this.analyserNode.fftSize = 256;
-    this.analyserNode.smoothingTimeConstant = 0.6;
+    this.analyserNode.fftSize = 2048;
+    this.analyserNode.smoothingTimeConstant = 0.75;
     this.analyserData = new Uint8Array(this.analyserNode.frequencyBinCount);
+    this.analyserFloatData = new Float32Array(this.analyserNode.frequencyBinCount);
 
     // Configure EQ defaults
     this.eqLow.type = 'lowshelf';
@@ -181,6 +183,11 @@ export class TrackNode {
     }
 
     return peak / 255;
+  }
+
+  getSpectrumData(): Float32Array<ArrayBuffer> {
+    this.analyserNode.getFloatFrequencyData(this.analyserFloatData);
+    return this.analyserFloatData.slice();
   }
 
   /**

--- a/src/engine/__tests__/TrackNode.test.ts
+++ b/src/engine/__tests__/TrackNode.test.ts
@@ -70,10 +70,11 @@ function makeAudioContext(): AudioContext {
     },
     createAnalyser() {
       return makeNode({
-        fftSize: 256,
+        fftSize: 2048,
         smoothingTimeConstant: 0.6,
-        frequencyBinCount: 128,
+        frequencyBinCount: 1024,
         getByteFrequencyData: vi.fn(),
+        getFloatFrequencyData: vi.fn(),
       });
     },
     createBuffer(_channels: number, length: number, sampleRate: number) {

--- a/src/engine/exportMix.ts
+++ b/src/engine/exportMix.ts
@@ -85,6 +85,19 @@ function buildOfflineEffects(
         nodes.push(high);
         break;
       }
+      case 'parametricEq': {
+        const p = effect.params;
+        for (const band of p.bands ?? []) {
+          if (band.enabled === false) continue;
+          const filter = ctx.createBiquadFilter();
+          filter.type = band.type as BiquadFilterType;
+          filter.frequency.value = band.frequency ?? 1000;
+          filter.gain.value = band.gain ?? 0;
+          filter.Q.value = band.q ?? 1;
+          nodes.push(filter);
+        }
+        break;
+      }
       case 'delay': {
         const p = effect.params;
         const delay = ctx.createDelay(5);

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -51,6 +51,7 @@ import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { getAudioEngine } from '../hooks/useAudioEngine';
 import { renderMidiTrackOffline, renderSequencerTrackOffline } from '../engine/offlineRender';
 import { convertClipAudioToMidi } from '../services/audioToMidi';
+import { createDefaultParametricEqBands } from '../utils/parametricEq';
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
   return (60 / bpm) * timeSig;
@@ -276,6 +277,16 @@ function createDefaultTrackEffect(type: TrackEffectType): TrackEffect {
         type,
         enabled: true,
         params: { low: 0, mid: 0, high: 0, lowFrequency: 250, highFrequency: 4000 },
+      };
+    case 'parametricEq':
+      return {
+        id,
+        type,
+        enabled: true,
+        params: {
+          mode: 'parametric',
+          bands: createDefaultParametricEqBands(),
+        },
       };
     case 'compressor':
       return {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -43,6 +43,28 @@ export interface EQ3Params {
   highFrequency: number;
 }
 
+export type ParametricEQBandType =
+  | 'peaking'
+  | 'lowshelf'
+  | 'highshelf'
+  | 'notch'
+  | 'highpass'
+  | 'lowpass';
+
+export interface ParametricEQBand {
+  id: string;
+  enabled: boolean;
+  type: ParametricEQBandType;
+  frequency: number;
+  gain: number;
+  q: number;
+}
+
+export interface ParametricEQParams {
+  mode: 'simple' | 'parametric';
+  bands: ParametricEQBand[];
+}
+
 export interface CompressorParams {
   threshold: number;
   ratio: number;
@@ -81,6 +103,7 @@ export interface FilterParams {
 
 export type TrackEffect =
   | EffectBase<'eq3', EQ3Params>
+  | EffectBase<'parametricEq', ParametricEQParams>
   | EffectBase<'compressor', CompressorParams>
   | EffectBase<'reverb', ReverbParams>
   | EffectBase<'delay', DelayParams>

--- a/src/utils/parametricEq.ts
+++ b/src/utils/parametricEq.ts
@@ -1,0 +1,216 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { ParametricEQBand, ParametricEQBandType } from '../types/project';
+
+export const PARAMETRIC_EQ_MIN_FREQUENCY = 20;
+export const PARAMETRIC_EQ_MAX_FREQUENCY = 20000;
+export const PARAMETRIC_EQ_MIN_GAIN = -18;
+export const PARAMETRIC_EQ_MAX_GAIN = 18;
+export const PARAMETRIC_EQ_MIN_Q = 0.1;
+export const PARAMETRIC_EQ_MAX_Q = 18;
+export const PARAMETRIC_EQ_SAMPLE_RATE = 48000;
+
+export function clampParametricEqFrequency(frequency: number): number {
+  return Math.max(PARAMETRIC_EQ_MIN_FREQUENCY, Math.min(PARAMETRIC_EQ_MAX_FREQUENCY, frequency));
+}
+
+export function clampParametricEqGain(gain: number): number {
+  return Math.max(PARAMETRIC_EQ_MIN_GAIN, Math.min(PARAMETRIC_EQ_MAX_GAIN, gain));
+}
+
+export function clampParametricEqQ(q: number): number {
+  return Math.max(PARAMETRIC_EQ_MIN_Q, Math.min(PARAMETRIC_EQ_MAX_Q, q));
+}
+
+export function createParametricEqBand(
+  overrides: Partial<ParametricEQBand> = {},
+): ParametricEQBand {
+  return {
+    id: overrides.id ?? uuidv4(),
+    enabled: overrides.enabled ?? true,
+    type: overrides.type ?? 'peaking',
+    frequency: clampParametricEqFrequency(overrides.frequency ?? 1000),
+    gain: clampParametricEqGain(overrides.gain ?? 0),
+    q: clampParametricEqQ(overrides.q ?? 1),
+  };
+}
+
+export function createDefaultParametricEqBands(): ParametricEQBand[] {
+  return [
+    createParametricEqBand({ type: 'highpass', frequency: 40, gain: 0, q: 0.7 }),
+    createParametricEqBand({ type: 'peaking', frequency: 220, gain: 0, q: 1.2 }),
+    createParametricEqBand({ type: 'peaking', frequency: 2000, gain: 0, q: 1.2 }),
+    createParametricEqBand({ type: 'highshelf', frequency: 8000, gain: 0, q: 0.7 }),
+  ];
+}
+
+export function createSimpleParametricEqBands(
+  low = 0,
+  mid = 0,
+  high = 0,
+  lowFrequency = 250,
+  highFrequency = 4000,
+): ParametricEQBand[] {
+  return [
+    createParametricEqBand({ type: 'lowshelf', frequency: lowFrequency, gain: low, q: 0.7 }),
+    createParametricEqBand({ type: 'peaking', frequency: 1000, gain: mid, q: 1 }),
+    createParametricEqBand({ type: 'highshelf', frequency: highFrequency, gain: high, q: 0.7 }),
+    createParametricEqBand({ type: 'highpass', frequency: 20, gain: 0, q: 0.7, enabled: false }),
+  ];
+}
+
+export function frequencyToRatio(frequency: number): number {
+  const clamped = clampParametricEqFrequency(frequency);
+  return (
+    Math.log10(clamped / PARAMETRIC_EQ_MIN_FREQUENCY) /
+    Math.log10(PARAMETRIC_EQ_MAX_FREQUENCY / PARAMETRIC_EQ_MIN_FREQUENCY)
+  );
+}
+
+export function ratioToFrequency(ratio: number): number {
+  const clamped = Math.max(0, Math.min(1, ratio));
+  return clampParametricEqFrequency(
+    PARAMETRIC_EQ_MIN_FREQUENCY *
+      Math.pow(PARAMETRIC_EQ_MAX_FREQUENCY / PARAMETRIC_EQ_MIN_FREQUENCY, clamped),
+  );
+}
+
+type BiquadCoefficients = {
+  b0: number;
+  b1: number;
+  b2: number;
+  a0: number;
+  a1: number;
+  a2: number;
+};
+
+function createBypassCoefficients(): BiquadCoefficients {
+  return { b0: 1, b1: 0, b2: 0, a0: 1, a1: 0, a2: 0 };
+}
+
+function getBandCoefficients(
+  band: ParametricEQBand,
+  sampleRate: number,
+): BiquadCoefficients {
+  if (!band.enabled) return createBypassCoefficients();
+
+  const omega = (2 * Math.PI * clampParametricEqFrequency(band.frequency)) / sampleRate;
+  const cosOmega = Math.cos(omega);
+  const sinOmega = Math.sin(omega);
+  const q = clampParametricEqQ(band.q);
+  const gain = clampParametricEqGain(band.gain);
+  const a = Math.pow(10, gain / 40);
+  const alpha = sinOmega / (2 * q);
+  const shelfSlope = 1;
+  const shelfAlpha =
+    (sinOmega / 2) *
+    Math.sqrt((a + 1 / a) * (1 / shelfSlope - 1) + 2);
+  const twoSqrtAAlpha = 2 * Math.sqrt(a) * shelfAlpha;
+
+  switch (band.type) {
+    case 'peaking':
+      return {
+        b0: 1 + alpha * a,
+        b1: -2 * cosOmega,
+        b2: 1 - alpha * a,
+        a0: 1 + alpha / a,
+        a1: -2 * cosOmega,
+        a2: 1 - alpha / a,
+      };
+    case 'notch':
+      return {
+        b0: 1,
+        b1: -2 * cosOmega,
+        b2: 1,
+        a0: 1 + alpha,
+        a1: -2 * cosOmega,
+        a2: 1 - alpha,
+      };
+    case 'highpass':
+      return {
+        b0: (1 + cosOmega) / 2,
+        b1: -(1 + cosOmega),
+        b2: (1 + cosOmega) / 2,
+        a0: 1 + alpha,
+        a1: -2 * cosOmega,
+        a2: 1 - alpha,
+      };
+    case 'lowpass':
+      return {
+        b0: (1 - cosOmega) / 2,
+        b1: 1 - cosOmega,
+        b2: (1 - cosOmega) / 2,
+        a0: 1 + alpha,
+        a1: -2 * cosOmega,
+        a2: 1 - alpha,
+      };
+    case 'lowshelf':
+      return {
+        b0: a * ((a + 1) - (a - 1) * cosOmega + twoSqrtAAlpha),
+        b1: 2 * a * ((a - 1) - (a + 1) * cosOmega),
+        b2: a * ((a + 1) - (a - 1) * cosOmega - twoSqrtAAlpha),
+        a0: (a + 1) + (a - 1) * cosOmega + twoSqrtAAlpha,
+        a1: -2 * ((a - 1) + (a + 1) * cosOmega),
+        a2: (a + 1) + (a - 1) * cosOmega - twoSqrtAAlpha,
+      };
+    case 'highshelf':
+      return {
+        b0: a * ((a + 1) + (a - 1) * cosOmega + twoSqrtAAlpha),
+        b1: -2 * a * ((a - 1) + (a + 1) * cosOmega),
+        b2: a * ((a + 1) + (a - 1) * cosOmega - twoSqrtAAlpha),
+        a0: (a + 1) - (a - 1) * cosOmega + twoSqrtAAlpha,
+        a1: 2 * ((a - 1) - (a + 1) * cosOmega),
+        a2: (a + 1) - (a - 1) * cosOmega - twoSqrtAAlpha,
+      };
+  }
+}
+
+function getBandMagnitudeAtFrequency(
+  band: ParametricEQBand,
+  frequency: number,
+  sampleRate: number,
+): number {
+  const c = getBandCoefficients(band, sampleRate);
+  const omega = (2 * Math.PI * clampParametricEqFrequency(frequency)) / sampleRate;
+  const cos1 = Math.cos(omega);
+  const sin1 = Math.sin(omega);
+  const cos2 = Math.cos(2 * omega);
+  const sin2 = Math.sin(2 * omega);
+
+  const numeratorReal = c.b0 + c.b1 * cos1 + c.b2 * cos2;
+  const numeratorImag = -c.b1 * sin1 - c.b2 * sin2;
+  const denominatorReal = c.a0 + c.a1 * cos1 + c.a2 * cos2;
+  const denominatorImag = -c.a1 * sin1 - c.a2 * sin2;
+
+  const numeratorMagnitude = Math.hypot(numeratorReal, numeratorImag);
+  const denominatorMagnitude = Math.max(1e-12, Math.hypot(denominatorReal, denominatorImag));
+  return numeratorMagnitude / denominatorMagnitude;
+}
+
+export function getEqResponseAtFrequency(
+  bands: ParametricEQBand[],
+  frequency: number,
+  sampleRate = PARAMETRIC_EQ_SAMPLE_RATE,
+): number {
+  const magnitude = bands.reduce(
+    (product, band) => product * getBandMagnitudeAtFrequency(band, frequency, sampleRate),
+    1,
+  );
+  return 20 * Math.log10(Math.max(1e-9, magnitude));
+}
+
+export function getBandControlLabel(type: ParametricEQBandType): string {
+  switch (type) {
+    case 'peaking':
+      return 'Peak';
+    case 'lowshelf':
+      return 'Low Shelf';
+    case 'highshelf':
+      return 'High Shelf';
+    case 'notch':
+      return 'Notch';
+    case 'highpass':
+      return 'High Pass';
+    case 'lowpass':
+      return 'Low Pass';
+  }
+}

--- a/tests/unit/parametricEq.test.ts
+++ b/tests/unit/parametricEq.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultParametricEqBands,
+  createSimpleParametricEqBands,
+  frequencyToRatio,
+  getEqResponseAtFrequency,
+  ratioToFrequency,
+} from '../../src/utils/parametricEq';
+
+describe('parametricEq utilities', () => {
+  it('creates four adjustable default bands', () => {
+    const bands = createDefaultParametricEqBands();
+
+    expect(bands).toHaveLength(4);
+    expect(bands.every((band) => typeof band.id === 'string' && band.id.length > 0)).toBe(true);
+    expect(bands.map((band) => band.type)).toEqual([
+      'highpass',
+      'peaking',
+      'peaking',
+      'highshelf',
+    ]);
+  });
+
+  it('maps simple mode bands to the legacy three-band EQ layout', () => {
+    const bands = createSimpleParametricEqBands(6, -2, 4, 300, 5500);
+
+    expect(bands).toHaveLength(4);
+    expect(bands[0]).toMatchObject({ type: 'lowshelf', gain: 6, frequency: 300, enabled: true });
+    expect(bands[1]).toMatchObject({ type: 'peaking', gain: -2, frequency: 1000, enabled: true });
+    expect(bands[2]).toMatchObject({ type: 'highshelf', gain: 4, frequency: 5500, enabled: true });
+    expect(bands[3]).toMatchObject({ enabled: false });
+  });
+
+  it('round-trips frequency positions across the log-scale display mapping', () => {
+    const original = 2450;
+    const ratio = frequencyToRatio(original);
+    const mapped = ratioToFrequency(ratio);
+
+    expect(mapped).toBeCloseTo(original, -1);
+  });
+
+  it('boosts response near a peaking band center frequency', () => {
+    const bands = createDefaultParametricEqBands();
+    bands[1] = { ...bands[1], frequency: 1000, gain: 6, q: 1.2 };
+
+    expect(getEqResponseAtFrequency(bands, 1000)).toBeGreaterThan(3);
+    expect(getEqResponseAtFrequency(bands, 100)).toBeLessThan(2);
+  });
+
+  it('cuts response around a notch filter center', () => {
+    const bands = createDefaultParametricEqBands();
+    bands[1] = { ...bands[1], type: 'notch', frequency: 3000, gain: 0, q: 6 };
+
+    expect(getEqResponseAtFrequency(bands, 3000)).toBeLessThan(-6);
+  });
+});

--- a/tests/unit/projectStore.test.ts
+++ b/tests/unit/projectStore.test.ts
@@ -206,6 +206,22 @@ describe('projectStore', () => {
       expect(note.startBeat).toBe(0.5); // 0.6 → 0.5
     });
   });
+
+  describe('track effects', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject();
+    });
+
+    it('adds a parametric EQ effect with four default bands', () => {
+      const track = useProjectStore.getState().addTrack('bass');
+      const effectId = useProjectStore.getState().addTrackEffect(track.id, 'parametricEq');
+
+      const effect = useProjectStore.getState().project?.tracks[0].effects?.find((item) => item.id === effectId);
+      expect(effect?.type).toBe('parametricEq');
+      expect(effect?.params.mode).toBe('parametric');
+      expect(effect?.params.bands).toHaveLength(4);
+    });
+  });
 });
 
   describe('duplicateTrack', () => {


### PR DESCRIPTION
## Summary
- add a new `parametricEq` mixer effect with simple and parametric modes
- render a canvas frequency display with draggable band nodes, response curve, and real-time spectrum overlay
- add live engine, offline export, and unit-test coverage for EQ parameter math and store defaults

## Verification
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `npx playwright test tests/e2e/mixer.spec.ts`