### PR TITLE
feat: add effect parameter automation lanes (closes #234)

### DIFF
--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -2,12 +2,14 @@
  * EffectCards.tsx — Individual effect parameter UIs (EQ3, Compressor, Reverb, Delay, Distortion, Filter)
  * Extracted from EffectChain.tsx to keep components under 600 lines.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Knob } from '../ui/Knob';
 import { useProjectStore } from '../../store/projectStore';
 import { effectsEngine } from '../../engine/EffectsEngine';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
 import type {
+  AutomationParameter,
+  AutomatableEffectTarget,
   TrackEffect,
   TrackEffectType,
   EQ3Params,
@@ -35,6 +37,8 @@ import {
   getEqResponseAtFrequency,
   ratioToFrequency,
 } from '../../utils/parametricEq';
+import { automationParamEquals } from '../../types/project';
+import { getEffectAutomationLabel, normalizeEffectParamValue } from '../../utils/effectAutomation';
 
 interface HSliderProps {
   value: number;
@@ -98,6 +102,97 @@ export function HSlider({ value, onChange, min = 0, max = 1, label, displayValue
   );
 }
 
+interface AutomationControlShellProps {
+  trackId: string;
+  effect: TrackEffect;
+  target: AutomatableEffectTarget;
+  normalizedValue: number;
+  children: ReactNode;
+}
+
+function AutomationControlShell({
+  trackId,
+  effect,
+  target,
+  normalizedValue,
+  children,
+}: AutomationControlShellProps) {
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const parameter = {
+    type: 'effect',
+    effectId: effect.id,
+    effectType: target.effectType,
+    param: target.param,
+  } as AutomationParameter;
+  const ensureAutomationLane = useProjectStore((s) => s.ensureAutomationLane);
+  const clearAutomationLane = useProjectStore((s) => s.clearAutomationLane);
+  const hasLane = useProjectStore((s) =>
+    (s.project?.automationLanes ?? []).some(
+      (lane) =>
+        lane.trackId === trackId &&
+        automationParamEquals(lane.parameter, parameter),
+    ),
+  );
+  const label = getEffectAutomationLabel(target.effectType, target.param);
+
+  return (
+    <>
+      <div
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setMenu({ x: e.clientX, y: e.clientY });
+        }}
+        title={`${label} (right-click for automation lane)`}
+      >
+        {children}
+      </div>
+      {menu && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setMenu(null)}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              setMenu(null);
+            }}
+          />
+          <div
+            className="fixed z-50 min-w-[170px] rounded-md border border-white/10 bg-[#16162b] p-1 shadow-xl"
+            style={{
+              left: Math.min(menu.x, window.innerWidth - 190),
+              top: Math.min(menu.y, window.innerHeight - (hasLane ? 88 : 54)),
+            }}
+            onClick={(e) => e.stopPropagation()}
+            onContextMenu={(e) => e.preventDefault()}
+          >
+            <button
+              className="w-full rounded px-2 py-1 text-left text-[11px] text-white/75 hover:bg-white/8"
+              onClick={() => {
+                ensureAutomationLane(trackId, parameter, normalizedValue);
+                setMenu(null);
+              }}
+            >
+              Show Automation Lane
+            </button>
+            {hasLane && (
+              <button
+                className="w-full rounded px-2 py-1 text-left text-[11px] text-white/55 hover:bg-white/8"
+                onClick={() => {
+                  clearAutomationLane(trackId, parameter);
+                  setMenu(null);
+                }}
+              >
+                Hide Automation Lane
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
 // ─── Per-Effect Cards ────────────────────────────────────────────────────────
 
 export function EQ3Card({ effect, trackId }: { effect: TrackEffect & { type: 'eq3' }; trackId: string }) {
@@ -113,14 +208,24 @@ export function EQ3Card({ effect, trackId }: { effect: TrackEffect & { type: 'eq
   return (
     <div className="flex flex-col gap-2 p-2">
       <div className="flex gap-3 justify-center">
-        <Knob value={p.low} onChange={(v) => update({ low: v })} min={-12} max={12} defaultValue={0} label="Low" unit="dB" size={30} step={0.5} />
-        <Knob value={p.mid} onChange={(v) => update({ mid: v })} min={-12} max={12} defaultValue={0} label="Mid" unit="dB" size={30} step={0.5} />
-        <Knob value={p.high} onChange={(v) => update({ high: v })} min={-12} max={12} defaultValue={0} label="High" unit="dB" size={30} step={0.5} />
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'eq3', param: 'low' }} normalizedValue={normalizeEffectParamValue('eq3', 'low', p.low) ?? 0.5}>
+          <Knob value={p.low} onChange={(v) => update({ low: v })} min={-12} max={12} defaultValue={0} label="Low" unit="dB" size={30} step={0.5} />
+        </AutomationControlShell>
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'eq3', param: 'mid' }} normalizedValue={normalizeEffectParamValue('eq3', 'mid', p.mid) ?? 0.5}>
+          <Knob value={p.mid} onChange={(v) => update({ mid: v })} min={-12} max={12} defaultValue={0} label="Mid" unit="dB" size={30} step={0.5} />
+        </AutomationControlShell>
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'eq3', param: 'high' }} normalizedValue={normalizeEffectParamValue('eq3', 'high', p.high) ?? 0.5}>
+          <Knob value={p.high} onChange={(v) => update({ high: v })} min={-12} max={12} defaultValue={0} label="High" unit="dB" size={30} step={0.5} />
+        </AutomationControlShell>
       </div>
       <EQCurve low={p.low} mid={p.mid} high={p.high} />
       <div className="flex gap-2">
-        <HSlider value={p.lowFrequency} onChange={(v) => update({ lowFrequency: v })} min={100} max={1000} label="Low Freq" displayValue={`${Math.round(p.lowFrequency)} Hz`} color="#22c55e" width={70} />
-        <HSlider value={p.highFrequency} onChange={(v) => update({ highFrequency: v })} min={1000} max={8000} label="High Freq" displayValue={`${Math.round(p.highFrequency)} Hz`} color="#ef4444" width={70} />
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'eq3', param: 'lowFrequency' }} normalizedValue={normalizeEffectParamValue('eq3', 'lowFrequency', p.lowFrequency) ?? 0.5}>
+          <HSlider value={p.lowFrequency} onChange={(v) => update({ lowFrequency: v })} min={100} max={1000} label="Low Freq" displayValue={`${Math.round(p.lowFrequency)} Hz`} color="#22c55e" width={70} />
+        </AutomationControlShell>
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'eq3', param: 'highFrequency' }} normalizedValue={normalizeEffectParamValue('eq3', 'highFrequency', p.highFrequency) ?? 0.5}>
+          <HSlider value={p.highFrequency} onChange={(v) => update({ highFrequency: v })} min={1000} max={8000} label="High Freq" displayValue={`${Math.round(p.highFrequency)} Hz`} color="#ef4444" width={70} />
+        </AutomationControlShell>
       </div>
     </div>
   );
