### PR TITLE
feat: #210 — track height presets — small/medium/large/auto

### DIFF
--- a/src/components/tracks/TrackHeightPresetSelector.tsx
+++ b/src/components/tracks/TrackHeightPresetSelector.tsx
@@ -1,0 +1,65 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import type { TrackHeightPreset } from '../../constants/trackHeight';
+
+const PRESETS: { label: string; value: TrackHeightPreset }[] = [
+  { label: 'Small', value: 'small' },
+  { label: 'Medium', value: 'medium' },
+  { label: 'Large', value: 'large' },
+  { label: 'Auto', value: 'auto' },
+];
+
+export function TrackHeightPresetSelector() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const setAllTracksHeightPreset = useProjectStore((s) => s.setAllTracksHeightPreset);
+
+  const handleSelect = useCallback(
+    (preset: TrackHeightPreset) => {
+      setAllTracksHeightPreset(preset);
+      setOpen(false);
+    },
+    [setAllTracksHeightPreset],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        data-testid="track-height-preset-btn"
+        onClick={() => setOpen((v) => !v)}
+        title="Track height presets"
+        className="flex items-center justify-center w-5 h-5 text-zinc-500 hover:text-zinc-200 hover:bg-daw-surface-2 rounded transition-colors"
+      >
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round">
+          <line x1="1" y1="3" x2="11" y2="3" />
+          <line x1="1" y1="6" x2="11" y2="6" />
+          <line x1="1" y1="9" x2="11" y2="9" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 bg-[#2a2a2a] border border-[#444] rounded shadow-lg z-50 min-w-[90px] py-0.5">
+          {PRESETS.map(({ label, value }) => (
+            <button
+              key={value}
+              onClick={() => handleSelect(value)}
+              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/tracks/TrackList.tsx
+++ b/src/components/tracks/TrackList.tsx
@@ -3,6 +3,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { TrackHeader } from './TrackHeader';
 import { AddTrackButton } from './AddTrackButton';
+import { TrackHeightPresetSelector } from './TrackHeightPresetSelector';
 
 export function TrackList() {
   const project = useProjectStore((s) => s.project);
@@ -79,8 +80,9 @@ export function TrackList() {
       }}
     >
       {/* Header spacer aligned with TimeRuler */}
-      <div className="h-6 border-b border-[#3a3a3a] shrink-0 bg-[#333] flex items-center px-2">
+      <div className="h-6 border-b border-[#3a3a3a] shrink-0 bg-[#333] flex items-center px-2 justify-between">
         <span className="text-[10px] text-zinc-500 uppercase tracking-wider font-medium">Tracks</span>
+        <TrackHeightPresetSelector />
       </div>
 
       <div className="flex-1 overflow-y-auto">

--- a/tests/unit/trackHeightPresetSelector.test.tsx
+++ b/tests/unit/trackHeightPresetSelector.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TrackHeightPresetSelector } from '../../src/components/tracks/TrackHeightPresetSelector';
+import { useProjectStore } from '../../src/store/projectStore';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('TrackHeightPresetSelector', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+  });
+
+  it('renders a button with data-testid', () => {
+    render(<TrackHeightPresetSelector />);
+    expect(screen.getByTestId('track-height-preset-btn')).toBeInTheDocument();
+  });
+
+  it('opens a dropdown with preset options on click', () => {
+    render(<TrackHeightPresetSelector />);
+    fireEvent.click(screen.getByTestId('track-height-preset-btn'));
+    expect(screen.getByText('Small')).toBeInTheDocument();
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    expect(screen.getByText('Large')).toBeInTheDocument();
+    expect(screen.getByText('Auto')).toBeInTheDocument();
+  });
+
+  it('calls setAllTracksHeightPreset when a preset is clicked', () => {
+    useProjectStore.getState().addTrack('stems');
+    useProjectStore.getState().addTrack('stems', 'sequencer');
+
+    render(<TrackHeightPresetSelector />);
+    fireEvent.click(screen.getByTestId('track-height-preset-btn'));
+    fireEvent.click(screen.getByText('Small'));
+
+    const tracks = useProjectStore.getState().project!.tracks;
+    for (const t of tracks) {
+      expect(t.laneHeight).toBe(48);
+    }
+  });
+
+  it('closes the dropdown after selecting a preset', () => {
+    render(<TrackHeightPresetSelector />);
+    fireEvent.click(screen.getByTestId('track-height-preset-btn'));
+    expect(screen.getByText('Small')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Small'));
+    expect(screen.queryByText('Medium')).not.toBeInTheDocument();
+  });
+
+  it('closes the dropdown when clicking outside', () => {
+    render(
+      <div>
+        <TrackHeightPresetSelector />
+        <span data-testid="outside">outside</span>
+      </div>,
+    );
+    fireEvent.click(screen.getByTestId('track-height-preset-btn'));
+    expect(screen.getByText('Small')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByText('Small')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a quick-access dropdown button in the TrackList header for setting all tracks to a height preset (Small / Medium / Large / Auto)
- Leverages existing `setAllTracksHeightPreset` store action and `trackHeight` constants
- Includes 5 unit tests for the new `TrackHeightPresetSelector` component

Closes #210

## Test plan
- [x] Unit tests pass (309/309 including 5 new)
- [x] TypeScript type-check passes (0 errors)
- [x] Production build succeeds
- [ ] Manual: open DAW, click the height preset icon in the Tracks header, verify all tracks resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)