### PR TITLE
feat: track meter peak hold + clip indicator

### DIFF
--- a/src/components/mixer/LevelMeter.tsx
+++ b/src/components/mixer/LevelMeter.tsx
@@ -4,6 +4,7 @@ import { getAudioEngine } from '../../hooks/useAudioEngine';
 const METER_WIDTH = 8;
 const FALL_RATE_PER_FRAME = 0.012;
 const PEAK_HOLD_FRAMES = 18;
+const CLIP_INDICATOR_SIZE = 8;
 
 function levelToDb(level: number): number {
   if (level <= 0) return -Infinity;
@@ -28,17 +29,20 @@ export function LevelMeter({ trackId, masterStage }: LevelMeterProps) {
   const peakHoldFramesRef = useRef(0);
   const [level, setLevel] = useState(0);
   const [peakLevel, setPeakLevel] = useState(0);
+  const [clipped, setClipped] = useState(false);
 
   useEffect(() => {
     const engine = getAudioEngine();
 
     const tick = () => {
-      const nextLevel = masterStage
-        ? engine.getMasterLevel(masterStage)
+      const meter = masterStage
+        ? engine.getMasterMeter(masterStage)
         : trackId
-          ? engine.getTrackLevel(trackId)
-          : 0;
+          ? engine.getTrackMeter(trackId)
+          : { level: 0, clipped: false };
+      const nextLevel = meter.level;
       setLevel(nextLevel);
+      setClipped((wasClipped) => wasClipped || meter.clipped);
 
       if (nextLevel >= peakLevelRef.current) {
         peakLevelRef.current = nextLevel;
@@ -60,24 +64,51 @@ export function LevelMeter({ trackId, masterStage }: LevelMeterProps) {
   const label = masterStage
     ? `Master ${masterStage} level meter`
     : `Track level meter for ${trackId}`;
+  const clipResetLabel = masterStage
+    ? `Reset clip indicator for master ${masterStage}`
+    : `Reset clip indicator for ${trackId}`;
+
+  const resetClip = () => {
+    const engine = getAudioEngine();
+    if (masterStage) {
+      engine.resetMasterClip(masterStage);
+    } else if (trackId) {
+      engine.resetTrackClip(trackId);
+    }
+    setClipped(false);
+  };
 
   return (
-    <div
-      aria-label={label}
-      className="relative h-full rounded-full border border-white/10 bg-[#111] overflow-hidden"
-      style={{ width: METER_WIDTH }}
-    >
+    <div className="relative h-full" style={{ width: METER_WIDTH + 6 }}>
+      {clipped && (
+        <button
+          type="button"
+          aria-label={clipResetLabel}
+          className="absolute left-1/2 top-1 z-10 -translate-x-1/2 rounded-full border border-red-200/40 bg-red-500 shadow-[0_0_10px_rgba(239,68,68,0.75)]"
+          style={{ width: CLIP_INDICATOR_SIZE, height: CLIP_INDICATOR_SIZE }}
+          onClick={resetClip}
+          title="Reset clip indicator"
+        />
+      )}
       <div
-        className="absolute inset-x-0 bottom-0 transition-[height] duration-75 ease-out"
-        style={{
-          height: `${Math.max(0, Math.min(1, level)) * 100}%`,
-          background: `linear-gradient(to top, ${getMeterColor(level)} 0%, ${getMeterColor(level)}dd 100%)`,
-        }}
-      />
-      <div
-        className="absolute inset-x-0 h-[2px] bg-white/90 shadow-[0_0_4px_rgba(255,255,255,0.45)]"
-        style={{ bottom: `calc(${Math.max(0, Math.min(1, peakLevel)) * 100}% - 1px)` }}
-      />
+        aria-label={label}
+        className="absolute inset-y-0 left-[3px] rounded-full border border-white/10 bg-[#111] overflow-hidden"
+        style={{ width: METER_WIDTH }}
+      >
+        <div
+          data-testid="meter-level-fill"
+          className="absolute inset-x-0 bottom-0 transition-[height] duration-75 ease-out"
+          style={{
+            height: `${Math.max(0, Math.min(1, level)) * 100}%`,
+            background: `linear-gradient(to top, ${getMeterColor(level)} 0%, ${getMeterColor(level)}dd 100%)`,
+          }}
+        />
+        <div
+          data-testid="meter-peak-hold"
+          className="absolute inset-x-0 h-[2px] bg-white/90 shadow-[0_0_4px_rgba(255,255,255,0.45)]"
+          style={{ bottom: `calc(${Math.max(0, Math.min(1, peakLevel)) * 100}% - 1px)` }}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/timeline/TakeLaneStrip.tsx
+++ b/src/components/timeline/TakeLaneStrip.tsx
@@ -35,7 +35,7 @@ export function TakeLaneStrip({ clip, track }: TakeLaneStripProps) {
             className={`flex w-full items-center justify-between rounded-md border px-2 py-1 text-[11px] transition-colors ${
               take.selected
                 ? 'border-emerald-500/70 bg-emerald-500/10 text-emerald-100'
-                : 'border-[#303030] bg-[#202020] text-zinc-300 hover:border-[#5a5a5a]'
+                : 'border-[#303030] bg-[#202020] text-zinc-300 hover:border-[#5a5a5a] hover:bg-[#262626]'
             }`}
             aria-label={`Select take ${index + 1} for ${track.displayName}${take.selected ? ', selected' : ''}`}
           >

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -62,6 +62,10 @@ export class AudioEngine {
   private readonly widthRightToRight: GainNode;
   private readonly masterInputAnalyserData: Uint8Array<ArrayBuffer>;
   private readonly masterOutputAnalyserData: Uint8Array<ArrayBuffer>;
+  private readonly masterInputTimeDomainData: Float32Array<ArrayBuffer>;
+  private readonly masterOutputTimeDomainData: Float32Array<ArrayBuffer>;
+  private masterInputClipped = false;
+  private masterOutputClipped = false;
 
   // High-resolution spectrum analyser for the SpectrumAnalyzer component & LUFS metering
   private readonly spectrumAnalyser: AnalyserNode;
@@ -133,6 +137,8 @@ export class AudioEngine {
     this.masterOutputAnalyser.smoothingTimeConstant = 0.6;
     this.masterInputAnalyserData = new Uint8Array(this.masterInputAnalyser.frequencyBinCount);
     this.masterOutputAnalyserData = new Uint8Array(this.masterOutputAnalyser.frequencyBinCount);
+    this.masterInputTimeDomainData = new Float32Array(this.masterInputAnalyser.fftSize);
+    this.masterOutputTimeDomainData = new Float32Array(this.masterOutputAnalyser.fftSize);
 
     // High-resolution spectrum analyser (connected after limiter, before output)
     this.spectrumAnalyser = this.ctx.createAnalyser();
@@ -208,7 +214,15 @@ export class AudioEngine {
   set masterVolume(v: number) { this.masterOutputGain.gain.value = Math.max(0, Math.min(2, v)); }
 
   getTrackLevel(trackId: string): number {
-    return this.trackNodes.get(trackId)?.getLevel() ?? 0;
+    return this.getTrackMeter(trackId).level;
+  }
+
+  getTrackMeter(trackId: string): { level: number; clipped: boolean } {
+    return this.trackNodes.get(trackId)?.getMeter() ?? { level: 0, clipped: false };
+  }
+
+  resetTrackClip(trackId: string) {
+    this.trackNodes.get(trackId)?.resetClip();
   }
 
   getTrackSpectrum(trackId: string): Float32Array<ArrayBuffer> | null {
@@ -216,10 +230,31 @@ export class AudioEngine {
   }
 
   getMasterLevel(stage: 'input' | 'output'): number {
-    return this._getAnalyserLevel(
+    return this.getMasterMeter(stage).level;
+  }
+
+  getMasterMeter(stage: 'input' | 'output'): { level: number; clipped: boolean } {
+    const liveMeter = this._readAnalyserMeter(
       stage === 'input' ? this.masterInputAnalyser : this.masterOutputAnalyser,
       stage === 'input' ? this.masterInputAnalyserData : this.masterOutputAnalyserData,
+      stage === 'input' ? this.masterInputTimeDomainData : this.masterOutputTimeDomainData,
     );
+
+    if (stage === 'input') {
+      this.masterInputClipped = this.masterInputClipped || liveMeter.clipped;
+      return { level: liveMeter.level, clipped: this.masterInputClipped };
+    }
+
+    this.masterOutputClipped = this.masterOutputClipped || liveMeter.clipped;
+    return { level: liveMeter.level, clipped: this.masterOutputClipped };
+  }
+
+  resetMasterClip(stage: 'input' | 'output') {
+    if (stage === 'input') {
+      this.masterInputClipped = false;
+      return;
+    }
+    this.masterOutputClipped = false;
   }
 
   /** Get high-resolution spectrum data (dB) for the master output. */
@@ -274,13 +309,29 @@ export class AudioEngine {
     this.widthRightToRight.gain.value = same;
   }
 
-  private _getAnalyserLevel(analyser: AnalyserNode, data: Uint8Array<ArrayBuffer>): number {
+  private _readAnalyserMeter(
+    analyser: AnalyserNode,
+    data: Uint8Array<ArrayBuffer>,
+    timeData: Float32Array<ArrayBuffer>,
+  ): { level: number; clipped: boolean } {
     analyser.getByteFrequencyData(data);
-    let peak = 0;
+    analyser.getFloatTimeDomainData(timeData);
+
+    let spectralPeak = 0;
     for (let i = 0; i < data.length; i++) {
-      if (data[i] > peak) peak = data[i];
+      if (data[i] > spectralPeak) spectralPeak = data[i];
     }
-    return peak / 255;
+
+    let samplePeak = 0;
+    for (let i = 0; i < timeData.length; i++) {
+      const abs = Math.abs(timeData[i]);
+      if (abs > samplePeak) samplePeak = abs;
+    }
+
+    return {
+      level: Math.max(0, Math.min(1, Math.max(spectralPeak / 255, samplePeak))),
+      clipped: samplePeak >= 0.995,
+    };
   }
 
   updateSoloState() {

--- a/src/engine/TrackNode.ts
+++ b/src/engine/TrackNode.ts
@@ -22,6 +22,7 @@ export class TrackNode {
   private readonly analyserNode: AnalyserNode;
   private readonly analyserData: Uint8Array<ArrayBuffer>;
   private readonly analyserFloatData: Float32Array<ArrayBuffer>;
+  private readonly analyserTimeDomainData: Float32Array<ArrayBuffer>;
 
   private _volume = 0.8;
   private _muted = false;
@@ -31,6 +32,9 @@ export class TrackNode {
   private _reverbRoomSize = 0.5;
   private _effectsInput: AudioNode | null = null;
   private _effectsOutput: AudioNode | null = null;
+  private _clipped = false;
+
+  private static readonly CLIP_THRESHOLD = 0.995;
 
   constructor(private ctx: AudioContext, destination: AudioNode) {
     this.inputGain  = ctx.createGain();
@@ -49,6 +53,7 @@ export class TrackNode {
     this.analyserNode.smoothingTimeConstant = 0.75;
     this.analyserData = new Uint8Array(this.analyserNode.frequencyBinCount);
     this.analyserFloatData = new Float32Array(this.analyserNode.frequencyBinCount);
+    this.analyserTimeDomainData = new Float32Array(this.analyserNode.fftSize);
 
     // Configure EQ defaults
     this.eqLow.type = 'lowshelf';
@@ -173,16 +178,36 @@ export class TrackNode {
   }
 
   getLevel(): number {
-    this.analyserNode.getByteFrequencyData(this.analyserData);
+    return this.getMeter().level;
+  }
 
-    let peak = 0;
+  getMeter(): { level: number; clipped: boolean } {
+    this.analyserNode.getByteFrequencyData(this.analyserData);
+    this.analyserNode.getFloatTimeDomainData(this.analyserTimeDomainData);
+
+    let spectralPeak = 0;
     for (let i = 0; i < this.analyserData.length; i++) {
-      if (this.analyserData[i] > peak) {
-        peak = this.analyserData[i];
+      if (this.analyserData[i] > spectralPeak) {
+        spectralPeak = this.analyserData[i];
       }
     }
 
-    return peak / 255;
+    let samplePeak = 0;
+    for (let i = 0; i < this.analyserTimeDomainData.length; i++) {
+      const abs = Math.abs(this.analyserTimeDomainData[i]);
+      if (abs > samplePeak) samplePeak = abs;
+    }
+
+    const level = Math.max(spectralPeak / 255, samplePeak);
+    if (samplePeak >= TrackNode.CLIP_THRESHOLD) {
+      this._clipped = true;
+    }
+
+    return { level: Math.max(0, Math.min(1, level)), clipped: this._clipped };
+  }
+
+  resetClip() {
+    this._clipped = false;
   }
 
   getSpectrumData(): Float32Array<ArrayBuffer> {

--- a/src/engine/__tests__/TrackNode.test.ts
+++ b/src/engine/__tests__/TrackNode.test.ts
@@ -172,4 +172,36 @@ describe('TrackNode', () => {
       expect(param.cancelCalls.length).toBeGreaterThanOrEqual(1);
     });
   });
+
+  describe('meter clipping', () => {
+    function setMeterSamples(samples: number[]) {
+      const analyser = (node as unknown as { analyserNode: {
+        getByteFrequencyData: (data: Uint8Array) => void;
+        getFloatTimeDomainData: (data: Float32Array) => void;
+      } }).analyserNode;
+
+      analyser.getByteFrequencyData = vi.fn((data: Uint8Array) => {
+        data.fill(0);
+      });
+      analyser.getFloatTimeDomainData = vi.fn((data: Float32Array) => {
+        data.fill(0);
+        samples.forEach((sample, index) => {
+          if (index < data.length) data[index] = sample;
+        });
+      });
+    }
+
+    it('latches the clip state until resetClip is called', () => {
+      setMeterSamples([1]);
+
+      expect(node.getMeter()).toEqual({ level: 1, clipped: true });
+
+      setMeterSamples([0.25]);
+      expect(node.getMeter()).toEqual({ level: 0.25, clipped: true });
+
+      node.resetClip();
+
+      expect(node.getMeter()).toEqual({ level: 0.25, clipped: false });
+    });
+  });
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { getAudioEngine } from './hooks/useAudioEngine';
 import { useProjectStore } from './store/projectStore';
 import { useUIStore } from './store/uiStore';
 import { useTransportStore } from './store/transportStore';
@@ -14,6 +15,7 @@ import { generateProjectSummary, generateProjectStructure } from './utils/dawSta
 (window as unknown as Record<string, unknown>).__uiStore = useUIStore;
 (window as unknown as Record<string, unknown>).__transportStore = useTransportStore;
 (window as unknown as Record<string, unknown>).__collaborationStore = useCollaborationStore;
+(window as unknown as Record<string, unknown>).__getAudioEngine = () => getAudioEngine();
 
 // Expose DAW state summary for LLM agents
 // Agents can call: window.__dawSummary() for natural language, window.__dawStructure() for JSON

--- a/tests/e2e/mixer.spec.ts
+++ b/tests/e2e/mixer.spec.ts
@@ -5,8 +5,12 @@ test.describe('Mixer Operations', () => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
     await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
+    await page.waitForFunction(() => typeof (window as any).__uiStore !== 'undefined', null, { timeout: 10000 });
+    await page.waitForFunction(() => typeof (window as any).__getAudioEngine === 'function', null, { timeout: 10000 });
     await page.evaluate(() => {
       const store = (window as any).__store;
+      const uiStore = (window as any).__uiStore;
+      uiStore.getState().setShowNewProjectDialog(false);
       store.getState().createProject({ name: 'Mixer Test' });
       store.getState().addTrack('drums');
       store.getState().addTrack('bass');
@@ -136,5 +140,47 @@ test.describe('Mixer Operations', () => {
     expect(layout!.controlsScrollable).toBe(true);
 
     await page.screenshot({ path: 'test-screenshots/issue-296-master-layout.png', fullPage: true });
+  });
+
+  test('shows and resets the track clip indicator', async ({ page }) => {
+    const trackId = await page.evaluate(() => {
+      const store = (window as any).__store;
+      const uiStore = (window as any).__uiStore;
+      const engine = (window as any).__getAudioEngine();
+
+      let rafId = 0;
+      (window as any).requestAnimationFrame = (cb: FrameRequestCallback) => {
+        const id = ++rafId;
+        window.setTimeout(() => cb(performance.now()), 16);
+        return id;
+      };
+      (window as any).cancelAnimationFrame = () => {};
+
+      uiStore.getState().setShowMixer(true);
+
+      const firstTrackId = store.getState().project?.tracks[0]?.id;
+      let clipped = true;
+      engine.getTrackMeter = (id: string) => (
+        id === firstTrackId
+          ? { level: clipped ? 1 : 0.25, clipped }
+          : { level: 0, clipped: false }
+      );
+      engine.resetTrackClip = (id: string) => {
+        if (id === firstTrackId) clipped = false;
+      };
+
+      return firstTrackId;
+    });
+
+    await expect(page.getByLabel(`Track level meter for ${trackId}`)).toBeVisible();
+
+    const resetButton = page.getByRole('button', { name: `Reset clip indicator for ${trackId}` });
+    await expect(resetButton).toBeVisible();
+    const enableAudioOverlay = page.getByText('Click anywhere to enable audio');
+    if (await enableAudioOverlay.isVisible()) {
+      await enableAudioOverlay.click();
+    }
+    await resetButton.click();
+    await expect(resetButton).toBeHidden();
   });
 });

--- a/tests/unit/levelMeter.test.tsx
+++ b/tests/unit/levelMeter.test.tsx
@@ -1,0 +1,79 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LevelMeter } from '../../src/components/mixer/LevelMeter';
+
+const engine = {
+  getTrackMeter: vi.fn(),
+  getMasterMeter: vi.fn(),
+  resetTrackClip: vi.fn(),
+  resetMasterClip: vi.fn(),
+  getTrackLevel: vi.fn(),
+  getMasterLevel: vi.fn(),
+};
+
+vi.mock('../../src/hooks/useAudioEngine', () => ({
+  getAudioEngine: () => engine,
+}));
+
+describe('LevelMeter', () => {
+  let rafCallback: FrameRequestCallback | null = null;
+
+  beforeEach(() => {
+    rafCallback = null;
+    engine.getTrackMeter.mockReset();
+    engine.getMasterMeter.mockReset();
+    engine.resetTrackClip.mockReset();
+    engine.resetMasterClip.mockReset();
+    engine.getTrackLevel.mockReset();
+    engine.getMasterLevel.mockReset();
+
+    vi.stubGlobal('requestAnimationFrame', vi.fn((cb: FrameRequestCallback) => {
+      rafCallback = cb;
+      return 1;
+    }));
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function runFrame() {
+    if (!rafCallback) throw new Error('No animation frame scheduled');
+    const cb = rafCallback;
+    rafCallback = null;
+    act(() => {
+      cb(performance.now());
+    });
+  }
+
+  it('holds the peak marker after the current level falls', () => {
+    engine.getTrackMeter
+      .mockReturnValueOnce({ level: 0.8, clipped: false })
+      .mockReturnValue({ level: 0.2, clipped: false });
+
+    render(<LevelMeter trackId="track-1" />);
+
+    runFrame();
+    runFrame();
+
+    expect(screen.getByTestId('meter-level-fill')).toHaveStyle({ height: '20%' });
+    expect(screen.getByTestId('meter-peak-hold')).toHaveStyle({ bottom: 'calc(80% - 1px)' });
+  });
+
+  it('shows a resettable clip indicator when the engine reports clipping', () => {
+    engine.getTrackMeter
+      .mockReturnValueOnce({ level: 1, clipped: true })
+      .mockReturnValue({ level: 0.2, clipped: false });
+
+    render(<LevelMeter trackId="track-1" />);
+
+    runFrame();
+
+    const resetButton = screen.getByRole('button', { name: 'Reset clip indicator for track-1' });
+    fireEvent.click(resetButton);
+
+    expect(engine.resetTrackClip).toHaveBeenCalledWith('track-1');
+    expect(screen.queryByRole('button', { name: 'Reset clip indicator for track-1' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add latched meter-state APIs in the audio engine and track nodes so peak-hold meters can expose clipping and reset it
- add a resettable red clip indicator to mixer meters and keep the peak-hold marker active while the level falls
- expose a lazy audio-engine getter for browser automation, add regression coverage for the meter UI, and restore the missing take-lane strip component so build/browser validation passes

## Verification
- npm test
- npx tsc --noEmit
- npm run build
- npx playwright test tests/e2e/mixer.spec.ts

Closes #216