### PR TITLE
feat: tempo automation and time signature changes (closes #198)

### DIFF
--- a/src/components/timeline/GridOverlay.tsx
+++ b/src/components/timeline/GridOverlay.tsx
@@ -1,6 +1,8 @@
+import { useMemo } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { getBeatDuration, getBarDuration } from '../../utils/time';
+import { beatToTime, getBeatAtBar } from '../../utils/tempoMap';
 
 /**
  * Adaptive grid: resolution auto-adjusts based on zoom level.
@@ -20,23 +22,64 @@ export function GridOverlay() {
   const project = useProjectStore((s) => s.project);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
 
+  const lines = useMemo(() => {
+    if (!project) return [];
+
+    const { tempoMap, timeSignatureMap, bpm, timeSignature, totalDuration } = project;
+    const hasTempoMap = tempoMap && tempoMap.length > 0;
+    const hasTsMap = timeSignatureMap && timeSignatureMap.length > 0;
+
+    if (!hasTempoMap && !hasTsMap) {
+      // Fast path: constant tempo, constant time signature
+      const beatDuration = getBeatDuration(bpm);
+      const barDuration = getBarDuration(bpm, timeSignature);
+      const { division } = getGridDivision(pixelsPerSecond, bpm);
+      const stepDuration = beatDuration * division;
+
+      const result: { x: number; strength: 'bar' | 'beat' | 'sub' }[] = [];
+      for (let t = 0; t <= totalDuration; t += stepDuration) {
+        const isBar = Math.abs(t % barDuration) < 0.001 || Math.abs((t % barDuration) - barDuration) < 0.001;
+        const isBeat = Math.abs(t % beatDuration) < 0.001 || Math.abs((t % beatDuration) - beatDuration) < 0.001;
+        result.push({
+          x: t * pixelsPerSecond,
+          strength: isBar ? 'bar' : isBeat ? 'beat' : 'sub',
+        });
+      }
+      return result;
+    }
+
+    // Tempo-map/time-sig-aware path: iterate by beat subdivisions
+    const { division } = getGridDivision(pixelsPerSecond, bpm);
+    const result: { x: number; strength: 'bar' | 'beat' | 'sub' }[] = [];
+
+    const maxBeat = totalDuration * (300 / 60) * 2; // generous upper bound
+    let currentBar = 1;
+    let nextBarBeat = getBeatAtBar(2, timeSignatureMap, timeSignature);
+
+    for (let beat = 0; beat < maxBeat; beat += division) {
+      const time = beatToTime(beat, tempoMap, bpm);
+      if (time > totalDuration) break;
+
+      while (beat >= nextBarBeat) {
+        currentBar++;
+        nextBarBeat = getBeatAtBar(currentBar + 1, timeSignatureMap, timeSignature);
+      }
+
+      const barBeat = getBeatAtBar(currentBar, timeSignatureMap, timeSignature);
+      const isBar = Math.abs(beat - barBeat) < 0.001;
+      const isBeat = Math.abs(beat - Math.round(beat)) < 0.001;
+
+      result.push({
+        x: time * pixelsPerSecond,
+        strength: isBar ? 'bar' : isBeat ? 'beat' : 'sub',
+      });
+    }
+    return result;
+  }, [project, pixelsPerSecond]);
+
   if (!project) return null;
 
-  const beatDuration = getBeatDuration(project.bpm);
-  const barDuration = getBarDuration(project.bpm, project.timeSignature);
   const totalWidth = project.totalDuration * pixelsPerSecond;
-  const { division } = getGridDivision(pixelsPerSecond, project.bpm);
-  const stepDuration = beatDuration * division;
-
-  const lines: { x: number; strength: 'bar' | 'beat' | 'sub' }[] = [];
-  for (let t = 0; t <= project.totalDuration; t += stepDuration) {
-    const isBar = Math.abs(t % barDuration) < 0.001 || Math.abs((t % barDuration) - barDuration) < 0.001;
-    const isBeat = Math.abs(t % beatDuration) < 0.001 || Math.abs((t % beatDuration) - beatDuration) < 0.001;
-    lines.push({
-      x: t * pixelsPerSecond,
-      strength: isBar ? 'bar' : isBeat ? 'beat' : 'sub',
-    });
-  }
 
   const colors = {
     bar: '#555555',

--- a/src/components/timeline/TimeRuler.tsx
+++ b/src/components/timeline/TimeRuler.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { useTransportStore } from '../../store/transportStore';
 import { useTransport } from '../../hooks/useTransport';
 import { getBarDuration } from '../../utils/time';
+import { beatToTime, getBeatAtBar, getTimeSignatureAtBar } from '../../utils/tempoMap';
 
 export function TimeRuler() {
   const project = useProjectStore((s) => s.project);
@@ -37,17 +38,46 @@ export function TimeRuler() {
     window.addEventListener('mouseup', onMouseUp);
   }, [project, seekFromX]);
 
+  const markers = useMemo(() => {
+    if (!project) return [];
+    const { tempoMap, timeSignatureMap, bpm, timeSignature, totalDuration } = project;
+    const hasTempoMap = tempoMap && tempoMap.length > 0;
+    const hasTsMap = timeSignatureMap && timeSignatureMap.length > 0;
+
+    if (!hasTempoMap && !hasTsMap) {
+      const barDur = getBarDuration(bpm, timeSignature);
+      const totalBars = Math.ceil(totalDuration / barDur);
+      const result: { bar: number; x: number; tsLabel?: string }[] = [];
+      for (let bar = 1; bar <= totalBars; bar++) {
+        result.push({ bar, x: (bar - 1) * barDur * pixelsPerSecond });
+      }
+      return result;
+    }
+
+    const result: { bar: number; x: number; tsLabel?: string }[] = [];
+    let prevTs = '';
+    for (let bar = 1; bar <= 999; bar++) {
+      const barBeat = getBeatAtBar(bar, timeSignatureMap, timeSignature);
+      const time = beatToTime(barBeat, tempoMap, bpm);
+      if (time > totalDuration) break;
+
+      let tsLabel: string | undefined;
+      if (hasTsMap) {
+        const ts = getTimeSignatureAtBar(timeSignatureMap, bar, timeSignature, 4);
+        const label = `${ts.numerator}/${ts.denominator}`;
+        if (label !== prevTs) {
+          tsLabel = label;
+          prevTs = label;
+        }
+      }
+      result.push({ bar, x: time * pixelsPerSecond, tsLabel });
+    }
+    return result;
+  }, [project, pixelsPerSecond]);
+
   if (!project) return <div className="h-6 bg-[#333] border-b border-[#2a2a2a]" />;
 
-  const barDuration = getBarDuration(project.bpm, project.timeSignature);
-  const totalBars = Math.ceil(project.totalDuration / barDuration);
   const totalWidth = project.totalDuration * pixelsPerSecond;
-
-  const markers: { bar: number; x: number }[] = [];
-  for (let bar = 1; bar <= totalBars; bar++) {
-    const x = (bar - 1) * barDuration * pixelsPerSecond;
-    markers.push({ bar, x });
-  }
 
   return (
     <div
@@ -70,7 +100,7 @@ export function TimeRuler() {
       )}
 
       {/* Bar markers */}
