### PR TITLE
feat: AI stem separation workflow (closes #230)

### DIFF
--- a/src/components/generation/StemSeparationModal.tsx
+++ b/src/components/generation/StemSeparationModal.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import { useGenerationStore } from '../../store/generationStore';
+import type { StemCount } from '../../types/api';
+
+const STEM_OPTIONS: Array<{
+  count: StemCount;
+  title: string;
+  detail: string;
+}> = [
+  { count: 2, title: '2-Stem', detail: 'Vocals + Instrumental' },
+  { count: 4, title: '4-Stem', detail: 'Vocals + Drums + Bass + Other' },
+  { count: 6, title: '6-Stem', detail: 'Vocals + Drums + Bass + Guitar + Piano + Other' },
+];
+
+function parseProgressPercent(progress: string | undefined): number | null {
+  if (!progress) return null;
+  const match = progress.match(/(\d{1,3})%/);
+  if (!match) return null;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : null;
+}
+
+export function StemSeparationModal() {
+  const stemSeparationClipId = useUIStore((state) => state.stemSeparationClipId);
+  const setStemSeparationModal = useUIStore((state) => state.setStemSeparationModal);
+  const separateStems = useProjectStore((state) => state.separateStems);
+  const getClipById = useProjectStore((state) => state.getClipById);
+  const project = useProjectStore((state) => state.project);
+  const isGenerating = useGenerationStore((state) => state.isGenerating);
+  const activeJob = useGenerationStore((state) => [...state.jobs].reverse().find((job) => job.clipId === stemSeparationClipId));
+
+  const clip = stemSeparationClipId ? getClipById(stemSeparationClipId) : null;
+  const track = project?.tracks.find((candidate) => candidate.clips.some((candidateClip) => candidateClip.id === stemSeparationClipId)) ?? null;
+  const [stemCount, setStemCount] = useState<StemCount>(4);
+
+  useEffect(() => {
+    setStemCount(4);
+  }, [stemSeparationClipId]);
+
+  const onClose = useCallback(() => setStemSeparationModal(null), [setStemSeparationModal]);
+
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (activeJob?.status === 'done') {
+      onClose();
+    }
+  }, [activeJob?.status, onClose]);
+
+  const hasAudio = Boolean(clip?.isolatedAudioKey || clip?.cumulativeMixKey);
+  const progressPercent = parseProgressPercent(activeJob?.progress);
+  const isBusy = activeJob?.status === 'queued' || activeJob?.status === 'generating' || activeJob?.status === 'processing';
+
+  const handleSeparate = useCallback(async () => {
+    if (!stemSeparationClipId || !hasAudio || isGenerating) return;
+    await separateStems(stemSeparationClipId, stemCount);
+  }, [stemSeparationClipId, hasAudio, isGenerating, separateStems, stemCount]);
+
+  if (!stemSeparationClipId || !clip || !track) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className="w-[520px] max-w-[calc(100vw-24px)] rounded-xl border border-daw-border bg-daw-surface shadow-2xl text-xs text-zinc-200">
+        <div className="flex items-center justify-between border-b border-daw-border px-4 py-3">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Separate Stems</h2>
+            <p className="mt-1 text-[10px] text-zinc-500">Split one audio clip into isolated remixable tracks.</p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close stem separation modal"
+            onClick={onClose}
+            className="text-base leading-none text-zinc-500 transition-colors hover:text-zinc-200"
+          >
+            x
+          </button>
+        </div>
+
+        <div className="space-y-4 px-4 py-4">
+          <div className="rounded-lg border border-[#3a3a3a] bg-[#202020] px-3 py-2.5">
+            <p className="text-[9px] uppercase tracking-[0.2em] text-zinc-500">Source Clip</p>
+            <p className="mt-1 text-[11px] font-medium text-zinc-100">{track.displayName}</p>
+            <p className="mt-0.5 truncate text-[10px] text-zinc-400">{clip.prompt || 'Imported audio clip'}</p>
+            <p className="mt-0.5 text-[10px] text-zinc-500">
+              Starts at {clip.startTime.toFixed(2)}s, duration {clip.duration.toFixed(2)}s
+            </p>
+            {!hasAudio && (
+              <p className="mt-2 text-[10px] text-amber-400">
+                This clip has no audio yet. Generate or import audio before separating stems.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-[10px] font-medium uppercase tracking-[0.2em] text-zinc-500">Stem Count</p>
+            <div className="grid gap-2 sm:grid-cols-3">
+              {STEM_OPTIONS.map((option) => {
+                const selected = option.count === stemCount;
+                return (
+                  <button
+                    key={option.count}
+                    type="button"
+                    aria-label={`Select ${option.count} stem separation`}
+                    onClick={() => setStemCount(option.count)}
+                    className={`rounded-lg border px-3 py-2 text-left transition-colors ${
+                      selected
+                        ? 'border-sky-400 bg-sky-500/10 text-white'
+                        : 'border-[#3a3a3a] bg-[#1d1d1d] text-zinc-300 hover:border-[#525252] hover:bg-[#252525]'
+                    }`}
+                  >
+                    <div className="text-[11px] font-semibold">{option.title}</div>
+                    <div className="mt-1 text-[10px] text-zinc-500">{option.detail}</div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {(isBusy || activeJob?.status === 'error') && (
+            <div className="rounded-lg border border-[#3a3a3a] bg-[#202020] px-3 py-3">
+              <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+                <span>Progress</span>
+                <span>{activeJob?.status ?? 'queued'}</span>
+              </div>
+              <div className="mt-2 h-2 overflow-hidden rounded-full bg-[#111]">
+                <div
+                  className={`h-full rounded-full transition-all ${
+                    activeJob?.status === 'error' ? 'bg-red-500' : 'bg-sky-400'
+                  } ${progressPercent === null && activeJob?.status !== 'error' ? 'animate-pulse w-1/2' : ''}`}
+                  style={progressPercent !== null ? { width: `${progressPercent}%` } : undefined}
+                />
+              </div>
+              <p className={`mt-2 text-[10px] ${activeJob?.status === 'error' ? 'text-red-300' : 'text-zinc-400'}`}>
+                {activeJob?.progress ?? 'Waiting…'}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-daw-border px-4 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-[#444] px-3 py-1.5 text-[11px] text-zinc-300 transition-colors hover:border-[#5a5a5a] hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            aria-label="Run stem separation"
+            onClick={handleSeparate}
+            disabled={!hasAudio || isGenerating}
+            className="rounded-md bg-sky-500 px-3 py-1.5 text-[11px] font-medium text-white transition-colors hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-zinc-700 disabled:text-zinc-400"
+          >
+            {isBusy ? 'Separating…' : `Separate ${stemCount} Stems`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { CoverModal } from '../generation/CoverModal';
 import { RepaintModal } from '../generation/RepaintModal';
 import { Vocal2BGMModal } from '../generation/Vocal2BGMModal';
 import { AudioAnalysisPanel } from '../generation/AudioAnalysisPanel';
+import { StemSeparationModal } from '../generation/StemSeparationModal';
 import { NewProjectDialog } from '../dialogs/NewProjectDialog';
 import { InstrumentPicker } from '../dialogs/InstrumentPicker';
 import { ExportDialog } from '../dialogs/ExportDialog';
@@ -103,6 +104,7 @@ export function AppShell() {
       <RepaintModal />
       <Vocal2BGMModal />
       <AudioAnalysisPanel />
+      <StemSeparationModal />
       <ShareDialog />
     </div>
   );

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -46,9 +46,10 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const setRepaintModal = useUIStore((s) => s.setRepaintModal);
   const setVocal2BGMModal = useUIStore((s) => s.setVocal2BGMModal);
   const setAnalysisPanel = useUIStore((s) => s.setAnalysisPanel);
+  const setStemSeparationModal = useUIStore((s) => s.setStemSeparationModal);
 
   const generatingProgress = useGenerationStore((s) => {
-    const job = s.jobs.find(
+    const job = [...s.jobs].reverse().find(
       (j) => j.clipId === clip.id && (j.status === 'generating' || j.status === 'queued' || j.status === 'processing'),
     );
     return job?.progress ?? null;
@@ -457,6 +458,10 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           onAnalyze={() => {
             closeCtxMenu();
             setAnalysisPanel(clip.id);
+          }}
+          onSeparateStems={() => {
+            closeCtxMenu();
+            setStemSeparationModal(clip.id);
           }}
           onConvertToMidi={() => {
             closeCtxMenu();

--- a/src/components/timeline/ClipContextMenu.tsx
+++ b/src/components/timeline/ClipContextMenu.tsx
@@ -12,6 +12,7 @@ interface ClipContextMenuProps {
   onRepaint: () => void;
   onVocal2BGM: () => void;
   onAnalyze: () => void;
+  onSeparateStems: () => void;
   onConvertToMidi: () => void;
   onClose: () => void;
   hasPrompt: boolean;
@@ -35,6 +36,7 @@ export function ClipContextMenu({
   onRepaint,
   onVocal2BGM,
   onAnalyze,
+  onSeparateStems,
   onConvertToMidi,
   onClose,
   hasPrompt,
@@ -78,6 +80,11 @@ export function ClipContextMenu({
             <button onClick={onRepaint} className="w-full text-left px-3 py-1.5 text-[11px] text-rose-300 hover:bg-daw-accent hover:text-white transition-colors">
               Repaint Selection…
             </button>
+            {hasAudio && (
+              <button onClick={onSeparateStems} className="w-full text-left px-3 py-1.5 text-[11px] text-sky-300 hover:bg-daw-accent hover:text-white transition-colors">
+                Separate Stems…
+              </button>
+            )}
             {isVocalTrack && (
               <button onClick={onVocal2BGM} className="w-full text-left px-3 py-1.5 text-[11px] text-emerald-300 hover:bg-daw-accent hover:text-white transition-colors">
                 Generate Accompaniment…

--- a/src/services/aceStepApi.ts
+++ b/src/services/aceStepApi.ts
@@ -2,6 +2,7 @@ import type {
   LegoTaskParams,
   CoverTaskParams,
   RepaintTaskParams,
+  StemSeparationTaskParams,
   ApiEnvelope,
   ReleaseTaskResponse,
   TaskResultEntry,
@@ -11,7 +12,11 @@ import type {
   InitModelResponse,
 } from '../types/api';
 
-export type AceStepTaskParams = LegoTaskParams | CoverTaskParams | RepaintTaskParams;
+export type AceStepTaskParams =
+  | LegoTaskParams
+  | CoverTaskParams
+  | RepaintTaskParams
+  | StemSeparationTaskParams;
 import { downsampleWavBlob } from '../utils/audioDownsample';
 
 const BACKEND_URL_KEY = 'ace-step-daw-backend-url';
@@ -118,21 +123,21 @@ export async function getStats(): Promise<StatsResponse> {
 const RELEASE_TASK_TIMEOUT_MS = 3 * 60 * 1000;
 const RELEASE_TASK_MAX_RETRIES = 3;
 
-export async function releaseLegoTask(
+async function releaseTask(
   srcAudioBlob: Blob,
   params: AceStepTaskParams,
 ): Promise<ReleaseTaskResponse> {
   const base = getApiBase();
 
-  const legoParams = params as Partial<LegoTaskParams>;
-  const usePath = Boolean(legoParams.src_audio_path);
+  const taskParams = params as Partial<LegoTaskParams>;
+  const usePath = Boolean(taskParams.src_audio_path);
 
   console.log(
-    `[aceStepApi] releaseLegoTask: ${usePath ? `src_audio_path=${legoParams.src_audio_path}` : `src_audio blob size=${srcAudioBlob.size}`}`,
+    `[aceStepApi] releaseTask: ${usePath ? `src_audio_path=${taskParams.src_audio_path}` : `src_audio blob size=${srcAudioBlob.size}`}`,
     `task_type=${params.task_type}`,
-    `audio_duration=${params.audio_duration}`,
-    `repainting_start=${legoParams.repainting_start}`,
-    `repainting_end=${legoParams.repainting_end}`,
+    'audio_duration' in params ? `audio_duration=${params.audio_duration}` : 'audio_duration=n/a',
+    'repainting_start' in taskParams ? `repainting_start=${taskParams.repainting_start}` : 'repainting_start=n/a',
+    'repainting_end' in taskParams ? `repainting_end=${taskParams.repainting_end}` : 'repainting_end=n/a',
   );
 
   // Only downsample and upload the blob when no server-side path is provided.
@@ -193,7 +198,21 @@ export async function releaseLegoTask(
     }
   }
 
-  throw lastError ?? new Error('releaseLegoTask failed after retries');
+  throw lastError ?? new Error('releaseTask failed after retries');
+}
+
+export async function releaseLegoTask(
+  srcAudioBlob: Blob,
+  params: LegoTaskParams | CoverTaskParams | RepaintTaskParams,
+): Promise<ReleaseTaskResponse> {
+  return releaseTask(srcAudioBlob, params);
+}
+
+export async function releaseStemSeparationTask(
+  srcAudioBlob: Blob,
+  params: StemSeparationTaskParams,
+): Promise<ReleaseTaskResponse> {
+  return releaseTask(srcAudioBlob, params);
 }
 
 export async function queryResult(taskIds: string[]): Promise<TaskResultEntry[]> {

--- a/src/services/stemSeparation.ts
+++ b/src/services/stemSeparation.ts
@@ -1,0 +1,236 @@
+import { v4 as uuidv4 } from 'uuid';
+import { useGenerationStore } from '../store/generationStore';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+import { toastError, toastInfo, toastSuccess } from '../hooks/useToast';
+import { computeWaveformPeaks } from '../utils/waveformPeaks';
+import { audioBufferToWavBlob } from '../utils/wav';
+import { POLL_INTERVAL_MS, MAX_POLL_DURATION_MS } from '../constants/defaults';
+import { TRACK_CATALOG } from '../constants/tracks';
+import type { StemCount } from '../types/api';
+import type { TrackName } from '../types/project';
+import * as api from './aceStepApi';
+
+export interface PreparedSeparatedStem {
+  key: string;
+  trackName: TrackName;
+  displayName: string;
+  color: string;
+  audioBlob: Blob;
+  waveformPeaks: number[];
+  audioDuration: number;
+}
+
+interface RawStemResult {
+  key: string;
+  file: string;
+}
+
+const STEM_ORDER: Record<StemCount, string[]> = {
+  2: ['vocals', 'instrumental'],
+  4: ['vocals', 'drums', 'bass', 'other'],
+  6: ['vocals', 'drums', 'bass', 'guitar', 'piano', 'other'],
+};
+
+const STEM_META: Record<string, { trackName: TrackName; displayName: string; color: string }> = {
+  vocals: {
+    trackName: 'vocals',
+    displayName: 'Vocals',
+    color: TRACK_CATALOG.vocals.color,
+  },
+  drums: {
+    trackName: 'drums',
+    displayName: 'Drums',
+    color: TRACK_CATALOG.drums.color,
+  },
+  bass: {
+    trackName: 'bass',
+    displayName: 'Bass',
+    color: TRACK_CATALOG.bass.color,
+  },
+  guitar: {
+    trackName: 'guitar',
+    displayName: 'Guitar',
+    color: TRACK_CATALOG.guitar.color,
+  },
+  piano: {
+    trackName: 'keyboard',
+    displayName: 'Piano',
+    color: '#34d399',
+  },
+  instrumental: {
+    trackName: 'custom',
+    displayName: 'Instrumental',
+    color: '#60a5fa',
+  },
+  other: {
+    trackName: 'custom',
+    displayName: 'Other',
+    color: '#94a3b8',
+  },
+};
+
+function normalizeStemKey(value: string): string {
+  return value.trim().toLowerCase().replace(/[\s-]+/g, '_');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function extractRawStemResults(payload: unknown): RawStemResult[] {
+  if (Array.isArray(payload)) {
+    return payload.flatMap((entry) => extractRawStemResults(entry));
+  }
+
+  if (!isRecord(payload)) {
+    return [];
+  }
+
+  if (Array.isArray(payload.stems)) {
+    return extractRawStemResults(payload.stems);
+  }
+
+  if (isRecord(payload.stems)) {
+    return Object.entries(payload.stems).flatMap(([key, value]) => {
+      if (typeof value === 'string') {
+        return [{ key: normalizeStemKey(key), file: value }];
+      }
+      return [];
+    });
+  }
+
+  const rawFile = payload.file ?? payload.path ?? payload.audio_path ?? payload.url;
+  const rawKey = payload.stem ?? payload.stem_name ?? payload.name ?? payload.track_name ?? payload.label;
+  if (typeof rawFile === 'string' && typeof rawKey === 'string') {
+    return [{ key: normalizeStemKey(rawKey), file: rawFile }];
+  }
+
+  return Object.entries(payload).flatMap(([key, value]) => {
+    if (typeof value === 'string') {
+      return [{ key: normalizeStemKey(key), file: value }];
+    }
+    return [];
+  });
+}
+
+function parseStemResults(result: string, stemCount: StemCount): RawStemResult[] {
+  const parsed = JSON.parse(result) as unknown;
+  const extracted = extractRawStemResults(parsed);
+  const order = STEM_ORDER[stemCount];
+
+  const uniqueByKey = new Map<string, RawStemResult>();
+  for (const item of extracted) {
+    if (!order.includes(item.key) || uniqueByKey.has(item.key)) continue;
+    uniqueByKey.set(item.key, item);
+  }
+
+  const ordered = order
+    .map((key) => uniqueByKey.get(key))
+    .filter((item): item is RawStemResult => Boolean(item));
+
+  if (ordered.length !== order.length) {
+    throw new Error(`Stem separation returned ${ordered.length}/${order.length} expected stems`);
+  }
+
+  return ordered;
+}
+
+function prepareStemLabel(stemKey: string) {
+  return STEM_META[stemKey] ?? {
+    trackName: 'custom' as TrackName,
+    displayName: stemKey.replace(/_/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase()),
+    color: TRACK_CATALOG.custom.color,
+  };
+}
+
+export async function separateClipAudioToStems(options: {
+  clipId: string;
+  sourceBlob: Blob;
+  stemCount: StemCount;
+  sourceLabel: string;
+}): Promise<PreparedSeparatedStem[]> {
+  const { clipId, sourceBlob, stemCount, sourceLabel } = options;
+  const genStore = useGenerationStore.getState();
+  if (genStore.isGenerating) {
+    throw new Error('Another generation job is already running');
+  }
+
+  const jobId = uuidv4();
+  toastInfo('Stem separation started');
+  genStore.setIsGenerating(true);
+  genStore.addJob({
+    id: jobId,
+    clipId,
+    trackName: sourceLabel,
+    status: 'queued',
+    progress: `Queued ${stemCount}-stem separation`,
+  });
+
+  try {
+    genStore.updateJob(jobId, { status: 'generating', progress: 'Submitting stem separation...' });
+    const releaseResp = await api.releaseStemSeparationTask(sourceBlob, {
+      task_type: 'stem_separation',
+      stem_count: stemCount,
+      audio_format: 'wav',
+    });
+
+    const startedAt = Date.now();
+    let rawResults: RawStemResult[] | null = null;
+
+    while (Date.now() - startedAt < MAX_POLL_DURATION_MS) {
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+      const entries = await api.queryResult([releaseResp.task_id]);
+      const entry = entries[0];
+      if (!entry) continue;
+
+      genStore.updateJob(jobId, {
+        status: entry.status === 0 ? 'generating' : 'processing',
+        progress: entry.progress_text || 'Separating stems...',
+      });
+
+      if (entry.status === 1) {
+        rawResults = parseStemResults(entry.result, stemCount);
+        break;
+      }
+
+      if (entry.status === 2) {
+        throw new Error(`Stem separation failed: ${entry.result}`);
+      }
+    }
+
+    if (!rawResults) {
+      throw new Error('Stem separation timed out');
+    }
+
+    genStore.updateJob(jobId, { status: 'processing', progress: 'Downloading stems...' });
+
+    const engine = getAudioEngine();
+    const prepared = await Promise.all(
+      rawResults.map(async ({ key, file }) => {
+        const blob = await api.downloadAudio(file);
+        const buffer = await engine.decodeAudioData(blob);
+        const label = prepareStemLabel(key);
+        return {
+          key,
+          trackName: label.trackName,
+          displayName: label.displayName,
+          color: label.color,
+          audioBlob: audioBufferToWavBlob(buffer),
+          waveformPeaks: computeWaveformPeaks(buffer, 200),
+          audioDuration: buffer.duration,
+        };
+      }),
+    );
+
+    genStore.updateJob(jobId, { status: 'done', progress: 'Done' });
+    toastSuccess('Stem separation completed');
+    return prepared;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Stem separation failed';
+    genStore.updateJob(jobId, { status: 'error', progress: message, error: message });
+    toastError(message);
+    throw error;
+  } finally {
+    useGenerationStore.getState().setIsGenerating(false);
+  }
+}

--- a/src/store/__tests__/stemSeparation.test.ts
+++ b/src/store/__tests__/stemSeparation.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+import { useGenerationStore } from '../generationStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../constants/defaults', async () => {
+  const actual = await vi.importActual<typeof import('../../constants/defaults')>('../../constants/defaults');
+  return {
+    ...actual,
+    POLL_INTERVAL_MS: 0,
+    MAX_POLL_DURATION_MS: 10,
+  };
+});
+
+const mockReleaseStemSeparationTask = vi.fn();
+const mockQueryResult = vi.fn();
+const mockDownloadAudio = vi.fn();
+
+vi.mock('../../services/aceStepApi', () => ({
+  releaseStemSeparationTask: (...args: unknown[]) => mockReleaseStemSeparationTask(...args),
+  queryResult: (...args: unknown[]) => mockQueryResult(...args),
+  downloadAudio: (...args: unknown[]) => mockDownloadAudio(...args),
+}));
+
+const mockSaveAudioBlob = vi.fn();
+const mockLoadAudioBlobByKey = vi.fn();
+
+vi.mock('../../services/audioFileManager', () => ({
+  saveAudioBlob: (...args: unknown[]) => mockSaveAudioBlob(...args),
+  loadAudioBlobByKey: (...args: unknown[]) => mockLoadAudioBlobByKey(...args),
+}));
+
+const mockComputeWaveformPeaks = vi.fn(() => [0.1, 0.2, 0.3]);
+vi.mock('../../utils/waveformPeaks', () => ({
+  computeWaveformPeaks: (...args: unknown[]) => mockComputeWaveformPeaks(...args),
+}));
+
+const mockAudioBufferToWavBlob = vi.fn(() => new Blob(['wav-data'], { type: 'audio/wav' }));
+vi.mock('../../utils/wav', () => ({
+  audioBufferToWavBlob: (...args: unknown[]) => mockAudioBufferToWavBlob(...args),
+}));
+
+const mockToastInfo = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('../../hooks/useToast', () => ({
+  toastInfo: (...args: unknown[]) => mockToastInfo(...args),
+  toastSuccess: (...args: unknown[]) => mockToastSuccess(...args),
+  toastError: (...args: unknown[]) => mockToastError(...args),
+}));
+
+function createMockAudioBuffer(duration = 8, sampleRate = 44100): AudioBuffer {
+  const length = Math.ceil(duration * sampleRate);
+  const channelData = new Float32Array(length);
+  return {
+    duration,
+    sampleRate,
+    length,
+    numberOfChannels: 2,
+    getChannelData: () => channelData,
+    copyFromChannel: vi.fn(),
+    copyToChannel: vi.fn(),
+  } as unknown as AudioBuffer;
+}
+
+const mockDecodeAudioData = vi.fn();
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    decodeAudioData: (...args: unknown[]) => mockDecodeAudioData(...args),
+  }),
+}));
+
+describe('projectStore separateStems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProjectStore.setState({ project: null });
+    const genInitial = useGenerationStore.getInitialState?.() ?? { jobs: [], isGenerating: false, promptHistory: [] };
+    useGenerationStore.setState(genInitial, true);
+    mockLoadAudioBlobByKey.mockImplementation(async (key: string) => {
+      if (key === 'source-audio-key') {
+        return new Blob(['source-audio'], { type: 'audio/wav' });
+      }
+      return undefined;
+    });
+    mockSaveAudioBlob.mockImplementation(async (_projectId: string, clipId: string) => `saved-${clipId}`);
+    mockDecodeAudioData.mockResolvedValue(createMockAudioBuffer());
+  });
+
+  function createReadySourceClip() {
+    useProjectStore.getState().createProject({ name: 'Stem Test' });
+    const track = useProjectStore.getState().addTrack('custom', 'sample');
+    const clip = useProjectStore.getState().addClip(track.id, {
+      startTime: 12,
+      duration: 8,
+      prompt: 'Imported mix',
+      lyrics: '',
+      source: 'uploaded',
+    });
+    useProjectStore.getState().updateClipStatus(clip.id, 'ready', {
+      isolatedAudioKey: 'source-audio-key',
+      waveformPeaks: [0.5, 0.25],
+      audioDuration: 8,
+      audioOffset: 0,
+      source: 'uploaded',
+    });
+    return { track, clip };
+  }
+
+  it('creates aligned sample tracks for a 4-stem separation result', async () => {
+    const { clip } = createReadySourceClip();
+
+    mockReleaseStemSeparationTask.mockResolvedValue({ task_id: 'stem-job', status: 'queued' });
+    mockQueryResult.mockResolvedValue([{
+      task_id: 'stem-job',
+      status: 1,
+      result: JSON.stringify([
+        { stem: 'vocals', file: '/vocals.wav' },
+        { stem: 'drums', file: '/drums.wav' },
+        { stem: 'bass', file: '/bass.wav' },
+        { stem: 'other', file: '/other.wav' },
+      ]),
+      progress_text: '100%',
+    }]);
+    mockDownloadAudio.mockImplementation(async (path: string) => new Blob([path], { type: 'audio/wav' }));
+
+    const newTracks = await useProjectStore.getState().separateStems(clip.id, 4);
+
+    expect(newTracks).toHaveLength(4);
+    expect(newTracks?.map((track) => track.displayName)).toEqual(['Vocals', 'Drums', 'Bass', 'Other']);
+    expect(newTracks?.every((track) => track.trackType === 'sample')).toBe(true);
+
+    const clips = newTracks?.map((track) => track.clips[0]) ?? [];
+    expect(clips.every((createdClip) => createdClip.startTime === 12)).toBe(true);
+    expect(clips.every((createdClip) => createdClip.duration === 8)).toBe(true);
+    expect(clips.every((createdClip) => createdClip.generationStatus === 'ready')).toBe(true);
+    expect(clips.every((createdClip) => createdClip.source === 'uploaded')).toBe(true);
+
+    const project = useProjectStore.getState().project!;
+    expect(project.tracks).toHaveLength(5);
+    expect(project.assets?.slice(-4).map((asset) => asset.trackDisplayName)).toEqual(['Vocals', 'Drums', 'Bass', 'Other']);
+    expect(mockSaveAudioBlob).toHaveBeenCalledTimes(4);
+    expect(useGenerationStore.getState().jobs[0]?.status).toBe('done');
+    expect(mockToastSuccess).toHaveBeenCalledWith('Stem separation completed');
+  });
+
+  it('supports 6-stem object payloads and maps piano to a keyboard sample track', async () => {
+    const { clip } = createReadySourceClip();
+
+    mockReleaseStemSeparationTask.mockResolvedValue({ task_id: 'stem-job', status: 'queued' });
+    mockQueryResult.mockResolvedValue([{
+      task_id: 'stem-job',
+      status: 1,
+      result: JSON.stringify({
+        stems: {
+          vocals: '/vocals.wav',
+          drums: '/drums.wav',
+          bass: '/bass.wav',
+          guitar: '/guitar.wav',
+          piano: '/piano.wav',
+          other: '/other.wav',
+        },
+      }),
+      progress_text: 'done',
+    }]);
+    mockDownloadAudio.mockImplementation(async (path: string) => new Blob([path], { type: 'audio/wav' }));
+
+    const newTracks = await useProjectStore.getState().separateStems(clip.id, 6);
+
+    expect(newTracks?.map((track) => `${track.displayName}:${track.trackName}`)).toEqual([
+      'Vocals:vocals',
+      'Drums:drums',
+      'Bass:bass',
+      'Guitar:guitar',
+      'Piano:keyboard',
+      'Other:custom',
+    ]);
+  });
+
+  it('surfaces errors without mutating project tracks', async () => {
+    const { clip } = createReadySourceClip();
+
+    mockReleaseStemSeparationTask.mockResolvedValue({ task_id: 'stem-job', status: 'queued' });
+    mockQueryResult.mockResolvedValue([{
+      task_id: 'stem-job',
+      status: 2,
+      result: 'backend error',
+      progress_text: 'failed',
+    }]);
+
+    await expect(useProjectStore.getState().separateStems(clip.id, 4)).rejects.toThrow('Stem separation failed: backend error');
+
+    expect(useProjectStore.getState().project?.tracks).toHaveLength(1);
+    expect(useGenerationStore.getState().jobs[0]?.status).toBe('error');
+    expect(mockToastError).toHaveBeenCalled();
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -60,11 +60,13 @@ import {
 import { saveProject as saveProjectToIDB } from '../services/projectStorage';
 import { exportStemToWav, type ExportClip } from '../engine/exportMix';
 import { applyTransform, type TransformOptions } from '../utils/midiTransforms';
-import { loadAudioBlobByKey } from '../services/audioFileManager';
+import { loadAudioBlobByKey, saveAudioBlob } from '../services/audioFileManager';
 import { getAudioEngine } from '../hooks/useAudioEngine';
 import { renderMidiTrackOffline, renderSequencerTrackOffline } from '../engine/offlineRender';
 import { convertClipAudioToMidi } from '../services/audioToMidi';
 import { createDefaultParametricEqBands } from '../utils/parametricEq';
+import type { StemCount } from '../types/api';
+import { separateClipAudioToStems } from '../services/stemSeparation';
 import { beatToTime, getBeatAtBar } from '../utils/tempoMap';
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
@@ -275,6 +277,7 @@ interface ProjectState {
 
   /** Convert an audio clip to MIDI, creating a new piano roll track with detected notes. */
   convertAudioToMidi: (clipId: string, options?: { threshold?: number; minConfidence?: number; minNoteDuration?: number }) => Promise<{ trackId: string; clipId: string } | undefined>;
+  separateStems: (clipId: string, stemCount: StemCount) => Promise<Track[] | undefined>;
 
   /** Export each track as a separate WAV file (stem export). */
   exportStems: () => Promise<void>;
@@ -3203,6 +3206,117 @@ export const useProjectStore = create<ProjectState>()(
       }
     }
     return Math.max(MIN_TIMELINE_DURATION, maxEnd);
+  },
+
+  separateStems: async (clipId, stemCount) => {
+    const state = get();
+    const project = state.project;
+    if (!project) return undefined;
+
+    const sourceTrack = project.tracks.find((track) => track.clips.some((clip) => clip.id === clipId));
+    if (!sourceTrack) {
+      throw new Error(`Track for clip '${clipId}' not found`);
+    }
+
+    const sourceClip = sourceTrack.clips.find((clip) => clip.id === clipId);
+    if (!sourceClip) {
+      throw new Error(`Clip '${clipId}' not found`);
+    }
+
+    const audioKey = sourceClip.isolatedAudioKey ?? sourceClip.cumulativeMixKey;
+    if (!audioKey) {
+      throw new Error('Stem separation requires an audio clip');
+    }
+
+    const sourceBlob = await loadAudioBlobByKey(audioKey);
+    if (!sourceBlob) {
+      throw new Error(`Audio for clip '${clipId}' not found`);
+    }
+
+    const preparedStems = await separateClipAudioToStems({
+      clipId,
+      sourceBlob,
+      stemCount,
+      sourceLabel: sourceTrack.displayName,
+    });
+
+    const latest = get();
+    if (!latest.project) return undefined;
+    _pushHistory(latest.project);
+
+    const existingOrders = latest.project.tracks.map((track) => track.order);
+    let nextOrder = existingOrders.length > 0 ? Math.max(...existingOrders) + 1 : 1;
+    const existingNames = latest.project.tracks.map((track) => track.displayName);
+    const appendedTracks: Track[] = [];
+
+    for (const stem of preparedStems) {
+      let displayName = stem.displayName;
+      let suffix = 2;
+      while (existingNames.includes(displayName)) {
+        displayName = `${stem.displayName} ${suffix}`;
+        suffix += 1;
+      }
+      existingNames.push(displayName);
+
+      const newTrackId = uuidv4();
+      const newClipId = uuidv4();
+      const isolatedKey = await saveAudioBlob(latest.project.id, newClipId, 'isolated', stem.audioBlob);
+
+      appendedTracks.push({
+        id: newTrackId,
+        trackType: 'sample',
+        trackName: stem.trackName,
+        displayName,
+        color: stem.color,
+        order: nextOrder++,
+        volume: 0.8,
+        muted: false,
+        soloed: false,
+        clips: [{
+          id: newClipId,
+          trackId: newTrackId,
+          startTime: sourceClip.startTime,
+          duration: sourceClip.duration,
+          prompt: `${displayName} stem`,
+          lyrics: '',
+          generationStatus: 'ready',
+          generationJobId: null,
+          cumulativeMixKey: null,
+          isolatedAudioKey: isolatedKey,
+          waveformPeaks: stem.waveformPeaks,
+          audioDuration: stem.audioDuration,
+          audioOffset: 0,
+          source: 'uploaded',
+        }],
+        effects: [],
+      });
+    }
+
+    const newAssets: AssetClip[] = appendedTracks.flatMap((track) => track.clips.map((clip) => ({
+      id: uuidv4(),
+      clipId: clip.id,
+      trackDisplayName: track.displayName,
+      prompt: clip.prompt,
+      source: clip.source ?? 'uploaded',
+      isolatedAudioKey: clip.isolatedAudioKey,
+      cumulativeMixKey: clip.cumulativeMixKey,
+      waveformPeaks: clip.waveformPeaks,
+      starred: false,
+      createdAt: Date.now(),
+      duration: clip.duration,
+    })));
+    const updatedTracks = [...latest.project.tracks, ...appendedTracks];
+    set({
+      project: {
+        ...latest.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(updatedTracks, latest.project.measures, latest.project.bpm, latest.project.timeSignature),
+        tracks: updatedTracks,
+        assets: [...(latest.project.assets ?? []), ...newAssets],
+      },
+    });
+
+    return appendedTracks;
   },
 
   convertAudioToMidi: async (clipId, options) => {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -60,6 +60,7 @@ interface UIState {
   // Vocal2BGM / Audio Analysis
   vocal2bgmClipId: string | null;
   analysisClipId: string | null;
+  stemSeparationClipId: string | null;
 
   // Quantize dialog
   showQuantizeDialog: boolean;
@@ -119,6 +120,7 @@ interface UIState {
   // Vocal2BGM / Audio Analysis
   setVocal2BGMModal: (clipId: string | null) => void;
   setAnalysisPanel: (clipId: string | null) => void;
+  setStemSeparationModal: (clipId: string | null) => void;
 
   // Quantize dialog
   setShowQuantizeDialog: (v: boolean) => void;
@@ -178,6 +180,7 @@ export const useUIStore = create<UIState>()(
 
   vocal2bgmClipId: null,
   analysisClipId: null,
+  stemSeparationClipId: null,
 
   showQuantizeDialog: false,
   quantizeTarget: null,
@@ -269,6 +272,7 @@ export const useUIStore = create<UIState>()(
 
   setVocal2BGMModal: (clipId) => set({ vocal2bgmClipId: clipId }),
   setAnalysisPanel: (clipId) => set({ analysisClipId: clipId }),
+  setStemSeparationModal: (clipId) => set({ stemSeparationClipId: clipId }),
 
   setShowQuantizeDialog: (v) => set(v ? { showQuantizeDialog: v } : { showQuantizeDialog: false, quantizeTarget: null }),
   setQuantizeTarget: (target) => set({ quantizeTarget: target }),

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -36,6 +36,14 @@ export interface RepaintTaskParams {
   use_random_seed?: boolean;
 }
 
+export type StemCount = 2 | 4 | 6;
+
+export interface StemSeparationTaskParams {
+  task_type: 'stem_separation';
+  stem_count: StemCount;
+  audio_format: 'wav';
+}
+
 export interface LegoTaskParams {
   task_type: 'lego';
   track_name: string;

--- a/tests/e2e/stem-separation.spec.ts
+++ b/tests/e2e/stem-separation.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect } from '@playwright/test';
+
+function createWavBuffer(durationSeconds = 0.1, sampleRate = 44100): Buffer {
+  const numChannels = 1;
+  const bitsPerSample = 16;
+  const blockAlign = (numChannels * bitsPerSample) / 8;
+  const byteRate = sampleRate * blockAlign;
+  const sampleCount = Math.max(1, Math.floor(durationSeconds * sampleRate));
+  const dataSize = sampleCount * blockAlign;
+  const buffer = Buffer.alloc(44 + dataSize);
+
+  buffer.write('RIFF', 0);
+  buffer.writeUInt32LE(36 + dataSize, 4);
+  buffer.write('WAVE', 8);
+  buffer.write('fmt ', 12);
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(numChannels, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(byteRate, 28);
+  buffer.writeUInt16LE(blockAlign, 32);
+  buffer.writeUInt16LE(bitsPerSample, 34);
+  buffer.write('data', 36);
+  buffer.writeUInt32LE(dataSize, 40);
+
+  return buffer;
+}
+
+test.describe('Stem Separation', () => {
+  test('separates an audio clip into new tracks from the clip context menu', async ({ page }) => {
+    const wavBuffer = createWavBuffer();
+    let queryCount = 0;
+
+    await page.route('**/api/release_task', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: { task_id: 'stem-job-1', status: 'queued' },
+          code: 0,
+          error: null,
+          timestamp: Date.now(),
+          extra: null,
+        }),
+      });
+    });
+
+    await page.route('**/api/query_result', async (route) => {
+      queryCount += 1;
+      const payload = queryCount === 1
+        ? [{
+            task_id: 'stem-job-1',
+            status: 0,
+            result: '[]',
+            progress_text: 'Separating stems... 50%',
+          }]
+        : [{
+            task_id: 'stem-job-1',
+            status: 1,
+            result: JSON.stringify([
+              { stem: 'vocals', file: '/stems/vocals.wav' },
+              { stem: 'drums', file: '/stems/drums.wav' },
+              { stem: 'bass', file: '/stems/bass.wav' },
+              { stem: 'other', file: '/stems/other.wav' },
+            ]),
+            progress_text: 'Separating stems... 100%',
+          }];
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: payload,
+          code: 0,
+          error: null,
+          timestamp: Date.now(),
+          extra: null,
+        }),
+      });
+    });
+
+    await page.route('**/api/v1/audio?path=*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'audio/wav',
+        body: wavBuffer,
+      });
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
+
+    const clipId = await page.evaluate(async (wavBytes) => {
+      const openStore = (name: string) => new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open(name);
+        request.onupgradeneeded = () => {
+          request.result.createObjectStore('keyval');
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+
+      const putKeyval = async (key: string, blob: Blob) => {
+        const db = await openStore('keyval-store');
+        await new Promise<void>((resolve, reject) => {
+          const tx = db.transaction('keyval', 'readwrite');
+          tx.objectStore('keyval').put(blob, key);
+          tx.oncomplete = () => resolve();
+          tx.onerror = () => reject(tx.error);
+        });
+        db.close();
+      };
+
+      const sourceKey = 'source-audio-key';
+      await putKeyval(sourceKey, new Blob([new Uint8Array(wavBytes)], { type: 'audio/wav' }));
+
+      const store = (window as any).__store;
+      const uiStore = (window as any).__uiStore;
+      store.getState().createProject({ name: 'Stem Separation E2E' });
+      uiStore.getState().setShowNewProjectDialog(false);
+      const track = store.getState().addTrack('custom', 'sample');
+      const clip = store.getState().addClip(track.id, {
+        startTime: 4,
+        duration: 2,
+        prompt: 'Imported full mix',
+        lyrics: '',
+        source: 'uploaded',
+      });
+      store.getState().updateClipStatus(clip.id, 'ready', {
+        isolatedAudioKey: sourceKey,
+        waveformPeaks: [0.2, 0.4, 0.1],
+        audioDuration: 2,
+        audioOffset: 0,
+        source: 'uploaded',
+      });
+      return clip.id;
+    }, Array.from(wavBuffer));
+
+    await page.mouse.click(20, 20);
+    await expect(page.getByText('Click anywhere to enable audio')).toBeHidden();
+    await page.locator(`[data-testid="clip-${clipId}"]`).evaluate((element) => {
+      element.dispatchEvent(new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        button: 2,
+        buttons: 2,
+        clientX: 260,
+        clientY: 180,
+      }));
+    });
+    await expect(page.getByRole('button', { name: 'Edit Clip' })).toBeVisible();
+    await page.getByRole('button', { name: 'Separate Stems…' }).click();
+
+    await expect(page.getByText('Separate Stems')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Select 2 stem separation' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Select 4 stem separation' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Select 6 stem separation' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Run stem separation' }).click();
+    await expect(page.getByText('Separating stems... 50%').last()).toBeVisible();
+
+    await page.waitForFunction(() => {
+      const store = (window as any).__store;
+      return store.getState().project.tracks.length === 5;
+    });
+
+    const trackNames = await page.evaluate(() => {
+      const store = (window as any).__store;
+      return store.getState().project.tracks.map((track: { displayName: string }) => track.displayName);
+    });
+
+    expect(trackNames).toEqual(['Audio', 'Vocals', 'Drums', 'Bass', 'Other']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a clip context-menu entry and dedicated stem separation modal with 2/4/6 stem options and progress feedback
- add a stem separation service plus store action that polls backend jobs, downloads separated audio, and creates aligned color-coded sample tracks
- add regression coverage for store behavior and a Playwright flow covering the context-menu-to-track-creation path

## Verification
- npx tsc --noEmit
- npx vitest run src/store/__tests__/stemSeparation.test.ts
- npx vitest run tests/unit/
- npm test -- --run
- npx playwright test tests/e2e/stem-separation.spec.ts
- npm run build