@@ -515,12 +620,22 @@ export function CompressorCard({ effect, trackId }: { effect: TrackEffect & { ty
   return (
     <div className="flex flex-col gap-2 p-2">
       <div className="flex gap-2 justify-center">
-        <Knob value={p.threshold} onChange={(v) => update({ threshold: v })} min={-60} max={0} defaultValue={-24} label="Thresh" unit="dB" size={28} step={1} />
-        <Knob value={p.ratio} onChange={(v) => update({ ratio: v })} min={1} max={20} defaultValue={4} label="Ratio" size={28} step={0.5} />
-        <Knob value={p.attack} onChange={(v) => update({ attack: v })} min={0.001} max={0.1} defaultValue={0.02} label="Attack" size={28} step={0.001} />
-        <Knob value={p.release} onChange={(v) => update({ release: v })} min={0.01} max={1} defaultValue={0.2} label="Release" size={28} step={0.01} />
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'compressor', param: 'threshold' }} normalizedValue={normalizeEffectParamValue('compressor', 'threshold', p.threshold) ?? 0.5}>
+          <Knob value={p.threshold} onChange={(v) => update({ threshold: v })} min={-60} max={0} defaultValue={-24} label="Thresh" unit="dB" size={28} step={1} />
+        </AutomationControlShell>
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'compressor', param: 'ratio' }} normalizedValue={normalizeEffectParamValue('compressor', 'ratio', p.ratio) ?? 0.5}>
+          <Knob value={p.ratio} onChange={(v) => update({ ratio: v })} min={1} max={20} defaultValue={4} label="Ratio" size={28} step={0.5} />
+        </AutomationControlShell>
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'compressor', param: 'attack' }} normalizedValue={normalizeEffectParamValue('compressor', 'attack', p.attack) ?? 0.5}>
+          <Knob value={p.attack} onChange={(v) => update({ attack: v })} min={0.001} max={0.1} defaultValue={0.02} label="Attack" size={28} step={0.001} />
+        </AutomationControlShell>
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'compressor', param: 'release' }} normalizedValue={normalizeEffectParamValue('compressor', 'release', p.release) ?? 0.5}>
+          <Knob value={p.release} onChange={(v) => update({ release: v })} min={0.01} max={1} defaultValue={0.2} label="Release" size={28} step={0.01} />
+        </AutomationControlShell>
       </div>
-      <Knob value={p.knee} onChange={(v) => update({ knee: v })} min={0} max={40} defaultValue={6} label="Knee" size={24} step={1} />
+      <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'compressor', param: 'knee' }} normalizedValue={normalizeEffectParamValue('compressor', 'knee', p.knee) ?? 0.5}>
+        <Knob value={p.knee} onChange={(v) => update({ knee: v })} min={0} max={40} defaultValue={6} label="Knee" size={24} step={1} />
+      </AutomationControlShell>
 
       {/* Sidechain source dropdown */}
       <div className="border-t border-white/5 pt-1.5 mt-0.5">
@@ -584,10 +699,16 @@ export function ReverbCard({ effect, trackId }: { effect: TrackEffect & { type: 
   return (
     <div className="flex flex-col gap-2 p-2">
       <div className="flex gap-3 justify-center">
-        <Knob value={p.decay} onChange={(v) => update({ decay: v })} min={0.1} max={10} defaultValue={2.4} label="Decay" size={32} step={0.1} />
-        <Knob value={p.preDelay} onChange={(v) => update({ preDelay: v })} min={0} max={0.1} defaultValue={0.02} label="Pre-Dly" size={32} step={0.001} />
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'reverb', param: 'decay' }} normalizedValue={normalizeEffectParamValue('reverb', 'decay', p.decay) ?? 0.5}>
+          <Knob value={p.decay} onChange={(v) => update({ decay: v })} min={0.1} max={10} defaultValue={2.4} label="Decay" size={32} step={0.1} />
+        </AutomationControlShell>
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'reverb', param: 'preDelay' }} normalizedValue={normalizeEffectParamValue('reverb', 'preDelay', p.preDelay) ?? 0.5}>
+          <Knob value={p.preDelay} onChange={(v) => update({ preDelay: v })} min={0} max={0.1} defaultValue={0.02} label="Pre-Dly" size={32} step={0.001} />
+        </AutomationControlShell>
       </div>
