### PR TITLE
fix: track header name text hidden (closes #297)

### DIFF
--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -210,7 +210,7 @@ export function TrackHeader({
       </div>
 
       {/* Name + controls column */}
-      <div className="flex-1 min-w-0 flex flex-col gap-1 py-1">
+      <div className="flex-1 min-w-[48px] flex flex-col gap-1 py-1">
         {/* Name */}
         {isEditing ? (
           <input
@@ -318,7 +318,7 @@ export function TrackHeader({
           className={`flex items-center gap-0.5 rounded-lg border border-[#404040] bg-[#1f1f1f]/90 p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition-all ${
             showSecondaryActions
               ? 'opacity-100 translate-x-0'
-              : 'opacity-0 pointer-events-none translate-x-1 group-hover:opacity-100 group-hover:pointer-events-auto group-hover:translate-x-0'
+              : 'opacity-0 pointer-events-none translate-x-1 max-w-0 overflow-hidden group-hover:opacity-100 group-hover:pointer-events-auto group-hover:translate-x-0 group-hover:max-w-none group-hover:overflow-visible'
           }`}
         >
           <button

--- a/tests/unit/trackHeader.test.tsx
+++ b/tests/unit/trackHeader.test.tsx
@@ -170,4 +170,36 @@ describe('TrackHeader — icon bar cleanup (#267)', () => {
       expect(screen.getByTitle(/automation/i)).toBeInTheDocument();
     });
   });
+
+  describe('track name visibility (#297)', () => {
+    it('track display name text is visible in the DOM', () => {
+      renderHeader({ displayName: 'My Cool Track' });
+      expect(screen.getByText('My Cool Track')).toBeInTheDocument();
+    });
+
+    it('hidden secondary actions collapse layout space (max-w-0 overflow-hidden)', () => {
+      renderHeader({ inputMonitoring: 'off', frozen: false });
+      const monitorBtn = screen.getByTitle(/Input monitoring/);
+      const container = monitorBtn.parentElement!;
+      // When secondary actions are hidden, they must not consume layout width
+      expect(container.classList.contains('max-w-0')).toBe(true);
+      expect(container.classList.contains('overflow-hidden')).toBe(true);
+    });
+
+    it('visible secondary actions have layout space restored', () => {
+      renderHeader({ inputMonitoring: 'on' });
+      const monitorBtn = screen.getByTitle(/Input monitoring/);
+      const container = monitorBtn.parentElement!;
+      expect(container.classList.contains('max-w-0')).toBe(false);
+      expect(container.classList.contains('overflow-hidden')).toBe(false);
+    });
+
+    it('name column has a minimum width to prevent complete collapse', () => {
+      renderHeader();
+      const nameSpan = screen.getByText('Drums');
+      const nameColumn = nameSpan.parentElement!;
+      // The name+controls column must enforce a minimum width
+      expect(nameColumn.className).toMatch(/min-w-\[/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- **Root cause**: The secondary actions panel (monitor, freeze, automation buttons) used `opacity-0` to hide visually but still consumed ~70px of flex layout space. Combined with the primary actions (~82px), drag handle, icon, and padding, the total non-name width (~234px) exceeded the default 220px track list width, leaving zero room for the track name.
- **Fix**: Added `max-w-0 overflow-hidden` to hidden secondary actions so they collapse to zero width (restored on hover/show via `group-hover:max-w-none`). Also set `min-w-[48px]` on the name column as a safety net.
- Includes 4 regression tests verifying name visibility and layout collapse behavior.

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run` — 595/595 tests pass (including 4 new regression tests)
- [x] `npm run build` — succeeds
- [ ] Manual: verify track name visible at default (220px) and minimum (120px) track list widths
- [ ] Manual: verify secondary actions still appear on hover and when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)