### PR TITLE
feat: spectrum analyzer & loudness metering (LUFS) (closes #241)

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -5,6 +5,7 @@ import { getAudioEngine } from '../../hooks/useAudioEngine';
 import { Knob } from '../ui/Knob';
 import { LevelMeter } from './LevelMeter';
 import { MasteringPanel } from './MasteringPanel';
+import { SpectrumAnalyzer } from './SpectrumAnalyzer';
 import type { Track } from '../../types/project';
 
 const MIXER_MIN_VISIBLE_HEIGHT = 360;
@@ -109,13 +110,28 @@ interface MasterStripProps { faderHeight: number; }
 function MasterStrip({ faderHeight }: MasterStripProps) {
   const project = useProjectStore((s) => s.project);
   const updateProject = useProjectStore((s) => s.updateProject);
+  const showSpectrum = useUIStore((s) => s.showSpectrumAnalyzer);
+  const toggleSpectrum = useUIStore((s) => s.toggleSpectrumAnalyzer);
   if (!project) return null;
   const masterVol = project.masterVolume ?? 1.0;
   const handleChange = (v: number) => { updateProject({ masterVolume: v }); getAudioEngine().masterVolume = v; };
 
   return (
     <div className="flex h-full min-h-0 flex-col items-center gap-1.5 border-l-2 border-[#555] bg-[#252525] px-4 py-2 min-w-[250px]">
-      <span className="text-xs font-bold text-zinc-300 uppercase tracking-widest">Master</span>
+      <div className="flex items-center gap-2 w-full">
+        <span className="text-xs font-bold text-zinc-300 uppercase tracking-widest">Master</span>
+        <button
+          onClick={toggleSpectrum}
+          className={`text-[9px] font-semibold px-1.5 py-0.5 rounded transition-colors ml-auto ${
+            showSpectrum ? 'bg-blue-600 text-white' : 'bg-[#444] text-zinc-400 hover:bg-[#555]'
+          }`}
+          title="Toggle spectrum analyzer & LUFS meter"
+          data-testid="spectrum-toggle"
+        >
+          SPEC
+        </button>
+      </div>
+      {showSpectrum && <SpectrumAnalyzer width={220} height={120} />}
       <MasteringPanel />
       <div className="flex min-h-0 flex-1 flex-col items-center justify-end gap-1 w-full pb-1">
         <div className="relative flex justify-center gap-2" style={{ height: faderHeight }}>

--- a/src/components/mixer/SpectrumAnalyzer.tsx
+++ b/src/components/mixer/SpectrumAnalyzer.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+import {
+  computeMomentaryLoudness,
+  freqToX,
+  dbToY,
+} from '../../utils/loudnessMetering';
+
+const MIN_FREQ = 20;
+const MAX_FREQ = 20000;
+const MIN_DB = -90;
+const MAX_DB = 0;
+
+// Frequency labels for grid
+const FREQ_LABELS = [30, 60, 100, 200, 500, 1000, 2000, 5000, 10000, 20000];
+// dB labels for grid
+const DB_LABELS = [-80, -60, -40, -20, 0];
+
+const LUFS_SMOOTHING = 0.85;
+
+function formatFreq(hz: number): string {
+  return hz >= 1000 ? `${hz / 1000}k` : `${hz}`;
+}
+
+function formatLufs(lufs: number): string {
+  if (!Number.isFinite(lufs)) return '-inf';
+  return lufs.toFixed(1);
+}
+
+function getLufsColor(lufs: number): string {
+  if (!Number.isFinite(lufs)) return '#6b7280'; // gray
+  if (lufs > -3) return '#ef4444'; // red — clipping
+  if (lufs > -8) return '#f59e0b'; // amber — loud
+  if (lufs > -14) return '#22c55e'; // green — nominal
+  return '#3b82f6'; // blue — quiet
+}
+
+interface SpectrumAnalyzerProps {
+  width?: number;
+  height?: number;
+}
+
+export function SpectrumAnalyzer({
+  width = 320,
+  height = 160,
+}: SpectrumAnalyzerProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rafRef = useRef<number>(0);
+  const smoothedLufsRef = useRef<number>(-Infinity);
+  const lufsDisplayRef = useRef<HTMLSpanElement>(null);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const engine = getAudioEngine();
+    const dpr = window.devicePixelRatio || 1;
+
+    // Set canvas resolution for high DPI
+    if (canvas.width !== width * dpr || canvas.height !== height * dpr) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.scale(dpr, dpr);
+    }
+
+    // Clear
+    ctx.clearRect(0, 0, width, height);
+
+    // Background
+    ctx.fillStyle = 'rgba(8, 12, 24, 0.95)';
+    ctx.fillRect(0, 0, width, height);
+
+    // Grid lines — frequency (vertical)
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
+    ctx.lineWidth = 0.5;
+    ctx.font = '9px monospace';
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.25)';
+    ctx.textAlign = 'center';
+
+    for (const freq of FREQ_LABELS) {
+      const x = freqToX(freq, width, MIN_FREQ, MAX_FREQ);
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.stroke();
+      ctx.fillText(formatFreq(freq), x, height - 2);
+    }
+
+    // Grid lines — dB (horizontal)
+    ctx.textAlign = 'left';
+    for (const db of DB_LABELS) {
+      const y = dbToY(db, height, MIN_DB, MAX_DB);
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+      ctx.fillText(`${db}`, 2, y - 2);
+    }
+
+    // Get spectrum data
+    const spectrum = engine.getMasterSpectrum();
+    const sampleRate = engine.sampleRate;
+    const binCount = engine.spectrumBinCount;
+    const binWidth = sampleRate / (binCount * 2);
+
+    // Draw spectrum bars as filled area
+    ctx.beginPath();
+    ctx.moveTo(0, height);
+
+    let prevX = 0;
+    for (let i = 1; i < binCount; i++) {
+      const freq = i * binWidth;
+      if (freq < MIN_FREQ || freq > MAX_FREQ) continue;
+
+      const x = freqToX(freq, width, MIN_FREQ, MAX_FREQ);
+      const db = Math.max(MIN_DB, Math.min(MAX_DB, spectrum[i]));
+      const y = dbToY(db, height, MIN_DB, MAX_DB);
+
+      if (prevX === 0) {
+        ctx.moveTo(x, height);
+      }
+      ctx.lineTo(x, y);
+      prevX = x;
+    }
+
+    // Close the path to fill
+    ctx.lineTo(prevX, height);
+    ctx.closePath();
+
+    // Gradient fill
+    const gradient = ctx.createLinearGradient(0, 0, 0, height);
+    gradient.addColorStop(0, 'rgba(59, 130, 246, 0.6)'); // blue top
+    gradient.addColorStop(0.5, 'rgba(34, 197, 94, 0.3)'); // green middle
+    gradient.addColorStop(1, 'rgba(34, 197, 94, 0.05)'); // transparent bottom
+    ctx.fillStyle = gradient;
+    ctx.fill();
+
+    // Draw spectrum line on top
+    ctx.beginPath();
+    let started = false;
+    for (let i = 1; i < binCount; i++) {
+      const freq = i * binWidth;
+      if (freq < MIN_FREQ || freq > MAX_FREQ) continue;
+
+      const x = freqToX(freq, width, MIN_FREQ, MAX_FREQ);
+      const db = Math.max(MIN_DB, Math.min(MAX_DB, spectrum[i]));
+      const y = dbToY(db, height, MIN_DB, MAX_DB);
+
+      if (!started) {
+        ctx.moveTo(x, y);
+        started = true;
+      } else {
+        ctx.lineTo(x, y);
+      }
+    }
+    ctx.strokeStyle = 'rgba(59, 130, 246, 0.9)';
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+
+    // LUFS calculation from time-domain data
+    const timeDomainData = engine.getMasterTimeDomainData();
+    const momentaryLufs = computeMomentaryLoudness(timeDomainData, sampleRate);
+
+    // Smooth LUFS display
+    const prev = smoothedLufsRef.current;
+    if (!Number.isFinite(prev)) {
+      smoothedLufsRef.current = momentaryLufs;
+    } else if (!Number.isFinite(momentaryLufs)) {
+      smoothedLufsRef.current = prev * LUFS_SMOOTHING;
+      if (prev < MIN_DB) smoothedLufsRef.current = -Infinity;
+    } else {
+      smoothedLufsRef.current = prev * LUFS_SMOOTHING + momentaryLufs * (1 - LUFS_SMOOTHING);
+    }
+
+    // Update LUFS display via ref (avoid React re-renders)
+    const lufsEl = lufsDisplayRef.current;
+    if (lufsEl) {
+      const lufsVal = smoothedLufsRef.current;
+      lufsEl.textContent = `${formatLufs(lufsVal)} LUFS`;
+      lufsEl.style.color = getLufsColor(lufsVal);
+    }
+
+    rafRef.current = requestAnimationFrame(draw);
+  }, [width, height]);
+
+  useEffect(() => {
+    rafRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [draw]);
+
+  return (
+    <div className="flex flex-col items-center gap-1" data-testid="spectrum-analyzer">
+      <div className="flex items-center justify-between w-full px-0.5">
+        <span className="text-[9px] text-zinc-500 uppercase tracking-widest">Spectrum</span>
+        <span
+          ref={lufsDisplayRef}
+          className="text-[11px] font-mono font-bold tabular-nums"
+          style={{ color: '#6b7280' }}
+          data-testid="lufs-display"
+        >
+          -inf LUFS
+        </span>
+      </div>
+      <canvas
+        ref={canvasRef}
+        style={{ width, height }}
+        className="rounded border border-white/5"
+        data-testid="spectrum-canvas"
+      />
+    </div>
+  );
+}

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -63,6 +63,11 @@ export class AudioEngine {
   private readonly masterInputAnalyserData: Uint8Array<ArrayBuffer>;
   private readonly masterOutputAnalyserData: Uint8Array<ArrayBuffer>;
 
+  // High-resolution spectrum analyser for the SpectrumAnalyzer component & LUFS metering
+  private readonly spectrumAnalyser: AnalyserNode;
+  private readonly spectrumFloatData: Float32Array<ArrayBuffer>;
+  private readonly spectrumTimeDomainData: Float32Array<ArrayBuffer>;
+
   private _playing = false;
   private _startedAt = 0;
   private _offset = 0;
@@ -129,6 +134,13 @@ export class AudioEngine {
     this.masterInputAnalyserData = new Uint8Array(this.masterInputAnalyser.frequencyBinCount);
     this.masterOutputAnalyserData = new Uint8Array(this.masterOutputAnalyser.frequencyBinCount);
 
+    // High-resolution spectrum analyser (connected after limiter, before output)
+    this.spectrumAnalyser = this.ctx.createAnalyser();
+    this.spectrumAnalyser.fftSize = 2048;
+    this.spectrumAnalyser.smoothingTimeConstant = 0.7;
+    this.spectrumFloatData = new Float32Array(this.spectrumAnalyser.frequencyBinCount);
+    this.spectrumTimeDomainData = new Float32Array(this.spectrumAnalyser.fftSize);
+
     this.masterInputGain.connect(this.masterInputAnalyser);
     this.masterInputAnalyser.connect(this.masterDryGain);
     this.masterDryGain.connect(this.masterOutputGain);
@@ -150,7 +162,8 @@ export class AudioEngine {
     this.masterLimiter.connect(this.masterOutputAnalyser);
     this.masterOutputAnalyser.connect(this.masterProcessedGain);
     this.masterProcessedGain.connect(this.masterOutputGain);
-    this.masterOutputGain.connect(this.ctx.destination);
+    this.masterOutputGain.connect(this.spectrumAnalyser);
+    this.spectrumAnalyser.connect(this.ctx.destination);
 
     this._setMasterWidth(1);
     this.applyMastering(null);
@@ -207,6 +220,28 @@ export class AudioEngine {
       stage === 'input' ? this.masterInputAnalyser : this.masterOutputAnalyser,
       stage === 'input' ? this.masterInputAnalyserData : this.masterOutputAnalyserData,
     );
+  }
+
+  /** Get high-resolution spectrum data (dB) for the master output. */
+  getMasterSpectrum(): Float32Array<ArrayBuffer> {
+    this.spectrumAnalyser.getFloatFrequencyData(this.spectrumFloatData);
+    return this.spectrumFloatData;
+  }
+
+  /** Get time-domain samples from the master output (for LUFS calculation). */
+  getMasterTimeDomainData(): Float32Array<ArrayBuffer> {
+    this.spectrumAnalyser.getFloatTimeDomainData(this.spectrumTimeDomainData);
+    return this.spectrumTimeDomainData;
+  }
+
+  /** Sample rate of the audio context. */
+  get sampleRate(): number {
+    return this.ctx.sampleRate;
+  }
+
+  /** Number of frequency bins in the spectrum analyser. */
+  get spectrumBinCount(): number {
+    return this.spectrumAnalyser.frequencyBinCount;
   }
 
   applyMastering(mastering: MasteringState | null | undefined) {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -64,6 +64,9 @@ interface UIState {
   analysisClipId: string | null;
   stemSeparationClipId: string | null;
 
+  // Spectrum analyzer & loudness metering
+  showSpectrumAnalyzer: boolean;
+
   // Quantize dialog
   showQuantizeDialog: boolean;
   /** Clip ID + selected note IDs passed from the piano roll to the quantize dialog. */
@@ -126,6 +129,10 @@ interface UIState {
   setAnalysisPanel: (clipId: string | null) => void;
   setStemSeparationModal: (clipId: string | null) => void;
 
+  // Spectrum analyzer & loudness metering
+  setShowSpectrumAnalyzer: (v: boolean) => void;
+  toggleSpectrumAnalyzer: () => void;
+
   // Quantize dialog
   setShowQuantizeDialog: (v: boolean) => void;
   setQuantizeTarget: (target: { clipId: string; noteIds: string[] } | null) => void;
@@ -187,6 +194,8 @@ export const useUIStore = create<UIState>()(
   vocal2bgmClipId: null,
   analysisClipId: null,
   stemSeparationClipId: null,
+
+  showSpectrumAnalyzer: false,
 
   showQuantizeDialog: false,
   quantizeTarget: null,
@@ -282,6 +291,9 @@ export const useUIStore = create<UIState>()(
   setAnalysisPanel: (clipId) => set({ analysisClipId: clipId }),
   setStemSeparationModal: (clipId) => set({ stemSeparationClipId: clipId }),
 
+  setShowSpectrumAnalyzer: (v) => set({ showSpectrumAnalyzer: v }),
+  toggleSpectrumAnalyzer: () => set((s) => ({ showSpectrumAnalyzer: !s.showSpectrumAnalyzer })),
+
   setShowQuantizeDialog: (v) => set(v ? { showQuantizeDialog: v } : { showQuantizeDialog: false, quantizeTarget: null }),
   setQuantizeTarget: (target) => set({ quantizeTarget: target }),
   openQuantizeDialog: (clipId, noteIds) => set({ showQuantizeDialog: true, quantizeTarget: { clipId, noteIds } }),
@@ -307,6 +319,8 @@ export const useUIStore = create<UIState>()(
         pixelsPerSecond: state.pixelsPerSecond,
         // Snap
         snapEnabled: state.snapEnabled,
+        // Spectrum analyzer
+        showSpectrumAnalyzer: state.showSpectrumAnalyzer,
         // Loop Browser preference
         loopBrowserCategory: state.loopBrowserCategory,
       }),

--- a/src/utils/loudnessMetering.ts
+++ b/src/utils/loudnessMetering.ts
@@ -1,0 +1,182 @@
+/**
+ * Loudness metering utilities implementing BS.1770-4 K-weighting
+ * for LUFS (Loudness Units relative to Full Scale) measurement.
+ */
+
+export function linearToDb(linear: number): number {
+  if (linear <= 0) return -Infinity;
+  return 20 * Math.log10(linear);
+}
+
+export function dbToLinear(db: number): number {
+  return Math.pow(10, db / 20);
+}
+
+export function computeRMS(samples: Float32Array): number {
+  if (samples.length === 0) return 0;
+  let sum = 0;
+  for (let i = 0; i < samples.length; i++) {
+    sum += samples[i] * samples[i];
+  }
+  return Math.sqrt(sum / samples.length);
+}
+
+/** Biquad filter coefficients */
+export interface BiquadCoefficients {
+  b: [number, number, number]; // numerator
+  a: [number, number, number]; // denominator (a[0] always 1)
+}
+
+export interface KWeightingCoeffs {
+  stage1: BiquadCoefficients; // Pre-filter (high shelf boost)
+  stage2: BiquadCoefficients; // RLB weighting (high-pass)
+}
+
+/**
+ * Compute K-weighting filter coefficients for a given sample rate.
+ * Stage 1: Pre-filter (shelving) — boosts high frequencies ~+4dB
+ * Stage 2: RLB weighting — high-pass around 60Hz
+ *
+ * Coefficients derived from ITU-R BS.1770-4 specification.
+ */
+export function kWeightingCoefficients(sampleRate: number): KWeightingCoeffs {
+  // Stage 1: Pre-filter (high shelf at ~1500 Hz, +4 dB)
+  // These are the exact coefficients from the BS.1770-4 spec for 48kHz
+  if (sampleRate === 48000) {
+    return {
+      stage1: {
+        b: [1.53512485958697, -2.69169618940638, 1.19839281085285],
+        a: [1.0, -1.69065929318241, 0.73248077421585],
+      },
+      stage2: {
+        b: [1.0, -2.0, 1.0],
+        a: [1.0, -1.99004745483398, 0.99007225036621],
+      },
+    };
+  }
+
+  // For other sample rates, use bilinear transform approximation
+  // Stage 1: High shelf boost
+  const f0_1 = 1681.974450955533;
+  const G = 3.999843853973347; // dB
+  const Q_1 = 0.7071752369554196;
+
+  const K1 = Math.tan((Math.PI * f0_1) / sampleRate);
+  const Vh = Math.pow(10, G / 20);
+  const Vb = Math.pow(Vh, 0.4996667741545416);
+
+  const a0_1 = 1.0 + K1 / Q_1 + K1 * K1;
+  const b0_1 = (Vh + Vb * K1 / Q_1 + K1 * K1) / a0_1;
+  const b1_1 = (2.0 * (K1 * K1 - Vh)) / a0_1;
+  const b2_1 = (Vh - Vb * K1 / Q_1 + K1 * K1) / a0_1;
+  const a1_1 = (2.0 * (K1 * K1 - 1.0)) / a0_1;
+  const a2_1 = (1.0 - K1 / Q_1 + K1 * K1) / a0_1;
+
+  // Stage 2: RLB weighting (high-pass)
+  const f0_2 = 38.13547087602444;
+  const Q_2 = 0.5003270373238773;
+
+  const K2 = Math.tan((Math.PI * f0_2) / sampleRate);
+  const a0_2 = 1.0 + K2 / Q_2 + K2 * K2;
+
+  const b0_2 = 1.0 / a0_2;
+  const b1_2 = -2.0 / a0_2;
+  const b2_2 = 1.0 / a0_2;
+  const a1_2 = (2.0 * (K2 * K2 - 1.0)) / a0_2;
+  const a2_2 = (1.0 - K2 / Q_2 + K2 * K2) / a0_2;
+
+  return {
+    stage1: { b: [b0_1, b1_1, b2_1], a: [1.0, a1_1, a2_1] },
+    stage2: { b: [b0_2, b1_2, b2_2], a: [1.0, a1_2, a2_2] },
+  };
+}
+
+/** Apply a biquad filter (direct form II transposed) */
+function applyBiquad(
+  input: Float32Array,
+  coeffs: BiquadCoefficients,
+): Float32Array {
+  const output = new Float32Array(input.length);
+  const [b0, b1, b2] = coeffs.b;
+  const [, a1, a2] = coeffs.a;
+  let z1 = 0;
+  let z2 = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    const x = input[i];
+    const y = b0 * x + z1;
+    z1 = b1 * x - a1 * y + z2;
+    z2 = b2 * x - a2 * y;
+    output[i] = y;
+  }
+
+  return output;
+}
+
+/**
+ * Apply K-weighting filter chain (stage1 then stage2) to audio samples.
+ */
+export function applyKWeighting(
+  samples: Float32Array,
+  coeffs: KWeightingCoeffs,
+): Float32Array {
+  const afterStage1 = applyBiquad(samples, coeffs.stage1);
+  return applyBiquad(afterStage1, coeffs.stage2);
+}
+
+/**
+ * Compute momentary loudness in LUFS from a mono audio buffer.
+ * Uses K-weighting per BS.1770-4.
+ *
+ * @param samples - Audio samples (mono)
+ * @param sampleRate - Sample rate in Hz
+ * @returns Loudness in LUFS (-Infinity for silence)
+ */
+export function computeMomentaryLoudness(
+  samples: Float32Array,
+  sampleRate: number,
+): number {
+  if (samples.length === 0) return -Infinity;
+
+  const coeffs = kWeightingCoefficients(sampleRate);
+  const weighted = applyKWeighting(samples, coeffs);
+
+  // Mean square
+  let sumSquare = 0;
+  for (let i = 0; i < weighted.length; i++) {
+    sumSquare += weighted[i] * weighted[i];
+  }
+  const meanSquare = sumSquare / weighted.length;
+
+  if (meanSquare <= 0) return -Infinity;
+
+  // LUFS = -0.691 + 10 * log10(sum of channel mean squares)
+  // For mono, the channel weight is 1.0
+  return -0.691 + 10 * Math.log10(meanSquare);
+}
+
+/**
+ * Map frequency in Hz to a pixel x-position on a logarithmic scale.
+ */
+export function freqToX(freq: number, width: number, minFreq = 20, maxFreq = 20000): number {
+  const logMin = Math.log10(minFreq);
+  const logMax = Math.log10(maxFreq);
+  return ((Math.log10(freq) - logMin) / (logMax - logMin)) * width;
+}
+
+/**
+ * Map a pixel x-position back to frequency (Hz) on a logarithmic scale.
+ */
+export function xToFreq(x: number, width: number, minFreq = 20, maxFreq = 20000): number {
+  const logMin = Math.log10(minFreq);
+  const logMax = Math.log10(maxFreq);
+  return Math.pow(10, logMin + (x / width) * (logMax - logMin));
+}
+
+/**
+ * Map a dB value to a y-position in pixels.
+ */
+export function dbToY(db: number, height: number, minDb = -90, maxDb = 0): number {
+  const clamped = Math.max(minDb, Math.min(maxDb, db));
+  return height * (1 - (clamped - minDb) / (maxDb - minDb));
+}

--- a/tests/unit/loudnessMetering.test.ts
+++ b/tests/unit/loudnessMetering.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeMomentaryLoudness,
+  computeRMS,
+  kWeightingCoefficients,
+  applyKWeighting,
+  dbToLinear,
+  linearToDb,
+} from '../../src/utils/loudnessMetering';
+
+describe('loudnessMetering', () => {
+  describe('linearToDb / dbToLinear', () => {
+    it('converts 1.0 to 0 dB', () => {
+      expect(linearToDb(1)).toBeCloseTo(0, 5);
+    });
+
+    it('converts 0.5 to roughly -6 dB', () => {
+      expect(linearToDb(0.5)).toBeCloseTo(-6.02, 1);
+    });
+
+    it('converts 0 to -Infinity', () => {
+      expect(linearToDb(0)).toBe(-Infinity);
+    });
+
+    it('round-trips correctly', () => {
+      expect(dbToLinear(linearToDb(0.3))).toBeCloseTo(0.3, 5);
+    });
+
+    it('dbToLinear of 0 is 1', () => {
+      expect(dbToLinear(0)).toBeCloseTo(1, 5);
+    });
+
+    it('dbToLinear of -6 is ~0.5', () => {
+      expect(dbToLinear(-6)).toBeCloseTo(0.5012, 2);
+    });
+  });
+
+  describe('computeRMS', () => {
+    it('returns 0 for silence', () => {
+      const samples = new Float32Array(1024);
+      expect(computeRMS(samples)).toBe(0);
+    });
+
+    it('returns correct RMS for a DC signal', () => {
+      const samples = new Float32Array(1024).fill(0.5);
+      expect(computeRMS(samples)).toBeCloseTo(0.5, 5);
+    });
+
+    it('returns correct RMS for a sine wave', () => {
+      const N = 4800; // 100ms at 48kHz
+      const samples = new Float32Array(N);
+      for (let i = 0; i < N; i++) {
+        samples[i] = Math.sin((2 * Math.PI * 1000 * i) / 48000);
+      }
+      // RMS of a sine wave = 1/sqrt(2) ≈ 0.7071
+      expect(computeRMS(samples)).toBeCloseTo(1 / Math.sqrt(2), 2);
+    });
+
+    it('returns 0 for empty array', () => {
+      expect(computeRMS(new Float32Array(0))).toBe(0);
+    });
+  });
+
+  describe('kWeightingCoefficients', () => {
+    it('returns stage1 and stage2 coefficients', () => {
+      const coeffs = kWeightingCoefficients(48000);
+      expect(coeffs.stage1).toBeDefined();
+      expect(coeffs.stage2).toBeDefined();
+      expect(coeffs.stage1.b).toHaveLength(3);
+      expect(coeffs.stage1.a).toHaveLength(3);
+      expect(coeffs.stage2.b).toHaveLength(3);
+      expect(coeffs.stage2.a).toHaveLength(3);
+    });
+
+    it('returns coefficients for 44100 sample rate', () => {
+      const coeffs = kWeightingCoefficients(44100);
+      expect(coeffs.stage1.b[0]).toBeGreaterThan(0);
+    });
+  });
+
+  describe('applyKWeighting', () => {
+    it('returns same length array', () => {
+      const input = new Float32Array(1024);
+      const coeffs = kWeightingCoefficients(48000);
+      const result = applyKWeighting(input, coeffs);
+      expect(result.length).toBe(1024);
+    });
+
+    it('returns silence for silence input', () => {
+      const input = new Float32Array(1024);
+      const coeffs = kWeightingCoefficients(48000);
+      const result = applyKWeighting(input, coeffs);
+      for (let i = 0; i < result.length; i++) {
+        expect(result[i]).toBe(0);
+      }
+    });
+
+    it('modifies the signal (not passthrough)', () => {
+      const N = 4800;
+      const input = new Float32Array(N);
+      for (let i = 0; i < N; i++) {
+        input[i] = Math.sin((2 * Math.PI * 100 * i) / 48000); // 100Hz sine
+      }
+      const coeffs = kWeightingCoefficients(48000);
+      const result = applyKWeighting(input, coeffs);
+      // K-weighting attenuates low frequencies, so output RMS should be lower than input
+      const inputRMS = computeRMS(input);
+      const outputRMS = computeRMS(result);
+      expect(outputRMS).toBeLessThan(inputRMS);
+    });
+  });
+
+  describe('computeMomentaryLoudness', () => {
+    it('returns -Infinity for silence', () => {
+      const samples = new Float32Array(19200); // 400ms at 48kHz
+      expect(computeMomentaryLoudness(samples, 48000)).toBe(-Infinity);
+    });
+
+    it('returns a finite LUFS value for a signal', () => {
+      const N = 19200; // 400ms at 48kHz
+      const samples = new Float32Array(N);
+      for (let i = 0; i < N; i++) {
+        samples[i] = 0.5 * Math.sin((2 * Math.PI * 1000 * i) / 48000);
+      }
+      const lufs = computeMomentaryLoudness(samples, 48000);
+      expect(lufs).toBeGreaterThan(-100);
+      expect(lufs).toBeLessThan(0);
+      expect(Number.isFinite(lufs)).toBe(true);
+    });
+
+    it('louder signal produces higher LUFS', () => {
+      const N = 19200;
+      const quiet = new Float32Array(N);
+      const loud = new Float32Array(N);
+      for (let i = 0; i < N; i++) {
+        quiet[i] = 0.1 * Math.sin((2 * Math.PI * 1000 * i) / 48000);
+        loud[i] = 0.9 * Math.sin((2 * Math.PI * 1000 * i) / 48000);
+      }
+      const quietLufs = computeMomentaryLoudness(quiet, 48000);
+      const loudLufs = computeMomentaryLoudness(loud, 48000);
+      expect(loudLufs).toBeGreaterThan(quietLufs);
+    });
+
+    it('full-scale 1kHz sine is approximately -3 LUFS', () => {
+      // A full-scale 1kHz sine wave should be around -3.01 LUFS
+      // K-weighting at 1kHz is approximately unity gain
+      const N = 19200;
+      const samples = new Float32Array(N);
+      for (let i = 0; i < N; i++) {
+        samples[i] = Math.sin((2 * Math.PI * 1000 * i) / 48000);
+      }
+      const lufs = computeMomentaryLoudness(samples, 48000);
+      // Should be close to -3.01 LUFS (RMS of sine = -3.01 dB, K-weight at 1kHz ≈ 0)
+      expect(lufs).toBeGreaterThan(-5);
+      expect(lufs).toBeLessThan(-1);
+    });
+  });
+});

--- a/tests/unit/spectrumAnalyzer.test.ts
+++ b/tests/unit/spectrumAnalyzer.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  freqToX,
+  xToFreq,
+  dbToY,
+  linearToDb,
+  dbToLinear,
+} from '../../src/utils/loudnessMetering';
+
+describe('SpectrumAnalyzer utilities', () => {
+  describe('freqToX / xToFreq', () => {
+    const width = 320;
+
+    it('maps 20 Hz to x=0', () => {
+      expect(freqToX(20, width)).toBeCloseTo(0, 1);
+    });
+
+    it('maps 20000 Hz to x=width', () => {
+      expect(freqToX(20000, width)).toBeCloseTo(width, 1);
+    });
+
+    it('maps 200 Hz to ~1/3 of width (log scale)', () => {
+      const x = freqToX(200, width);
+      // log10(200) = 2.301, range = log10(20000) - log10(20) = 3
+      // x = ((2.301 - 1.301) / 3) * 320 = (1/3) * 320 ≈ 106.67
+      expect(x).toBeCloseTo(106.67, 0);
+    });
+
+    it('round-trips correctly', () => {
+      const freq = 1000;
+      const x = freqToX(freq, width);
+      const result = xToFreq(x, width);
+      expect(result).toBeCloseTo(freq, 0);
+    });
+
+    it('round-trips at extremes', () => {
+      expect(xToFreq(freqToX(20, width), width)).toBeCloseTo(20, 0);
+      expect(xToFreq(freqToX(20000, width), width)).toBeCloseTo(20000, 0);
+    });
+  });
+
+  describe('dbToY', () => {
+    const height = 160;
+
+    it('maps 0 dB to y=0 (top)', () => {
+      expect(dbToY(0, height)).toBeCloseTo(0, 1);
+    });
+
+    it('maps -90 dB to y=height (bottom)', () => {
+      expect(dbToY(-90, height)).toBeCloseTo(height, 1);
+    });
+
+    it('maps -45 dB to mid-height', () => {
+      expect(dbToY(-45, height)).toBeCloseTo(height / 2, 1);
+    });
+
+    it('clamps values above 0 dB', () => {
+      expect(dbToY(10, height)).toBeCloseTo(0, 1);
+    });
+
+    it('clamps values below -90 dB', () => {
+      expect(dbToY(-120, height)).toBeCloseTo(height, 1);
+    });
+  });
+
+  describe('dB conversion integration', () => {
+    it('full-scale level maps to 0 dB', () => {
+      expect(linearToDb(1.0)).toBeCloseTo(0, 5);
+    });
+
+    it('half level maps to ~-6 dB', () => {
+      expect(linearToDb(0.5)).toBeCloseTo(-6.02, 1);
+    });
+
+    it('conversions are invertible', () => {
+      const db = -12;
+      const linear = dbToLinear(db);
+      expect(linearToDb(linear)).toBeCloseTo(db, 5);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add real-time **spectrum analyzer** to the master bus with logarithmic frequency scale (20Hz–20kHz), gradient-filled visualization, and dB grid overlay
- Add **BS.1770-4 K-weighted LUFS metering** with color-coded loudness readout (blue=quiet, green=nominal, amber=loud, red=clipping)
- Dedicated high-resolution FFT analyser node (2048-point) on the master output chain, independent from existing level meters
- Toggle via **SPEC** button in the Master strip; visibility state persisted to localStorage

## Implementation
- `src/utils/loudnessMetering.ts` — K-weighting filter (2-stage biquad), RMS, momentary LUFS, frequency/dB mapping helpers
- `src/engine/AudioEngine.ts` — Spectrum analyser node (fftSize=2048), `getMasterSpectrum()`, `getMasterTimeDomainData()`, `sampleRate`, `spectrumBinCount`
- `src/components/mixer/SpectrumAnalyzer.tsx` — Canvas-based real-time spectrum + LUFS display using RAF loop
- `src/store/uiStore.ts` — `showSpectrumAnalyzer` toggle (persisted)
- `src/components/mixer/MixerPanel.tsx` — SPEC toggle button + conditional render in MasterStrip

## Test plan
- [x] 19 unit tests for loudness metering (K-weighting, RMS, LUFS calculation, dB conversion)
- [x] 13 unit tests for spectrum utilities (freqToX/xToFreq, dbToY, round-trips)
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run tests/unit/` — 361 tests pass (329 existing + 32 new)
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)