-      <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color="#8b5cf6" />
+      <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'reverb', param: 'wet' }} normalizedValue={normalizeEffectParamValue('reverb', 'wet', p.wet) ?? 0.5}>
+        <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color="#8b5cf6" />
+      </AutomationControlShell>
     </div>
   );
 }
@@ -604,9 +725,15 @@ export function DelayCard({ effect, trackId }: { effect: TrackEffect & { type: '
 
   return (
     <div className="flex flex-col gap-2 p-2">
-      <Knob value={p.time} onChange={(v) => update({ time: v })} min={0.01} max={1} defaultValue={0.25} label="Time" unit="s" size={36} step={0.01} />
-      <Knob value={p.feedback} onChange={(v) => update({ feedback: v })} min={0} max={0.95} defaultValue={0.3} label="Feedback" size={32} step={0.01} />
-      <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color="#f59e0b" />
+      <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'delay', param: 'time' }} normalizedValue={normalizeEffectParamValue('delay', 'time', p.time) ?? 0.5}>
+        <Knob value={p.time} onChange={(v) => update({ time: v })} min={0.01} max={1} defaultValue={0.25} label="Time" unit="s" size={36} step={0.01} />
+      </AutomationControlShell>
+      <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'delay', param: 'feedback' }} normalizedValue={normalizeEffectParamValue('delay', 'feedback', p.feedback) ?? 0.5}>
+        <Knob value={p.feedback} onChange={(v) => update({ feedback: v })} min={0} max={0.95} defaultValue={0.3} label="Feedback" size={32} step={0.01} />
+      </AutomationControlShell>
+      <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'delay', param: 'wet' }} normalizedValue={normalizeEffectParamValue('delay', 'wet', p.wet) ?? 0.5}>
+        <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color="#f59e0b" />
+      </AutomationControlShell>
     </div>
   );
 }
@@ -636,8 +763,12 @@ export function DistortionCard({ effect, trackId }: { effect: TrackEffect & { ty
           </button>
         ))}
       </div>
-      <Knob value={p.amount} onChange={(v) => update({ amount: v })} min={0} max={1} defaultValue={0.2} label="Amount" size={36} step={0.01} />
-      <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color="#ef4444" />
+      <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'distortion', param: 'amount' }} normalizedValue={normalizeEffectParamValue('distortion', 'amount', p.amount) ?? 0.5}>
+        <Knob value={p.amount} onChange={(v) => update({ amount: v })} min={0} max={1} defaultValue={0.2} label="Amount" size={36} step={0.01} />
+      </AutomationControlShell>
+      <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'distortion', param: 'wet' }} normalizedValue={normalizeEffectParamValue('distortion', 'wet', p.wet) ?? 0.5}>
+        <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color="#ef4444" />
+      </AutomationControlShell>
     </div>
   );
 }
@@ -668,8 +799,12 @@ export function FilterCard({ effect, trackId }: { effect: TrackEffect & { type: 
         ))}
       </div>
       <div className="flex gap-3 justify-center">
-        <Knob value={p.frequency} onChange={(v) => update({ frequency: v })} min={20} max={20000} defaultValue={1800} label="Cutoff" size={36} step={10} />
-        <Knob value={p.resonance} onChange={(v) => update({ resonance: v })} min={0} max={20} defaultValue={1} label="Reso" size={36} step={0.1} />
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'filter', param: 'frequency' }} normalizedValue={normalizeEffectParamValue('filter', 'frequency', p.frequency) ?? 0.5}>
+          <Knob value={p.frequency} onChange={(v) => update({ frequency: v })} min={20} max={20000} defaultValue={1800} label="Cutoff" size={36} step={10} />
+        </AutomationControlShell>
+        <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'filter', param: 'resonance' }} normalizedValue={normalizeEffectParamValue('filter', 'resonance', p.resonance) ?? 0.5}>
+          <Knob value={p.resonance} onChange={(v) => update({ resonance: v })} min={0} max={20} defaultValue={1} label="Reso" size={36} step={0.1} />
+        </AutomationControlShell>
       </div>
       <div className="border-t border-white/5 pt-1.5 mt-1">
         <div className="flex items-center gap-1.5 mb-1">
