### PR TITLE
feat: #214 — drum machine — 16-pad sample trigger instrument

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -20,6 +20,7 @@ import { MixerPanel } from '../mixer/MixerPanel';
 import { AssetsPanel } from '../assets/AssetsPanel';
 import { LoopBrowser } from '../assets/LoopBrowser';
 import { SequencerEditor } from '../sequencer/SequencerEditor';
+import { DrumMachineEditor } from '../sequencer/DrumMachineEditor';
 import { SmartControlsPanel } from '../controls/SmartControlsPanel';
 import { PianoRoll } from '../pianoroll/PianoRoll';
 import { EffectChain } from '../mixer/EffectChain';
@@ -86,6 +87,7 @@ export function AppShell() {
 
       {project && <SmartControlsPanel />}
       {project && <SequencerEditor />}
+      {project && <DrumMachineEditor />}
       {project && <PianoRoll />}
       {project && <EffectChain />}
       {project && <MixerPanel />}

--- a/src/components/sequencer/DrumMachineEditor.tsx
+++ b/src/components/sequencer/DrumMachineEditor.tsx
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import { drumEngine, DRUM_PAD_NAMES, BEAT_PAD_KEYS } from '../../engine/DrumEngine';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import type { DrumKitName } from '../../types/project';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { cacheUserSample } from '../../services/sampleManager';
+
+const PAD_COLORS = [
+  '#ef4444', '#f97316', '#eab308', '#22c55e',
+  '#06b6d4', '#3b82f6', '#8b5cf6', '#ec4899',
+  '#f59e0b', '#10b981', '#14b8a6', '#0ea5e9',
+  '#6366f1', '#d946ef', '#a855f7', '#78716c',
+];
+
+const KIT_OPTIONS: { value: DrumKitName; label: string }[] = [
+  { value: '808', label: '808' },
+  { value: 'acoustic', label: 'Acoustic' },
+  { value: 'electronic', label: 'Electronic' },
+  { value: 'lofi', label: 'Lo-Fi' },
+];
+
+export function DrumMachineEditor() {
+  const trackId = useUIStore((s) => s.openDrumMachineTrackId);
+  const editorHeight = useUIStore((s) => s.drumMachineEditorHeight);
+  const setEditorHeight = useUIStore((s) => s.setDrumMachineEditorHeight);
+  const closeEditor = useUIStore((s) => s.setOpenDrumMachineTrackId);
+
+  const project = useProjectStore((s) => s.project);
+  const track = useMemo(() => project?.tracks.find((t) => t.id === trackId) ?? null, [project, trackId]);
+  const setDrumPadSample = useProjectStore((s) => s.setDrumPadSample);
+  const setDrumPadVolume = useProjectStore((s) => s.setDrumPadVolume);
+  const setDrumMachineKit = useProjectStore((s) => s.setDrumMachineKit);
+
+  const [activePads, setActivePads] = useState<Set<number>>(new Set());
+  const [selectedPad, setSelectedPad] = useState<number | null>(null);
+  const timeoutRefs = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+  const padRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
+  const resizeRef = useRef<HTMLDivElement>(null);
+
+  const drumMachine = track?.drumMachine;
+  const pads = drumMachine?.pads ?? [];
+
+  // Ensure drum engine for this track
+  useEffect(() => {
+    if (track && trackId) {
+      drumEngine.ensureTrack(trackId, track.drumKit ?? '808');
+    }
+  }, [trackId, track?.drumKit]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Velocity-sensitive pad trigger: compute velocity from vertical position within pad
+  const triggerPad = useCallback(
+    (padIndex: number, velocity?: number) => {
+      if (!trackId) return;
+      const kit = track?.drumKit ?? '808';
+      const padVol = pads[padIndex]?.volume ?? 0.8;
+      const vel = Math.round((velocity ?? 0.8) * padVol * 127);
+      drumEngine.triggerPad(trackId, padIndex, vel, kit);
+
+      // Visual feedback
+      setActivePads((prev) => new Set(prev).add(padIndex));
+      const existing = timeoutRefs.current.get(padIndex);
+      if (existing) clearTimeout(existing);
+      const timeout = setTimeout(() => {
+        setActivePads((prev) => {
+          const next = new Set(prev);
+          next.delete(padIndex);
+          return next;
+        });
+        timeoutRefs.current.delete(padIndex);
+      }, 150);
+      timeoutRefs.current.set(padIndex, timeout);
+    },
+    [trackId, track?.drumKit, pads],
+  );
+
+  // Mouse-down handler: compute velocity from Y position within pad
+  const handlePadMouseDown = useCallback(
+    (padIndex: number, e: React.MouseEvent<HTMLButtonElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect();
+      // Top of pad = max velocity, bottom = min velocity (MPC-style)
+      const yRatio = 1 - (e.clientY - rect.top) / rect.height;
+      const velocity = 0.3 + yRatio * 0.7; // range 0.3 – 1.0
+      triggerPad(padIndex, velocity);
+      setSelectedPad(padIndex);
+    },
+    [triggerPad],
+  );
+
+  // Keyboard mapping
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      const key = e.key.toLowerCase();
+      const padIndex = BEAT_PAD_KEYS.indexOf(key);
+      if (padIndex !== -1) {
+        e.preventDefault();
+        triggerPad(padIndex);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [triggerPad]);
+
+  // Cleanup timeouts
+  useEffect(() => {
+    return () => {
+      for (const t of timeoutRefs.current.values()) clearTimeout(t);
+    };
+  }, []);
+
+  // Resize handle
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const startY = e.clientY;
+      const startH = editorHeight;
+      const onMove = (ev: MouseEvent) => {
+        setEditorHeight(startH - (ev.clientY - startY));
+      };
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [editorHeight, setEditorHeight],
+  );
+
+  if (!trackId || !track || track.trackType !== 'drumMachine') return null;
+
+  const selectedPadData = selectedPad !== null ? pads[selectedPad] : null;
+
+  return (
+    <div
+      className="flex flex-col border-t border-white/10 bg-[#1a1a2e]"
+      style={{ height: editorHeight }}
+      data-track-id={trackId}
+    >
+      {/* Resize handle */}
+      <div
+        ref={resizeRef}
+        className="h-1 cursor-row-resize bg-white/5 hover:bg-white/20 transition-colors"
+        onMouseDown={handleResizeStart}
+      />
+
+      {/* Header bar */}
+      <div className="flex items-center gap-3 px-3 py-1.5 border-b border-white/10 bg-[#16162a]">
+        <span className="text-xs font-semibold text-white/80 uppercase tracking-wider">
+          Drum Machine
+        </span>
+        <span className="text-[10px] text-white/40 truncate max-w-[120px]">
+          {track.displayName}
+        </span>
+
+        {/* Kit selector */}
+        <select
+          className="ml-auto text-[10px] bg-white/5 border border-white/10 rounded px-1.5 py-0.5 text-white/70 focus:outline-none"
+          value={drumMachine?.kitName ?? '808'}
+          onChange={(e) => setDrumMachineKit(trackId, e.target.value as DrumKitName)}
+        >
+          {KIT_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+
+        <button
+          className="text-white/40 hover:text-white/80 text-sm px-1"
+          onClick={() => closeEditor(null)}
+          title="Close"
+        >
+          &times;
+        </button>
+      </div>
+
+      {/* Main content */}
+      <div className="flex flex-1 min-h-0 overflow-hidden">
+        {/* Pad grid - 4x4 */}
+        <div className="flex-1 p-3 flex items-center justify-center">
+          <div
+            className="grid grid-cols-4 gap-2 w-full max-w-[480px] aspect-square"
+            style={{ maxHeight: editorHeight - 60 }}
+          >
+            {Array.from({ length: 16 }, (_, i) => {
+              const pad = pads[i];
+              const isActive = activePads.has(i);
+              const isSelected = selectedPad === i;
+              const color = pad?.color ?? PAD_COLORS[i];
+              const keyLabel = BEAT_PAD_KEYS[i]?.toUpperCase() ?? '';
+              const name = pad?.name ?? DRUM_PAD_NAMES[i] ?? `Pad ${i + 1}`;
+
+              return (
+                <button
+                  key={i}
+                  ref={(el) => { if (el) padRefs.current.set(i, el); }}
+                  className={`relative rounded-lg border-2 transition-all duration-75 flex flex-col items-center justify-center select-none ${
+                    isActive
+                      ? 'scale-95 brightness-150'
+                      : isSelected
+                        ? 'ring-2 ring-white/40'
+                        : 'hover:brightness-125 active:scale-95'
+                  }`}
+                  style={{
+                    backgroundColor: isActive ? color : `${color}30`,
+                    borderColor: isActive ? color : isSelected ? `${color}80` : `${color}50`,
+                    boxShadow: isActive ? `0 0 16px ${color}80` : 'none',
+                  }}
+                  onMouseDown={(e) => handlePadMouseDown(i, e)}
+                  data-pad-index={i}
+                >
+                  <span className="text-[10px] text-white/90 font-semibold leading-tight text-center px-1 truncate w-full">
+                    {name}
+                  </span>
+                  <span className="text-[8px] text-white/30 absolute bottom-1 right-1.5 font-mono">
+                    {keyLabel}
+                  </span>
+                  {pad && (
+                    <span className="text-[7px] text-white/20 absolute top-1 right-1.5">
+                      {Math.round(pad.volume * 100)}%
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Pad detail panel */}
+        <div className="w-52 border-l border-white/10 bg-[#12122a] p-3 flex flex-col gap-3 overflow-y-auto">
+          {selectedPadData ? (
+            <>
+              <div className="text-[10px] text-white/40 uppercase tracking-wider font-semibold">
+                Pad {(selectedPad ?? 0) + 1}
+              </div>
+              <div className="text-xs text-white/80 font-medium truncate">
+                {selectedPadData.name}
+              </div>
+
+              {/* Volume */}
+              <label className="flex flex-col gap-1">
+                <span className="text-[9px] text-white/40 uppercase">Volume</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={selectedPadData.volume}
+                  onChange={(e) => setDrumPadVolume(trackId, selectedPad!, parseFloat(e.target.value))}
+                  className="w-full accent-blue-500 h-1"
+                />
+                <span className="text-[9px] text-white/30 text-right">
+                  {Math.round(selectedPadData.volume * 100)}%
+                </span>
+              </label>
+
+              {/* Sample key display */}
+              <div className="flex flex-col gap-1">
+                <span className="text-[9px] text-white/40 uppercase">Sample</span>
+                <span className="text-[10px] text-white/60 bg-white/5 rounded px-2 py-1 truncate">
+                  {selectedPadData.sampleKey}
+                </span>
+              </div>
+
+              {/* Load custom sample */}
+              <label className="flex items-center gap-1 cursor-pointer text-[10px] text-blue-400 hover:text-blue-300">
+                <input
+                  type="file"
+                  accept="audio/*"
+                  className="hidden"
+                  onChange={async (e) => {
+                    const file = e.target.files?.[0];
+                    if (!file || !file.type.startsWith('audio/')) return;
+                    
+                    
+                    const engine = getAudioEngine();
+                    await engine.resume();
+                    const arrayBuffer = await file.arrayBuffer();
+                    const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
+                    const key = `user-sample-${Date.now()}-${file.name}`;
+                    cacheUserSample(key, audioBuffer);
+                    setDrumPadSample(trackId, selectedPad!, key);
+                  }}
+                />
+                Load Sample...
+              </label>
+            </>
+          ) : (
+            <div className="text-[10px] text-white/30 mt-4 text-center">
+              Click a pad to see its details
+            </div>
+          )}
+
+          {/* Velocity hint */}
+          <div className="mt-auto text-[8px] text-white/20 leading-relaxed">
+            Velocity: click higher on pad for louder hits.
+            <br />
+            Keys: 1-4, Q-R, A-F, Z-V
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -3,6 +3,7 @@ import type { Track } from '../../types/project';
 import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
 import { ClipBlock } from './ClipBlock';
+import { TakeLaneStrip } from './TakeLaneStrip';
 import { AutomationLaneView } from './AutomationLaneView';
 import { AddLayerModal } from '../generation/AddLayerModal';
 import { snapToGrid } from '../../utils/time';
@@ -74,6 +75,7 @@ export function TrackLane({ track }: TrackLaneProps) {
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const contextWindow = useUIStore((s) => s.contextWindow);
   const setOpenSequencerTrackId = useUIStore((s) => s.setOpenSequencerTrackId);
+  const setOpenDrumMachineTrackId = useUIStore((s) => s.setOpenDrumMachineTrackId);
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
   const project = useProjectStore((s) => s.project);
   const updateTrack = useProjectStore((s) => s.updateTrack);
@@ -117,6 +119,7 @@ export function TrackLane({ track }: TrackLaneProps) {
 
   const trackType = track.trackType ?? 'stems';
   const isSequencer = trackType === 'sequencer';
+  const isDrumMachine = trackType === 'drumMachine';
   const isPianoRoll = trackType === 'pianoRoll';
   const totalWidth = project.totalDuration * pixelsPerSecond;
 
@@ -145,6 +148,11 @@ export function TrackLane({ track }: TrackLaneProps) {
     if (e.target !== e.currentTarget) return;
 
     // For sequencer tracks, double-click opens the editor
+    if (isDrumMachine) {
+      e.stopPropagation();
+      setOpenDrumMachineTrackId(track.id);
+      return;
+    }
     if (isSequencer) {
       e.stopPropagation();
       setOpenSequencerTrackId(track.id);
@@ -304,6 +312,15 @@ export function TrackLane({ track }: TrackLaneProps) {
           onMouseDown={onResizeMouseDown}
         />
       </div>
+
+      {/* Take Lanes — rendered below the track lane when showTakeLanes is enabled */}
+      {track.showTakeLanes && track.clips.map((clip) =>
+        clip.takes && clip.takes.length > 0 ? (
+          <div key={`takes-${clip.id}`} className="relative border-b border-[#2a2a2a]" style={{ width: totalWidth }}>
+            <TakeLaneStrip clip={clip} track={track} />
+          </div>
+        ) : null,
+      )}
 
       {/* Automation Lanes — rendered below the track lane when present */}
       {automationLanes.map((lane) => (

--- a/src/constants/trackHeight.ts
+++ b/src/constants/trackHeight.ts
@@ -15,6 +15,7 @@ const AUTO_DEFAULTS: Record<TrackType, number> = {
   sample: 64,
   sequencer: 80,
   pianoRoll: 88,
+  drumMachine: 80,
 };
 
 /** Resolve a preset to a pixel height, considering track type for 'auto'. */

--- a/src/constants/tracks.ts
+++ b/src/constants/tracks.ts
@@ -44,6 +44,7 @@ export const TRACK_TYPE_CATALOG: Record<TrackType, TrackTypeInfo> = {
   sample:    { type: 'sample',    label: 'Sample',     abbr: 'SMP', emoji: '📁', color: '#f97316', description: 'User-imported audio clips' },
   sequencer: { type: 'sequencer', label: 'Sequencer',  abbr: 'SEQ', emoji: '🎹', color: '#22c55e', description: 'Step-based drum pattern editor' },
   pianoRoll: { type: 'pianoRoll', label: 'Piano Roll', abbr: 'PNO', emoji: '🎵', color: '#a855f7', description: 'MIDI note editor with built-in synth presets' },
+  drumMachine: { type: 'drumMachine', label: 'Drum Machine', abbr: 'DRM', emoji: '🥁', color: '#ef4444', description: 'MPC-style 16-pad sample trigger instrument' },
 };
 
 export interface DrumKitSample {

--- a/src/store/__tests__/drumMachine.test.ts
+++ b/src/store/__tests__/drumMachine.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+// Mock projectStorage to prevent IndexedDB calls during testing
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('drumMachine store actions', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+  });
+
+  describe('addTrack with drumMachine type', () => {
+    it('creates a drum machine track with 16 pads initialized', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      expect(track.trackType).toBe('drumMachine');
+      expect(track.drumKit).toBe('808');
+      expect(track.drumMachine).toBeDefined();
+      expect(track.drumMachine!.pads).toHaveLength(16);
+      expect(track.drumMachine!.kitName).toBe('808');
+    });
+
+    it('initializes pads with default names and properties', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      const pads = track.drumMachine!.pads;
+      expect(pads[0].name).toBe('Kick');
+      expect(pads[0].sampleKey).toBe('kick');
+      expect(pads[0].volume).toBe(0.8);
+      expect(pads[0].pan).toBe(0);
+      expect(pads[1].name).toBe('Snare');
+      expect(pads[15].name).toBe('Perc');
+    });
+
+    it('assigns unique IDs to each pad', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      const ids = track.drumMachine!.pads.map((p) => p.id);
+      expect(new Set(ids).size).toBe(16);
+    });
+
+    it('sets laneHeight to 80 for drum machine tracks', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      expect(track.laneHeight).toBe(80);
+    });
+  });
+
+  describe('setDrumPadSample', () => {
+    it('changes the sample key of a pad', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().setDrumPadSample(track.id, 0, 'user-sample-custom');
+      const updated = useProjectStore.getState().project!.tracks[0].drumMachine!.pads[0];
+      expect(updated.sampleKey).toBe('user-sample-custom');
+    });
+
+    it('does not affect other pads', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().setDrumPadSample(track.id, 0, 'new-sample');
+      const pads = useProjectStore.getState().project!.tracks[0].drumMachine!.pads;
+      expect(pads[1].sampleKey).toBe('snare');
+      expect(pads[2].sampleKey).toBe('closed_hh');
+    });
+  });
+
+  describe('setDrumPadVolume', () => {
+    it('sets pad volume within bounds', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().setDrumPadVolume(track.id, 3, 0.5);
+      const pad = useProjectStore.getState().project!.tracks[0].drumMachine!.pads[3];
+      expect(pad.volume).toBe(0.5);
+    });
+
+    it('clamps volume to 0-1 range', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().setDrumPadVolume(track.id, 0, 1.5);
+      expect(useProjectStore.getState().project!.tracks[0].drumMachine!.pads[0].volume).toBe(1);
+      useProjectStore.getState().setDrumPadVolume(track.id, 0, -0.5);
+      expect(useProjectStore.getState().project!.tracks[0].drumMachine!.pads[0].volume).toBe(0);
+    });
+  });
+
+  describe('setDrumPadPan', () => {
+    it('sets pad pan within bounds', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().setDrumPadPan(track.id, 2, -0.5);
+      const pad = useProjectStore.getState().project!.tracks[0].drumMachine!.pads[2];
+      expect(pad.pan).toBe(-0.5);
+    });
+
+    it('clamps pan to -1 to +1 range', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().setDrumPadPan(track.id, 0, 2);
+      expect(useProjectStore.getState().project!.tracks[0].drumMachine!.pads[0].pan).toBe(1);
+      useProjectStore.getState().setDrumPadPan(track.id, 0, -3);
+      expect(useProjectStore.getState().project!.tracks[0].drumMachine!.pads[0].pan).toBe(-1);
+    });
+  });
+
+  describe('renameDrumPad', () => {
+    it('renames a pad', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().renameDrumPad(track.id, 0, 'My Kick');
+      const pad = useProjectStore.getState().project!.tracks[0].drumMachine!.pads[0];
+      expect(pad.name).toBe('My Kick');
+    });
+  });
+
+  describe('setDrumMachineKit', () => {
+    it('changes the kit name', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().setDrumMachineKit(track.id, 'acoustic');
+      const dm = useProjectStore.getState().project!.tracks[0].drumMachine!;
+      expect(dm.kitName).toBe('acoustic');
+    });
+
+    it('also updates the track drumKit field', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().setDrumMachineKit(track.id, 'lofi');
+      const updated = useProjectStore.getState().project!.tracks[0];
+      expect(updated.drumKit).toBe('lofi');
+    });
+  });
+
+  describe('initDrumMachine', () => {
+    it('reinitializes a drum machine config', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      // Modify a pad
+      useProjectStore.getState().setDrumPadSample(track.id, 0, 'custom');
+      // Reinitialize
+      useProjectStore.getState().initDrumMachine(track.id, 'acoustic');
+      const dm = useProjectStore.getState().project!.tracks[0].drumMachine!;
+      expect(dm.kitName).toBe('acoustic');
+      expect(dm.pads[0].sampleKey).toBe('kick'); // reset to default
+    });
+  });
+
+  describe('undo/redo', () => {
+    it('undoes a pad sample change', () => {
+      const track = useProjectStore.getState().addTrack('drums', 'drumMachine');
+      useProjectStore.getState().setDrumPadSample(track.id, 0, 'custom');
+      expect(useProjectStore.getState().project!.tracks[0].drumMachine!.pads[0].sampleKey).toBe('custom');
+      useProjectStore.getState().undo();
+      expect(useProjectStore.getState().project!.tracks[0].drumMachine!.pads[0].sampleKey).toBe('kick');
+    });
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -38,6 +38,8 @@ import type {
   LoudnessTarget,
   MasteringPreset,
   MasteringState,
+  DrumMachineConfig,
+  DrumKitName,
 } from '../types/project';
 import { automationParamEquals } from '../types/project';
 import { quantizeNotes as applyQuantize, type QuantizeOptions } from '../utils/midiQuantize';
@@ -205,6 +207,14 @@ interface ProjectState {
   setSequencerRowColor: (trackId: string, rowId: string, color: string) => void;
   fillSequencerRow: (trackId: string, rowId: string, every: number) => void;
   batchSetSequencerSteps: (trackId: string, ops: { rowId: string; stepIndex: number; active: boolean; velocity: number }[]) => void;
+
+  // Drum machine actions
+  initDrumMachine: (trackId: string, kit?: DrumKitName) => void;
+  setDrumPadSample: (trackId: string, padIndex: number, sampleKey: string) => void;
+  setDrumPadVolume: (trackId: string, padIndex: number, volume: number) => void;
+  setDrumPadPan: (trackId: string, padIndex: number, pan: number) => void;
+  renameDrumPad: (trackId: string, padIndex: number, name: string) => void;
+  setDrumMachineKit: (trackId: string, kit: DrumKitName) => void;
   addMidiNote: (clipId: string, note: Omit<MidiNote, 'id'> & { id?: string }) => string | undefined;
   updateMidiNote: (clipId: string, noteId: string, updates: Partial<MidiNote>) => void;
   removeMidiNote: (clipId: string, noteId: string) => void;
@@ -439,6 +449,39 @@ function createDefaultSequencerPattern(): SequencerPattern {
   };
 }
 
+const DRUM_PAD_DEFAULTS: { name: string; sampleKey: string; color: string }[] = [
+  { name: 'Kick',       sampleKey: 'kick',       color: '#ef4444' },
+  { name: 'Snare',      sampleKey: 'snare',      color: '#f97316' },
+  { name: 'Closed HH',  sampleKey: 'closed_hh',  color: '#eab308' },
+  { name: 'Open HH',    sampleKey: 'open_hh',    color: '#84cc16' },
+  { name: 'Clap',       sampleKey: 'clap',       color: '#22c55e' },
+  { name: 'Rim',        sampleKey: 'rim',        color: '#06b6d4' },
+  { name: 'Tom High',   sampleKey: 'high_tom',   color: '#3b82f6' },
+  { name: 'Tom Low',    sampleKey: 'low_tom',    color: '#8b5cf6' },
+  { name: 'Crash',      sampleKey: 'crash',      color: '#ec4899' },
+  { name: 'Ride',       sampleKey: 'ride',       color: '#f59e0b' },
+  { name: 'Shaker',     sampleKey: 'shaker',     color: '#10b981' },
+  { name: 'Cowbell',    sampleKey: 'cowbell',     color: '#14b8a6' },
+  { name: 'Conga',      sampleKey: 'conga',      color: '#0ea5e9' },
+  { name: 'Bongo',      sampleKey: 'bongo',      color: '#6366f1' },
+  { name: 'Tambourine', sampleKey: 'tambourine', color: '#d946ef' },
+  { name: 'Perc',       sampleKey: 'perc',       color: '#a855f7' },
+];
+
+function createDefaultDrumMachineConfig(kit: DrumKitName = '808'): DrumMachineConfig {
+  return {
+    kitName: kit,
+    pads: DRUM_PAD_DEFAULTS.map((d) => ({
+      id: uuidv4(),
+      name: d.name,
+      sampleKey: d.sampleKey,
+      color: d.color,
+      volume: 0.8,
+      pan: 0,
+    })),
+  };
+}
+
 function getDefaultTrackSynthPreset(trackName: TrackName): Track['synthPreset'] {
   return trackName === 'bass' ? 'bass'
     : trackName === 'strings' ? 'strings'
@@ -481,9 +524,9 @@ function createTrackFromTemplate(
   const track: Track = {
     color: info.color,
     volume: 0.8,
-    laneHeight: trackType === 'sequencer' ? 80 : trackType === 'pianoRoll' ? 88 : undefined,
+    laneHeight: trackType === 'sequencer' ? 80 : trackType === 'drumMachine' ? 80 : trackType === 'pianoRoll' ? 88 : undefined,
     synthPreset: getDefaultTrackSynthPreset(trackName),
-    drumKit: trackName === 'drums' || trackType === 'sequencer' ? '808' : undefined,
+    drumKit: trackName === 'drums' || trackType === 'sequencer' || trackType === 'drumMachine' ? '808' : undefined,
     ...trackOverrides,
     id: uuidv4(),
     trackType,
@@ -510,6 +553,10 @@ function createTrackFromTemplate(
       : createDefaultSequencerPattern();
   } else {
     delete track.sequencerPattern;
+  }
+
+  if (track.trackType === 'drumMachine') {
+    track.drumMachine = createDefaultDrumMachineConfig(track.drumKit ?? '808');
   }
 
   return track;
@@ -2293,6 +2340,138 @@ export const useProjectStore = create<ProjectState>()(
                 };
               }),
             },
+          };
+        }),
+      },
+    });
+  },
+
+  // ─── Drum Machine Actions ──────────────────────────────────────────────────
+  initDrumMachine: (trackId, kit) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId ? { ...t, drumMachine: createDefaultDrumMachineConfig(kit ?? t.drumKit ?? '808') } : t,
+        ),
+      },
+    });
+  },
+
+  setDrumPadSample: (trackId, padIndex, sampleKey) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.drumMachine) return t;
+          return {
+            ...t,
+            drumMachine: {
+              ...t.drumMachine,
+              pads: t.drumMachine.pads.map((p, i) =>
+                i === padIndex ? { ...p, sampleKey } : p,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  setDrumPadVolume: (trackId, padIndex, volume) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.drumMachine) return t;
+          return {
+            ...t,
+            drumMachine: {
+              ...t.drumMachine,
+              pads: t.drumMachine.pads.map((p, i) =>
+                i === padIndex ? { ...p, volume: Math.max(0, Math.min(1, volume)) } : p,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  setDrumPadPan: (trackId, padIndex, pan) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.drumMachine) return t;
+          return {
+            ...t,
+            drumMachine: {
+              ...t.drumMachine,
+              pads: t.drumMachine.pads.map((p, i) =>
+                i === padIndex ? { ...p, pan: Math.max(-1, Math.min(1, pan)) } : p,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  renameDrumPad: (trackId, padIndex, name) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.drumMachine) return t;
+          return {
+            ...t,
+            drumMachine: {
+              ...t.drumMachine,
+              pads: t.drumMachine.pads.map((p, i) =>
+                i === padIndex ? { ...p, name } : p,
+              ),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  setDrumMachineKit: (trackId, kit) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.drumMachine) return t;
+          return {
+            ...t,
+            drumKit: kit,
+            drumMachine: { ...t.drumMachine, kitName: kit },
           };
         }),
       },

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -31,17 +31,19 @@ interface UIState {
   expandedTrackId: string | null;
   /** Track whose sequencer editor is currently open (bottom panel). */
   openSequencerTrackId: string | null;
+  openDrumMachineTrackId: string | null;
   openPianoRollTrackId: string | null;
   openPianoRollClipId: string | null;
   openEffectChainTrackId: string | null;
   openMidiEffectChainTrackId: string | null;
+  drumMachineEditorHeight: number;
   sequencerEditorHeight: number;
   pianoRollHeight: number;
   effectChainHeight: number;
   showSmartControls: boolean;
   showLibrary: boolean;
   /** Which bottom editor is visible: null = none, 'smart' = smart controls, 'editor' = region editor */
-  activeBottomPanel: 'smart' | 'editor' | 'pianoRoll' | 'effects' | null;
+  activeBottomPanel: 'smart' | 'editor' | 'pianoRoll' | 'effects' | 'drumMachine' | null;
 
   // Tempo lane
   showTempoLane: boolean;
@@ -94,15 +96,17 @@ interface UIState {
   setSelectWindow: (v: { startTime: number; endTime: number; trackIds: string[] } | null) => void;
   setExpandedTrackId: (id: string | null) => void;
   setOpenSequencerTrackId: (id: string | null) => void;
+  setOpenDrumMachineTrackId: (id: string | null) => void;
   setOpenPianoRoll: (trackId: string | null, clipId?: string | null) => void;
   setOpenEffectChainTrackId: (id: string | null) => void;
   setOpenMidiEffectChainTrackId: (id: string | null) => void;
+  setDrumMachineEditorHeight: (v: number) => void;
   setSequencerEditorHeight: (v: number) => void;
   setPianoRollHeight: (v: number) => void;
   setEffectChainHeight: (v: number) => void;
   setShowSmartControls: (v: boolean) => void;
   setShowLibrary: (v: boolean) => void;
-  setActiveBottomPanel: (v: 'smart' | 'editor' | 'pianoRoll' | 'effects' | null) => void;
+  setActiveBottomPanel: (v: 'smart' | 'editor' | 'pianoRoll' | 'effects' | 'drumMachine' | null) => void;
 
   // Tempo lane
   toggleTempoLane: () => void;
@@ -156,10 +160,12 @@ export const useUIStore = create<UIState>()(
   selectWindow: null,
   expandedTrackId: null,
   openSequencerTrackId: null,
+  openDrumMachineTrackId: null,
   openPianoRollTrackId: null,
   openPianoRollClipId: null,
   openEffectChainTrackId: null,
   openMidiEffectChainTrackId: null,
+  drumMachineEditorHeight: 400,
   sequencerEditorHeight: 320,
   pianoRollHeight: 360,
   effectChainHeight: 320,
@@ -240,6 +246,7 @@ export const useUIStore = create<UIState>()(
   setSelectWindow: (v) => set({ selectWindow: v }),
   setExpandedTrackId: (id) => set({ expandedTrackId: id }),
   setOpenSequencerTrackId: (id) => set({ openSequencerTrackId: id, activeBottomPanel: id ? 'editor' : null }),
+  setOpenDrumMachineTrackId: (id) => set({ openDrumMachineTrackId: id, activeBottomPanel: id ? 'drumMachine' : null }),
   setOpenPianoRoll: (trackId, clipId = null) => set({
     openPianoRollTrackId: trackId,
     openPianoRollClipId: clipId,
@@ -253,6 +260,7 @@ export const useUIStore = create<UIState>()(
     openMidiEffectChainTrackId: id,
     activeBottomPanel: id ? 'effects' : null,
   }),
+  setDrumMachineEditorHeight: (v) => set({ drumMachineEditorHeight: Math.min(600, Math.max(300, v)) }),
   setSequencerEditorHeight: (v) => set({ sequencerEditorHeight: Math.min(600, Math.max(200, v)) }),
   setPianoRollHeight: (v) => set({ pianoRollHeight: Math.min(700, Math.max(220, v)) }),
   setEffectChainHeight: (v) => set({ effectChainHeight: Math.min(520, Math.max(180, v)) }),
@@ -289,6 +297,7 @@ export const useUIStore = create<UIState>()(
         showSmartControls: state.showSmartControls,
         // Panel sizes
         mixerHeight: state.mixerHeight,
+        drumMachineEditorHeight: state.drumMachineEditorHeight,
         sequencerEditorHeight: state.sequencerEditorHeight,
         pianoRollHeight: state.pianoRollHeight,
         effectChainHeight: state.effectChainHeight,

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -4,13 +4,27 @@ export type TrackName =
   | 'backing_vocals' | 'vocals'
   | 'custom';
 
-export type TrackType = 'stems' | 'sample' | 'sequencer' | 'pianoRoll';
+export type TrackType = 'stems' | 'sample' | 'sequencer' | 'pianoRoll' | 'drumMachine';
 export type InputMonitoringMode = 'off' | 'auto' | 'on';
 export type SynthPreset = 'piano' | 'strings' | 'pad' | 'lead' | 'bass' | 'organ';
 export type DrumKitName = '808' | 'acoustic' | 'electronic' | 'lofi';
 /** Time-stretch algorithm mode. 'repitch' uses playbackRate (changes pitch), 'slice' uses warp markers. */
 export type StretchMode = 'repitch' | 'slice';
 export type PianoRollGrid = '1/4' | '1/8' | '1/16' | '1/32';
+
+export interface DrumPad {
+  id: string;
+  name: string;
+  sampleKey: string;       // built-in drum name or user sample IndexedDB key
+  color: string;
+  volume: number;          // 0–1
+  pan: number;             // -1 to +1
+}
+
+export interface DrumMachineConfig {
+  pads: DrumPad[];
+  kitName: DrumKitName;
+}
 
 export type ClipGenerationStatus =
   | 'empty' | 'queued' | 'generating' | 'processing' | 'ready' | 'error' | 'stale';
@@ -371,6 +385,7 @@ export interface Track {
   effects?: TrackEffect[];
   midiEffects?: MidiEffect[];
   drumKit?: DrumKitName;
+  drumMachine?: DrumMachineConfig;
   // Mixer / channel-strip settings
   pan?: number;               // -1 (full left) to +1 (full right), default 0
   panMode?: 'stereo' | 'dual-mono';  // default 'stereo'


### PR DESCRIPTION
## Summary
- **New `drumMachine` track type** with `DrumPad` and `DrumMachineConfig` types, 16-pad MPC-style sample trigger instrument
- **DrumMachineEditor component**: 4×4 pad grid with velocity-sensitive triggering (Y-position on pad), per-pad sample loading, kit selection (808/acoustic/electronic/lofi), keyboard shortcuts (1-4, Q-R, A-F, Z-V), and pad detail panel with volume/sample controls
- **6 new store actions**: `initDrumMachine`, `setDrumPadSample`, `setDrumPadVolume`, `setDrumPadPan`, `renameDrumPad`, `setDrumMachineKit` — all with undo/redo support via `_pushHistory()`
- **15 unit tests** covering track creation, pad sample/volume/pan mutations, clamping, kit switching, and undo

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 578 tests pass (including 15 new drum machine tests)
- [x] `npm run build` — succeeds

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)