### PR TITLE
feat: in-DAW AI assistant — context-aware help panel (closes #242)

### DIFF
--- a/src/components/dialogs/AIAssistantPanel.tsx
+++ b/src/components/dialogs/AIAssistantPanel.tsx
@@ -1,0 +1,277 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { useUIStore } from '../../store/uiStore';
+import { useProjectStore } from '../../store/projectStore';
+import { buildAssistantContext } from '../../utils/aiAssistantContext';
+import type { AIChatMessage } from '../../types/aiAssistant';
+
+const SYSTEM_PROMPT = `You are an AI music production assistant built into ACE-Step DAW. You help users with:
+- Music production techniques and tips
+- Explaining DAW features and how to use them
+- Suggesting effects, mixing settings, and arrangement ideas
+- Answering questions about music theory, genres, and instruments
+
+You have context about the user's current project state. Be concise and practical.
+Always relate advice to what the user is currently working on when possible.`;
+
+function generateId(): string {
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function MessageBubble({ message }: { message: AIChatMessage }) {
+  const isUser = message.role === 'user';
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-2`}>
+      <div
+        className={`max-w-[85%] px-3 py-2 rounded-lg text-[12px] leading-relaxed whitespace-pre-wrap ${
+          isUser
+            ? 'bg-daw-accent/80 text-white'
+            : 'bg-[#2a2a2a] text-zinc-200 border border-[#3a3a3a]'
+        }`}
+        data-message-role={message.role}
+      >
+        {message.content}
+      </div>
+    </div>
+  );
+}
+
+export function AIAssistantPanel() {
+  const show = useUIStore((s) => s.showAIAssistant);
+  const messages = useUIStore((s) => s.aiChatMessages);
+  const streaming = useUIStore((s) => s.aiAssistantStreaming);
+  const addMessage = useUIStore((s) => s.addAIChatMessage);
+  const clearMessages = useUIStore((s) => s.clearAIChatMessages);
+  const setStreaming = useUIStore((s) => s.setAIAssistantStreaming);
+  const setShow = useUIStore((s) => s.setShowAIAssistant);
+  const project = useProjectStore((s) => s.project);
+  const expandedTrackId = useUIStore((s) => s.expandedTrackId);
+
+  const [input, setInput] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.length]);
+
+  // Focus input when panel opens
+  useEffect(() => {
+    if (show) {
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [show]);
+
+  const handleSend = useCallback(() => {
+    const trimmed = input.trim();
+    if (!trimmed || streaming) return;
+
+    const userMsg: AIChatMessage = {
+      id: generateId(),
+      role: 'user',
+      content: trimmed,
+      timestamp: Date.now(),
+    };
+    addMessage(userMsg);
+    setInput('');
+
+    // Build context and generate response
+    const context = buildAssistantContext(project, expandedTrackId);
+    setStreaming(true);
+
+    // Simulate assistant response (Phase 1: local knowledge base, no API call)
+    // In Phase 2, this will be replaced with actual LLM API integration
+    setTimeout(() => {
+      const response = generateLocalResponse(trimmed, context);
+      const assistantMsg: AIChatMessage = {
+        id: generateId(),
+        role: 'assistant',
+        content: response,
+        timestamp: Date.now(),
+      };
+      addMessage(assistantMsg);
+      setStreaming(false);
+    }, 300);
+  }, [input, streaming, addMessage, setStreaming, project, expandedTrackId]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }, [handleSend]);
+
+  if (!show) return null;
+
+  return (
+    <div
+      className="fixed right-0 top-11 bottom-6 w-[340px] bg-[#1e1e1e] border-l border-[#333] flex flex-col z-50 shadow-xl"
+      data-testid="ai-assistant-panel"
+      role="complementary"
+      aria-label="AI Assistant"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-[#333] shrink-0">
+        <div className="flex items-center gap-2">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" className="text-daw-accent">
+            <circle cx="7" cy="7" r="5.5" />
+            <path d="M5 6.5h4M5 8.5h2.5" strokeLinecap="round" />
+            <circle cx="7" cy="4.5" r="0.8" fill="currentColor" />
+          </svg>
+          <span className="text-[12px] font-medium text-zinc-200">AI Assistant</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={clearMessages}
+            className="w-6 h-6 flex items-center justify-center text-zinc-500 hover:text-zinc-300 rounded hover:bg-[#333] transition-colors"
+            title="Clear conversation"
+            aria-label="Clear conversation"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.3">
+              <path d="M2 3h8M4.5 3V2h3v1M3 3v7a1 1 0 001 1h4a1 1 0 001-1V3" />
+            </svg>
+          </button>
+          <button
+            onClick={() => setShow(false)}
+            className="w-6 h-6 flex items-center justify-center text-zinc-500 hover:text-zinc-300 rounded hover:bg-[#333] transition-colors"
+            title="Close (Escape)"
+            aria-label="Close AI Assistant"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M2 2l8 8M10 2l-8 8" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-3 py-3 min-h-0">
+        {messages.length === 0 && (
+          <div className="text-center text-zinc-500 text-[11px] mt-8 space-y-3">
+            <div className="text-2xl">✨</div>
+            <div className="font-medium text-zinc-400">AI Music Assistant</div>
+            <div>Ask about production techniques, effects, mixing tips, or how to use DAW features.</div>
+            <div className="space-y-1.5 mt-4">
+              <SuggestionChip text="How do I make my drums punch harder?" onClick={(t) => { setInput(t); }} />
+              <SuggestionChip text="Suggest effects for vocals" onClick={(t) => { setInput(t); }} />
+              <SuggestionChip text="What BPM is good for lo-fi hip hop?" onClick={(t) => { setInput(t); }} />
+            </div>
+          </div>
+        )}
+        {messages.map((msg) => (
+          <MessageBubble key={msg.id} message={msg} />
+        ))}
+        {streaming && (
+          <div className="flex justify-start mb-2">
+            <div className="bg-[#2a2a2a] border border-[#3a3a3a] px-3 py-2 rounded-lg">
+              <div className="flex gap-1">
+                <span className="w-1.5 h-1.5 bg-zinc-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+                <span className="w-1.5 h-1.5 bg-zinc-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+                <span className="w-1.5 h-1.5 bg-zinc-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+              </div>
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input area */}
+      <div className="shrink-0 border-t border-[#333] p-2">
+        <div className="flex gap-2">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about music production..."
+            className="flex-1 bg-[#2a2a2a] border border-[#444] rounded-lg px-3 py-2 text-[12px] text-zinc-200 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent/50 transition-colors"
+            rows={2}
+            disabled={streaming}
+            aria-label="Chat input"
+          />
+          <button
+            onClick={handleSend}
+            disabled={!input.trim() || streaming}
+            className="self-end px-3 py-2 bg-daw-accent/80 hover:bg-daw-accent text-white text-[11px] font-medium rounded-lg disabled:opacity-30 disabled:hover:bg-daw-accent/80 transition-colors"
+            aria-label="Send message"
+          >
+            Send
+          </button>
+        </div>
+        <div className="text-[10px] text-zinc-600 mt-1 px-1">
+          Shift+Enter for new line · Phase 1: built-in knowledge
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SuggestionChip({ text, onClick }: { text: string; onClick: (text: string) => void }) {
+  return (
+    <button
+      onClick={() => onClick(text)}
+      className="block w-full text-left px-3 py-1.5 text-[11px] text-zinc-400 hover:text-zinc-200 bg-[#2a2a2a] hover:bg-[#333] border border-[#3a3a3a] rounded-md transition-colors"
+    >
+      {text}
+    </button>
+  );
+}
+
+/**
+ * Phase 1: Local knowledge-based response generation.
+ * Matches keywords from the user's question against a built-in knowledge base.
+ * Phase 2 will replace this with actual LLM API streaming.
+ */
+function generateLocalResponse(question: string, context: string): string {
+  const q = question.toLowerCase();
+
+  // Context-aware responses
+  if (context.includes('No project loaded')) {
+    return 'It looks like you don\'t have a project open yet. Create a new project first, then I can help you with production tips specific to your setup!';
+  }
+
+  // Effects & mixing
+  if (q.includes('reverb')) {
+    return 'Reverb adds space and depth to your sound. In ACE-Step DAW:\n\n1. Select the track you want to add reverb to\n2. Open the Effect Chain (click the FX button or use the mixer)\n3. Add a Reverb effect\n4. Adjust Decay (room size), Pre-Delay (space before reverb starts), and Wet mix\n\nTips:\n- Vocals: Use a medium room (decay 1.5-2.5s) with 20-30% wet\n- Drums: Short room reverb (0.5-1s) to add body without muddiness\n- Use pre-delay (20-50ms) to keep the original sound clear';
+  }
+
+  if (q.includes('compressor') || q.includes('compression')) {
+    return 'Compression controls dynamic range — it makes loud parts quieter and quiet parts louder.\n\nKey parameters:\n- **Threshold**: Level where compression starts (lower = more compression)\n- **Ratio**: How much to compress (4:1 is a good starting point)\n- **Attack**: How fast compression kicks in (fast = tighter, slow = more punch)\n- **Release**: How fast compression lets go\n\nQuick settings:\n- Vocals: Threshold -18dB, Ratio 3:1, Attack 10ms, Release 100ms\n- Drums: Threshold -12dB, Ratio 4:1, Attack 1ms, Release 50ms\n- Bass: Threshold -15dB, Ratio 4:1, Attack 5ms, Release 80ms';
+  }
+
+  if (q.includes('eq') || q.includes('equaliz')) {
+    return 'EQ shapes the tonal balance of your tracks.\n\nACE-Step DAW has a 3-band EQ and a parametric EQ on each track.\n\nCommon EQ moves:\n- **Cut muddy frequencies**: Reduce 200-400 Hz on non-bass instruments\n- **Add vocal presence**: Boost 2-5 kHz slightly\n- **Air and brightness**: Gentle boost at 10-12 kHz\n- **Kick drum punch**: Boost 60-80 Hz, cut 300 Hz, boost 3-5 kHz for click\n- **High-pass everything except kick/bass**: Set a filter at 80-100 Hz to remove rumble';
+  }
+
+  if (q.includes('effect') && q.includes('vocal')) {
+    return 'Essential vocal effects chain:\n\n1. **EQ** — High-pass at 80 Hz, cut 200-300 Hz if muddy, boost 3-5 kHz for presence\n2. **Compressor** — Ratio 3:1, threshold to catch -6dB peaks, fast attack\n3. **Reverb** — Medium room, 20-30% wet, 30ms pre-delay\n4. **Delay** — Optional, 1/4 note, 15-20% wet for depth\n\nIn ACE-Step: Select the vocal track → open Effect Chain → add effects in this order.';
+  }
+
+  // BPM & genre
+  if (q.includes('bpm') || q.includes('tempo')) {
+    return 'Common BPM ranges by genre:\n\n- **Lo-fi Hip Hop**: 70-90 BPM\n- **Hip Hop / Trap**: 130-160 BPM (half-time feel)\n- **Pop**: 100-130 BPM\n- **House / EDM**: 120-130 BPM\n- **Drum & Bass**: 160-180 BPM\n- **Dubstep**: 140 BPM (half-time)\n- **R&B**: 60-80 BPM\n- **Rock**: 110-140 BPM\n\nYou can change BPM in the Settings dialog (Cmd+,) or click the BPM display in the toolbar.';
+  }
+
+  // Drums
+  if (q.includes('drum') && (q.includes('punch') || q.includes('hard') || q.includes('hit'))) {
+    return 'To make drums punch harder:\n\n1. **Compression**: Use fast attack (1-5ms) and medium release. Ratio 4:1-6:1\n2. **Transient shaping**: Boost the attack of kick and snare\n3. **EQ**: Boost kick at 60-80 Hz and 3-5 kHz (beater click). Boost snare at 200 Hz (body) and 5-7 kHz (crack)\n4. **Parallel compression**: Mix heavily compressed drums with the original\n5. **Saturation/Distortion**: Light distortion adds harmonics and perceived loudness\n6. **Sidechain**: Use the kick to duck other elements slightly\n\nIn ACE-Step: Add Compressor and Distortion effects to your drum track from the Effect Chain panel.';
+  }
+
+  // Mixing
+  if (q.includes('mix') && (q.includes('tip') || q.includes('better') || q.includes('how'))) {
+    return 'Mixing fundamentals:\n\n1. **Gain staging**: Keep individual tracks around -12 to -6 dBFS before summing\n2. **Start with the faders**: Set relative levels before adding effects\n3. **EQ to separate**: Give each instrument its own frequency space\n4. **Pan for width**: Spread instruments across the stereo field\n5. **Use high-pass filters**: On everything except kick and bass\n6. **Reference tracks**: Compare against professional mixes frequently\n7. **Take breaks**: Your ears fatigue — rest every 30-45 minutes\n\nACE-Step Mixer (X key) gives you faders, pan, and EQ for every track.';
+  }
+
+  // DAW-specific features
+  if (q.includes('shortcut') || q.includes('keyboard')) {
+    return 'Essential ACE-Step DAW shortcuts:\n\n- **Space**: Play/Pause\n- **Enter**: Stop/Return to start\n- **R**: Toggle recording\n- **X**: Toggle mixer\n- **B**: Smart controls\n- **Y**: Library panel\n- **N**: Toggle snap\n- **?**: Show all shortcuts\n- **Cmd+G**: Generate (batch)\n- **Cmd+Shift+G**: Context generation\n- **Cmd+Enter**: Generate selected clip\n- **Cmd+Z / Cmd+Shift+Z**: Undo/Redo';
+  }
+
+  if (q.includes('generate') || q.includes('ai') && q.includes('music')) {
+    return 'ACE-Step AI music generation:\n\n1. **Add a track** (Cmd+Shift+I) — choose instrument type\n2. **Add a clip** — click on the timeline lane\n3. **Write a prompt** — describe the sound (e.g., "groovy bass line, funky, 120bpm")\n4. **Generate** — Cmd+Enter to generate the selected clip\n5. **Batch generate** — Cmd+G to generate multiple clips at once\n\nTips:\n- Be specific in prompts: genre, mood, tempo, instrument style\n- Use context generation (Cmd+Shift+G) to make new clips that match existing ones\n- Use "repaint" to partially regenerate sections you want to change';
+  }
+
+  // Fallback — still context-aware
+  const trackInfo = context.includes('Selected track') ? '\n\nI can see you have a track selected — feel free to ask specific questions about it!' : '';
+  return `I can help with music production questions! Here are some things I know about:\n\n- **Effects**: Reverb, compression, EQ, delay, distortion\n- **Mixing tips**: Gain staging, panning, frequency separation\n- **BPM/Genre guidance**: Tempo ranges for different genres\n- **ACE-Step features**: Shortcuts, AI generation, effects chain\n- **Music theory**: Chord progressions, scales, arrangement\n\nTry asking something specific like "How do I add reverb to vocals?" or "What BPM for lo-fi?"${trackInfo}`;
+}

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -70,6 +70,7 @@ const SECTIONS: Section[] = [
       { keys: ['B'],                    description: 'Toggle Smart Controls' },
       { keys: ['O'],                    description: 'Toggle Loop Browser' },
       { keys: ['T'],                    description: 'Toggle Tempo Lane' },
+      { keys: [`${mod}`, '/'],           description: 'Toggle AI Assistant' },
     ],
   },
   {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -16,6 +16,7 @@ import { SettingsDialog } from '../dialogs/SettingsDialog';
 import { ProjectListDialog } from '../dialogs/ProjectListDialog';
 import { KeyboardShortcutsDialog } from '../dialogs/KeyboardShortcutsDialog';
 import { ShareDialog } from '../dialogs/ShareDialog';
+import { AIAssistantPanel } from '../dialogs/AIAssistantPanel';
 import { MixerPanel } from '../mixer/MixerPanel';
 import { AssetsPanel } from '../assets/AssetsPanel';
 import { LoopBrowser } from '../assets/LoopBrowser';
@@ -108,6 +109,7 @@ export function AppShell() {
       <AudioAnalysisPanel />
       <StemSeparationModal />
       <ShareDialog />
+      <AIAssistantPanel />
     </div>
   );
 }

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -81,6 +81,8 @@ export function Toolbar() {
   const setShowLibrary = useUIStore((s) => s.setShowLibrary);
   const showSmartControls = useUIStore((s) => s.showSmartControls);
   const setShowSmartControls = useUIStore((s) => s.setShowSmartControls);
+  const showAIAssistant = useUIStore((s) => s.showAIAssistant);
+  const toggleAIAssistant = useUIStore((s) => s.toggleAIAssistant);
   const setShowShareDialog = useCollaborationStore((s) => s.setShowShareDialog);
   const isViewerMode = useCollaborationStore((s) => s.isViewerMode);
   const { openFilePicker } = useAudioImport();
@@ -240,6 +242,17 @@ export function Toolbar() {
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4">
             <circle cx="6" cy="6" r="4" />
             <path d="M9 9l3.5 3.5" strokeLinecap="round" />
+          </svg>
+        </ControlBarButton>
+        <ControlBarButton
+          active={showAIAssistant}
+          onClick={toggleAIAssistant}
+          title="AI Assistant (Cmd+/)"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3">
+            <circle cx="7" cy="7" r="5.5" />
+            <path d="M5 6.5h4M5 8.5h2.5" strokeLinecap="round" />
+            <circle cx="7" cy="4.5" r="0.8" fill="currentColor" />
           </svg>
         </ControlBarButton>
       </div>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -51,7 +51,10 @@ export function useKeyboardShortcuts() {
       // Escape — close topmost modal in priority order
       // -----------------------------------------------------------------------
       if (e.code === 'Escape') {
-        if (ui.editingClipId !== null) {
+        if (ui.showAIAssistant) {
+          e.preventDefault();
+          ui.setShowAIAssistant(false);
+        } else if (ui.editingClipId !== null) {
           e.preventDefault();
           ui.setEditingClip(null);
         } else if (ui.batchGenerateMode !== null) {
@@ -141,6 +144,12 @@ export function useKeyboardShortcuts() {
                 ui.setBatchGenerateMode('silence');
               }
             }
+            return;
+
+          // AI Assistant toggle (Cmd+/)
+          case 'Slash':
+            e.preventDefault();
+            ui.toggleAIAssistant();
             return;
 
           // Export

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import type { AIChatMessage } from '../types/aiAssistant';
 
 interface UIState {
   pixelsPerSecond: number;
@@ -76,6 +77,11 @@ interface UIState {
   showGeneratePatternDialog: boolean;
   generatePatternClipId: string | null;
 
+  // AI Assistant
+  showAIAssistant: boolean;
+  aiChatMessages: AIChatMessage[];
+  aiAssistantStreaming: boolean;
+
   setPixelsPerSecond: (pps: number) => void;
   toggleSnap: () => void;
   zoomIn: () => void;
@@ -145,6 +151,13 @@ interface UIState {
   // Generate pattern dialog
   setShowGeneratePatternDialog: (v: boolean) => void;
   openGeneratePatternDialog: (clipId: string) => void;
+
+  // AI Assistant
+  toggleAIAssistant: () => void;
+  setShowAIAssistant: (v: boolean) => void;
+  addAIChatMessage: (msg: AIChatMessage) => void;
+  clearAIChatMessages: () => void;
+  setAIAssistantStreaming: (v: boolean) => void;
 }
 
 const ZOOM_LEVELS = [10, 25, 50, 100, 200, 500];
@@ -210,6 +223,10 @@ export const useUIStore = create<UIState>()(
 
   showGeneratePatternDialog: false,
   generatePatternClipId: null,
+
+  showAIAssistant: false,
+  aiChatMessages: [],
+  aiAssistantStreaming: false,
 
   setPixelsPerSecond: (pps) => set({ pixelsPerSecond: pps }),
   toggleSnap: () => set((s) => ({ snapEnabled: !s.snapEnabled })),
@@ -311,6 +328,12 @@ export const useUIStore = create<UIState>()(
 
   setShowGeneratePatternDialog: (v) => set(v ? { showGeneratePatternDialog: v } : { showGeneratePatternDialog: false, generatePatternClipId: null }),
   openGeneratePatternDialog: (clipId) => set({ showGeneratePatternDialog: true, generatePatternClipId: clipId }),
+
+  toggleAIAssistant: () => set((s) => ({ showAIAssistant: !s.showAIAssistant })),
+  setShowAIAssistant: (v) => set({ showAIAssistant: v }),
+  addAIChatMessage: (msg) => set((s) => ({ aiChatMessages: [...s.aiChatMessages, msg] })),
+  clearAIChatMessages: () => set({ aiChatMessages: [] }),
+  setAIAssistantStreaming: (v) => set({ aiAssistantStreaming: v }),
 }),
     {
       name: 'ace-step-daw-ui',
@@ -337,6 +360,8 @@ export const useUIStore = create<UIState>()(
         showSpectrumAnalyzer: state.showSpectrumAnalyzer,
         // Loop Browser preference
         loopBrowserCategory: state.loopBrowserCategory,
+        // AI Assistant
+        showAIAssistant: state.showAIAssistant,
       }),
     },
   ),

--- a/src/types/aiAssistant.ts
+++ b/src/types/aiAssistant.ts
@@ -1,0 +1,6 @@
+export interface AIChatMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp: number;
+}

--- a/src/utils/aiAssistantContext.ts
+++ b/src/utils/aiAssistantContext.ts
@@ -1,0 +1,94 @@
+/**
+ * aiAssistantContext.ts — Build a context string for the AI assistant
+ * that describes the current DAW project state, selected track, and effects.
+ */
+import type { Project, Track } from '../types/project';
+
+/**
+ * Build a context string summarizing the current DAW state for the AI assistant.
+ * Includes project settings, track layout, selected track details, and effects.
+ */
+export function buildAssistantContext(
+  project: Project | null,
+  selectedTrackId: string | null,
+): string {
+  if (!project) return 'No project loaded.';
+
+  const lines: string[] = [];
+
+  // Project overview
+  lines.push(`Project: "${project.name}"`);
+  lines.push(`BPM: ${project.bpm} | Key: ${project.keyScale || 'none'} | Time Signature: ${project.timeSignature}/4`);
+  lines.push(`Duration: ${fmtDur(project.totalDuration)} | Tracks: ${project.tracks.length}`);
+
+  if (project.globalCaption) {
+    lines.push(`Description: ${project.globalCaption}`);
+  }
+
+  // Track summary
+  if (project.tracks.length > 0) {
+    lines.push('');
+    lines.push('Tracks:');
+    for (const track of project.tracks) {
+      const flags = [
+        track.muted ? 'muted' : null,
+        track.soloed ? 'solo' : null,
+        track.armed ? 'armed' : null,
+      ].filter(Boolean).join(', ');
+      const flagStr = flags ? ` (${flags})` : '';
+      lines.push(`  - ${track.displayName} [${track.trackType || 'stems'}]${flagStr} — ${track.clips.length} clip(s), vol: ${Math.round(track.volume * 100)}%`);
+    }
+  }
+
+  // Selected track detail
+  if (selectedTrackId) {
+    const track = project.tracks.find((t) => t.id === selectedTrackId);
+    if (track) {
+      lines.push('');
+      lines.push(`Selected track: ${track.displayName} (${track.trackType || 'stems'})`);
+      lines.push(`  Volume: ${Math.round(track.volume * 100)}% | Pan: ${track.pan ?? 0}`);
+
+      if (track.localCaption) {
+        lines.push(`  Caption: ${track.localCaption}`);
+      }
+
+      // Effects
+      if (track.effects && track.effects.length > 0) {
+        const fxList = track.effects.map((e) => `${e.type}${e.enabled ? '' : ' (bypassed)'}`).join(', ');
+        lines.push(`  Effects: ${fxList}`);
+      }
+
+      // MIDI effects
+      if (track.midiEffects && track.midiEffects.length > 0) {
+        const mfxList = track.midiEffects.map((e) => `${e.type}${e.enabled ? '' : ' (bypassed)'}`).join(', ');
+        lines.push(`  MIDI Effects: ${mfxList}`);
+      }
+
+      // Synth/drum info
+      if (track.synthPreset) {
+        lines.push(`  Synth: ${track.synthPreset}`);
+      }
+      if (track.drumKit) {
+        lines.push(`  Drum Kit: ${track.drumKit}`);
+      }
+
+      // Clips detail
+      if (track.clips.length > 0) {
+        lines.push(`  Clips:`);
+        for (const clip of track.clips) {
+          const status = clip.generationStatus === 'ready' ? 'ready' : clip.generationStatus;
+          const type = clip.midiData ? `MIDI (${clip.midiData.notes.length} notes)` : (clip.prompt || 'audio');
+          lines.push(`    [${status}] ${fmtDur(clip.startTime)}-${fmtDur(clip.startTime + clip.duration)}: ${type}`);
+        }
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function fmtDur(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}

--- a/tests/unit/aiAssistant.test.ts
+++ b/tests/unit/aiAssistant.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUIStore } from '../../src/store/uiStore';
+import { useProjectStore } from '../../src/store/projectStore';
+import { buildAssistantContext } from '../../src/utils/aiAssistantContext';
+import type { AIChatMessage } from '../../src/types/aiAssistant';
+
+describe('AI Assistant', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useUIStore.setState(useUIStore.getInitialState(), true);
+  });
+
+  describe('uiStore — assistant panel state', () => {
+    it('assistant panel is closed by default', () => {
+      expect(useUIStore.getState().showAIAssistant).toBe(false);
+    });
+
+    it('toggles assistant panel open/closed', () => {
+      useUIStore.getState().toggleAIAssistant();
+      expect(useUIStore.getState().showAIAssistant).toBe(true);
+
+      useUIStore.getState().toggleAIAssistant();
+      expect(useUIStore.getState().showAIAssistant).toBe(false);
+    });
+
+    it('sets assistant panel visibility directly', () => {
+      useUIStore.getState().setShowAIAssistant(true);
+      expect(useUIStore.getState().showAIAssistant).toBe(true);
+
+      useUIStore.getState().setShowAIAssistant(false);
+      expect(useUIStore.getState().showAIAssistant).toBe(false);
+    });
+
+    it('manages chat messages', () => {
+      expect(useUIStore.getState().aiChatMessages).toEqual([]);
+
+      const msg: AIChatMessage = {
+        id: 'msg-1',
+        role: 'user',
+        content: 'How do I add reverb?',
+        timestamp: Date.now(),
+      };
+      useUIStore.getState().addAIChatMessage(msg);
+      expect(useUIStore.getState().aiChatMessages).toHaveLength(1);
+      expect(useUIStore.getState().aiChatMessages[0].content).toBe('How do I add reverb?');
+
+      const reply: AIChatMessage = {
+        id: 'msg-2',
+        role: 'assistant',
+        content: 'You can add reverb from the effects chain.',
+        timestamp: Date.now(),
+      };
+      useUIStore.getState().addAIChatMessage(reply);
+      expect(useUIStore.getState().aiChatMessages).toHaveLength(2);
+    });
+
+    it('clears chat messages', () => {
+      useUIStore.getState().addAIChatMessage({
+        id: 'msg-1',
+        role: 'user',
+        content: 'test',
+        timestamp: Date.now(),
+      });
+      useUIStore.getState().clearAIChatMessages();
+      expect(useUIStore.getState().aiChatMessages).toEqual([]);
+    });
+
+    it('tracks streaming state', () => {
+      expect(useUIStore.getState().aiAssistantStreaming).toBe(false);
+
+      useUIStore.getState().setAIAssistantStreaming(true);
+      expect(useUIStore.getState().aiAssistantStreaming).toBe(true);
+
+      useUIStore.getState().setAIAssistantStreaming(false);
+      expect(useUIStore.getState().aiAssistantStreaming).toBe(false);
+    });
+
+    it('persists assistant panel open state', () => {
+      useUIStore.getState().setShowAIAssistant(true);
+      // Partialize should include showAIAssistant
+      const persisted = JSON.parse(localStorage.getItem('ace-step-daw-ui') || '{}');
+      expect(persisted.state.showAIAssistant).toBe(true);
+    });
+  });
+
+  describe('buildAssistantContext', () => {
+    it('returns minimal context when no project is loaded', () => {
+      const ctx = buildAssistantContext(null, null);
+      expect(ctx).toContain('No project loaded');
+    });
+
+    it('includes project info in context', () => {
+      useProjectStore.getState().createProject({ name: 'My Song', bpm: 128 });
+      const project = useProjectStore.getState().project;
+      const ctx = buildAssistantContext(project, null);
+      expect(ctx).toContain('My Song');
+      expect(ctx).toContain('128');
+    });
+
+    it('includes selected track details when provided', () => {
+      useProjectStore.getState().createProject({ name: 'Track Test' });
+      const track = useProjectStore.getState().addTrack('drums');
+      const project = useProjectStore.getState().project;
+      const ctx = buildAssistantContext(project, track.id);
+      expect(ctx).toContain('Drums');
+      expect(ctx).toContain('Selected track');
+    });
+
+    it('includes effect chain info for selected track', () => {
+      useProjectStore.getState().createProject({ name: 'FX Test' });
+      const track = useProjectStore.getState().addTrack('vocals');
+      useProjectStore.getState().addTrackEffect(track.id, 'reverb');
+      const project = useProjectStore.getState().project;
+      const ctx = buildAssistantContext(project, track.id);
+      expect(ctx).toContain('reverb');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add collapsible AI assistant side panel with built-in music production knowledge base
- Context-aware: reads project state, selected track info, and effects chain to provide relevant help
- Keyboard shortcut `Cmd+/` to toggle panel, `Escape` to close, toolbar toggle button
- Phase 1 implementation with local knowledge; Phase 2 will add LLM API streaming

## Changes
- **New files**: `AIAssistantPanel.tsx`, `aiAssistant.ts` (types), `aiAssistantContext.ts` (context builder)
- **Modified**: `uiStore.ts` (panel state + chat messages), `AppShell.tsx`, `Toolbar.tsx`, `useKeyboardShortcuts.ts`, `KeyboardShortcutsDialog.tsx`
- **Tests**: 11 unit tests covering store state management and context builder

## Test plan
- [ ] Verify `Cmd+/` toggles the AI assistant panel
- [ ] Verify `Escape` closes the panel
- [ ] Verify toolbar button shows active state when panel is open
- [ ] Verify suggestion chips populate the input field
- [ ] Verify sending a message shows a context-aware response
- [ ] Verify "Clear conversation" button works
- [ ] Verify panel persists open/closed state across page reloads
- [ ] Run `npx tsc --noEmit` — 0 errors
- [ ] Run `npm test` — 602 tests pass
- [ ] Run `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)