### PR TITLE
feat: snap to zero crossing — prevent audio clicks (closes #219)

### DIFF
--- a/src/utils/zeroCrossing.ts
+++ b/src/utils/zeroCrossing.ts
@@ -1,0 +1,89 @@
+/**
+ * Zero-crossing detection utilities for click-free audio editing.
+ *
+ * When splitting or trimming audio clips, snapping edit points to the nearest
+ * zero crossing prevents audible clicks caused by discontinuities in the waveform.
+ */
+
+/**
+ * Find the nearest zero crossing to a target sample index.
+ *
+ * A zero crossing occurs when consecutive samples change sign (positive → negative
+ * or vice versa). At a crossing, this function returns the sample whose absolute
+ * value is smaller (i.e., closer to zero) to minimize the discontinuity.
+ *
+ * If no crossing is found within the search radius, the original target index is returned.
+ *
+ * @param samples - Raw audio sample data (mono channel, Float32Array)
+ * @param targetIndex - The sample index to search around
+ * @param searchRadius - Maximum number of samples to search in each direction
+ * @returns The sample index of the nearest zero crossing, or targetIndex if none found
+ */
+export function findNearestZeroCrossing(
+  samples: Float32Array,
+  targetIndex: number,
+  searchRadius: number,
+): number {
+  if (samples.length < 2) return targetIndex;
+
+  const target = Math.max(0, Math.min(targetIndex, samples.length - 1));
+  const lo = Math.max(0, target - searchRadius);
+  const hi = Math.min(samples.length - 1, target + searchRadius);
+
+  // If the target sample is exactly zero, return it immediately
+  if (samples[target] === 0) return target;
+
+  let bestIndex = -1;
+  let bestDistance = Infinity;
+
+  for (let i = lo; i < hi; i++) {
+    const a = samples[i];
+    const b = samples[i + 1];
+
+    // Check for sign change (zero crossing) or exact zero
+    if (a === 0) {
+      const dist = Math.abs(i - target);
+      if (dist < bestDistance) {
+        bestDistance = dist;
+        bestIndex = i;
+      }
+      continue;
+    }
+
+    if ((a > 0 && b < 0) || (a < 0 && b > 0)) {
+      // Pick the sample closer to zero
+      const idx = Math.abs(a) <= Math.abs(b) ? i : i + 1;
+      const dist = Math.abs(idx - target);
+      if (dist < bestDistance) {
+        bestDistance = dist;
+        bestIndex = idx;
+      }
+    }
+  }
+
+  return bestIndex >= 0 ? bestIndex : target;
+}
+
+/**
+ * Snap a time position (in seconds) to the nearest zero crossing in the audio data.
+ *
+ * @param samples - Raw audio sample data (mono channel, Float32Array)
+ * @param sampleRate - Sample rate of the audio (e.g. 44100)
+ * @param timeSeconds - The target time in seconds
+ * @param searchRadiusMs - How far to search in each direction, in milliseconds (default 5ms)
+ * @returns The snapped time in seconds, or the original time if no crossing found
+ */
+export function snapTimeToZeroCrossing(
+  samples: Float32Array,
+  sampleRate: number,
+  timeSeconds: number,
+  searchRadiusMs: number = 5,
+): number {
+  if (samples.length === 0) return timeSeconds;
+
+  const targetSample = Math.round(timeSeconds * sampleRate);
+  const radiusSamples = Math.round((searchRadiusMs / 1000) * sampleRate);
+
+  const snappedSample = findNearestZeroCrossing(samples, targetSample, radiusSamples);
+  return snappedSample / sampleRate;
+}

--- a/tests/unit/zeroCrossing.test.ts
+++ b/tests/unit/zeroCrossing.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findNearestZeroCrossing,
+  snapTimeToZeroCrossing,
+} from '../../src/utils/zeroCrossing';
+
+describe('findNearestZeroCrossing', () => {
+  it('returns the target index when it is already at a zero crossing', () => {
+    // Signal: ..., 0.5, 0.0, -0.3, ...
+    const samples = new Float32Array([0.5, 0.0, -0.3, 0.2]);
+    expect(findNearestZeroCrossing(samples, 1, 10)).toBe(1);
+  });
+
+  it('finds a zero crossing to the right of the target', () => {
+    // Signal crosses zero between index 2 (0.1) and index 3 (-0.2)
+    const samples = new Float32Array([0.5, 0.4, 0.1, -0.2, -0.5]);
+    // Target is index 1; crossing between 2→3, picks 2 since |0.1| < |-0.2|
+    expect(findNearestZeroCrossing(samples, 1, 10)).toBe(2);
+  });
+
+  it('finds a zero crossing to the left of the target', () => {
+    // Zero crossings between 0→1 and 1→2
+    const samples = new Float32Array([0.5, -0.1, 0.3, 0.4, 0.5]);
+    // Target is index 4; nearest crossing picks index 1 (|-0.1| is closest to zero)
+    expect(findNearestZeroCrossing(samples, 4, 10)).toBe(1);
+  });
+
+  it('returns the closer zero crossing when crossings exist on both sides', () => {
+    // Crossing between 1(0.1)→2(-0.2) and between 5(-0.1)→6(0.3)
+    const samples = new Float32Array([0.5, 0.1, -0.2, -0.3, -0.2, -0.1, 0.3, 0.5]);
+    // Target index 3 → left picks idx 1 (dist 2), right picks idx 5 (dist 2) → tie, picks first found (1)
+    expect(findNearestZeroCrossing(samples, 3, 10)).toBe(1);
+  });
+
+  it('respects the search radius and returns target if no crossing found', () => {
+    // No zero crossing within radius 1 of target index 0
+    const samples = new Float32Array([0.5, 0.4, 0.3, -0.1]);
+    expect(findNearestZeroCrossing(samples, 0, 1)).toBe(0);
+  });
+
+  it('handles an empty array gracefully', () => {
+    const samples = new Float32Array([]);
+    expect(findNearestZeroCrossing(samples, 0, 10)).toBe(0);
+  });
+
+  it('handles single sample', () => {
+    const samples = new Float32Array([0.5]);
+    expect(findNearestZeroCrossing(samples, 0, 10)).toBe(0);
+  });
+
+  it('picks the sample closer to zero at a crossing', () => {
+    // Crossing between index 2 (0.05) and index 3 (-0.8)
+    // Should pick index 2 since |0.05| < |-0.8|
+    const samples = new Float32Array([0.5, 0.3, 0.05, -0.8, -0.5]);
+    expect(findNearestZeroCrossing(samples, 1, 10)).toBe(2);
+  });
+
+  it('clamps search to array bounds', () => {
+    const samples = new Float32Array([0.5, 0.3, -0.1, 0.4]);
+    // Search from index 0 with large radius; crossing at index 2
+    expect(findNearestZeroCrossing(samples, 0, 100)).toBe(2);
+  });
+
+  it('handles negative-to-positive crossing', () => {
+    const samples = new Float32Array([-0.5, -0.3, -0.1, 0.2, 0.5]);
+    // Target at index 0; crossing between index 2 (-0.1) and 3 (0.2)
+    // Picks index 2 since |−0.1| < |0.2|
+    expect(findNearestZeroCrossing(samples, 0, 10)).toBe(2);
+  });
+});
+
+describe('snapTimeToZeroCrossing', () => {
+  it('snaps a time position to the nearest zero crossing', () => {
+    // 8 samples at 8 Hz = 1 second of audio
+    // Crossing between sample 3 (0.1) and sample 4 (-0.2)
+    const samples = new Float32Array([0.5, 0.4, 0.3, 0.1, -0.2, -0.5, -0.3, 0.1]);
+    const sampleRate = 8;
+
+    // Target time 0.25s = sample 2; search radius 500ms = 4 samples
+    const result = snapTimeToZeroCrossing(samples, sampleRate, 0.25, 500);
+    // Should snap to sample 3 (|0.1| < |-0.2|) → 3/8 = 0.375s
+    expect(result).toBeCloseTo(0.375, 3);
+  });
+
+  it('returns the original time when no crossing is found within radius', () => {
+    const samples = new Float32Array([0.5, 0.4, 0.3, 0.2]);
+    const sampleRate = 4;
+    // No zero crossing in all-positive data within radius 1 sample (250ms at 4Hz)
+    const result = snapTimeToZeroCrossing(samples, sampleRate, 0.25, 250);
+    expect(result).toBeCloseTo(0.25, 3);
+  });
+
+  it('handles multi-channel by using the first channel only', () => {
+    // This tests the samples parameter directly (pre-extracted channel data)
+    const samples = new Float32Array([0.5, -0.2, 0.3]);
+    const sampleRate = 3;
+    // Crossing between 0 (0.5) and 1 (-0.2) → pick 1 since |-0.2| < |0.5|
+    const result = snapTimeToZeroCrossing(samples, sampleRate, 0.0, 500);
+    expect(result).toBeCloseTo(1 / 3, 3);
+  });
+
+  it('returns 0 for empty samples', () => {
+    const samples = new Float32Array([]);
+    expect(snapTimeToZeroCrossing(samples, 44100, 0.5, 10)).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `findNearestZeroCrossing()` — finds the nearest zero crossing to a target sample index within a configurable search radius, picking the sample closest to zero at each crossing point
- Add `snapTimeToZeroCrossing()` — converts time-based positions to sample indices, snaps to zero crossing, and returns the adjusted time
- 14 unit tests covering edge cases: exact zeros, left/right search, tie-breaking, empty arrays, radius limits

## How it works
When splitting or trimming audio clips, the edit point may land mid-waveform, causing an audible click due to a sudden amplitude discontinuity. These utilities find the nearest point where the waveform naturally crosses zero (sign change between consecutive samples), eliminating the click artifact.

The store's `splitClip` action works with clip metadata (offsets/durations) without access to audio buffers, so this utility is designed to be called at the component/hook layer where `AudioBuffer` data is available, before invoking split/trim operations.

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run` — 605 tests pass (14 new)
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)