### PR TITLE
feat: project templates — save and load (closes #217)

### DIFF
--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -13,7 +13,11 @@ import {
 import {
   listProjects,
   loadProject,
+  listTemplates,
+  loadTemplate,
+  deleteTemplate,
   type ProjectSummary,
+  type TemplateSummary,
 } from '../../services/projectStorage';
 import { toastSuccess } from '../../hooks/useToast';
 
@@ -58,6 +62,7 @@ export function NewProjectDialog() {
   const setShow = useUIStore((s) => s.setShowNewProjectDialog);
   const createProject = useProjectStore((s) => s.createProject);
   const setProject = useProjectStore((s) => s.setProject);
+  const createProjectFromTemplate = useProjectStore((s) => s.createProjectFromTemplate);
 
   const [name, setName] = useState(DEFAULT_PROJECT_NAME);
   const [bpm, setBpm] = useState(DEFAULT_BPM);
@@ -66,8 +71,9 @@ export function NewProjectDialog() {
   const [timeSignature, setTimeSignature] = useState(DEFAULT_TIME_SIGNATURE);
 
   const [recentProjects, setRecentProjects] = useState<ProjectSummary[]>([]);
+  const [templates, setTemplates] = useState<TemplateSummary[]>([]);
 
-  // Reset form and load recent projects when dialog opens
+  // Reset form and load recent projects + templates when dialog opens
   useEffect(() => {
     if (show) {
       setName(DEFAULT_PROJECT_NAME);
@@ -76,6 +82,7 @@ export function NewProjectDialog() {
       setKeyScale(DEFAULT_KEY_SCALE);
       setTimeSignature(DEFAULT_TIME_SIGNATURE);
       listProjects().then((list) => setRecentProjects(list));
+      listTemplates().then((list) => setTemplates(list));
     }
   }, [show]);
 
@@ -95,9 +102,23 @@ export function NewProjectDialog() {
     }
   };
 
+  const handleUseTemplate = async (templateId: string) => {
+    const template = await loadTemplate(templateId);
+    if (template) {
+      createProjectFromTemplate(template);
+      toastSuccess(`Project created from template "${template.name}"`);
+      setShow(false);
+    }
+  };
+
+  const handleDeleteTemplate = async (templateId: string) => {
+    await deleteTemplate(templateId);
+    setTemplates((prev) => prev.filter((t) => t.id !== templateId));
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className={`${recentProjects.length > 0 ? 'w-[600px]' : 'w-[400px]'} max-h-[80vh] bg-daw-surface rounded-lg border border-daw-border shadow-2xl flex flex-col`}>
+      <div className={`${recentProjects.length > 0 || templates.length > 0 ? 'w-[600px]' : 'w-[400px]'} max-h-[80vh] bg-daw-surface rounded-lg border border-daw-border shadow-2xl flex flex-col`}>
         <div className="flex items-center justify-between px-4 py-3 border-b border-daw-border">
           <h2 className="text-sm font-medium">New Project</h2>
           <button
@@ -129,6 +150,43 @@ export function NewProjectDialog() {
                       {p.trackCount} track{p.trackCount !== 1 ? 's' : ''} &middot; {formatDate(p.updatedAt)}
                     </p>
                   </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* ── Templates ── */}
+          {templates.length > 0 && (
+            <div className="p-4 border-b border-daw-border">
+              <h3 className="text-xs font-medium text-zinc-400 mb-3">Templates</h3>
+              <div className="grid grid-cols-3 gap-2">
+                {templates.slice(0, 6).map((t) => (
+                  <div
+                    key={t.id}
+                    data-template-id={t.id}
+                    className="relative text-left rounded-lg border border-daw-border/50 hover:border-daw-accent/50 hover:bg-daw-surface-2 transition-colors p-2 group"
+                  >
+                    <button
+                      onClick={() => handleUseTemplate(t.id)}
+                      className="w-full text-left"
+                    >
+                      <ProjectThumbnail trackCount={t.trackCount} />
+                      <p className="text-xs text-zinc-200 truncate mt-1.5 group-hover:text-white">
+                        {t.name}
+                      </p>
+                      <p className="text-[10px] text-zinc-500 truncate">
+                        {t.trackCount} track{t.trackCount !== 1 ? 's' : ''}
+                        {t.description ? ` · ${t.description}` : ''}
+                      </p>
+                    </button>
+                    <button
+                      onClick={() => handleDeleteTemplate(t.id)}
+                      className="absolute top-1 right-1 text-zinc-600 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100 transition-opacity p-0.5"
+                      title="Delete template"
+                    >
+                      ×
+                    </button>
+                  </div>
                 ))}
               </div>
             </div>

--- a/src/components/dialogs/ProjectListDialog.tsx
+++ b/src/components/dialogs/ProjectListDialog.tsx
@@ -9,6 +9,7 @@ import {
   saveProject,
   exportProjectArchive,
   importProjectArchive,
+  saveTemplate,
   type ProjectSummary,
 } from '../../services/projectStorage';
 import { deleteAllProjectAudio } from '../../services/audioFileManager';
@@ -19,10 +20,13 @@ export function ProjectListDialog() {
   const setShow = useUIStore((s) => s.setShowProjectListDialog);
   const currentProject = useProjectStore((s) => s.project);
   const setProject = useProjectStore((s) => s.setProject);
+  const saveProjectAsTemplate = useProjectStore((s) => s.saveProjectAsTemplate);
 
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [exporting, setExporting] = useState(false);
+  const [showTemplateName, setShowTemplateName] = useState(false);
+  const [templateName, setTemplateName] = useState('');
 
   useEffect(() => {
     if (show) {
@@ -69,6 +73,15 @@ export function ProjectListDialog() {
     } finally {
       setExporting(false);
     }
+  };
+
+  const handleSaveAsTemplate = async () => {
+    if (!currentProject || !templateName.trim()) return;
+    const template = saveProjectAsTemplate(templateName);
+    await saveTemplate(template);
+    toastSuccess(`Template "${template.name}" saved`);
+    setShowTemplateName(false);
+    setTemplateName('');
   };
 
   const handleImport = async () => {
@@ -154,6 +167,33 @@ export function ProjectListDialog() {
           )}
         </div>
 
+        {showTemplateName && (
+          <div className="flex items-center gap-2 px-4 py-2 border-t border-daw-border bg-daw-surface-2/50">
+            <input
+              type="text"
+              value={templateName}
+              onChange={(e) => setTemplateName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleSaveAsTemplate(); if (e.key === 'Escape') setShowTemplateName(false); }}
+              placeholder="Template name..."
+              className="flex-1 px-2 py-1 text-xs bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
+              autoFocus
+            />
+            <button
+              onClick={handleSaveAsTemplate}
+              disabled={!templateName.trim()}
+              className="px-2 py-1 text-[10px] font-medium bg-daw-accent hover:bg-daw-accent-hover text-white rounded transition-colors disabled:opacity-50"
+            >
+              Save
+            </button>
+            <button
+              onClick={() => setShowTemplateName(false)}
+              className="px-2 py-1 text-[10px] font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+
         <div className="flex items-center justify-between px-4 py-3 border-t border-daw-border">
           <div className="flex gap-2">
             <button
@@ -168,6 +208,13 @@ export function ProjectListDialog() {
               className="px-3 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors disabled:opacity-50"
             >
               {exporting ? 'Packing...' : 'Export .acedaw'}
+            </button>
+            <button
+              onClick={() => { setShowTemplateName(true); setTemplateName(currentProject?.name ?? ''); }}
+              disabled={!currentProject}
+              className="px-3 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors disabled:opacity-50"
+            >
+              Save as Template
             </button>
           </div>
           <button

--- a/src/services/projectStorage.ts
+++ b/src/services/projectStorage.ts
@@ -1,7 +1,8 @@
 import { get, set, del, keys } from 'idb-keyval';
-import type { Project } from '../types/project';
+import type { Project, ProjectTemplate } from '../types/project';
 
 const PROJECT_PREFIX = 'project:';
+const TEMPLATE_PREFIX = 'template:';
 const AUDIO_PREFIX = 'audio:';
 const ARCHIVE_MAGIC = 'ACED';
 
@@ -10,6 +11,14 @@ export interface ProjectSummary {
   name: string;
   createdAt: number;
   updatedAt: number;
+  trackCount: number;
+}
+
+export interface TemplateSummary {
+  id: string;
+  name: string;
+  description: string;
+  createdAt: number;
   trackCount: number;
 }
 
@@ -51,6 +60,46 @@ export async function listProjects(): Promise<ProjectSummary[]> {
   }
 
   return summaries.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+// ── Project templates (IndexedDB) ──
+
+export async function saveTemplate(template: ProjectTemplate): Promise<void> {
+  await set(`${TEMPLATE_PREFIX}${template.id}`, JSON.stringify(template));
+}
+
+export async function loadTemplate(id: string): Promise<ProjectTemplate | null> {
+  const data = await get<string>(`${TEMPLATE_PREFIX}${id}`);
+  if (!data) return null;
+  return JSON.parse(data);
+}
+
+export async function deleteTemplate(id: string): Promise<void> {
+  await del(`${TEMPLATE_PREFIX}${id}`);
+}
+
+export async function listTemplates(): Promise<TemplateSummary[]> {
+  const allKeys = await keys();
+  const templateKeys = allKeys.filter(
+    (k) => typeof k === 'string' && k.startsWith(TEMPLATE_PREFIX),
+  );
+
+  const summaries: TemplateSummary[] = [];
+  for (const key of templateKeys) {
+    const data = await get<string>(key as string);
+    if (data) {
+      const template = JSON.parse(data) as ProjectTemplate;
+      summaries.push({
+        id: template.id,
+        name: template.name,
+        description: template.description,
+        createdAt: template.createdAt,
+        trackCount: template.tracks.length,
+      });
+    }
+  }
+
+  return summaries.sort((a, b) => b.createdAt - a.createdAt);
 }
 
 // ── Archive file export/import (.acedaw) ──

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -4,6 +4,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { type TrackHeightPreset, getTrackHeightForPreset } from '../constants/trackHeight';
 import type {
   Project,
+  ProjectTemplate,
+  ProjectTemplateTrack,
   Track,
   Clip,
   ClipVersion,
@@ -291,6 +293,12 @@ interface ProjectState {
 
   /** Export each track as a separate WAV file (stem export). */
   exportStems: () => Promise<void>;
+
+  // Project templates
+  /** Save current project as a reusable template (strips clips/audio, keeps track layout & settings). */
+  saveProjectAsTemplate: (name: string, description?: string) => ProjectTemplate;
+  /** Create a new project from a template. */
+  createProjectFromTemplate: (template: ProjectTemplate, projectName?: string) => void;
 }
 
 function computeTotalDuration(
@@ -3585,6 +3593,91 @@ export const useProjectStore = create<ProjectState>()(
       a.click();
       URL.revokeObjectURL(url);
     }
+  },
+
+  // ── Project Templates ─────────────────────────────────────────────────────
+
+  saveProjectAsTemplate: (name, description) => {
+    const state = get();
+    if (!state.project) throw new Error('No project');
+
+    const trimmedName = name.trim();
+    if (!trimmedName) throw new Error('Template name is required');
+
+    const templateTracks: ProjectTemplateTrack[] = state.project.tracks.map((track) => ({
+      trackName: track.trackName,
+      trackType: track.trackType ?? 'stems',
+      displayName: track.displayName,
+      color: track.color,
+      volume: track.volume,
+      pan: track.pan,
+      effects: track.effects ? structuredClone(track.effects) : undefined,
+      midiEffects: track.midiEffects ? structuredClone(track.midiEffects) : undefined,
+      synthPreset: track.synthPreset,
+      drumKit: track.drumKit,
+      localCaption: track.localCaption,
+      sequencerPattern: track.sequencerPattern ? structuredClone(track.sequencerPattern) : undefined,
+    }));
+
+    const template: ProjectTemplate = {
+      id: uuidv4(),
+      name: trimmedName,
+      description: (description ?? '').trim(),
+      createdAt: Date.now(),
+      bpm: state.project.bpm,
+      keyScale: state.project.keyScale,
+      timeSignature: state.project.timeSignature,
+      measures: state.project.measures ?? DEFAULT_MEASURES,
+      tracks: templateTracks,
+      generationDefaults: structuredClone(state.project.generationDefaults),
+    };
+
+    return template;
+  },
+
+  createProjectFromTemplate: (template, projectName) => {
+    const bpm = template.bpm;
+    const timeSig = template.timeSignature;
+    const measures = template.measures;
+
+    const tracks: Track[] = template.tracks.map((tt, idx) => ({
+      id: uuidv4(),
+      trackName: tt.trackName,
+      trackType: tt.trackType,
+      displayName: tt.displayName,
+      color: tt.color,
+      order: idx,
+      volume: tt.volume,
+      muted: false,
+      soloed: false,
+      clips: [],
+      pan: tt.pan,
+      effects: tt.effects ? structuredClone(tt.effects).map((e) => ({ ...e, id: uuidv4() })) : undefined,
+      midiEffects: tt.midiEffects ? structuredClone(tt.midiEffects).map((e) => ({ ...e, id: uuidv4() })) : undefined,
+      synthPreset: tt.synthPreset,
+      drumKit: tt.drumKit,
+      localCaption: tt.localCaption,
+      sequencerPattern: tt.sequencerPattern ? structuredClone(tt.sequencerPattern) : undefined,
+    }));
+
+    const project: Project = {
+      id: uuidv4(),
+      name: projectName?.trim() || template.name,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      bpm,
+      keyScale: template.keyScale,
+      timeSignature: timeSig,
+      totalDuration: measures * getBarDurationSec(bpm, timeSig),
+      measures,
+      tracks,
+      trackPresets: [],
+      generationDefaults: structuredClone(template.generationDefaults),
+      globalCaption: '',
+      mastering: createDefaultMasteringState(),
+    };
+
+    set({ project });
   },
 }),
     {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -445,6 +445,39 @@ export interface Marker {
   color: string;
 }
 
+/** A saved project template — a snapshot of project settings and track layout (without audio). */
+export interface ProjectTemplate {
+  id: string;
+  name: string;
+  description: string;
+  createdAt: number;
+  /** Musical settings */
+  bpm: number;
+  keyScale: string;
+  timeSignature: number;
+  measures: number;
+  /** Track layout snapshot (clips stripped, only structure preserved). */
+  tracks: ProjectTemplateTrack[];
+  /** Generation defaults captured from the source project. */
+  generationDefaults: GenerationDefaults;
+}
+
+/** Lightweight track snapshot stored inside a project template (no clips or audio references). */
+export interface ProjectTemplateTrack {
+  trackName: TrackName;
+  trackType: TrackType;
+  displayName: string;
+  color: string;
+  volume: number;
+  pan?: number;
+  effects?: TrackEffect[];
+  midiEffects?: MidiEffect[];
+  synthPreset?: SynthPreset;
+  drumKit?: DrumKitName;
+  localCaption?: string;
+  sequencerPattern?: SequencerPattern;
+}
+
 export interface Project {
   id: string;
   name: string;

--- a/tests/unit/bpmInput.test.tsx
+++ b/tests/unit/bpmInput.test.tsx
@@ -16,6 +16,9 @@ vi.mock('../../src/services/projectStorage', () => ({
   saveProject: vi.fn(),
   listProjects: vi.fn().mockResolvedValue([]),
   loadProject: vi.fn().mockResolvedValue(null),
+  listTemplates: vi.fn().mockResolvedValue([]),
+  loadTemplate: vi.fn().mockResolvedValue(null),
+  deleteTemplate: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe('BPM input — clamp on blur, not keystroke', () => {

--- a/tests/unit/newProjectDialog.test.tsx
+++ b/tests/unit/newProjectDialog.test.tsx
@@ -14,6 +14,9 @@ vi.mock('../../src/services/projectStorage', () => ({
   listProjects: (...args: unknown[]) => mockListProjects(...(args as [])),
   loadProject: (...args: unknown[]) => mockLoadProject(...(args as [])),
   saveProject: (...args: unknown[]) => mockSaveProject(...(args as [])),
+  listTemplates: vi.fn().mockResolvedValue([]),
+  loadTemplate: vi.fn().mockResolvedValue(null),
+  deleteTemplate: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../src/services/aceStepApi', () => ({

--- a/tests/unit/projectTemplates.test.ts
+++ b/tests/unit/projectTemplates.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../../src/store/projectStore';
+import type { ProjectTemplate } from '../../src/types/project';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('project templates', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useProjectStore.getState().createProject({ name: 'Source Project', bpm: 140, keyScale: 'D minor', timeSignature: 3 });
+  });
+
+  describe('saveProjectAsTemplate', () => {
+    it('creates a template from the current project with correct settings', () => {
+      const template = useProjectStore.getState().saveProjectAsTemplate('My Template', 'A cool template');
+
+      expect(template.name).toBe('My Template');
+      expect(template.description).toBe('A cool template');
+      expect(template.bpm).toBe(140);
+      expect(template.keyScale).toBe('D minor');
+      expect(template.timeSignature).toBe(3);
+      expect(template.measures).toBe(64);
+      expect(template.id).toBeTruthy();
+      expect(template.createdAt).toBeGreaterThan(0);
+    });
+
+    it('captures track layout without clips', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('drums', 'sequencer');
+
+      // Add a clip to the track
+      store.addClip(track.id, {
+        startTime: 0,
+        duration: 4,
+        prompt: 'test',
+        lyrics: '',
+      });
+
+      const template = store.saveProjectAsTemplate('Template with tracks');
+
+      expect(template.tracks).toHaveLength(1);
+      expect(template.tracks[0].trackName).toBe('drums');
+      expect(template.tracks[0].trackType).toBe('sequencer');
+      expect(template.tracks[0].displayName).toBeTruthy();
+      // Template tracks should NOT contain clips
+      expect((template.tracks[0] as Record<string, unknown>).clips).toBeUndefined();
+    });
+
+    it('captures track effects and settings', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('bass', 'pianoRoll');
+      store.updateTrack(track.id, { volume: 0.7 });
+      store.addTrackEffect(track.id, 'reverb');
+
+      const template = store.saveProjectAsTemplate('FX Template');
+
+      expect(template.tracks[0].volume).toBe(0.7);
+      expect(template.tracks[0].effects).toHaveLength(1);
+      expect(template.tracks[0].effects![0].type).toBe('reverb');
+    });
+
+    it('throws when no project is loaded', () => {
+      useProjectStore.setState({ project: null });
+      expect(() => useProjectStore.getState().saveProjectAsTemplate('test')).toThrow('No project');
+    });
+
+    it('throws when name is empty', () => {
+      expect(() => useProjectStore.getState().saveProjectAsTemplate('  ')).toThrow('Template name is required');
+    });
+
+    it('defaults description to empty string when not provided', () => {
+      const template = useProjectStore.getState().saveProjectAsTemplate('No Desc');
+      expect(template.description).toBe('');
+    });
+
+    it('captures generation defaults', () => {
+      const template = useProjectStore.getState().saveProjectAsTemplate('Gen Defaults');
+      expect(template.generationDefaults).toBeDefined();
+      expect(template.generationDefaults.inferenceSteps).toBeGreaterThan(0);
+    });
+  });
+
+  describe('createProjectFromTemplate', () => {
+    let template: ProjectTemplate;
+
+    beforeEach(() => {
+      const store = useProjectStore.getState();
+      store.addTrack('drums', 'sequencer');
+      store.addTrack('bass', 'pianoRoll');
+      store.addTrack('vocals', 'stems');
+      template = store.saveProjectAsTemplate('Session Template', 'For live sessions');
+    });
+
+    it('creates a new project with template settings', () => {
+      useProjectStore.getState().createProjectFromTemplate(template);
+
+      const project = useProjectStore.getState().project!;
+      expect(project.bpm).toBe(140);
+      expect(project.keyScale).toBe('D minor');
+      expect(project.timeSignature).toBe(3);
+      expect(project.measures).toBe(64);
+      expect(project.name).toBe('Session Template');
+    });
+
+    it('allows overriding the project name', () => {
+      useProjectStore.getState().createProjectFromTemplate(template, 'Custom Name');
+
+      const project = useProjectStore.getState().project!;
+      expect(project.name).toBe('Custom Name');
+    });
+
+    it('creates tracks matching template layout', () => {
+      useProjectStore.getState().createProjectFromTemplate(template);
+
+      const project = useProjectStore.getState().project!;
+      expect(project.tracks).toHaveLength(3);
+      expect(project.tracks[0].trackName).toBe('drums');
+      expect(project.tracks[0].trackType).toBe('sequencer');
+      expect(project.tracks[1].trackName).toBe('bass');
+      expect(project.tracks[1].trackType).toBe('pianoRoll');
+      expect(project.tracks[2].trackName).toBe('vocals');
+      expect(project.tracks[2].trackType).toBe('stems');
+    });
+
+    it('assigns new unique IDs to tracks', () => {
+      useProjectStore.getState().createProjectFromTemplate(template);
+
+      const project = useProjectStore.getState().project!;
+      const ids = project.tracks.map((t) => t.id);
+      // All IDs unique
+      expect(new Set(ids).size).toBe(ids.length);
+      // Project ID is new
+      expect(project.id).not.toBe('');
+      expect(project.createdAt).toBeGreaterThan(0);
+    });
+
+    it('tracks start with empty clips', () => {
+      useProjectStore.getState().createProjectFromTemplate(template);
+
+      const project = useProjectStore.getState().project!;
+      for (const track of project.tracks) {
+        expect(track.clips).toHaveLength(0);
+      }
+    });
+
+    it('preserves track colors and display names', () => {
+      useProjectStore.getState().createProjectFromTemplate(template);
+
+      const project = useProjectStore.getState().project!;
+      for (let i = 0; i < template.tracks.length; i++) {
+        expect(project.tracks[i].color).toBe(template.tracks[i].color);
+        expect(project.tracks[i].displayName).toBe(template.tracks[i].displayName);
+      }
+    });
+
+    it('deep-clones effects so mutations are independent', () => {
+      // Create a fresh project with just an effect-bearing track
+      useProjectStore.getState().createProject({ name: 'FX Project', bpm: 120 });
+      const store = useProjectStore.getState();
+      const trackWithEffect = store.addTrack('synth', 'pianoRoll');
+      useProjectStore.getState().addTrackEffect(trackWithEffect.id, 'delay');
+
+      const tmpl = useProjectStore.getState().saveProjectAsTemplate('FX Template');
+      expect(tmpl.tracks).toHaveLength(1);
+      expect(tmpl.tracks[0].effects).toHaveLength(1);
+
+      useProjectStore.getState().createProjectFromTemplate(tmpl);
+
+      const project = useProjectStore.getState().project!;
+      expect(project.tracks[0].effects).toHaveLength(1);
+      expect(project.tracks[0].effects![0].enabled).toBe(true);
+
+      // Mutating the template effect should not affect the project
+      tmpl.tracks[0].effects![0].enabled = false;
+      const reloaded = useProjectStore.getState().project!;
+      expect(reloaded.tracks[0].effects![0].enabled).toBe(true);
+    });
+  });
+});

--- a/tests/unit/templateStorage.test.ts
+++ b/tests/unit/templateStorage.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectTemplate } from '../../src/types/project';
+
+// Mock idb-keyval
+const mockStore = new Map<string, string>();
+vi.mock('idb-keyval', () => ({
+  get: vi.fn((key: string) => Promise.resolve(mockStore.get(key) ?? undefined)),
+  set: vi.fn((key: string, value: string) => { mockStore.set(key, value); return Promise.resolve(); }),
+  del: vi.fn((key: string) => { mockStore.delete(key); return Promise.resolve(); }),
+  keys: vi.fn(() => Promise.resolve([...mockStore.keys()])),
+}));
+
+import {
+  saveTemplate,
+  loadTemplate,
+  deleteTemplate,
+  listTemplates,
+} from '../../src/services/projectStorage';
+
+function makeTemplate(overrides?: Partial<ProjectTemplate>): ProjectTemplate {
+  return {
+    id: 'tmpl-1',
+    name: 'Test Template',
+    description: 'A test template',
+    createdAt: 1000,
+    bpm: 120,
+    keyScale: 'C major',
+    timeSignature: 4,
+    measures: 64,
+    tracks: [
+      {
+        trackName: 'drums',
+        trackType: 'sequencer',
+        displayName: 'Drums',
+        color: '#ef4444',
+        volume: 0.8,
+      },
+    ],
+    generationDefaults: {
+      inferenceSteps: 50,
+      guidanceScale: 7.0,
+      shift: 3.0,
+      thinking: false,
+      model: '',
+    },
+    ...overrides,
+  };
+}
+
+describe('template storage', () => {
+  beforeEach(() => {
+    mockStore.clear();
+  });
+
+  it('saves and loads a template', async () => {
+    const template = makeTemplate();
+    await saveTemplate(template);
+
+    const loaded = await loadTemplate('tmpl-1');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.name).toBe('Test Template');
+    expect(loaded!.bpm).toBe(120);
+    expect(loaded!.tracks).toHaveLength(1);
+    expect(loaded!.tracks[0].trackName).toBe('drums');
+  });
+
+  it('returns null for non-existent template', async () => {
+    const loaded = await loadTemplate('nonexistent');
+    expect(loaded).toBeNull();
+  });
+
+  it('deletes a template', async () => {
+    const template = makeTemplate();
+    await saveTemplate(template);
+    await deleteTemplate('tmpl-1');
+
+    const loaded = await loadTemplate('tmpl-1');
+    expect(loaded).toBeNull();
+  });
+
+  it('lists templates sorted by createdAt descending', async () => {
+    await saveTemplate(makeTemplate({ id: 'tmpl-a', name: 'Older', createdAt: 100 }));
+    await saveTemplate(makeTemplate({ id: 'tmpl-b', name: 'Newer', createdAt: 200 }));
+
+    const list = await listTemplates();
+    expect(list).toHaveLength(2);
+    expect(list[0].name).toBe('Newer');
+    expect(list[1].name).toBe('Older');
+  });
+
+  it('listTemplates returns correct summary fields', async () => {
+    await saveTemplate(makeTemplate({
+      id: 'tmpl-x',
+      name: 'Full',
+      description: 'Detailed desc',
+      createdAt: 500,
+      tracks: [
+        { trackName: 'drums', trackType: 'sequencer', displayName: 'Drums', color: '#f00', volume: 1 },
+        { trackName: 'bass', trackType: 'pianoRoll', displayName: 'Bass', color: '#0f0', volume: 1 },
+      ],
+    }));
+
+    const list = await listTemplates();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe('tmpl-x');
+    expect(list[0].name).toBe('Full');
+    expect(list[0].description).toBe('Detailed desc');
+    expect(list[0].trackCount).toBe(2);
+    expect(list[0].createdAt).toBe(500);
+  });
+
+  it('does not interfere with project storage keys', async () => {
+    // Store a project key alongside templates
+    mockStore.set('project:proj-1', JSON.stringify({ id: 'proj-1' }));
+    await saveTemplate(makeTemplate());
+
+    const list = await listTemplates();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe('tmpl-1');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ProjectTemplate` type and storage layer (IndexedDB) for saving/loading project templates
- Templates capture track layout, settings, effects, and musical parameters — without clips or audio data
- New "Save as Template" button in the Projects dialog; saved templates appear in the New Project dialog
- `saveProjectAsTemplate` and `createProjectFromTemplate` store actions with full undo support

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 349 tests pass (20 new template tests)
- [x] `npm run build` — succeeds
- [ ] Manual: open Projects dialog → click "Save as Template" → enter name → verify template appears in New Project dialog
- [ ] Manual: create project from template → verify tracks, BPM, key, time signature match
- [ ] Manual: delete a template from New Project dialog → verify it disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)