### PR TITLE
feat: track meter peak hold + clip indicator (closes #216)

### DIFF
--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { TRACK_CATALOG } from '../../constants/tracks';
 import { TrackEditModal } from './TrackEditModal';
+import { TrackHeaderMeter } from './TrackHeaderMeter';
 import { useRecording } from '../../hooks/useRecording';
 import { freezeTrackToAudio, flattenTrackToAudio } from '../../services/freezeTrack';
 
@@ -250,6 +251,9 @@ export function TrackHeader({
             />
           </div>
         )}
+
+        {/* Level meter with peak hold + clip indicator */}
+        <TrackHeaderMeter trackId={track.id} />
       </div>
 
       {/* Primary and secondary track actions */}

--- a/src/components/tracks/TrackHeaderMeter.tsx
+++ b/src/components/tracks/TrackHeaderMeter.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from 'react';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+
+const FALL_RATE_PER_FRAME = 0.012;
+const PEAK_HOLD_FRAMES = 18;
+const CLIP_THRESHOLD = 0.95;
+
+function levelToDb(level: number): number {
+  if (level <= 0) return -Infinity;
+  return 20 * Math.log10(level);
+}
+
+function getMeterColor(level: number): string {
+  const db = levelToDb(level);
+  if (db > -3) return '#ef4444';
+  if (db >= -12) return '#facc15';
+  return '#22c55e';
+}
+
+interface TrackHeaderMeterProps {
+  trackId: string;
+}
+
+export function TrackHeaderMeter({ trackId }: TrackHeaderMeterProps) {
+  const rafRef = useRef<number>(0);
+  const peakLevelRef = useRef(0);
+  const peakHoldFramesRef = useRef(0);
+  const [level, setLevel] = useState(0);
+  const [peakLevel, setPeakLevel] = useState(0);
+  const [clipping, setClipping] = useState(false);
+  const clippingRef = useRef(false);
+
+  useEffect(() => {
+    const engine = getAudioEngine();
+
+    const tick = () => {
+      const nextLevel = engine.getTrackLevel(trackId);
+      setLevel(nextLevel);
+
+      // Peak hold logic
+      if (nextLevel >= peakLevelRef.current) {
+        peakLevelRef.current = nextLevel;
+        peakHoldFramesRef.current = PEAK_HOLD_FRAMES;
+      } else if (peakHoldFramesRef.current > 0) {
+        peakHoldFramesRef.current -= 1;
+      } else {
+        peakLevelRef.current = Math.max(
+          nextLevel,
+          peakLevelRef.current - FALL_RATE_PER_FRAME,
+        );
+      }
+      setPeakLevel(peakLevelRef.current);
+
+      // Clip detection — latches on until manually reset
+      if (nextLevel >= CLIP_THRESHOLD && !clippingRef.current) {
+        clippingRef.current = true;
+        setClipping(true);
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [trackId]);
+
+  const resetClip = () => {
+    clippingRef.current = false;
+    setClipping(false);
+  };
+
+  const clampedLevel = Math.max(0, Math.min(1, level));
+  const clampedPeak = Math.max(0, Math.min(1, peakLevel));
+
+  return (
+    <div className="flex items-center gap-1 w-full">
+      <div
+        aria-label={`Track level meter for ${trackId}`}
+        className="relative flex-1 h-[4px] rounded-full bg-[#111] overflow-hidden border border-white/5"
+      >
+        {/* Level bar */}
+        <div
+          data-testid="meter-level"
+          className="absolute inset-y-0 left-0 rounded-full transition-[width] duration-75 ease-out"
+          style={{
+            width: `${clampedLevel * 100}%`,
+            background: getMeterColor(level),
+          }}
+        />
+        {/* Peak hold indicator */}
+        <div
+          data-testid="meter-peak"
+          className="absolute top-0 bottom-0 w-[2px] bg-white/80"
+          style={{ left: `${clampedPeak * 100}%` }}
+        />
+      </div>
+      {/* Clip indicator dot */}
+      <div
+        data-testid="clip-indicator"
+        className={`w-[6px] h-[6px] rounded-full flex-shrink-0 cursor-pointer transition-colors ${
+          clipping
+            ? 'bg-red-500 shadow-[0_0_4px_rgba(239,68,68,0.6)]'
+            : 'bg-zinc-700'
+        }`}
+        title={clipping ? 'Clipping detected — click to reset' : 'Clip indicator'}
+        onClick={resetClip}
+      />
+    </div>
+  );
+}

--- a/src/components/tracks/__tests__/TrackHeader.test.tsx
+++ b/src/components/tracks/__tests__/TrackHeader.test.tsx
@@ -19,6 +19,12 @@ vi.mock('../../../services/freezeTrack', () => ({
   flattenTrackToAudio: vi.fn(),
 }));
 
+vi.mock('../../../hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    getTrackLevel: () => 0,
+  }),
+}));
+
 function makeTrack(overrides: Partial<Track> = {}): Track {
   return {
     id: 'track-1',

--- a/src/components/tracks/__tests__/TrackHeaderMeter.test.tsx
+++ b/src/components/tracks/__tests__/TrackHeaderMeter.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { TrackHeaderMeter } from '../TrackHeaderMeter';
+
+// Mock the audio engine
+let mockLevel = 0;
+vi.mock('../../../hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    getTrackLevel: () => mockLevel,
+  }),
+}));
+
+describe('TrackHeaderMeter', () => {
+  let rafCallbacks: Array<FrameRequestCallback>;
+  let rafId: number;
+
+  beforeEach(() => {
+    mockLevel = 0;
+    rafCallbacks = [];
+    rafId = 1;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb);
+      return rafId++;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function tickFrame(level?: number) {
+    if (level !== undefined) mockLevel = level;
+    const cbs = [...rafCallbacks];
+    rafCallbacks = [];
+    cbs.forEach((cb) => cb(performance.now()));
+  }
+
+  it('renders with an accessible label', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    expect(screen.getByLabelText(/level meter/i)).toBeInTheDocument();
+  });
+
+  it('shows a level bar that reflects the current audio level', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    act(() => tickFrame(0.5));
+
+    const meter = screen.getByLabelText(/level meter/i);
+    const levelBar = meter.querySelector('[data-testid="meter-level"]') as HTMLElement;
+    expect(levelBar).toBeTruthy();
+    // Width should reflect the level (50%)
+    expect(levelBar.style.width).toBe('50%');
+  });
+
+  it('shows a peak hold indicator', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    act(() => tickFrame(0.8));
+
+    const meter = screen.getByLabelText(/level meter/i);
+    const peakHold = meter.querySelector('[data-testid="meter-peak"]') as HTMLElement;
+    expect(peakHold).toBeTruthy();
+    // Peak should be at 80%
+    expect(peakHold.style.left).toBe('80%');
+  });
+
+  it('holds the peak after level drops', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    // Spike to 0.9
+    act(() => tickFrame(0.9));
+    // Drop to 0.2
+    act(() => tickFrame(0.2));
+
+    const meter = screen.getByLabelText(/level meter/i);
+    const peakHold = meter.querySelector('[data-testid="meter-peak"]') as HTMLElement;
+    // Peak should still be at 90% (held)
+    expect(peakHold.style.left).toBe('90%');
+  });
+
+  it('shows clip indicator when level exceeds threshold', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    act(() => tickFrame(0.97));
+
+    const clipIndicator = screen.getByTestId('clip-indicator');
+    expect(clipIndicator).toBeInTheDocument();
+    // Should have red color when clipping
+    expect(clipIndicator.className).toMatch(/bg-red/);
+  });
+
+  it('clip indicator stays lit after level drops below threshold', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    act(() => tickFrame(0.97));
+    act(() => tickFrame(0.3));
+
+    const clipIndicator = screen.getByTestId('clip-indicator');
+    expect(clipIndicator.className).toMatch(/bg-red/);
+  });
+
+  it('clip indicator resets on click', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    act(() => tickFrame(0.97));
+
+    const clipIndicator = screen.getByTestId('clip-indicator');
+    expect(clipIndicator.className).toMatch(/bg-red/);
+
+    fireEvent.click(clipIndicator);
+
+    // After click + level below threshold, clip indicator should be inactive
+    act(() => tickFrame(0.3));
+    const resetIndicator = screen.getByTestId('clip-indicator');
+    expect(resetIndicator.className).not.toMatch(/bg-red/);
+  });
+
+  it('uses green color for normal levels', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    act(() => tickFrame(0.15)); // ~-16 dB, below -12 dB threshold
+
+    const meter = screen.getByLabelText(/level meter/i);
+    const levelBar = meter.querySelector('[data-testid="meter-level"]') as HTMLElement;
+    // jsdom converts hex to rgb
+    expect(levelBar.style.background).toContain('rgb(34, 197, 94)');
+  });
+
+  it('uses yellow color for medium levels', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    act(() => tickFrame(0.35));
+
+    const meter = screen.getByLabelText(/level meter/i);
+    const levelBar = meter.querySelector('[data-testid="meter-level"]') as HTMLElement;
+    expect(levelBar.style.background).toContain('rgb(250, 204, 21)');
+  });
+
+  it('uses red color for hot levels', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    act(() => tickFrame(0.85));
+
+    const meter = screen.getByLabelText(/level meter/i);
+    const levelBar = meter.querySelector('[data-testid="meter-level"]') as HTMLElement;
+    expect(levelBar.style.background).toContain('rgb(239, 68, 68)');
+  });
+
+  it('cleans up animation frame on unmount', () => {
+    const { unmount } = render(<TrackHeaderMeter trackId="track-1" />);
+    unmount();
+    expect(window.cancelAnimationFrame).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/trackHeader.test.tsx
+++ b/tests/unit/trackHeader.test.tsx
@@ -27,6 +27,12 @@ vi.mock('../../src/hooks/useRecording', () => ({
   }),
 }));
 
+vi.mock('../../src/hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    getTrackLevel: () => 0,
+  }),
+}));
+
 function makeTrack(overrides: Partial<Track> = {}): Track {
   return {
     id: 'track-1',


### PR DESCRIPTION
## Summary
- Add `TrackHeaderMeter` component: a compact horizontal level meter displayed in every track header
- Real-time audio level bar with color coding (green < -12 dB, yellow -12 to -3 dB, red > -3 dB)
- Peak hold indicator (white line) that holds for 18 frames then decays
- Latching clip indicator dot that turns red when signal exceeds -0.45 dB (0.95 normalized), click to reset
- 11 unit tests covering level display, peak hold, clip detection/reset, color thresholds, and cleanup

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run` — all 602 tests pass (11 new)
- [x] `npm run build` — succeeds
- [ ] Manual: open DAW, play audio, verify meter animates in track headers
- [ ] Manual: drive a track into clipping, verify red dot appears and persists
- [ ] Manual: click clip dot to reset it

🤖 Generated with [Claude Code](https://claude.com/claude-code)