### PR TITLE
feat: #212 — recent projects list on startup dialog

### DIFF
--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -10,11 +10,54 @@ import {
   MIN_BPM,
   MAX_BPM,
 } from '../../constants/defaults';
+import {
+  listProjects,
+  loadProject,
+  type ProjectSummary,
+} from '../../services/projectStorage';
+import { toastSuccess } from '../../hooks/useToast';
+
+function formatDate(ts: number) {
+  const d = new Date(ts);
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function ProjectThumbnail({ trackCount }: { trackCount: number }) {
+  const lanes = Math.min(trackCount, 6);
+  const colors = ['#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7'];
+  return (
+    <div
+      data-testid="project-thumbnail"
+      className="w-full h-16 bg-daw-bg rounded border border-daw-border/50 overflow-hidden flex flex-col justify-center gap-0.5 p-1.5"
+    >
+      {Array.from({ length: lanes }).map((_, i) => (
+        <div
+          key={i}
+          className="rounded-sm opacity-60"
+          style={{
+            backgroundColor: colors[i % colors.length],
+            height: `${Math.max(2, 12 / lanes)}px`,
+            width: `${40 + ((i * 17) % 50)}%`,
+          }}
+        />
+      ))}
+      {trackCount === 0 && (
+        <div className="text-[9px] text-zinc-600 text-center">Empty</div>
+      )}
+    </div>
+  );
+}
 
 export function NewProjectDialog() {
   const show = useUIStore((s) => s.showNewProjectDialog);
   const setShow = useUIStore((s) => s.setShowNewProjectDialog);
   const createProject = useProjectStore((s) => s.createProject);
+  const setProject = useProjectStore((s) => s.setProject);
 
   const [name, setName] = useState(DEFAULT_PROJECT_NAME);
   const [bpm, setBpm] = useState(DEFAULT_BPM);
@@ -22,7 +65,9 @@ export function NewProjectDialog() {
   const [keyScale, setKeyScale] = useState(DEFAULT_KEY_SCALE);
   const [timeSignature, setTimeSignature] = useState(DEFAULT_TIME_SIGNATURE);
 
-  // Reset form when dialog opens
+  const [recentProjects, setRecentProjects] = useState<ProjectSummary[]>([]);
+
+  // Reset form and load recent projects when dialog opens
   useEffect(() => {
     if (show) {
       setName(DEFAULT_PROJECT_NAME);
@@ -30,6 +75,7 @@ export function NewProjectDialog() {
       setBpmText(String(DEFAULT_BPM));
       setKeyScale(DEFAULT_KEY_SCALE);
       setTimeSignature(DEFAULT_TIME_SIGNATURE);
+      listProjects().then((list) => setRecentProjects(list));
     }
   }, [show]);
 
@@ -40,9 +86,18 @@ export function NewProjectDialog() {
     setShow(false);
   };
 
+  const handleOpenRecent = async (id: string) => {
+    const project = await loadProject(id);
+    if (project) {
+      setProject(project);
+      toastSuccess('Project loaded');
+      setShow(false);
+    }
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="w-[400px] bg-daw-surface rounded-lg border border-daw-border shadow-2xl">
+      <div className={`${recentProjects.length > 0 ? 'w-[600px]' : 'w-[400px]'} max-h-[80vh] bg-daw-surface rounded-lg border border-daw-border shadow-2xl flex flex-col`}>
         <div className="flex items-center justify-between px-4 py-3 border-b border-daw-border">
           <h2 className="text-sm font-medium">New Project</h2>
           <button
@@ -53,65 +108,93 @@ export function NewProjectDialog() {
           </button>
         </div>
 
-        <div className="p-4 space-y-3">
-          <div>
-            <label className="block text-xs text-zinc-400 mb-1">Project Name</label>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
-            />
-          </div>
-
-          <div>
-            <label className="block text-xs text-zinc-400 mb-1">BPM</label>
-            <input
-              type="number"
-              value={bpmText}
-              onChange={(e) => setBpmText(e.target.value)}
-              onBlur={() => {
-                const parsed = parseInt(bpmText);
-                const valid = isNaN(parsed) ? DEFAULT_BPM : Math.min(MAX_BPM, Math.max(MIN_BPM, parsed));
-                setBpm(valid);
-                setBpmText(String(valid));
-              }}
-              min={MIN_BPM}
-              max={MAX_BPM}
-              className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs text-zinc-400 mb-1">Key</label>
-              <select
-                value={keyScale}
-                onChange={(e) => setKeyScale(e.target.value)}
-                className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
-              >
-                {KEY_SCALES.map((k) => (
-                  <option key={k} value={k}>{k}</option>
+        <div className="flex-1 overflow-y-auto">
+          {/* ── Recent Projects ── */}
+          {recentProjects.length > 0 && (
+            <div className="p-4 border-b border-daw-border">
+              <h3 className="text-xs font-medium text-zinc-400 mb-3">Recent Projects</h3>
+              <div className="grid grid-cols-3 gap-2">
+                {recentProjects.slice(0, 6).map((p) => (
+                  <button
+                    key={p.id}
+                    data-project-id={p.id}
+                    onClick={() => handleOpenRecent(p.id)}
+                    className="text-left rounded-lg border border-daw-border/50 hover:border-daw-accent/50 hover:bg-daw-surface-2 transition-colors p-2 group"
+                  >
+                    <ProjectThumbnail trackCount={p.trackCount} />
+                    <p className="text-xs text-zinc-200 truncate mt-1.5 group-hover:text-white">
+                      {p.name}
+                    </p>
+                    <p className="text-[10px] text-zinc-500">
+                      {p.trackCount} track{p.trackCount !== 1 ? 's' : ''} &middot; {formatDate(p.updatedAt)}
+                    </p>
+                  </button>
                 ))}
-              </select>
+              </div>
             </div>
-            <div>
-              <label className="block text-xs text-zinc-400 mb-1">Time Signature</label>
-              <select
-                value={timeSignature}
-                onChange={(e) => setTimeSignature(parseInt(e.target.value))}
-                className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
-              >
-                {TIME_SIGNATURES.map((ts) => (
-                  <option key={ts} value={ts}>{ts}/4</option>
-                ))}
-              </select>
-            </div>
-          </div>
+          )}
 
-          <p className="text-[10px] text-zinc-500">
-            Duration is determined automatically by your clips. Individual clips can override BPM, key, and time signature.
-          </p>
+          {/* ── New Project Form ── */}
+          <div className="p-4 space-y-3">
+            <div>
+              <label className="block text-xs text-zinc-400 mb-1">Project Name</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs text-zinc-400 mb-1">BPM</label>
+              <input
+                type="number"
+                value={bpmText}
+                onChange={(e) => setBpmText(e.target.value)}
+                onBlur={() => {
+                  const parsed = parseInt(bpmText);
+                  const valid = isNaN(parsed) ? DEFAULT_BPM : Math.min(MAX_BPM, Math.max(MIN_BPM, parsed));
+                  setBpm(valid);
+                  setBpmText(String(valid));
+                }}
+                min={MIN_BPM}
+                max={MAX_BPM}
+                className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Key</label>
+                <select
+                  value={keyScale}
+                  onChange={(e) => setKeyScale(e.target.value)}
+                  className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
+                >
+                  {KEY_SCALES.map((k) => (
+                    <option key={k} value={k}>{k}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Time Signature</label>
+                <select
+                  value={timeSignature}
+                  onChange={(e) => setTimeSignature(parseInt(e.target.value))}
+                  className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
+                >
+                  {TIME_SIGNATURES.map((ts) => (
+                    <option key={ts} value={ts}>{ts}/4</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <p className="text-[10px] text-zinc-500">
+              Duration is determined automatically by your clips. Individual clips can override BPM, key, and time signature.
+            </p>
+          </div>
         </div>
 
         <div className="flex justify-end px-4 py-3 border-t border-daw-border gap-2">

--- a/tests/unit/bpmInput.test.tsx
+++ b/tests/unit/bpmInput.test.tsx
@@ -14,6 +14,8 @@ vi.mock('../../src/services/aceStepApi', () => ({
 
 vi.mock('../../src/services/projectStorage', () => ({
   saveProject: vi.fn(),
+  listProjects: vi.fn().mockResolvedValue([]),
+  loadProject: vi.fn().mockResolvedValue(null),
 }));
 
 describe('BPM input — clamp on blur, not keystroke', () => {

--- a/tests/unit/newProjectDialog.test.tsx
+++ b/tests/unit/newProjectDialog.test.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { NewProjectDialog } from '../../src/components/dialogs/NewProjectDialog';
+import { useUIStore } from '../../src/store/uiStore';
+import { useProjectStore } from '../../src/store/projectStore';
+import type { ProjectSummary } from '../../src/services/projectStorage';
+
+const mockListProjects = vi.fn<() => Promise<ProjectSummary[]>>();
+const mockLoadProject = vi.fn();
+const mockSaveProject = vi.fn();
+
+vi.mock('../../src/services/projectStorage', () => ({
+  listProjects: (...args: unknown[]) => mockListProjects(...(args as [])),
+  loadProject: (...args: unknown[]) => mockLoadProject(...(args as [])),
+  saveProject: (...args: unknown[]) => mockSaveProject(...(args as [])),
+}));
+
+vi.mock('../../src/services/aceStepApi', () => ({
+  listModels: vi.fn().mockResolvedValue([]),
+  initModel: vi.fn().mockResolvedValue({}),
+  getBackendUrl: vi.fn().mockReturnValue('http://localhost:8001'),
+  setBackendUrl: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useToast', () => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+}));
+
+const recentProjects: ProjectSummary[] = [
+  { id: 'p1', name: 'My Song', createdAt: 1710000000000, updatedAt: 1710100000000, trackCount: 3 },
+  { id: 'p2', name: 'Demo Beat', createdAt: 1709000000000, updatedAt: 1709900000000, trackCount: 5 },
+  { id: 'p3', name: 'Chill Vibes', createdAt: 1708000000000, updatedAt: 1708800000000, trackCount: 2 },
+];
+
+function openDialog() {
+  useUIStore.getState().setShowNewProjectDialog(true);
+}
+
+describe('NewProjectDialog — recent projects (#212)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useUIStore.setState(useUIStore.getInitialState?.() ?? {}, true);
+    useProjectStore.setState(useProjectStore.getInitialState?.() ?? {}, true);
+    mockListProjects.mockReset();
+    mockLoadProject.mockReset();
+    mockSaveProject.mockReset();
+  });
+
+  it('shows "Recent Projects" heading when saved projects exist', async () => {
+    mockListProjects.mockResolvedValue(recentProjects);
+    openDialog();
+    render(<NewProjectDialog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Recent Projects')).toBeInTheDocument();
+    });
+  });
+
+  it('renders project names and track counts from listProjects', async () => {
+    mockListProjects.mockResolvedValue(recentProjects);
+    openDialog();
+    render(<NewProjectDialog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Song')).toBeInTheDocument();
+      expect(screen.getByText('Demo Beat')).toBeInTheDocument();
+      expect(screen.getByText('Chill Vibes')).toBeInTheDocument();
+    });
+
+    // Track counts should appear somewhere
+    expect(screen.getByText(/3 track/)).toBeInTheDocument();
+    expect(screen.getByText(/5 track/)).toBeInTheDocument();
+    expect(screen.getByText(/2 track/)).toBeInTheDocument();
+  });
+
+  it('clicking a recent project loads it and closes the dialog', async () => {
+    const fakeProject = {
+      id: 'p1',
+      name: 'My Song',
+      createdAt: 1710000000000,
+      updatedAt: 1710100000000,
+      bpm: 120,
+      keyScale: 'C major',
+      timeSignature: 4,
+      totalDuration: 60,
+      tracks: [
+        { id: 't1', trackName: 'drums', displayName: 'Drums', color: '#ef4444', order: 0, volume: 0.8, muted: false, soloed: false, clips: [] },
+        { id: 't2', trackName: 'bass', displayName: 'Bass', color: '#3b82f6', order: 1, volume: 0.8, muted: false, soloed: false, clips: [] },
+        { id: 't3', trackName: 'keyboard', displayName: 'Keys', color: '#22c55e', order: 2, volume: 0.8, muted: false, soloed: false, clips: [] },
+      ],
+      generationDefaults: { inferenceSteps: 20, guidanceScale: 7.5, shift: 0, thinking: false, model: 'test' },
+    };
+    mockListProjects.mockResolvedValue(recentProjects);
+    mockLoadProject.mockResolvedValue(fakeProject);
+    openDialog();
+    render(<NewProjectDialog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Song')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('My Song'));
+
+    await waitFor(() => {
+      expect(mockLoadProject).toHaveBeenCalledWith('p1');
+      // Dialog should close
+      expect(useUIStore.getState().showNewProjectDialog).toBe(false);
+    });
+  });
+
+  it('does not show recent projects section when no projects are saved', async () => {
+    mockListProjects.mockResolvedValue([]);
+    openDialog();
+    render(<NewProjectDialog />);
+
+    // Wait for async load to finish
+    await waitFor(() => {
+      expect(mockListProjects).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText('Recent Projects')).not.toBeInTheDocument();
+  });
+
+  it('still shows the "New Project" creation form', async () => {
+    mockListProjects.mockResolvedValue(recentProjects);
+    openDialog();
+    render(<NewProjectDialog />);
+
+    // The new project form elements should still be present
+    expect(screen.getByText('New Project')).toBeInTheDocument();
+    expect(screen.getByText('Create')).toBeInTheDocument();
+  });
+
+  it('recent project cards have data-project-id attributes for E2E', async () => {
+    mockListProjects.mockResolvedValue(recentProjects);
+    openDialog();
+    const { container } = render(<NewProjectDialog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Song')).toBeInTheDocument();
+    });
+
+    const cards = container.querySelectorAll('[data-project-id]');
+    expect(cards.length).toBe(3);
+    expect(cards[0].getAttribute('data-project-id')).toBe('p1');
+  });
+
+  it('shows thumbnail placeholder with track count visual', async () => {
+    mockListProjects.mockResolvedValue(recentProjects);
+    openDialog();
+    const { container } = render(<NewProjectDialog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Song')).toBeInTheDocument();
+    });
+
+    // Each card should have a thumbnail area
+    const thumbnails = container.querySelectorAll('[data-testid="project-thumbnail"]');
+    expect(thumbnails.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a "Recent Projects" section to the New Project startup dialog showing up to 6 saved projects
- Each project card displays a track-count thumbnail, project name, track count, and last updated date
- Clicking a card loads the project directly and closes the dialog
- Dialog widens to 600px when recent projects exist, stays at 400px when empty

## Test plan
- [x] 7 new unit tests in `newProjectDialog.test.tsx` covering:
  - Recent projects heading appears when projects exist
  - Project names and track counts rendered from `listProjects()`
  - Clicking a project calls `loadProject()` and closes dialog
  - No recent section when project list is empty
  - New project form still accessible
  - `data-project-id` attributes for E2E
  - Thumbnail placeholders rendered
- [x] Updated `bpmInput.test.tsx` mock to include new `listProjects` import
- [x] All 558 unit tests pass
- [x] `npm run build` succeeds with 0 errors

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)