-      {markers.map(({ bar, x }) => (
+      {markers.map(({ bar, x, tsLabel }) => (
         <div
           key={bar}
           className="absolute top-0 h-full flex items-end pb-0.5 pointer-events-none"
@@ -78,6 +108,9 @@ export function TimeRuler() {
         >
           <div className="w-px h-3 bg-[#666] mr-1" />
           <span className="text-[10px] text-zinc-400 font-medium">{bar}</span>
+          {tsLabel && (
+            <span className="text-[8px] text-amber-400/60 ml-0.5">{tsLabel}</span>
+          )}
         </div>
       ))}
     </div>

--- a/src/components/transport/TempoDisplay.tsx
+++ b/src/components/transport/TempoDisplay.tsx
@@ -1,15 +1,35 @@
 import { useProjectStore } from '../../store/projectStore';
+import { useTransportStore } from '../../store/transportStore';
+import { getTempoAtBeat, timeToBeat, getTimeSignatureAtBar, getBarAtBeat } from '../../utils/tempoMap';
 
 export function TempoDisplay() {
   const project = useProjectStore((s) => s.project);
+  const currentTime = useTransportStore((s) => s.currentTime);
 
   if (!project) return null;
 
+  const { bpm, tempoMap, timeSignature, timeSignatureMap } = project;
+
+  // Show current tempo at playhead position (accounts for tempo map)
+  const currentBeat = timeToBeat(currentTime, tempoMap, bpm);
+  const currentBpm = Math.round(getTempoAtBeat(tempoMap, currentBeat, bpm));
+
+  // Show current time signature at playhead
+  const currentBar = getBarAtBeat(Math.floor(currentBeat), timeSignatureMap, timeSignature);
+  const currentTs = getTimeSignatureAtBar(timeSignatureMap, currentBar, timeSignature, 4);
+
+  const hasTempoMap = tempoMap && tempoMap.length > 0;
+
   return (
     <div className="flex items-center gap-2 text-xs text-zinc-400">
-      <span className="font-medium text-zinc-300">{project.bpm} BPM</span>
+      <span className="font-medium text-zinc-300">
+        {currentBpm} BPM
+        {hasTempoMap && currentBpm !== bpm && (
+          <span className="text-amber-400/60 ml-0.5" title={`Project default: ${bpm} BPM`}>*</span>
+        )}
+      </span>
       <span>{project.keyScale}</span>
-      <span>{project.timeSignature}/4</span>
+      <span>{currentTs.numerator}/{currentTs.denominator}</span>
     </div>
   );
 }

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -1,7 +1,14 @@
 import * as Tone from 'tone';
 import { TrackNode } from './TrackNode';
-import type { GainEnvelopePoint, MasteringState, SequencerPattern } from '../types/project';
+import type {
+  GainEnvelopePoint,
+  MasteringState,
+  SequencerPattern,
+  TempoEvent,
+  TimeSignatureEvent,
+} from '../types/project';
 import { ensureMasteringState } from '../utils/mastering';
+import { beatToTime, getBarAtBeat } from '../utils/tempoMap';
 
 export interface ScheduledSource {
   source: AudioBufferSourceNode;
@@ -513,20 +520,30 @@ export class AudioEngine {
    * Schedule metronome clicks at every beat from `fromTime` to `totalDuration`.
    * Beat 1 of each bar gets a higher-pitched click (accent).
    */
-  scheduleMetronome(bpm: number, timeSignature: number, fromTime: number, totalDuration: number) {
+  scheduleMetronome(
+    bpm: number,
+    timeSignature: number,
+    fromTime: number,
+    totalDuration: number,
+    tempoMap?: TempoEvent[],
+    timeSignatureMap?: TimeSignatureEvent[],
+  ) {
     this.stopMetronome();
-    const beatDuration = 60 / bpm;
     const contextNow = this.ctx.currentTime;
-    const firstBeatIdx = Math.ceil(fromTime / beatDuration);
-    const lastBeatIdx = Math.floor(totalDuration / beatDuration);
+    const peakBpm = tempoMap?.reduce((m, e) => Math.max(m, e.bpm), bpm) ?? bpm;
+    const maxBeats = Math.ceil((totalDuration / 60) * peakBpm) + 8;
 
-    for (let i = firstBeatIdx; i <= lastBeatIdx; i++) {
-      const beatTime = i * beatDuration;
+    for (let beat = 0; beat <= maxBeats; beat++) {
+      const beatTime = beatToTime(beat, tempoMap, bpm);
+      if (beatTime > totalDuration) break;
+      if (beatTime < fromTime) continue;
+
       const delay = beatTime - fromTime;
-      if (delay < 0) continue;
+      const bar = getBarAtBeat(beat, timeSignatureMap, timeSignature);
+      const prevBar = beat > 0 ? getBarAtBeat(beat - 1, timeSignatureMap, timeSignature) : 0;
+      const isDownbeat = beat === 0 || bar > prevBar;
 
-      const isAccent = (i % timeSignature) === 0;
-      const freq = isAccent ? 1200 : 800;
+      const freq = isDownbeat ? 1200 : 800;
       const clickDuration = 0.03;
 
       const osc = this.ctx.createOscillator();

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -8,6 +8,7 @@ import { synthEngine } from '../engine/SynthEngine';
 import { drumEngine } from '../engine/DrumEngine';
 import { automationEngine } from '../engine/AutomationEngine';
 import { useRecording } from './useRecording';
+import { beatToTime } from '../utils/tempoMap';
 
 const DRUM_PAD_INDEX_BY_SAMPLE_KEY: Record<string, number> = {
   kick: 0,
@@ -176,12 +177,16 @@ export function useTransport() {
 
     const { metronomeEnabled } = useTransportStore.getState();
     if (metronomeEnabled) {
-      engine.scheduleMetronome(proj.bpm, proj.timeSignature, startFrom, effectiveEnd);
+      engine.scheduleMetronome(
+        proj.bpm, proj.timeSignature, startFrom, effectiveEnd,
+        proj.tempoMap, proj.timeSignatureMap,
+      );
     }
 
     // Schedule MIDI events using AudioEngine's time base (RAF-driven),
     // so playhead and note triggering stay perfectly in sync.
-    const secondsPerBeat = 60 / proj.bpm;
+    const tempoMap = proj.tempoMap;
+    const fallbackBpm = proj.bpm;
     const anySoloed = proj.tracks.some((track) => track.soloed);
 
     for (const track of proj.tracks) {
@@ -198,8 +203,8 @@ export function useTransport() {
           if (notes.length === 0) continue;
 
           for (const note of notes) {
-            const noteStart = clip.startTime + note.startBeat * secondsPerBeat;
-            const noteDuration = Math.max(0, note.durationBeats * secondsPerBeat);
+            const noteStart = clip.startTime + beatToTime(note.startBeat, tempoMap, fallbackBpm);
+            const noteDuration = Math.max(0, beatToTime(note.startBeat + note.durationBeats, tempoMap, fallbackBpm) - beatToTime(note.startBeat, tempoMap, fallbackBpm));
             const noteEnd = noteStart + noteDuration;
             if (noteEnd <= startFrom || noteStart >= effectiveEnd || noteDuration <= 0) continue;
 
@@ -229,7 +234,8 @@ export function useTransport() {
         if (hasReadyClips) continue;
 
         const { sequencerPattern } = track;
-        const stepDuration = (60 / proj.bpm) / (sequencerPattern.stepsPerBar / 4);
+        const stepsPerBeat = sequencerPattern.stepsPerBar / 4;
+        const stepDuration = (60 / fallbackBpm) / stepsPerBeat;
         const totalSteps = sequencerPattern.stepsPerBar * sequencerPattern.bars;
         const patternDuration = stepDuration * totalSteps;
         if (patternDuration <= 0) continue;

--- a/src/store/__tests__/tempoMap.test.ts
+++ b/src/store/__tests__/tempoMap.test.ts
@@ -73,6 +73,32 @@ describe('tempoMap store actions', () => {
       expect(useProjectStore.getState().project!.tempoMap).toEqual([]);
     });
   });
+
+  describe('totalDuration recomputation', () => {
+    it('recomputes totalDuration when tempo event is added', () => {
+      const durationBefore = useProjectStore.getState().project!.totalDuration;
+      // Adding a slower tempo should increase total duration
+      useProjectStore.getState().addTempoEvent({ beat: 0, bpm: 60 });
+      const durationAfter = useProjectStore.getState().project!.totalDuration;
+      expect(durationAfter).toBeGreaterThan(durationBefore);
+    });
+
+    it('recomputes totalDuration when tempo event is removed', () => {
+      useProjectStore.getState().addTempoEvent({ beat: 0, bpm: 60 });
+      const durationWithSlow = useProjectStore.getState().project!.totalDuration;
+      useProjectStore.getState().removeTempoEvent(0);
+      const durationAfter = useProjectStore.getState().project!.totalDuration;
+      expect(durationAfter).toBeLessThan(durationWithSlow);
+    });
+
+    it('recomputes totalDuration when tempo map is cleared', () => {
+      useProjectStore.getState().addTempoEvent({ beat: 0, bpm: 60 });
+      const durationWithSlow = useProjectStore.getState().project!.totalDuration;
+      useProjectStore.getState().clearTempoMap();
+      const durationAfter = useProjectStore.getState().project!.totalDuration;
+      expect(durationAfter).toBeLessThan(durationWithSlow);
+    });
+  });
 });
 
 describe('timeSignatureMap store actions', () => {
@@ -122,6 +148,16 @@ describe('timeSignatureMap store actions', () => {
       useProjectStore.getState().addTimeSignatureEvent({ bar: 1, numerator: 4, denominator: 4 });
       useProjectStore.getState().clearTimeSignatureMap();
       expect(useProjectStore.getState().project!.timeSignatureMap).toEqual([]);
+    });
+  });
+
+  describe('totalDuration recomputation', () => {
+    it('recomputes totalDuration when time signature event changes beats per bar', () => {
+      const durationBefore = useProjectStore.getState().project!.totalDuration;
+      // Changing to 6/8 effectively increases beats per bar from 4 to 6
+      useProjectStore.getState().addTimeSignatureEvent({ bar: 1, numerator: 6, denominator: 8 });
+      const durationAfter = useProjectStore.getState().project!.totalDuration;
+      expect(durationAfter).toBeGreaterThan(durationBefore);
     });
   });
 });

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -65,6 +65,7 @@ import { getAudioEngine } from '../hooks/useAudioEngine';
 import { renderMidiTrackOffline, renderSequencerTrackOffline } from '../engine/offlineRender';
 import { convertClipAudioToMidi } from '../services/audioToMidi';
 import { createDefaultParametricEqBands } from '../utils/parametricEq';
+import { beatToTime, getBeatAtBar } from '../utils/tempoMap';
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
   return (60 / bpm) * timeSig;
@@ -284,6 +285,8 @@ function computeTotalDuration(
   measures?: number,
   bpm?: number,
   timeSig?: number,
+  tempoMap?: TempoEvent[],
+  timeSignatureMap?: TimeSignatureEvent[],
 ): number {
   let maxEnd = 0;
   for (const track of tracks) {
@@ -292,8 +295,17 @@ function computeTotalDuration(
       if (end > maxEnd) maxEnd = end;
     }
   }
-  const barDur = getBarDurationSec(bpm ?? DEFAULT_BPM, timeSig ?? DEFAULT_TIME_SIGNATURE);
-  const measuredDuration = (measures ?? DEFAULT_MEASURES) * barDur;
+  const effectiveBpm = bpm ?? DEFAULT_BPM;
+  const effectiveTimeSig = timeSig ?? DEFAULT_TIME_SIGNATURE;
+  const effectiveMeasures = measures ?? DEFAULT_MEASURES;
+  let measuredDuration: number;
+  if ((tempoMap && tempoMap.length > 0) || (timeSignatureMap && timeSignatureMap.length > 0)) {
+    const totalBeats = getBeatAtBar(effectiveMeasures + 1, timeSignatureMap, effectiveTimeSig);
+    measuredDuration = beatToTime(totalBeats, tempoMap, effectiveBpm);
+  } else {
+    const barDur = getBarDurationSec(effectiveBpm, effectiveTimeSig);
+    measuredDuration = effectiveMeasures * barDur;
+  }
   return Math.max(measuredDuration, maxEnd + TIMELINE_PADDING);
 }
 
@@ -949,7 +961,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1030,7 +1042,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1057,7 +1069,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1207,7 +1219,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1250,7 +1262,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1268,7 +1280,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1307,7 +1319,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1448,7 +1460,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1657,7 +1669,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1701,7 +1713,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -1723,7 +1735,7 @@ export const useProjectStore = create<ProjectState>()(
       project: {
         ...state.project,
         updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
         tracks: newTracks,
       },
     });
@@ -2953,7 +2965,9 @@ export const useProjectStore = create<ProjectState>()(
       map.push(event);
       map.sort((a: TempoEvent, b: TempoEvent) => a.beat - b.beat);
     }
-    set({ project: { ...state.project, updatedAt: Date.now(), tempoMap: map } });
+    const updated = { ...state.project, updatedAt: Date.now(), tempoMap: map };
+    updated.totalDuration = computeTotalDuration(updated.tracks, updated.measures, updated.bpm, updated.timeSignature, updated.tempoMap, updated.timeSignatureMap);
+    set({ project: updated });
   },
 
   removeTempoEvent: (beat: number) => {
@@ -2961,7 +2975,9 @@ export const useProjectStore = create<ProjectState>()(
     if (!state.project) return;
     _pushHistory(state.project);
     const map = (state.project.tempoMap ?? []).filter((e: TempoEvent) => e.beat !== beat);
-    set({ project: { ...state.project, updatedAt: Date.now(), tempoMap: map } });
+    const updated = { ...state.project, updatedAt: Date.now(), tempoMap: map };
+    updated.totalDuration = computeTotalDuration(updated.tracks, updated.measures, updated.bpm, updated.timeSignature, updated.tempoMap, updated.timeSignatureMap);
+    set({ project: updated });
   },
 
   updateTempoEvent: (beat: number, updates: Partial<TempoEvent>) => {
@@ -2972,14 +2988,18 @@ export const useProjectStore = create<ProjectState>()(
       e.beat === beat ? { ...e, ...updates } : e,
     );
     if ('beat' in updates) map.sort((a: TempoEvent, b: TempoEvent) => a.beat - b.beat);
-    set({ project: { ...state.project, updatedAt: Date.now(), tempoMap: map } });
+    const updated = { ...state.project, updatedAt: Date.now(), tempoMap: map };
+    updated.totalDuration = computeTotalDuration(updated.tracks, updated.measures, updated.bpm, updated.timeSignature, updated.tempoMap, updated.timeSignatureMap);
+    set({ project: updated });
   },
 
   clearTempoMap: () => {
     const state = get();
     if (!state.project) return;
     _pushHistory(state.project);
-    set({ project: { ...state.project, updatedAt: Date.now(), tempoMap: [] } });
+    const updated = { ...state.project, updatedAt: Date.now(), tempoMap: [] };
+    updated.totalDuration = computeTotalDuration(updated.tracks, updated.measures, updated.bpm, updated.timeSignature, updated.tempoMap, updated.timeSignatureMap);
+    set({ project: updated });
   },
 
   // ── Time Signature Map ────────────────────────────────────────────────────
@@ -2996,7 +3016,9 @@ export const useProjectStore = create<ProjectState>()(
       map.push(event);
       map.sort((a: TimeSignatureEvent, b: TimeSignatureEvent) => a.bar - b.bar);
     }
-    set({ project: { ...state.project, updatedAt: Date.now(), timeSignatureMap: map } });
+    const updated = { ...state.project, updatedAt: Date.now(), timeSignatureMap: map };
+    updated.totalDuration = computeTotalDuration(updated.tracks, updated.measures, updated.bpm, updated.timeSignature, updated.tempoMap, updated.timeSignatureMap);
+    set({ project: updated });
   },
 
   removeTimeSignatureEvent: (bar: number) => {
@@ -3004,7 +3026,9 @@ export const useProjectStore = create<ProjectState>()(
     if (!state.project) return;
     _pushHistory(state.project);
     const map = (state.project.timeSignatureMap ?? []).filter((e: TimeSignatureEvent) => e.bar !== bar);
-    set({ project: { ...state.project, updatedAt: Date.now(), timeSignatureMap: map } });
+    const updated = { ...state.project, updatedAt: Date.now(), timeSignatureMap: map };
+    updated.totalDuration = computeTotalDuration(updated.tracks, updated.measures, updated.bpm, updated.timeSignature, updated.tempoMap, updated.timeSignatureMap);
+    set({ project: updated });
   },
 
   updateTimeSignatureEvent: (bar: number, updates: Partial<TimeSignatureEvent>) => {
@@ -3015,14 +3039,18 @@ export const useProjectStore = create<ProjectState>()(
       e.bar === bar ? { ...e, ...updates } : e,
     );
     if ('bar' in updates) map.sort((a: TimeSignatureEvent, b: TimeSignatureEvent) => a.bar - b.bar);
-    set({ project: { ...state.project, updatedAt: Date.now(), timeSignatureMap: map } });
+    const updated = { ...state.project, updatedAt: Date.now(), timeSignatureMap: map };
+    updated.totalDuration = computeTotalDuration(updated.tracks, updated.measures, updated.bpm, updated.timeSignature, updated.tempoMap, updated.timeSignatureMap);
+    set({ project: updated });
   },
 
   clearTimeSignatureMap: () => {
     const state = get();
     if (!state.project) return;
     _pushHistory(state.project);
-    set({ project: { ...state.project, updatedAt: Date.now(), timeSignatureMap: [] } });
+    const updated = { ...state.project, updatedAt: Date.now(), timeSignatureMap: [] };
+    updated.totalDuration = computeTotalDuration(updated.tracks, updated.measures, updated.bpm, updated.timeSignature, updated.tempoMap, updated.timeSignatureMap);
+    set({ project: updated });
   },
 
   // ── Markers ────────────────────────────────────────────────────────────────

--- a/src/utils/__tests__/tempoMapIntegration.test.ts
+++ b/src/utils/__tests__/tempoMapIntegration.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  secondsToBarsBeats,
+  formatBarsBeats,
+  snapToGrid,
+} from '../time';
+import type { TempoEvent, TimeSignatureEvent } from '../../types/project';
+
+describe('tempo-map-aware time utilities', () => {
+  describe('secondsToBarsBeats with tempoMap', () => {
+    it('uses tempoMap when provided', () => {
+      const tempoMap: TempoEvent[] = [
+        { beat: 0, bpm: 120 },
+        { beat: 4, bpm: 60 },
+      ];
+      // At 120 BPM, 4 beats = 2s. After that, at 60 BPM.
+      // At t=2s, we are at beat 4 = bar 2
+      const result = secondsToBarsBeats(2.0, 120, 4, tempoMap);
+      expect(result.bars).toBe(2);
+      expect(result.beats).toBe(1);
+    });
+
+    it('falls back to constant BPM when tempoMap is empty', () => {
+      const result = secondsToBarsBeats(2.0, 120, 4, []);
+      expect(result.bars).toBe(2);
+      expect(result.beats).toBe(1);
+    });
+
+    it('falls back to constant BPM when tempoMap is undefined', () => {
+      const result = secondsToBarsBeats(2.0, 120, 4, undefined);
+      expect(result.bars).toBe(2);
+      expect(result.beats).toBe(1);
+    });
+  });
+
+  describe('secondsToBarsBeats with timeSignatureMap', () => {
+    it('accounts for time signature changes', () => {
+      const tsMap: TimeSignatureEvent[] = [
+        { bar: 1, numerator: 4, denominator: 4 },
+        { bar: 3, numerator: 3, denominator: 4 },
+      ];
+      // 4/4: bars 1-2 = 8 beats. Then 3/4: bar 3 = beats 8-10
+      // At 120 BPM, beat 8 = 4s, beat 11 = 5.5s
+      // At t=5s => 10 beats. Bar 3 starts at beat 8. 10-8=2 beats into 3/4.
+      // Bar = 3, beat = 3 (2 beats into bar + 1-indexed)
+      const result = secondsToBarsBeats(5.0, 120, 4, undefined, tsMap);
+      expect(result.bars).toBe(3);
+      expect(result.beats).toBe(3);
+    });
+  });
+
+  describe('formatBarsBeats with tempoMap', () => {
+    it('formats correctly with tempo changes', () => {
+      const tempoMap: TempoEvent[] = [
+        { beat: 0, bpm: 120 },
+        { beat: 4, bpm: 60 },
+      ];
+      // At t=2s: beat 4 = bar 2, beat 1
+      const result = formatBarsBeats(2.0, 120, 4, tempoMap);
+      expect(result).toBe('2.1.00');
+    });
+
+    it('formats correctly without tempo map', () => {
+      const result = formatBarsBeats(2.0, 120, 4);
+      expect(result).toBe('2.1.00');
+    });
+  });
+
+  describe('snapToGrid with tempoMap', () => {
+    it('snaps in beat-space when tempoMap provided', () => {
+      const tempoMap: TempoEvent[] = [
+        { beat: 0, bpm: 120 },
+        { beat: 4, bpm: 60 },
+      ];
+      // At 120 BPM, beat 1 = 0.5s. Snap 0.3s to nearest beat.
+      // 0.3s at 120 BPM = 0.6 beats -> snaps to 1 beat -> 0.5s
+      const result = snapToGrid(0.3, 120, 1, tempoMap);
+      expect(result).toBeCloseTo(0.5);
+    });
+
+    it('handles snapping after tempo change', () => {
+      const tempoMap: TempoEvent[] = [
+        { beat: 0, bpm: 120 },
+        { beat: 4, bpm: 60 },
+      ];
+      // After beat 4 (t=2s), BPM is 60.
+      // Beat 5 at 60 BPM = 2s + 1s = 3s.
+      // A time of 2.6s should snap to beat 5 = 3s (since 2.6s is closer to beat 5 than beat 4)
+      // Actually let's check: at t=2.6s with tempo map:
+      // beat 4 = 2s, then at 60BPM: 0.6s * 60/60 = 0.6 beats. So 4.6 beats.
+      // Snaps to 5 beats => beat 5 = 2s + 1s = 3s
+      const result = snapToGrid(2.6, 120, 1, tempoMap);
+      expect(result).toBeCloseTo(3.0);
+    });
+
+    it('works the same as before when tempoMap is undefined', () => {
+      const result = snapToGrid(0.3, 120, 1, undefined);
+      expect(result).toBeCloseTo(0.5);
+    });
+
+    it('works the same as before when tempoMap is empty', () => {
+      const result = snapToGrid(0.3, 120, 1, []);
+      expect(result).toBeCloseTo(0.5);
+    });
+
+    it('snaps to sub-divisions with tempoMap', () => {
+      const tempoMap: TempoEvent[] = [
+        { beat: 0, bpm: 120 },
+      ];
+      // 0.13s at 120 BPM = 0.26 beats. Quarter of a beat (0.25) -> 0.125s
+      const result = snapToGrid(0.13, 120, 0.25, tempoMap);
+      expect(result).toBeCloseTo(0.125);
+    });
+  });
+});

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,3 +1,6 @@
+import type { TempoEvent, TimeSignatureEvent } from '../types/project';
+import { beatToTime, timeToBeat, getBarAtBeat, getBeatAtBar, getTimeSignatureAtBar } from './tempoMap';
+
 export function secondsToBeats(seconds: number, bpm: number): number {
   return (seconds / 60) * bpm;
 }
@@ -10,12 +13,17 @@ export function secondsToBarsBeats(
   seconds: number,
   bpm: number,
   timeSignature: number,
+  tempoMap?: TempoEvent[],
+  timeSignatureMap?: TimeSignatureEvent[],
 ): { bars: number; beats: number; ticks: number } {
-  const totalBeats = secondsToBeats(seconds, bpm);
-  const bars = Math.floor(totalBeats / timeSignature) + 1;
-  const beats = Math.floor(totalBeats % timeSignature) + 1;
-  const ticks = Math.round((totalBeats % 1) * 100);
-  return { bars, beats, ticks };
+  const totalBeats = timeToBeat(seconds, tempoMap, bpm);
+  const bar = getBarAtBeat(totalBeats, timeSignatureMap, timeSignature);
+  const { numerator } = getTimeSignatureAtBar(timeSignatureMap, bar, timeSignature, 4);
+  const barStartBeat = getBeatAtBar(bar, timeSignatureMap, timeSignature);
+  const beatsIntoBar = totalBeats - barStartBeat;
+  const beatInBar = Math.floor(beatsIntoBar);
+  const ticks = Math.round((beatsIntoBar % 1) * 100);
+  return { bars: bar, beats: Math.min(beatInBar, numerator - 1) + 1, ticks };
 }
 
 export function formatTime(seconds: number): string {
@@ -28,19 +36,27 @@ export function formatBarsBeats(
   seconds: number,
   bpm: number,
   timeSignature: number,
+  tempoMap?: TempoEvent[],
+  timeSignatureMap?: TimeSignatureEvent[],
 ): string {
-  const { bars, beats, ticks } = secondsToBarsBeats(seconds, bpm, timeSignature);
+  const { bars, beats, ticks } = secondsToBarsBeats(seconds, bpm, timeSignature, tempoMap, timeSignatureMap);
   return `${bars}.${beats}.${ticks.toString().padStart(2, '0')}`;
 }
 
 export function snapToGrid(
   time: number,
   bpm: number,
-  division: number = 1, // 1 = beat, 0.5 = half beat, 0.25 = 16th note
+  division: number = 1,
+  tempoMap?: TempoEvent[],
 ): number {
-  const beatDuration = 60 / bpm;
-  const gridSize = beatDuration * division;
-  return Math.round(time / gridSize) * gridSize;
+  if (!tempoMap || tempoMap.length === 0) {
+    const beatDuration = 60 / bpm;
+    const gridSize = beatDuration * division;
+    return Math.round(time / gridSize) * gridSize;
+  }
+  const beat = timeToBeat(time, tempoMap, bpm);
+  const snappedBeat = Math.round(beat / division) * division;
+  return beatToTime(snappedBeat, tempoMap, bpm);
 }
 
 export function getBarDuration(bpm: number, timeSignature: number): number {


### PR DESCRIPTION
## Summary
- Integrate tempo map (variable BPM) and time signature map (mixed meter) across the entire DAW
- AudioEngine metronome, transport MIDI scheduling, TimeRuler, GridOverlay, TempoDisplay, and `computeTotalDuration` now all use `beatToTime()`/`timeToBeat()` from the tempo map
- `time.ts` functions (`secondsToBarsBeats`, `formatBarsBeats`, `snapToGrid`) accept optional `tempoMap`/`timeSignatureMap` for tempo-aware conversions
- Store actions (`addTempoEvent`, `removeTempoEvent`, etc.) recompute `totalDuration` when maps change
- TimeRuler shows time signature change labels at bar boundaries

## Test plan
- [x] All 66 tempo-related unit tests pass (tempoMap.test, tempoMapIntegration.test, time.test, store tempoMap.test)
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm run build` — builds successfully
- [ ] Manual: add tempo events in the TempoLane, verify grid/ruler update correctly
- [ ] Manual: add time signature changes, verify bar numbering and display
- [ ] Manual: play back with tempo changes, verify metronome follows tempo map

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)