### PR TITLE
feat: sampler instrument — load and play audio samples (closes #213)

### DIFF
--- a/src/engine/SamplerEngine.ts
+++ b/src/engine/SamplerEngine.ts
@@ -1,0 +1,170 @@
+import * as Tone from 'tone';
+import type { SamplerConfig } from '../types/project';
+
+interface SamplerInstance {
+  sampler: Tone.Sampler;
+  gain: Tone.Gain;
+  audioKey: string;
+}
+
+/** Default ADSR values for new sampler configs. */
+export const DEFAULT_SAMPLER_CONFIG: Omit<SamplerConfig, 'audioKey'> = {
+  rootNote: 60,
+  attack: 0.005,
+  decay: 0.1,
+  sustain: 1,
+  release: 0.3,
+};
+
+/**
+ * Create a SamplerConfig with sensible defaults.
+ */
+export function createSamplerConfig(audioKey: string, overrides?: Partial<SamplerConfig>): SamplerConfig {
+  return {
+    ...DEFAULT_SAMPLER_CONFIG,
+    audioKey,
+    ...overrides,
+  };
+}
+
+/**
+ * Engine that manages Tone.js Sampler instances per track.
+ * A sampler loads an audio buffer and pitch-shifts playback based on
+ * the MIDI note relative to the configured root note.
+ */
+class SamplerEngine {
+  private samplers = new Map<string, SamplerInstance>();
+  private previewSampler: Tone.Sampler | null = null;
+  private previewGain: Tone.Gain | null = null;
+
+  async ensureStarted() {
+    if (Tone.getContext().state !== 'running') {
+      await Tone.start();
+    }
+  }
+
+  /**
+   * Create or update a Tone.js Sampler for a track.
+   * If the audioKey hasn't changed, returns the existing sampler.
+   */
+  ensureTrackSampler(
+    trackId: string,
+    config: SamplerConfig,
+    audioBuffer: AudioBuffer,
+    connectTo?: Tone.InputNode,
+  ): Tone.Sampler {
+    const existing = this.samplers.get(trackId);
+    if (existing && existing.audioKey === config.audioKey) {
+      // Update envelope on existing sampler
+      this._applyEnvelope(existing.sampler, config);
+      return existing.sampler;
+    }
+
+    // Dispose old sampler if audioKey changed
+    if (existing) {
+      this._disposeInstance(existing);
+    }
+
+    const toneBuffer = new Tone.ToneAudioBuffer(audioBuffer);
+    const noteName = Tone.Frequency(config.rootNote, 'midi').toNote();
+
+    const sampler = new Tone.Sampler({
+      urls: { [noteName]: toneBuffer },
+      attack: config.attack,
+      release: config.release,
+    });
+
+    const gain = new Tone.Gain(0.55);
+    sampler.connect(gain);
+    if (connectTo) {
+      gain.connect(connectTo);
+    } else {
+      gain.toDestination();
+    }
+
+    this.samplers.set(trackId, { sampler, gain, audioKey: config.audioKey });
+    return sampler;
+  }
+
+  getSampler(trackId: string): Tone.Sampler | null {
+    return this.samplers.get(trackId)?.sampler ?? null;
+  }
+
+  /**
+   * Preview a sample at a given pitch (for audition / piano roll click).
+   */
+  async previewNote(
+    audioBuffer: AudioBuffer,
+    rootNote: number,
+    pitch: number,
+    velocity = 100,
+    duration = 0.3,
+  ) {
+    await this.ensureStarted();
+    if (this.previewSampler) {
+      this.previewSampler.dispose();
+      this.previewGain?.dispose();
+    }
+    const toneBuffer = new Tone.ToneAudioBuffer(audioBuffer);
+    const noteName = Tone.Frequency(rootNote, 'midi').toNote();
+    this.previewSampler = new Tone.Sampler({ urls: { [noteName]: toneBuffer } });
+    this.previewGain = new Tone.Gain(0.3).toDestination();
+    this.previewSampler.connect(this.previewGain);
+
+    const freq = Tone.Frequency(pitch, 'midi').toNote();
+    this.previewSampler.triggerAttackRelease(freq, duration, undefined, velocity / 127);
+  }
+
+  /** Trigger note on for a track sampler (for live playing / recording). */
+  noteOn(trackId: string, pitch: number, velocity = 100) {
+    const instance = this.samplers.get(trackId);
+    if (!instance) return;
+    const note = Tone.Frequency(pitch, 'midi').toNote();
+    instance.sampler.triggerAttack(note, undefined, velocity / 127);
+  }
+
+  /** Trigger note off for a track sampler. */
+  noteOff(trackId: string, pitch: number) {
+    const instance = this.samplers.get(trackId);
+    if (!instance) return;
+    const note = Tone.Frequency(pitch, 'midi').toNote();
+    instance.sampler.triggerRelease(note);
+  }
+
+  /** Release all currently sounding notes on all track samplers. */
+  releaseAll() {
+    for (const instance of this.samplers.values()) {
+      instance.sampler.releaseAll();
+    }
+  }
+
+  removeTrackSampler(trackId: string) {
+    const instance = this.samplers.get(trackId);
+    if (!instance) return;
+    this._disposeInstance(instance);
+    this.samplers.delete(trackId);
+  }
+
+  dispose() {
+    for (const trackId of this.samplers.keys()) {
+      this.removeTrackSampler(trackId);
+    }
+    this.previewSampler?.dispose();
+    this.previewGain?.dispose();
+    this.previewSampler = null;
+    this.previewGain = null;
+  }
+
+  private _applyEnvelope(sampler: Tone.Sampler, config: SamplerConfig) {
+    sampler.attack = config.attack;
+    sampler.release = config.release;
+  }
+
+  private _disposeInstance(instance: SamplerInstance) {
+    instance.sampler.releaseAll();
+    instance.sampler.dispose();
+    instance.gain.dispose();
+  }
+}
+
+export const samplerEngine = new SamplerEngine();

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -5,6 +5,7 @@ import { useProjectStore } from '../store/projectStore';
 import { getAudioEngine } from './useAudioEngine';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { synthEngine } from '../engine/SynthEngine';
+import { samplerEngine } from '../engine/SamplerEngine';
 import { drumEngine } from '../engine/DrumEngine';
 import { automationEngine } from '../engine/AutomationEngine';
 import { useRecording } from './useRecording';
@@ -68,6 +69,7 @@ export function useTransport() {
     const engine = getAudioEngine();
     await engine.resume();
     await synthEngine.ensureStarted();
+    await samplerEngine.ensureStarted();
     await drumEngine.ensureStarted();
 
     const proj = useProjectStore.getState().project;
@@ -194,9 +196,25 @@ export function useTransport() {
       if (track.frozen && track.frozenAudioKey) continue;
 
       if (track.trackType === 'pianoRoll') {
-        const preset = track.synthPreset ?? 'piano';
-        synthEngine.removeTrackSynth(track.id);
-        synthEngine.ensureTrackSynth(track.id, preset);
+        const useSampler = !!track.samplerConfig;
+
+        if (useSampler && track.samplerConfig) {
+          // Load the sample audio buffer and create a Tone.js Sampler
+          const sampleBlob = await loadAudioBlobByKey(track.samplerConfig.audioKey);
+          if (sampleBlob) {
+            const sampleBuffer = await engine.decodeAudioData(sampleBlob);
+            const trackNode = engine.getOrCreateTrackNode(track.id);
+            samplerEngine.removeTrackSampler(track.id);
+            samplerEngine.ensureTrackSampler(
+              track.id, track.samplerConfig, sampleBuffer,
+              trackNode.inputGain as unknown as Tone.InputNode,
+            );
+          }
+        } else {
+          const preset = track.synthPreset ?? 'piano';
+          synthEngine.removeTrackSynth(track.id);
+          synthEngine.ensureTrackSynth(track.id, preset);
+        }
 
         for (const clip of track.clips) {
           const notes = clip.midiData?.notes ?? [];
@@ -211,15 +229,25 @@ export function useTransport() {
             const scheduledStart = Math.max(noteStart, startFrom);
             const scheduledDuration = noteEnd - scheduledStart;
             const velocity = Math.max(0, Math.min(1, note.velocity));
-            const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
             const trackId = track.id;
 
-            engine.scheduleMidiEvent(scheduledStart, () => {
-              const synth = synthEngine.getSynth(trackId);
-              if (synth) {
-                synth.triggerAttackRelease(freq, scheduledDuration, undefined, velocity);
-              }
-            });
+            if (useSampler) {
+              const noteName = Tone.Frequency(note.pitch, 'midi').toNote();
+              engine.scheduleMidiEvent(scheduledStart, () => {
+                const sampler = samplerEngine.getSampler(trackId);
+                if (sampler) {
+                  sampler.triggerAttackRelease(noteName, scheduledDuration, undefined, velocity);
+                }
+              });
+            } else {
+              const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
+              engine.scheduleMidiEvent(scheduledStart, () => {
+                const synth = synthEngine.getSynth(trackId);
+                if (synth) {
+                  synth.triggerAttackRelease(freq, scheduledDuration, undefined, velocity);
+                }
+              });
+            }
           }
         }
       }
@@ -296,6 +324,7 @@ export function useTransport() {
     const time = engine.getCurrentTime();
     engine.stop();
     synthEngine.releaseAll();
+    samplerEngine.releaseAll();
     automationEngine.stop();
     useTransportStore.getState().pause();
     useTransportStore.getState().seek(time);
@@ -308,6 +337,7 @@ export function useTransport() {
     const engine = getAudioEngine();
     engine.stop();
     synthEngine.releaseAll();
+    samplerEngine.releaseAll();
     automationEngine.stop();
     useTransportStore.getState().stop();
   }, [isRecording, stopRecording]);
@@ -317,6 +347,7 @@ export function useTransport() {
     if (engine.playing) {
       engine.stop();
       synthEngine.releaseAll();
+      samplerEngine.releaseAll();
       useTransportStore.getState().seek(time);
       play(time);
     } else {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -40,6 +40,7 @@ import type {
   MasteringState,
   DrumMachineConfig,
   DrumKitName,
+  SamplerConfig,
 } from '../types/project';
 import { automationParamEquals } from '../types/project';
 import { quantizeNotes as applyQuantize, type QuantizeOptions } from '../utils/midiQuantize';
@@ -144,6 +145,8 @@ interface ProjectState {
   removeTrack: (trackId: string) => void;
   duplicateTrack: (trackId: string) => Track | undefined;
   updateTrack: (trackId: string, updates: Partial<Pick<Track, 'displayName' | 'volume' | 'muted' | 'soloed' | 'armed' | 'laneHeight' | 'trackType' | 'synthPreset' | 'drumKit' | 'color'>>) => void;
+  /** Set or clear the sampler config on a pianoRoll track. Pass null to remove. */
+  updateSamplerConfig: (trackId: string, config: SamplerConfig | null) => void;
   saveTrackPreset: (trackId: string, presetName: string) => TrackPreset;
   applyTrackPreset: (presetId: string) => Track | undefined;
   deleteTrackPreset: (presetId: string) => void;
@@ -1141,6 +1144,22 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
+  updateSamplerConfig: (trackId, config) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) =>
+          t.id === trackId
+            ? { ...t, samplerConfig: config ?? undefined }
+            : t,
+        ),
+      },
+    });
+  },
 
   setTrackHeightPreset: (trackId, preset) => {
     const state = get();

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -12,6 +12,22 @@ export type DrumKitName = '808' | 'acoustic' | 'electronic' | 'lofi';
 export type StretchMode = 'repitch' | 'slice';
 export type PianoRollGrid = '1/4' | '1/8' | '1/16' | '1/32';
 
+/** Configuration for the sampler instrument on a pianoRoll track. */
+export interface SamplerConfig {
+  /** IndexedDB audio key for the loaded sample. */
+  audioKey: string;
+  /** MIDI note number the sample was recorded at (default 60 = C4). */
+  rootNote: number;
+  /** ADSR attack time in seconds. */
+  attack: number;
+  /** ADSR decay time in seconds. */
+  decay: number;
+  /** ADSR sustain level (0–1). */
+  sustain: number;
+  /** ADSR release time in seconds. */
+  release: number;
+}
+
 export interface DrumPad {
   id: string;
   name: string;
@@ -386,6 +402,8 @@ export interface Track {
   midiEffects?: MidiEffect[];
   drumKit?: DrumKitName;
   drumMachine?: DrumMachineConfig;
+  /** Sampler instrument config — when set on a pianoRoll track, uses loaded audio sample instead of synth preset. */
+  samplerConfig?: SamplerConfig;
   // Mixer / channel-strip settings
   pan?: number;               // -1 (full left) to +1 (full right), default 0
   panMode?: 'stereo' | 'dual-mono';  // default 'stereo'

--- a/tests/unit/samplerEngine.test.ts
+++ b/tests/unit/samplerEngine.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSamplerConfig, DEFAULT_SAMPLER_CONFIG } from '../../src/engine/SamplerEngine';
+import type { SamplerConfig } from '../../src/types/project';
+import { useProjectStore } from '../../src/store/projectStore';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+// ─── createSamplerConfig ─────────────────────────────────────────────────────
+
+describe('createSamplerConfig', () => {
+  it('creates a config with sensible defaults', () => {
+    const config = createSamplerConfig('audio:proj:clip:iso:123');
+
+    expect(config).toEqual({
+      audioKey: 'audio:proj:clip:iso:123',
+      rootNote: 60,
+      attack: 0.005,
+      decay: 0.1,
+      sustain: 1,
+      release: 0.3,
+    });
+  });
+
+  it('allows overriding individual fields', () => {
+    const config = createSamplerConfig('key-1', { rootNote: 48, release: 1.5 });
+
+    expect(config.audioKey).toBe('key-1');
+    expect(config.rootNote).toBe(48);
+    expect(config.release).toBe(1.5);
+    // Non-overridden fields keep defaults
+    expect(config.attack).toBe(DEFAULT_SAMPLER_CONFIG.attack);
+    expect(config.sustain).toBe(DEFAULT_SAMPLER_CONFIG.sustain);
+  });
+
+  it('audioKey override wins over default-less base', () => {
+    const config = createSamplerConfig('original', { audioKey: 'overridden' });
+    expect(config.audioKey).toBe('overridden');
+  });
+});
+
+// ─── DEFAULT_SAMPLER_CONFIG ──────────────────────────────────────────────────
+
+describe('DEFAULT_SAMPLER_CONFIG', () => {
+  it('has C4 as root note', () => {
+    expect(DEFAULT_SAMPLER_CONFIG.rootNote).toBe(60);
+  });
+
+  it('has ADSR in valid ranges', () => {
+    expect(DEFAULT_SAMPLER_CONFIG.attack).toBeGreaterThan(0);
+    expect(DEFAULT_SAMPLER_CONFIG.decay).toBeGreaterThan(0);
+    expect(DEFAULT_SAMPLER_CONFIG.sustain).toBeGreaterThanOrEqual(0);
+    expect(DEFAULT_SAMPLER_CONFIG.sustain).toBeLessThanOrEqual(1);
+    expect(DEFAULT_SAMPLER_CONFIG.release).toBeGreaterThan(0);
+  });
+});
+
+// ─── SamplerConfig on Track type ─────────────────────────────────────────────
+
+describe('SamplerConfig type integration', () => {
+  it('SamplerConfig has required fields', () => {
+    const config: SamplerConfig = {
+      audioKey: 'test-key',
+      rootNote: 60,
+      attack: 0.01,
+      decay: 0.1,
+      sustain: 0.8,
+      release: 0.5,
+    };
+    expect(config.audioKey).toBe('test-key');
+    expect(config.rootNote).toBe(60);
+  });
+});
+
+// ─── Store: updateSamplerConfig ──────────────────────────────────────────────
+
+describe('projectStore.updateSamplerConfig', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useProjectStore.getState().createProject();
+  });
+
+  it('sets samplerConfig on an existing track', () => {
+    const track = useProjectStore.getState().addTrack('custom', 'pianoRoll');
+    const config = createSamplerConfig('audio:sample-1');
+
+    useProjectStore.getState().updateSamplerConfig(track.id, config);
+
+    const updated = useProjectStore.getState().project!.tracks.find((t) => t.id === track.id)!;
+    expect(updated.samplerConfig).toEqual(config);
+  });
+
+  it('clears samplerConfig when null is passed', () => {
+    const track = useProjectStore.getState().addTrack('custom', 'pianoRoll');
+    const config = createSamplerConfig('audio:sample-1');
+
+    useProjectStore.getState().updateSamplerConfig(track.id, config);
+    useProjectStore.getState().updateSamplerConfig(track.id, null);
+
+    const updated = useProjectStore.getState().project!.tracks.find((t) => t.id === track.id)!;
+    expect(updated.samplerConfig).toBeUndefined();
+  });
+
+  it('pushes to undo history', () => {
+    const track = useProjectStore.getState().addTrack('custom', 'pianoRoll');
+    const config = createSamplerConfig('audio:sample-1');
+
+    useProjectStore.getState().updateSamplerConfig(track.id, config);
+    useProjectStore.getState().undo();
+
+    const after = useProjectStore.getState().project!.tracks.find((t) => t.id === track.id)!;
+    expect(after.samplerConfig).toBeUndefined();
+  });
+
+  it('does not affect other tracks', () => {
+    const track1 = useProjectStore.getState().addTrack('custom', 'pianoRoll');
+    const track2 = useProjectStore.getState().addTrack('synth', 'pianoRoll');
+    const config = createSamplerConfig('audio:only-track-1');
+
+    useProjectStore.getState().updateSamplerConfig(track1.id, config);
+
+    const t2 = useProjectStore.getState().project!.tracks.find((t) => t.id === track2.id)!;
+    expect(t2.samplerConfig).toBeUndefined();
+  });
+
+  it('updates updatedAt timestamp', () => {
+    const track = useProjectStore.getState().addTrack('custom', 'pianoRoll');
+    const before = useProjectStore.getState().project!.updatedAt;
+    const config = createSamplerConfig('audio:sample-1');
+
+    useProjectStore.getState().updateSamplerConfig(track.id, config);
+
+    const after = useProjectStore.getState().project!.updatedAt;
+    expect(after).toBeGreaterThanOrEqual(before);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `SamplerEngine` that wraps Tone.js `Sampler` to load audio buffers and play them back at different pitches via MIDI notes on pianoRoll tracks
- Add `SamplerConfig` type (audioKey, rootNote, ADSR envelope) and `samplerConfig` field on `Track`
- Add `updateSamplerConfig` store action with full undo/redo support
- Integrate sampler playback in `useTransport.ts` — when a pianoRoll track has `samplerConfig`, notes are routed through the sampler engine instead of the synth engine

## Test plan
- [x] 11 new unit tests covering config creation, store actions, undo, and isolation
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 602 tests pass (72 files)
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)