@@ -684,8 +819,12 @@ export function FilterCard({ effect, trackId }: { effect: TrackEffect & { type: 
         </div>
         {p.lfoEnabled && (
           <div className="flex gap-3 justify-center">
-            <Knob value={p.lfoRate} onChange={(v) => update({ lfoRate: v })} min={0.1} max={20} defaultValue={2} label="Rate" size={26} step={0.1} />
-            <Knob value={p.lfoDepth} onChange={(v) => update({ lfoDepth: v })} min={0} max={1} defaultValue={0.25} label="Depth" size={26} step={0.01} />
+            <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'filter', param: 'lfoRate' }} normalizedValue={normalizeEffectParamValue('filter', 'lfoRate', p.lfoRate) ?? 0.5}>
+              <Knob value={p.lfoRate} onChange={(v) => update({ lfoRate: v })} min={0.1} max={20} defaultValue={2} label="Rate" size={26} step={0.1} />
+            </AutomationControlShell>
+            <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'filter', param: 'lfoDepth' }} normalizedValue={normalizeEffectParamValue('filter', 'lfoDepth', p.lfoDepth) ?? 0.5}>
+              <Knob value={p.lfoDepth} onChange={(v) => update({ lfoDepth: v })} min={0} max={1} defaultValue={0.25} label="Depth" size={26} step={0.01} />
+            </AutomationControlShell>
           </div>
         )}
       </div>

--- a/src/components/timeline/AutomationLaneView.tsx
+++ b/src/components/timeline/AutomationLaneView.tsx
@@ -2,14 +2,10 @@ import { useRef, useCallback, useMemo } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import type { AutomationLane, AutomationParameter, AutomationPoint } from '../../types/project';
+import { getEffectAutomationColor, getEffectAutomationLabel } from '../../utils/effectAutomation';
 
 const LANE_HEIGHT = 60;
 const POINT_RADIUS = 4;
