### PR TITLE
feat: add track presets for reusable track settings (closes #220)

### DIFF
--- a/src/components/dialogs/InstrumentPicker.tsx
+++ b/src/components/dialogs/InstrumentPicker.tsx
@@ -11,6 +11,7 @@ export function InstrumentPicker() {
   const show = useUIStore((s) => s.showInstrumentPicker);
   const setShow = useUIStore((s) => s.setShowInstrumentPicker);
   const addTrack = useProjectStore((s) => s.addTrack);
+  const applyTrackPreset = useProjectStore((s) => s.applyTrackPreset);
   const project = useProjectStore((s) => s.project);
   const { openFilePicker } = useAudioImport();
 
@@ -37,6 +38,11 @@ export function InstrumentPicker() {
 
   const handleInstrumentSelect = (name: TrackName) => {
     addTrack(name, selectedType);
+    close();
+  };
+
+  const handlePresetSelect = (presetId: string) => {
+    applyTrackPreset(presetId);
     close();
   };
 
@@ -68,30 +74,73 @@ export function InstrumentPicker() {
         </div>
 
         {step === 'type' && (
-          <div className="p-4 grid grid-cols-2 gap-3">
-            {typeOrder.map((type) => {
-              const info = TRACK_TYPE_CATALOG[type];
-              return (
-                <button
-                  key={type}
-                  onClick={() => handleTypeSelect(type)}
-                  className="flex flex-col gap-1.5 p-3 rounded-lg text-left transition-colors relative bg-daw-surface-2 hover:bg-[#484848]"
-                  style={{ borderLeft: `3px solid ${info.color}` }}
-                >
-                  <div className="flex items-center gap-2">
-                    <span className="text-xl">{info.emoji}</span>
-                    <span className="text-sm font-medium">{info.label}</span>
-                    <span
-                      className="ml-auto text-[9px] font-bold px-1.5 py-0.5 rounded"
-                      style={{ backgroundColor: info.color + '30', color: info.color }}
-                    >
-                      {info.abbr}
-                    </span>
-                  </div>
-                  <span className="text-[11px] text-zinc-400 leading-tight">{info.description}</span>
-                </button>
-              );
-            })}
+          <div className="p-4 space-y-4">
+            {(project.trackPresets ?? []).length > 0 && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Track Presets</h3>
+                  <span className="text-[10px] text-zinc-600">Apply to new tracks</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {(project.trackPresets ?? []).map((preset) => {
+                    const typeInfo = TRACK_TYPE_CATALOG[preset.trackType];
+                    const trackInfo = TRACK_CATALOG[preset.trackName];
+
+                    return (
+                      <button
+                        key={preset.id}
+                        onClick={() => handlePresetSelect(preset.id)}
+                        aria-label={`Apply track preset ${preset.name}`}
+                        className="flex flex-col gap-1.5 p-3 rounded-lg text-left transition-colors bg-[#262626] hover:bg-[#343434] border border-white/6"
+                        style={{ borderLeft: `3px solid ${preset.settings.color || typeInfo.color}` }}
+                      >
+                        <div className="flex items-center gap-2">
+                          <span className="text-lg">{trackInfo.emoji}</span>
+                          <span className="text-sm font-medium text-zinc-100 truncate">{preset.name}</span>
+                        </div>
+                        <div className="flex items-center gap-1.5 text-[10px] text-zinc-500">
+                          <span>{typeInfo.label}</span>
+                          <span>•</span>
+                          <span>{trackInfo.displayName}</span>
+                          {preset.effects.length > 0 && (
+                            <>
+                              <span>•</span>
+                              <span>{preset.effects.length} FX</span>
+                            </>
+                          )}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-3">
+              {typeOrder.map((type) => {
+                const info = TRACK_TYPE_CATALOG[type];
+                return (
+                  <button
+                    key={type}
+                    onClick={() => handleTypeSelect(type)}
+                    className="flex flex-col gap-1.5 p-3 rounded-lg text-left transition-colors relative bg-daw-surface-2 hover:bg-[#484848]"
+                    style={{ borderLeft: `3px solid ${info.color}` }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-xl">{info.emoji}</span>
+                      <span className="text-sm font-medium">{info.label}</span>
+                      <span
+                        className="ml-auto text-[9px] font-bold px-1.5 py-0.5 rounded"
+                        style={{ backgroundColor: info.color + '30', color: info.color }}
+                      >
+                        {info.abbr}
+                      </span>
+                    </div>
+                    <span className="text-[11px] text-zinc-400 leading-tight">{info.description}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         )}
 

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -31,6 +31,7 @@ export function TrackHeader({
   const renameTrack = useProjectStore((s) => s.renameTrack);
   const removeTrack = useProjectStore((s) => s.removeTrack);
   const duplicateTrack = useProjectStore((s) => s.duplicateTrack);
+  const saveTrackPreset = useProjectStore((s) => s.saveTrackPreset);
   const setTrackHeightPreset = useProjectStore((s) => s.setTrackHeightPreset);
   const setAllTracksHeightPreset = useProjectStore((s) => s.setAllTracksHeightPreset);
   const setInputMonitoring = useProjectStore((s) => s.setInputMonitoring);
@@ -133,6 +134,14 @@ export function TrackHeader({
     e.stopPropagation();
     setCtxMenu({ x: e.clientX, y: e.clientY });
   }, []);
+
+  const handleSavePreset = useCallback(() => {
+    const presetName = window.prompt('Preset name', `${track.displayName} Preset`);
+    if (!presetName) return;
+    const trimmedName = presetName.trim();
+    if (!trimmedName) return;
+    saveTrackPreset(track.id, trimmedName);
+  }, [saveTrackPreset, track.displayName, track.id]);
 
   return (
     <>
@@ -421,6 +430,12 @@ export function TrackHeader({
             className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
           >
             Track Settings...
+          </button>
+          <button
+            onClick={() => { setCtxMenu(null); handleSavePreset(); }}
+            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
+          >
+            Save as Track Preset...
           </button>
           {/* Track Height submenu */}
           <div

--- a/src/store/__tests__/projectStore.test.ts
+++ b/src/store/__tests__/projectStore.test.ts
@@ -150,6 +150,130 @@ describe('projectStore', () => {
     });
   });
 
+  describe('track presets', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject();
+    });
+
+    it('saves track type, effects, and settings as a reusable preset', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('keyboard', 'pianoRoll');
+
+      store.updateTrack(track.id, { color: '#112233', volume: 0.42, synthPreset: 'pad' });
+      store.updateTrackMixer(track.id, {
+        pan: -0.35,
+        eqLowGain: 3,
+        eqMidGain: -2,
+        eqHighGain: 5,
+        compressorEnabled: true,
+        compressorThreshold: -18,
+        compressorRatio: 6,
+      });
+      store.setTrackLocalCaption(track.id, 'Warm pad stack');
+      store.setTrackReverb(track.id, 0.33, 0.72);
+
+      const effectId = store.addTrackEffect(track.id, 'reverb');
+      expect(effectId).toBeDefined();
+      store.updateTrackEffect(track.id, effectId!, {
+        enabled: false,
+        params: { decay: 8.4, preDelay: 0.2, wet: 0.61 },
+      });
+
+      const midiEffectId = store.addMidiEffect(track.id, 'arpeggiator');
+      expect(midiEffectId).toBeDefined();
+      store.updateMidiEffect(track.id, midiEffectId!, {
+        params: { rate: '1/16', pattern: 'up-down', octaves: 2 },
+      });
+
+      const preset = store.saveTrackPreset(track.id, 'Dream Keys');
+
+      expect(preset.name).toBe('Dream Keys');
+      expect(preset.trackName).toBe('keyboard');
+      expect(preset.trackType).toBe('pianoRoll');
+      expect(preset.settings).toMatchObject({
+        color: '#112233',
+        volume: 0.42,
+        synthPreset: 'pad',
+        pan: -0.35,
+        eqLowGain: 3,
+        eqMidGain: -2,
+        eqHighGain: 5,
+        compressorEnabled: true,
+        compressorThreshold: -18,
+        compressorRatio: 6,
+        reverbMix: 0.33,
+        reverbRoomSize: 0.72,
+        localCaption: 'Warm pad stack',
+      });
+      expect(preset.effects).toHaveLength(1);
+      expect(preset.effects[0]).toMatchObject({
+        type: 'reverb',
+        enabled: false,
+        params: { decay: 8.4, preDelay: 0.2, wet: 0.61 },
+      });
+      expect(preset.midiEffects).toHaveLength(1);
+      expect(preset.midiEffects[0]).toMatchObject({
+        type: 'arpeggiator',
+        enabled: true,
+        params: { rate: '1/16', pattern: 'up-down', octaves: 2 },
+      });
+      expect(useProjectStore.getState().project!.trackPresets).toHaveLength(1);
+    });
+
+    it('applies a track preset to a new track with fresh ids and no clips', () => {
+      const store = useProjectStore.getState();
+      const sourceTrack = store.addTrack('drums', 'sequencer');
+
+      store.updateTrack(sourceTrack.id, { color: '#445566', volume: 0.55, drumKit: 'lofi' });
+      store.updateTrackMixer(sourceTrack.id, {
+        pan: 0.2,
+        eqLowGain: 4,
+        compressorEnabled: true,
+        compressorThreshold: -12,
+        compressorRatio: 8,
+      });
+      const effectId = store.addTrackEffect(sourceTrack.id, 'compressor');
+      expect(effectId).toBeDefined();
+      store.updateTrackEffect(sourceTrack.id, effectId!, {
+        params: {
+          threshold: -10,
+          ratio: 10,
+          attack: 0.02,
+          release: 0.15,
+          knee: 4,
+          sidechainSourceTrackId: undefined,
+        },
+      });
+      const midiEffectId = store.addMidiEffect(sourceTrack.id, 'scale-lock');
+      expect(midiEffectId).toBeDefined();
+
+      const preset = store.saveTrackPreset(sourceTrack.id, 'Dusty Drums');
+      const appliedTrack = useProjectStore.getState().applyTrackPreset(preset.id);
+
+      expect(appliedTrack).toBeDefined();
+      expect(appliedTrack!.id).not.toBe(sourceTrack.id);
+      expect(appliedTrack!.trackName).toBe('drums');
+      expect(appliedTrack!.trackType).toBe('sequencer');
+      expect(appliedTrack!.displayName).not.toBe(sourceTrack.displayName);
+      expect(appliedTrack!.clips).toEqual([]);
+      expect(appliedTrack!.color).toBe('#445566');
+      expect(appliedTrack!.volume).toBe(0.55);
+      expect(appliedTrack!.drumKit).toBe('lofi');
+      expect(appliedTrack!.pan).toBe(0.2);
+      expect(appliedTrack!.eqLowGain).toBe(4);
+      expect(appliedTrack!.compressorEnabled).toBe(true);
+      expect(appliedTrack!.compressorThreshold).toBe(-12);
+      expect(appliedTrack!.compressorRatio).toBe(8);
+      expect(appliedTrack!.effects).toHaveLength(1);
+      expect(appliedTrack!.effects?.[0].type).toBe('compressor');
+      expect(appliedTrack!.effects?.[0].id).not.toBe(effectId);
+      expect(appliedTrack!.midiEffects).toHaveLength(1);
+      expect(appliedTrack!.midiEffects?.[0].id).not.toBe(midiEffectId);
+      expect(appliedTrack!.sequencerPattern).toBeDefined();
+      expect(appliedTrack!.sequencerPattern?.id).not.toBe(sourceTrack.sequencerPattern?.id);
+    });
+  });
+
   describe('renameTrack', () => {
     beforeEach(() => {
       useProjectStore.getState().createProject();

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -26,6 +26,8 @@ import type {
   AutomationPoint,
   AutomationLane,
   ReturnTrack,
+  TrackPreset,
+  TrackPresetSettings,
   Take,
   Marker,
   TempoEvent,
@@ -119,6 +121,9 @@ interface ProjectState {
   removeTrack: (trackId: string) => void;
   duplicateTrack: (trackId: string) => Track | undefined;
   updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'armed' | 'laneHeight' | 'trackType' | 'synthPreset' | 'drumKit' | 'color'>>) => void;
+  saveTrackPreset: (trackId: string, presetName: string) => TrackPreset;
+  applyTrackPreset: (presetId: string) => Track | undefined;
+  deleteTrackPreset: (presetId: string) => void;
   renameTrack: (trackId: string, newName: string) => void;
   setInputMonitoring: (trackId: string, mode: InputMonitoringMode) => void;
   setTrackHeightPreset: (trackId: string, preset: TrackHeightPreset) => void;
@@ -334,18 +339,172 @@ function createDefaultMidiEffect(type: MidiEffectType): MidiEffect {
   }
 }
 
-function ensureTrackDefaults(track: Track): Track {
-  const defaultSynthPreset =
-    track.trackName === 'bass' ? 'bass'
-      : track.trackName === 'strings' ? 'strings'
-        : track.trackName === 'synth' ? 'lead'
-          : track.trackName === 'keyboard' ? 'organ'
-            : 'piano';
+function cloneTrackEffectsForPreset(effects: TrackEffect[] | undefined): TrackEffect[] {
+  return (effects ?? []).map((effect) => {
+    if (effect.type !== 'compressor') {
+      return structuredClone(effect);
+    }
+
+    const params = { ...effect.params };
+    delete params.sidechainSourceTrackId;
+    return { ...effect, params };
+  });
+}
+
+function cloneTrackEffectsWithNewIds(effects: TrackEffect[] | undefined): TrackEffect[] {
+  return cloneTrackEffectsForPreset(effects).map((effect) => ({
+    ...effect,
+    id: uuidv4(),
+  }));
+}
+
+function cloneMidiEffectsWithNewIds(effects: MidiEffect[] | undefined): MidiEffect[] {
+  return (effects ?? []).map((effect) => ({
+    ...structuredClone(effect),
+    id: uuidv4(),
+  }));
+}
+
+function createDefaultSequencerPattern(): SequencerPattern {
+  const stepsPerBar = 16;
+  const bars = 1;
+  const totalSteps = stepsPerBar * bars;
 
   return {
+    id: uuidv4(),
+    name: 'Pattern 1',
+    rows: DEFAULT_DRUM_KIT.map((kit) => ({
+      id: uuidv4(),
+      name: kit.name,
+      sampleKey: kit.id,
+      steps: Array.from({ length: totalSteps }, () => ({ active: false, velocity: 0.8 })),
+      volume: 0.8,
+      pan: 0,
+      muted: false,
+      color: kit.color,
+    })),
+    stepsPerBar,
+    bars,
+    swing: 0,
+  };
+}
+
+function getDefaultTrackSynthPreset(trackName: TrackName): Track['synthPreset'] {
+  return trackName === 'bass' ? 'bass'
+    : trackName === 'strings' ? 'strings'
+      : trackName === 'synth' ? 'lead'
+        : trackName === 'keyboard' ? 'organ'
+          : 'piano';
+}
+
+function buildTrackDisplayName(existingTracks: Track[], trackName: TrackName): string {
+  const info = TRACK_CATALOG[trackName] ?? TRACK_CATALOG.custom;
+  const sameNameCount = existingTracks.filter((track) => track.trackName === trackName).length;
+  return sameNameCount === 0 ? info.displayName : `${info.displayName} ${sameNameCount + 1}`;
+}
+
+function createTrackFromTemplate(
+  existingTracks: Track[],
+  trackName: TrackName,
+  trackType: TrackType,
+  overrides?: Partial<Track>,
+): Track {
+  const info = TRACK_CATALOG[trackName] ?? TRACK_CATALOG.custom;
+  const existingOrders = existingTracks.map((track) => track.order);
+  const maxOrder = existingOrders.length > 0 ? Math.max(...existingOrders) : 0;
+  const displayName = buildTrackDisplayName(existingTracks, trackName);
+  const {
+    id: _ignoredId,
+    trackType: _ignoredTrackType,
+    trackName: _ignoredTrackName,
+    displayName: _ignoredDisplayName,
+    order: _ignoredOrder,
+    muted: _ignoredMuted,
+    soloed: _ignoredSoloed,
+    clips: _ignoredClips,
+    effects: presetEffects,
+    midiEffects: presetMidiEffects,
+    sequencerPattern: presetSequencerPattern,
+    ...trackOverrides
+  } = overrides ?? {};
+
+  const track: Track = {
+    color: info.color,
+    volume: 0.8,
+    laneHeight: trackType === 'sequencer' ? 80 : trackType === 'pianoRoll' ? 88 : undefined,
+    synthPreset: getDefaultTrackSynthPreset(trackName),
+    drumKit: trackName === 'drums' || trackType === 'sequencer' ? '808' : undefined,
+    ...trackOverrides,
+    id: uuidv4(),
+    trackType,
+    trackName,
+    displayName,
+    order: maxOrder + 1,
+    muted: false,
+    soloed: false,
+    clips: [],
+    effects: cloneTrackEffectsWithNewIds(presetEffects),
+    midiEffects: cloneMidiEffectsWithNewIds(presetMidiEffects),
+  };
+
+  if (track.trackType === 'sequencer') {
+    track.sequencerPattern = presetSequencerPattern
+      ? {
+          ...structuredClone(presetSequencerPattern),
+          id: uuidv4(),
+          rows: presetSequencerPattern.rows.map((row) => ({
+            ...structuredClone(row),
+            id: uuidv4(),
+          })),
+        }
+      : createDefaultSequencerPattern();
+  } else {
+    delete track.sequencerPattern;
+  }
+
+  return track;
+}
+
+function createTrackPresetSnapshot(track: Track, name: string): TrackPreset {
+  const settings: TrackPresetSettings = {
+    color: track.color,
+    volume: track.volume,
+    laneHeight: track.laneHeight,
+    synthPreset: track.synthPreset,
+    drumKit: track.drumKit,
+    pan: track.pan,
+    panMode: track.panMode,
+    panLeft: track.panLeft,
+    panRight: track.panRight,
+    eqLowGain: track.eqLowGain,
+    eqMidGain: track.eqMidGain,
+    eqHighGain: track.eqHighGain,
+    compressorEnabled: track.compressorEnabled,
+    compressorThreshold: track.compressorThreshold,
+    compressorRatio: track.compressorRatio,
+    reverbMix: track.reverbMix,
+    reverbRoomSize: track.reverbRoomSize,
+    localCaption: track.localCaption,
+  };
+
+  return {
+    id: uuidv4(),
+    name,
+    trackName: track.trackName,
+    trackType: track.trackType ?? (track.trackName === 'custom' ? 'sample' : 'stems'),
+    settings,
+    effects: cloneTrackEffectsForPreset(track.effects),
+    midiEffects: structuredClone(track.midiEffects ?? []),
+    createdAt: Date.now(),
+  };
+}
+
+function ensureTrackDefaults(track: Track): Track {
+  return {
     ...track,
-    synthPreset: track.synthPreset ?? defaultSynthPreset,
+    synthPreset: track.synthPreset ?? getDefaultTrackSynthPreset(track.trackName),
     effects: track.effects ?? [],
+    midiEffects: track.midiEffects ?? [],
     drumKit: track.drumKit ?? '808',
     clips: track.clips.map((clip) => ({
       ...clip,
@@ -370,6 +529,7 @@ export const useProjectStore = create<ProjectState>()(
     // Migration: backfill trackType for projects created before the field existed
     const migrated: Project = {
       ...project,
+      trackPresets: project.trackPresets ?? [],
       tracks: project.tracks.map((t) => {
         if (t.trackType) return t;
         const inferred: TrackType =
@@ -424,6 +584,7 @@ export const useProjectStore = create<ProjectState>()(
       totalDuration: measures * getBarDurationSec(bpm, timeSig),
       measures,
       tracks: [],
+      trackPresets: [],
       generationDefaults: { ...DEFAULT_GENERATION },
       globalCaption: '',
     };
@@ -601,58 +762,7 @@ export const useProjectStore = create<ProjectState>()(
     _pushHistory(state.project);
 
     const resolvedType: TrackType = trackType ?? (trackName === 'custom' ? 'sample' : 'stems');
-    const info = TRACK_CATALOG[trackName] ?? TRACK_CATALOG['custom'];
-    const existingOrders = state.project.tracks.map((t) => t.order);
-    const maxOrder = existingOrders.length > 0 ? Math.max(...existingOrders) : 0;
-
-    const sameNameCount = state.project.tracks.filter((t) => t.trackName === trackName).length;
-    const displayName = sameNameCount === 0 ? info.displayName : `${info.displayName} ${sameNameCount + 1}`;
-
-    const track: Track = {
-      id: uuidv4(),
-      trackType: resolvedType,
-      trackName,
-      displayName,
-      color: info.color,
-      order: maxOrder + 1,
-      volume: 0.8,
-      muted: false,
-      soloed: false,
-      clips: [],
-      laneHeight: resolvedType === 'sequencer' ? 80 : resolvedType === 'pianoRoll' ? 88 : undefined,
-      synthPreset:
-        trackName === 'bass' ? 'bass'
-          : trackName === 'strings' ? 'strings'
-            : trackName === 'synth' ? 'lead'
-              : trackName === 'keyboard' ? 'organ'
-                : 'piano',
-      effects: [],
-      drumKit: trackName === 'drums' || resolvedType === 'sequencer' ? '808' : undefined,
-    };
-
-    // Auto-initialize sequencer pattern for sequencer tracks
-    if (resolvedType === 'sequencer') {
-      const stepsPerBar = 16;
-      const bars = 1;
-      const totalSteps = stepsPerBar * bars;
-      track.sequencerPattern = {
-        id: uuidv4(),
-        name: 'Pattern 1',
-        rows: DEFAULT_DRUM_KIT.map((kit) => ({
-          id: uuidv4(),
-          name: kit.name,
-          sampleKey: kit.id,
-          steps: Array.from({ length: totalSteps }, () => ({ active: false, velocity: 0.8 })),
-          volume: 0.8,
-          pan: 0,
-          muted: false,
-          color: kit.color,
-        })),
-        stepsPerBar,
-        bars,
-        swing: 0,
-      };
-    }
+    const track = createTrackFromTemplate(state.project.tracks, trackName, resolvedType);
 
     const newTracks = [...state.project.tracks, track];
     set({
@@ -665,6 +775,70 @@ export const useProjectStore = create<ProjectState>()(
     });
 
     return track;
+  },
+
+  saveTrackPreset: (trackId, presetName) => {
+    const state = get();
+    if (!state.project) throw new Error('No project');
+    const track = state.project.tracks.find((candidate) => candidate.id === trackId);
+    if (!track) throw new Error(`Track '${trackId}' not found`);
+
+    const trimmedName = presetName.trim();
+    if (!trimmedName) throw new Error('Preset name is required');
+
+    const preset = createTrackPresetSnapshot(track, trimmedName);
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        trackPresets: [...(state.project.trackPresets ?? []), preset],
+      },
+    });
+    return preset;
+  },
+
+  applyTrackPreset: (presetId) => {
+    const state = get();
+    if (!state.project) return undefined;
+    const preset = (state.project.trackPresets ?? []).find((candidate) => candidate.id === presetId);
+    if (!preset) return undefined;
+
+    _pushHistory(state.project);
+    const track = createTrackFromTemplate(
+      state.project.tracks,
+      preset.trackName,
+      preset.trackType,
+      {
+        ...preset.settings,
+        effects: preset.effects,
+        midiEffects: preset.midiEffects,
+      },
+    );
+
+    const newTracks = [...state.project.tracks, track];
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        tracks: newTracks,
+      },
+    });
+    return track;
+  },
+
+  deleteTrackPreset: (presetId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        trackPresets: (state.project.trackPresets ?? []).filter((preset) => preset.id !== presetId),
+      },
+    });
   },
 
   removeTrack: (trackId) => {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -245,6 +245,38 @@ export interface ReturnTrack {
   pan: number;     // -1 (full left) to +1 (full right)
 }
 
+export interface TrackPresetSettings {
+  color: string;
+  volume: number;
+  laneHeight?: number;
+  synthPreset?: SynthPreset;
+  drumKit?: DrumKitName;
+  pan?: number;
+  panMode?: 'stereo' | 'dual-mono';
+  panLeft?: number;
+  panRight?: number;
+  eqLowGain?: number;
+  eqMidGain?: number;
+  eqHighGain?: number;
+  compressorEnabled?: boolean;
+  compressorThreshold?: number;
+  compressorRatio?: number;
+  reverbMix?: number;
+  reverbRoomSize?: number;
+  localCaption?: string;
+}
+
+export interface TrackPreset {
+  id: string;
+  name: string;
+  trackName: TrackName;
+  trackType: TrackType;
+  settings: TrackPresetSettings;
+  effects: TrackEffect[];
+  midiEffects: MidiEffect[];
+  createdAt: number;
+}
+
 export interface Track {
   id: string;
   trackType?: TrackType;
@@ -349,6 +381,8 @@ export interface Project {
   automationLanes?: AutomationLane[];
   /** Shared effect return tracks (mixer buses). */
   returnTracks?: ReturnTrack[];
+  /** Reusable track templates saved from existing tracks. */
+  trackPresets?: TrackPreset[];
   /** Timeline markers (sorted by time). */
   markers?: Marker[];
   /** Tempo map: discrete tempo changes sorted by beat. Empty = use project.bpm everywhere. */

--- a/tests/e2e/track-presets.spec.ts
+++ b/tests/e2e/track-presets.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Track Presets', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
+  });
+
+  test('can save a track preset and apply it to a new track via the browser store API', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const store = (window as any).__store;
+      store.getState().createProject({ name: 'Track Preset E2E' });
+
+      const sourceTrack = store.getState().addTrack('keyboard', 'pianoRoll');
+      store.getState().updateTrack(sourceTrack.id, { color: '#123456', synthPreset: 'pad' });
+      store.getState().updateTrackMixer(sourceTrack.id, { pan: -0.25, eqHighGain: 4 });
+      store.getState().addTrackEffect(sourceTrack.id, 'reverb');
+
+      const preset = store.getState().saveTrackPreset(sourceTrack.id, 'Dream Keys');
+      const appliedTrack = store.getState().applyTrackPreset(preset.id);
+
+      return {
+        presetCount: store.getState().project?.trackPresets?.length ?? 0,
+        trackCount: store.getState().project?.tracks?.length ?? 0,
+        appliedTrack: appliedTrack
+          ? {
+              trackType: appliedTrack.trackType,
+              synthPreset: appliedTrack.synthPreset,
+              color: appliedTrack.color,
+              pan: appliedTrack.pan,
+              eqHighGain: appliedTrack.eqHighGain,
+              effectTypes: (appliedTrack.effects ?? []).map((effect: { type: string }) => effect.type),
+            }
+          : null,
+      };
+    });
+
+    expect(result).toEqual({
+      presetCount: 1,
+      trackCount: 2,
+      appliedTrack: {
+        trackType: 'pianoRoll',
+        synthPreset: 'pad',
+        color: '#123456',
+        pan: -0.25,
+        eqHighGain: 4,
+        effectTypes: ['reverb'],
+      },
+    });
+  });
+});

--- a/tests/unit/projectStore.test.ts
+++ b/tests/unit/projectStore.test.ts
@@ -18,6 +18,7 @@ function makeProject(): Project {
     totalDuration: 128,
     measures: 64,
     tracks: [],
+    trackPresets: [],
     generationDefaults: {
       inferenceSteps: 20,
       guidanceScale: 7.5,

--- a/tests/unit/trackPresets.test.tsx
+++ b/tests/unit/trackPresets.test.tsx
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { InstrumentPicker } from '../../src/components/dialogs/InstrumentPicker';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useUIStore } from '../../src/store/uiStore';
+
+vi.mock('../../src/hooks/useAudioImport', () => ({
+  useAudioImport: () => ({
+    openFilePicker: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('InstrumentPicker track presets', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState({ project: null });
+    useUIStore.setState({
+      showInstrumentPicker: true,
+    });
+
+    const store = useProjectStore.getState();
+    store.createProject({ name: 'Preset Test Project' });
+    const track = store.addTrack('keyboard', 'pianoRoll');
+    store.updateTrack(track.id, { synthPreset: 'pad', color: '#123456' });
+    store.saveTrackPreset(track.id, 'Dream Keys');
+  });
+
+  it('shows saved presets and applies them as new tracks', () => {
+    render(<InstrumentPicker />);
+
+    expect(screen.getByText('Track Presets')).toBeInTheDocument();
+    const presetButton = screen.getByRole('button', { name: /dream keys/i });
+    fireEvent.click(presetButton);
+
+    const project = useProjectStore.getState().project;
+    expect(project?.tracks).toHaveLength(2);
+
+    const appliedTrack = project?.tracks.at(-1);
+    expect(appliedTrack?.trackType).toBe('pianoRoll');
+    expect(appliedTrack?.synthPreset).toBe('pad');
+    expect(appliedTrack?.color).toBe('#123456');
+    expect(useUIStore.getState().showInstrumentPicker).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add project-level track preset types and Zustand actions to save, apply, and delete reusable track templates
- surface saved presets in the add-track picker and add a track-header action to save the current track as a preset
- add store, unit, and Playwright browser coverage for preset save/apply flows

## Verification
- npx tsc --noEmit
- npx vitest run tests/unit/
- npm test
- npm run build
- npx playwright test tests/e2e/track-presets.spec.ts