-const COLORS: Record<string, string> = {
-  volume: '#22c55e',
-  pan: '#3b82f6',
-};
-
 interface AutomationLaneViewProps {
   trackId: string;
   lane: AutomationLane;
@@ -22,8 +18,13 @@ export function AutomationLaneView({ trackId, lane }: AutomationLaneViewProps) {
   const addAutomationPoint = useProjectStore((s) => s.addAutomationPoint);
   const updateAutomationPoint = useProjectStore((s) => s.updateAutomationPoint);
   const removeAutomationPoint = useProjectStore((s) => s.removeAutomationPoint);
+  const effect = useProjectStore((s) =>
+    s.project?.tracks.find((track) => track.id === trackId)?.effects?.find((trackEffect) =>
+      lane.parameter.type === 'effect' && trackEffect.id === lane.parameter.effectId,
+    ) ?? null,
+  );
 
-  const color = lane.parameter.type === 'mixer' ? (COLORS[lane.parameter.param] ?? '#8b5cf6') : '#8b5cf6';
+  const color = getEffectAutomationColor(lane.parameter);
   const width = totalDuration * pixelsPerSecond;
 
   const timeToX = useCallback((time: number) => time * pixelsPerSecond, [pixelsPerSecond]);
@@ -57,7 +58,7 @@ export function AutomationLaneView({ trackId, lane }: AutomationLaneViewProps) {
 
   const paramLabel = lane.parameter.type === 'mixer'
     ? lane.parameter.param.charAt(0).toUpperCase() + lane.parameter.param.slice(1)
-    : 'Param';
+    : `${effect?.type ?? lane.parameter.effectType} • ${getEffectAutomationLabel(lane.parameter.effectType, lane.parameter.param)}`;
 
   // Double-click to add a new point
   const handleDoubleClick = useCallback((e: React.MouseEvent<SVGSVGElement>) => {

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -342,17 +342,13 @@ export function TrackHeader({
               if (!project) return;
               const hasLane = (project.automationLanes ?? []).some((l) => l.trackId === track.id);
               if (!hasLane) {
-                useProjectStore.getState().addAutomationPoint(
+                useProjectStore.getState().ensureAutomationLane(
                   track.id,
                   { type: 'mixer', param: 'volume' },
-                  { time: 0, value: track.volume },
-                );
-                useProjectStore.getState().addAutomationPoint(
-                  track.id,
-                  { type: 'mixer', param: 'volume' },
-                  { time: project.totalDuration, value: track.volume },
+                  track.volume,
                 );
               } else {
+                // Clear all automation for this track
                 for (const lane of (project.automationLanes ?? []).filter((l) => l.trackId === track.id)) {
                   useProjectStore.getState().clearAutomationLane(track.id, lane.parameter);
                 }

--- a/src/engine/AutomationEngine.ts
+++ b/src/engine/AutomationEngine.ts
@@ -1,6 +1,7 @@
 import type { AutomationLane, AutomationParameter } from '../types/project';
 import { automationParamEquals, normalizedToMixerValue } from '../types/project';
 import { getAudioEngine } from '../hooks/useAudioEngine';
+import { effectsEngine } from './EffectsEngine';
 
 /**
  * Automation playback engine.
@@ -12,6 +13,7 @@ export class AutomationEngine {
   private getTime: (() => number) | null = null;
   private trackVolumes: Map<string, number> = new Map();
   private trackPans: Map<string, number> = new Map();
+  private effectValues: Map<string, number> = new Map();
 
   /**
    * Start applying automation during playback
@@ -24,6 +26,7 @@ export class AutomationEngine {
     this.getTime = getCurrentTime;
     this.trackVolumes.clear();
     this.trackPans.clear();
+    this.effectValues.clear();
     this.tick();
   }
 
@@ -38,6 +41,7 @@ export class AutomationEngine {
     this.getTime = null;
     this.trackVolumes.clear();
     this.trackPans.clear();
+    this.effectValues.clear();
   }
 
   /**
@@ -105,6 +109,15 @@ export class AutomationEngine {
         const panValue = normalizedToMixerValue('pan', normalized);
         getAudioEngine().setTrackPan(trackId, panValue);
       }
+      return;
+    }
+
+    if (param.type === 'effect') {
+      const key = `${trackId}:${param.effectId}:${param.param}`;
+      const last = this.effectValues.get(key);
+      if (last !== undefined && Math.abs(last - normalized) < 0.001) return;
+      this.effectValues.set(key, normalized);
+      effectsEngine.applyAutomationValue(trackId, param.effectId, param, normalized);
     }
   }
 

--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -1,5 +1,6 @@
 import * as Tone from 'tone';
 import type {
+  AutomatableEffectTarget,
   TrackEffect,
   TrackEffectType,
   EQ3Params,
@@ -10,6 +11,8 @@ import type {
   DistortionParams,
   FilterParams,
 } from '../types/project';
+import { denormalizeEffectParamValue } from '../utils/effectAutomation';
+import { useProjectStore } from '../store/projectStore';
 import { SidechainFollower } from './sidechainFollower';
 
 type EffectNode = {
@@ -215,6 +218,7 @@ class EffectsEngine {
         const p = params as ReverbParams;
         const rev = effectNode.node as Tone.Reverb;
         rev.decay = p.decay;
+        rev.preDelay = p.preDelay;
         rev.wet.value = p.wet;
         break;
       }
@@ -260,6 +264,93 @@ class EffectsEngine {
           effectNode.lfo.frequency.value = p.lfoRate;
           effectNode.lfo.min = Math.max(20, p.frequency * (1 - p.lfoDepth));
           effectNode.lfo.max = Math.min(20000, p.frequency * (1 + p.lfoDepth));
+        }
+        break;
+      }
+    }
+  }
+
+  applyAutomationValue(
+    trackId: string,
+    effectId: string,
+    target: AutomatableEffectTarget,
+    normalized: number,
+  ) {
+    const nodes = this.chains.get(trackId);
+    if (!nodes) return;
+    const effectNode = nodes.find((node) => node.id === effectId && node.type === target.effectType);
+    if (!effectNode) return;
+
+    const value = denormalizeEffectParamValue(target.effectType, target.param, normalized);
+    if (value === null) return;
+
+    switch (target.effectType) {
+      case 'eq3': {
+        const eq = effectNode.node as Tone.EQ3;
+        if (target.param === 'low') eq.low.value = value;
+        if (target.param === 'mid') eq.mid.value = value;
+        if (target.param === 'high') eq.high.value = value;
+        if (target.param === 'lowFrequency') eq.lowFrequency.value = value;
+        if (target.param === 'highFrequency') eq.highFrequency.value = value;
+        break;
+      }
+      case 'compressor': {
+        const comp = effectNode.node as Tone.Compressor;
+        if (target.param === 'threshold') comp.threshold.value = value;
+        if (target.param === 'ratio') comp.ratio.value = value;
+        if (target.param === 'attack') comp.attack.value = value;
+        if (target.param === 'release') comp.release.value = value;
+        if (target.param === 'knee') comp.knee.value = value;
+        break;
+      }
+      case 'reverb': {
+        const rev = effectNode.node as Tone.Reverb;
+        if (target.param === 'decay') rev.decay = value;
+        if (target.param === 'preDelay') rev.preDelay = value;
+        if (target.param === 'wet') rev.wet.value = value;
+        break;
+      }
+      case 'delay': {
+        const delay = effectNode.node as Tone.FeedbackDelay;
+        if (target.param === 'time') delay.delayTime.value = value;
+        if (target.param === 'feedback') delay.feedback.value = value;
+        if (target.param === 'wet') delay.wet.value = value;
+        break;
+      }
+      case 'distortion': {
+        const dist = effectNode.node as Tone.Distortion;
+        if (target.param === 'amount') {
+          const effect = useProjectStore.getState().project?.tracks
+            .find((track) => track.id === trackId)
+            ?.effects?.find((trackEffect) => trackEffect.id === effectId && trackEffect.type === 'distortion');
+          const distortionType = effect?.type === 'distortion' ? effect.params.distortionType : 'soft';
+          dist.distortion =
+            distortionType === 'overdrive' ? value * 0.5 :
+            distortionType === 'fuzz' ? Math.min(1, value * 1.5) :
+            value;
+        }
+        if (target.param === 'wet') dist.wet.value = value;
+        break;
+      }
+      case 'filter': {
+        const filter = effectNode.node as Tone.Filter;
+        if (target.param === 'frequency') {
+          const currentFrequency = Number(filter.frequency.value);
+          filter.frequency.value = value;
+          if (effectNode.lfo) {
+            const depth = currentFrequency > 0
+              ? Math.max(0, Math.min(1, (effectNode.lfo.max - currentFrequency) / currentFrequency))
+              : 0;
+            effectNode.lfo.min = Math.max(20, value * (1 - depth));
+            effectNode.lfo.max = Math.min(20000, value * (1 + depth));
+          }
+        }
+        if (target.param === 'resonance') filter.Q.value = value;
+        if (target.param === 'lfoRate' && effectNode.lfo) effectNode.lfo.frequency.value = value;
+        if (target.param === 'lfoDepth' && effectNode.lfo) {
+          const freq = Number(filter.frequency.value);
+          effectNode.lfo.min = Math.max(20, freq * (1 - value));
+          effectNode.lfo.max = Math.min(20000, freq * (1 + value));
         }
         break;
       }

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -202,6 +202,7 @@ interface ProjectState {
   reorderMidiEffect: (trackId: string, fromIndex: number, toIndex: number) => void;
 
   // Automation
+  ensureAutomationLane: (trackId: string, parameter: AutomationParameter, initialValue?: number) => void;
   addAutomationPoint: (trackId: string, parameter: AutomationParameter, point: AutomationPoint) => void;
   removeAutomationPoint: (trackId: string, parameter: AutomationParameter, pointIndex: number) => void;
   updateAutomationPoint: (trackId: string, parameter: AutomationParameter, pointIndex: number, updates: Partial<AutomationPoint>) => void;
@@ -2205,6 +2206,9 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
+        automationLanes: (state.project.automationLanes ?? []).filter(
+          (lane) => lane.parameter.type !== 'effect' || lane.parameter.effectId !== effectId,
+        ),
         tracks: state.project.tracks.map((track) =>
           track.id === trackId
             ? { ...track, effects: (track.effects ?? []).filter((effect) => effect.id !== effectId) }
@@ -2368,6 +2372,29 @@ export const useProjectStore = create<ProjectState>()(
   },
 
   // ─── Automation ───────────────────────────────────────────────────────────
+
+  ensureAutomationLane: (trackId, parameter, initialValue = 0.5) => {
+    const state = get();
+    if (!state.project) return;
+    const existingLane = (state.project.automationLanes ?? []).find(
+      (lane) => lane.trackId === trackId && automationParamEquals(lane.parameter, parameter),
+    );
+    if (existingLane) return;
+    _pushHistory(state.project);
+    const lanes = [
+      ...(state.project.automationLanes ?? []),
+      {
+        id: uuidv4(),
+        trackId,
+        parameter,
+        points: [
+          { time: 0, value: initialValue },
+          { time: state.project.totalDuration, value: initialValue },
+        ],
+      },
+    ];
+    set({ project: { ...state.project, updatedAt: Date.now(), automationLanes: lanes } });
+  },
 
   addAutomationPoint: (trackId, parameter, point) => {
     const state = get();

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -418,8 +418,17 @@ export interface AutomationPoint {
   curve?: number; // -1 (ease-in) to +1 (ease-out), 0 = linear
 }
 
+export type AutomatableEffectTarget =
+  | { effectType: 'eq3'; param: keyof EQ3Params }
+  | { effectType: 'compressor'; param: Exclude<keyof CompressorParams, 'sidechainSourceTrackId'> }
+  | { effectType: 'reverb'; param: keyof ReverbParams }
+  | { effectType: 'delay'; param: keyof DelayParams }
+  | { effectType: 'distortion'; param: Exclude<keyof DistortionParams, 'distortionType'> }
+  | { effectType: 'filter'; param: Exclude<keyof FilterParams, 'filterType' | 'lfoEnabled'> };
+
 export type AutomationParameter =
-  | { type: 'mixer'; param: 'volume' | 'pan' };
+  | { type: 'mixer'; param: 'volume' | 'pan' }
+  | ({ type: 'effect'; effectId: string } & AutomatableEffectTarget);
 
 export interface AutomationLane {
   id: string;
@@ -430,7 +439,14 @@ export interface AutomationLane {
 
 /** Compare two AutomationParameter values for equality */
 export function automationParamEquals(a: AutomationParameter, b: AutomationParameter): boolean {
-  return a.type === b.type && a.param === b.param;
+  if (a.type !== b.type) return false;
+  if (a.type === 'mixer' && b.type === 'mixer') {
+    return a.param === b.param;
+  }
+  if (a.type === 'effect' && b.type === 'effect') {
+    return a.effectId === b.effectId && a.effectType === b.effectType && a.param === b.param;
+  }
+  return false;
 }
 
 /** Map normalized 0–1 value to mixer parameter range */

--- a/src/utils/effectAutomation.ts
+++ b/src/utils/effectAutomation.ts
@@ -1,0 +1,138 @@
+import type {
+  AutomationParameter,
+  AutomatableEffectTarget,
+  TrackEffect,
+  TrackEffectType,
+} from '../types/project';
+
+type EffectAutomationSpec = {
+  label: string;
+  min: number;
+  max: number;
+  color: string;
+};
+
+const EFFECT_AUTOMATION_SPECS: Record<TrackEffectType, Record<string, EffectAutomationSpec>> = {
+  eq3: {
+    low: { label: 'Low Gain', min: -12, max: 12, color: '#22c55e' },
+    mid: { label: 'Mid Gain', min: -12, max: 12, color: '#22c55e' },
+    high: { label: 'High Gain', min: -12, max: 12, color: '#22c55e' },
+    lowFrequency: { label: 'Low Frequency', min: 100, max: 1000, color: '#22c55e' },
+    highFrequency: { label: 'High Frequency', min: 1000, max: 8000, color: '#22c55e' },
+  },
+  compressor: {
+    threshold: { label: 'Threshold', min: -60, max: 0, color: '#f59e0b' },
+    ratio: { label: 'Ratio', min: 1, max: 20, color: '#f59e0b' },
+    attack: { label: 'Attack', min: 0.001, max: 0.1, color: '#f59e0b' },
+    release: { label: 'Release', min: 0.01, max: 1, color: '#f59e0b' },
+    knee: { label: 'Knee', min: 0, max: 40, color: '#f59e0b' },
+  },
+  reverb: {
+    decay: { label: 'Decay', min: 0.1, max: 10, color: '#8b5cf6' },
+    preDelay: { label: 'Pre-Delay', min: 0, max: 0.1, color: '#8b5cf6' },
+    wet: { label: 'Dry/Wet', min: 0, max: 1, color: '#8b5cf6' },
+  },
+  delay: {
+    time: { label: 'Time', min: 0.01, max: 1, color: '#f59e0b' },
+    feedback: { label: 'Feedback', min: 0, max: 0.95, color: '#f59e0b' },
+    wet: { label: 'Dry/Wet', min: 0, max: 1, color: '#f59e0b' },
+  },
+  distortion: {
+    amount: { label: 'Amount', min: 0, max: 1, color: '#ef4444' },
+    wet: { label: 'Dry/Wet', min: 0, max: 1, color: '#ef4444' },
+  },
+  filter: {
+    frequency: { label: 'Cutoff', min: 20, max: 20000, color: '#06b6d4' },
+    resonance: { label: 'Resonance', min: 0, max: 20, color: '#06b6d4' },
+    lfoRate: { label: 'LFO Rate', min: 0.1, max: 20, color: '#06b6d4' },
+    lfoDepth: { label: 'LFO Depth', min: 0, max: 1, color: '#06b6d4' },
+  },
+  parametricEq: {},
+};
+
+function clampNormalized(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function getNumericParamValue(effect: TrackEffect, param: string): number | null {
+  switch (effect.type) {
+    case 'eq3': {
+      const value = effect.params[param as keyof typeof effect.params];
+      return typeof value === 'number' ? value : null;
+    }
+    case 'compressor': {
+      const value = effect.params[param as keyof typeof effect.params];
+      return typeof value === 'number' ? value : null;
+    }
+    case 'reverb': {
+      const value = effect.params[param as keyof typeof effect.params];
+      return typeof value === 'number' ? value : null;
+    }
+    case 'delay': {
+      const value = effect.params[param as keyof typeof effect.params];
+      return typeof value === 'number' ? value : null;
+    }
+    case 'distortion': {
+      const value = effect.params[param as keyof typeof effect.params];
+      return typeof value === 'number' ? value : null;
+    }
+    case 'filter': {
+      const value = effect.params[param as keyof typeof effect.params];
+      return typeof value === 'number' ? value : null;
+    }
+    case 'parametricEq':
+      return null;
+  }
+}
+
+export function getEffectAutomationSpec(
+  effectType: TrackEffectType,
+  param: string,
+): EffectAutomationSpec | null {
+  return EFFECT_AUTOMATION_SPECS[effectType][param] ?? null;
+}
+
+export function getEffectAutomationColor(parameter: AutomationParameter): string {
+  if (parameter.type === 'mixer') {
+    return parameter.param === 'volume' ? '#22c55e' : '#3b82f6';
+  }
+  return getEffectAutomationSpec(parameter.effectType, parameter.param)?.color ?? '#8b5cf6';
+}
+
+export function getEffectAutomationLabel(
+  effectType: TrackEffectType,
+  param: string,
+): string {
+  return getEffectAutomationSpec(effectType, param)?.label ?? param;
+}
+
+export function normalizeEffectParamValue(
+  effectType: TrackEffectType,
+  param: string,
+  value: number,
+): number | null {
+  const spec = getEffectAutomationSpec(effectType, param);
+  if (!spec) return null;
+  if (spec.max === spec.min) return 0;
+  return clampNormalized((value - spec.min) / (spec.max - spec.min));
+}
+
+export function denormalizeEffectParamValue(
+  effectType: TrackEffectType,
+  param: string,
+  normalized: number,
+): number | null {
+  const spec = getEffectAutomationSpec(effectType, param);
+  if (!spec) return null;
+  return spec.min + clampNormalized(normalized) * (spec.max - spec.min);
+}
+
+export function getNormalizedEffectAutomationValue(
+  effect: TrackEffect,
+  target: AutomatableEffectTarget,
+): number | null {
+  if (effect.type !== target.effectType) return null;
+  const rawValue = getNumericParamValue(effect, target.param);
+  if (rawValue === null) return null;
+  return normalizeEffectParamValue(effect.type, target.param, rawValue);
+}

--- a/tests/unit/automationEngine.test.ts
+++ b/tests/unit/automationEngine.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  setTrackVolume: vi.fn(),
+  setTrackPan: vi.fn(),
+  applyAutomationValue: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    setTrackVolume: mocks.setTrackVolume,
+    setTrackPan: mocks.setTrackPan,
+  }),
+}));
+
+vi.mock('../../src/engine/EffectsEngine', () => ({
+  effectsEngine: {
+    applyAutomationValue: mocks.applyAutomationValue,
+  },
+}));
+
+import { AutomationEngine } from '../../src/engine/AutomationEngine';
+import type { AutomationLane } from '../../src/types/project';
+
+describe('AutomationEngine', () => {
+  beforeEach(() => {
+    mocks.setTrackVolume.mockReset();
+    mocks.setTrackPan.mockReset();
+    mocks.applyAutomationValue.mockReset();
+    vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1));
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  it('routes effect automation lanes into the effects engine during playback', () => {
+    const engine = new AutomationEngine();
+    const lanes: AutomationLane[] = [
+      {
+        id: 'lane-1',
+        trackId: 'track-1',
+        parameter: {
+          type: 'effect',
+          effectId: 'fx-1',
+          effectType: 'filter',
+          param: 'frequency',
+        },
+        points: [
+          { time: 0, value: 0.2 },
+          { time: 2, value: 0.8 },
+        ],
+      },
+    ];
+
+    engine.start(lanes, () => 1);
+
+    expect(mocks.applyAutomationValue).toHaveBeenCalledWith(
+      'track-1',
+      'fx-1',
+      {
+        type: 'effect',
+        effectId: 'fx-1',
+        effectType: 'filter',
+        param: 'frequency',
+      },
+      0.5,
+    );
+  });
+});

--- a/tests/unit/automationTypes.test.ts
+++ b/tests/unit/automationTypes.test.ts
@@ -32,5 +32,38 @@ describe('automation types', () => {
 
       expect(automationParamEquals(left, right)).toBe(false);
     });
+
+    it('matches identical effect automation params including effect identity', () => {
+      const param: AutomationParameter = {
+        type: 'effect',
+        effectId: 'fx-1',
+        effectType: 'filter',
+        param: 'frequency',
+      };
+
+      expect(automationParamEquals(param, {
+        type: 'effect',
+        effectId: 'fx-1',
+        effectType: 'filter',
+        param: 'frequency',
+      })).toBe(true);
+    });
+
+    it('treats different effects as different automation lanes even when the parameter name matches', () => {
+      const left: AutomationParameter = {
+        type: 'effect',
+        effectId: 'fx-1',
+        effectType: 'filter',
+        param: 'frequency',
+      };
+      const right: AutomationParameter = {
+        type: 'effect',
+        effectId: 'fx-2',
+        effectType: 'filter',
+        param: 'frequency',
+      };
+
+      expect(automationParamEquals(left, right)).toBe(false);
+    });
   });
 });

--- a/tests/unit/effectAutomation.test.ts
+++ b/tests/unit/effectAutomation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  denormalizeEffectParamValue,
+  getNormalizedEffectAutomationValue,
+  normalizeEffectParamValue,
+} from '../../src/utils/effectAutomation';
+import type { TrackEffect } from '../../src/types/project';
+
+describe('effectAutomation utils', () => {
+  it('round-trips numeric effect parameters through normalization', () => {
+    const normalized = normalizeEffectParamValue('filter', 'frequency', 10010);
+    expect(normalized).not.toBeNull();
+    expect(denormalizeEffectParamValue('filter', 'frequency', normalized ?? 0)).toBeCloseTo(10010, 5);
+  });
+
+  it('reads the normalized value from a track effect target', () => {
+    const effect: TrackEffect = {
+      id: 'fx-filter',
+      type: 'filter',
+      enabled: true,
+      params: {
+        frequency: 5020,
+        resonance: 5,
+        filterType: 'lowpass',
+        lfoEnabled: true,
+        lfoRate: 4,
+        lfoDepth: 0.25,
+      },
+    };
+
+    expect(getNormalizedEffectAutomationValue(effect, {
+      effectType: 'filter',
+      param: 'lfoDepth',
+    })).toBeCloseTo(0.25, 5);
+  });
+});

--- a/tests/unit/projectStore.test.ts
+++ b/tests/unit/projectStore.test.ts
@@ -160,6 +160,36 @@ describe('projectStore', () => {
         }),
       ]);
     });
+
+    it('creates a default effect automation lane once and removes it when the effect is deleted', () => {
+      const track = useProjectStore.getState().addTrack('drums');
+      const effectId = useProjectStore.getState().addTrackEffect(track.id, 'filter');
+      expect(effectId).toBeDefined();
+
+      const filterParameter = {
+        type: 'effect',
+        effectId: effectId!,
+        effectType: 'filter',
+        param: 'frequency',
+      } as const;
+
+      useProjectStore.getState().ensureAutomationLane(track.id, filterParameter, 0.4);
+      useProjectStore.getState().ensureAutomationLane(track.id, filterParameter, 0.8);
+
+      expect(useProjectStore.getState().project?.automationLanes).toEqual([
+        expect.objectContaining({
+          trackId: track.id,
+          parameter: filterParameter,
+          points: [
+            { time: 0, value: 0.4 },
+            { time: useProjectStore.getState().project?.totalDuration, value: 0.4 },
+          ],
+        }),
+      ]);
+
+      useProjectStore.getState().removeTrackEffect(track.id, effectId!);
+      expect(useProjectStore.getState().project?.automationLanes).toEqual([]);
+    });
   });
 
   describe('quantizeMidiNotes', () => {


### PR DESCRIPTION
## Summary
- expand automation targets to support per-effect parameters with stable effect IDs
- add right-click "Show Automation Lane" support on effect knobs and sliders, plus labeled effect lanes in the timeline
- route effect automation through the playback engine and clean up orphaned lanes when effects are removed
- add regression coverage for automation target identity, effect-lane store behavior, and playback routing

## Verification
- ./node_modules/.bin/tsc --noEmit
- npm test
- ./node_modules/.bin/vitest run tests/unit/
- npm run build
