### PR TITLE
feat: add context-aware in-DAW AI assistant panel (closes #242)

### DIFF
--- a/docs/plans/feat-ai-assistant-help-panel.md
+++ b/docs/plans/feat-ai-assistant-help-panel.md
@@ -1,0 +1,85 @@
+# Feature Plan: In-DAW AI Assistant Help Panel
+
+Issue: #242
+
+## 1. Problem
+
+ACE-Step has an AI assistant panel scaffold on `origin/main`, but it does not yet satisfy the issue acceptance criteria.
+
+- The panel currently simulates a delayed full reply instead of streaming output.
+- The reply logic only uses project context in a shallow way, so answers are mostly generic.
+- The assistant logic lives inside the React component, which makes programmatic testing and agent-driven usage weak.
+- There is no dedicated E2E workflow proving keyboard open, chat submission, streaming, and context-aware output.
+
+## 2. Root Cause
+
+- `src/components/dialogs/AIAssistantPanel.tsx` owns chat orchestration, message mutation, and response generation in component-local callbacks.
+- `src/utils/aiAssistantContext.ts` returns a single string, but it does not encode panel visibility, transport state, selected clip count, or robust focused-track resolution.
+- `src/store/uiStore.ts` stores assistant UI state, but it does not provide an async action that agents can call directly.
+- `src/main.tsx` exposes project/UI stores globally, but not an assistant-specific API surface.
+
+## 3. Solution
+
+### 3a. Move assistant orchestration into store/service layers
+
+- Add `src/services/aiAssistantService.ts`.
+- Add pure functions for:
+  - deriving contextual suggestions
+  - generating a context-aware response
+  - streaming the response as deltas
+- Add `askAIAssistant(question)` and `updateAIChatMessage(...)` actions in `src/store/uiStore.ts`.
+
+### 3b. Strengthen DAW context injection
+
+- Expand `src/utils/aiAssistantContext.ts` so it derives:
+  - focused track from expanded/editor/open-panel state and selected clips
+  - active panels
+  - transport state
+  - project summary text for the assistant
+
+### 3c. Update the panel UI
+
+- Keep the panel docked and collapsible.
+- Render streamed assistant text as it arrives.
+- Replace static suggestion chips with context-aware suggestions.
+- Keep ARIA labels and keyboard submission behavior intact.
+
+### 3d. Expose agent-friendly API
+
+- Expose `window.__assistantStore = useUIStore` in `src/main.tsx`.
+- Allow agent/browser tests to call `window.__assistantStore.getState().askAIAssistant(...)`.
+
+### 3e. Verify with tests
+
+- Unit test the assistant service for context-aware output and multi-chunk streaming.
+- Extend store tests to cover async assistant actions.
+- Add Playwright coverage for:
+  - opening via `Cmd+/`
+  - sending a production question
+  - observing streaming state
+  - verifying response content references current session context
+
+## 4. Verification
+
+- `npx tsc --noEmit`
+- `npm test`
+- `npm run build`
+- `npx playwright test tests/e2e/ai-assistant.spec.ts`
+
+User-story verification:
+
+- As a human user, I want to press `Cmd+/`, ask how to improve my drum track, and see a streamed reply that references the current project context.
+- As an AI agent, I want to call `window.__assistantStore.getState().askAIAssistant(question)` and inspect the streamed messages in store state, so I can automate help workflows programmatically.
+
+## 5. Files To Touch
+
+- `docs/research-notes/ai-assistant-competitive-research-20260319.md`
+- `docs/plans/feat-ai-assistant-help-panel.md`
+- `src/components/dialogs/AIAssistantPanel.tsx`
+- `src/main.tsx`
+- `src/services/aiAssistantService.ts`
+- `src/store/uiStore.ts`
+- `src/utils/aiAssistantContext.ts`
+- `tests/e2e/ai-assistant.spec.ts`
+- `tests/unit/aiAssistant.test.ts`
+- `tests/unit/aiAssistantService.test.ts`

--- a/docs/research-notes/ai-assistant-competitive-research-20260319.md
+++ b/docs/research-notes/ai-assistant-competitive-research-20260319.md
@@ -1,0 +1,58 @@
+# Competitive Research: In-DAW Assistant and Context Help
+
+Date: 2026-03-19
+Issue: #242
+
+## Sources
+
+- FL Studio manual: Title & Hint Panel / Online Panel
+  https://www.image-line.com/fl-studio-learning/fl-studio-online-manual/index_frame_left_offline.html
+- Ableton Live 12 manual
+  https://cdn-resources.ableton.com/resources/pdfs/live-manual/12/2025-01-23/live12-manual-en.pdf
+- Internal issue framing for ACE-Step
+  `gh issue view 242 --repo ace-step/ACE-Step-DAW`
+
+## Interaction Findings
+
+### FL Studio
+
+- FL Studio keeps contextual guidance close to the working surface instead of hiding it in a separate docs flow.
+- The manual exposes a dedicated hint/help surface in the main application chrome. That establishes a strong precedent for always-visible, context-sensitive guidance.
+- FL also treats online/help tooling as part of the DAW workspace, not a detached support site workflow.
+
+### Ableton Live 12
+
+- Ableton relies on contextual inspection patterns: the selected object determines what details are surfaced in adjacent panels.
+- The manual consistently teaches users through the currently focused track, device, or clip instead of generic DAW advice.
+- This implies that ACE-Step assistant replies should anchor to current project state first, then provide broader production tips.
+
+## Product Implications for ACE-Step
+
+- The assistant should be a docked side panel, not a modal, so users can keep editing while asking questions.
+- The assistant must understand the current project snapshot:
+  - BPM, key, time signature
+  - focused or selected track
+  - clip counts and track types
+  - active effects / MIDI effects
+  - visible panels such as Mixer, Piano Roll, Loop Browser
+- Responses should be actionable inside ACE-Step, not only educational. Good answers should reference existing shortcuts or panels.
+- Streaming matters because it makes the panel feel like a live assistant rather than a static FAQ card.
+
+## Copy / Improve / Skip
+
+- Copy: docked contextual help behavior from FL/Ableton style side surfaces.
+- Improve: add agent-friendly store actions and `window` exposure so the assistant is usable from browser automation and CLI flows.
+- Improve: inject project context automatically instead of requiring the user to describe their session.
+- Skip for now: remote LLM dependency and action execution. The repo has no stable chat endpoint contract yet, so a local streaming assistant is the correct Phase 1 architecture.
+
+## Implementation Standard for #242
+
+- Docked right-side panel with collapse via toolbar and shortcut.
+- Context object derived from current DAW state on every question.
+- Streaming response rendering, not a delayed full-message swap.
+- Replies must handle common production prompts:
+  - drums punch / compression / EQ
+  - vocal effects
+  - BPM / tempo guidance
+  - mixing and balance
+  - ACE-Step feature discovery and shortcuts

--- a/src/components/dialogs/AIAssistantPanel.tsx
+++ b/src/components/dialogs/AIAssistantPanel.tsx
@@ -1,103 +1,61 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useUIStore } from '../../store/uiStore';
-import { useProjectStore } from '../../store/projectStore';
-import { buildAssistantContext } from '../../utils/aiAssistantContext';
 import type { AIChatMessage } from '../../types/aiAssistant';
-
-const SYSTEM_PROMPT = `You are an AI music production assistant built into ACE-Step DAW. You help users with:
-- Music production techniques and tips
-- Explaining DAW features and how to use them
-- Suggesting effects, mixing settings, and arrangement ideas
-- Answering questions about music theory, genres, and instruments
-
-You have context about the user's current project state. Be concise and practical.
-Always relate advice to what the user is currently working on when possible.`;
-
-function generateId(): string {
-  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
 
 function MessageBubble({ message }: { message: AIChatMessage }) {
   const isUser = message.role === 'user';
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-2`}>
+    <div className={`mb-2 flex ${isUser ? 'justify-end' : 'justify-start'}`}>
       <div
-        className={`max-w-[85%] px-3 py-2 rounded-lg text-[12px] leading-relaxed whitespace-pre-wrap ${
+        className={`max-w-[85%] rounded-lg px-3 py-2 text-[12px] leading-relaxed whitespace-pre-wrap ${
           isUser
             ? 'bg-daw-accent/80 text-white'
-            : 'bg-[#2a2a2a] text-zinc-200 border border-[#3a3a3a]'
+            : 'border border-[#3a3a3a] bg-[#2a2a2a] text-zinc-200'
         }`}
         data-message-role={message.role}
       >
-        {message.content}
+        {message.content || '…'}
       </div>
     </div>
   );
 }
 
 export function AIAssistantPanel() {
-  const show = useUIStore((s) => s.showAIAssistant);
-  const messages = useUIStore((s) => s.aiChatMessages);
-  const streaming = useUIStore((s) => s.aiAssistantStreaming);
-  const addMessage = useUIStore((s) => s.addAIChatMessage);
-  const clearMessages = useUIStore((s) => s.clearAIChatMessages);
-  const setStreaming = useUIStore((s) => s.setAIAssistantStreaming);
-  const setShow = useUIStore((s) => s.setShowAIAssistant);
-  const project = useProjectStore((s) => s.project);
-  const expandedTrackId = useUIStore((s) => s.expandedTrackId);
+  const show = useUIStore((state) => state.showAIAssistant);
+  const messages = useUIStore((state) => state.aiChatMessages);
+  const streaming = useUIStore((state) => state.aiAssistantStreaming);
+  const suggestions = useUIStore((state) => state.aiAssistantSuggestions);
+  const error = useUIStore((state) => state.aiAssistantError);
+  const clearMessages = useUIStore((state) => state.clearAIChatMessages);
+  const refreshSuggestions = useUIStore((state) => state.refreshAIAssistantSuggestions);
+  const setShow = useUIStore((state) => state.setShowAIAssistant);
+  const askAIAssistant = useUIStore((state) => state.askAIAssistant);
 
   const [input, setInput] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  // Auto-scroll to bottom on new messages
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages.length]);
+  }, [messages]);
 
-  // Focus input when panel opens
   useEffect(() => {
-    if (show) {
-      setTimeout(() => inputRef.current?.focus(), 100);
-    }
-  }, [show]);
+    if (!show) return;
+    refreshSuggestions();
+    setTimeout(() => inputRef.current?.focus(), 100);
+  }, [refreshSuggestions, show]);
 
-  const handleSend = useCallback(() => {
+  const handleSend = useCallback(async () => {
     const trimmed = input.trim();
     if (!trimmed || streaming) return;
-
-    const userMsg: AIChatMessage = {
-      id: generateId(),
-      role: 'user',
-      content: trimmed,
-      timestamp: Date.now(),
-    };
-    addMessage(userMsg);
     setInput('');
+    await askAIAssistant(trimmed);
+  }, [askAIAssistant, input, streaming]);
 
-    // Build context and generate response
-    const context = buildAssistantContext(project, expandedTrackId);
-    setStreaming(true);
-
-    // Simulate assistant response (Phase 1: local knowledge base, no API call)
-    // In Phase 2, this will be replaced with actual LLM API integration
-    setTimeout(() => {
-      const response = generateLocalResponse(trimmed, context);
-      const assistantMsg: AIChatMessage = {
-        id: generateId(),
-        role: 'assistant',
-        content: response,
-        timestamp: Date.now(),
-      };
-      addMessage(assistantMsg);
-      setStreaming(false);
-    }, 300);
-  }, [input, streaming, addMessage, setStreaming, project, expandedTrackId]);
-
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
+  const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      void handleSend();
     }
   }, [handleSend]);
 
@@ -105,13 +63,12 @@ export function AIAssistantPanel() {
 
   return (
     <div
-      className="fixed right-0 top-11 bottom-6 w-[340px] bg-[#1e1e1e] border-l border-[#333] flex flex-col z-50 shadow-xl"
+      className="fixed top-11 right-0 bottom-6 z-50 flex w-[340px] flex-col border-l border-[#333] bg-[#1e1e1e] shadow-xl"
       data-testid="ai-assistant-panel"
       role="complementary"
       aria-label="AI Assistant"
     >
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-[#333] shrink-0">
+      <div className="flex items-center justify-between border-b border-[#333] px-3 py-2 shrink-0">
         <div className="flex items-center gap-2">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" className="text-daw-accent">
             <circle cx="7" cy="7" r="5.5" />
@@ -123,7 +80,7 @@ export function AIAssistantPanel() {
         <div className="flex items-center gap-1">
           <button
             onClick={clearMessages}
-            className="w-6 h-6 flex items-center justify-center text-zinc-500 hover:text-zinc-300 rounded hover:bg-[#333] transition-colors"
+            className="flex h-6 w-6 items-center justify-center rounded text-zinc-500 transition-colors hover:bg-[#333] hover:text-zinc-300"
             title="Clear conversation"
             aria-label="Clear conversation"
           >
@@ -133,7 +90,7 @@ export function AIAssistantPanel() {
           </button>
           <button
             onClick={() => setShow(false)}
-            className="w-6 h-6 flex items-center justify-center text-zinc-500 hover:text-zinc-300 rounded hover:bg-[#333] transition-colors"
+            className="flex h-6 w-6 items-center justify-center rounded text-zinc-500 transition-colors hover:bg-[#333] hover:text-zinc-300"
             title="Close (Escape)"
             aria-label="Close AI Assistant"
           >
@@ -144,62 +101,57 @@ export function AIAssistantPanel() {
         </div>
       </div>
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-3 py-3 min-h-0">
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
         {messages.length === 0 && (
-          <div className="text-center text-zinc-500 text-[11px] mt-8 space-y-3">
+          <div className="mt-8 space-y-3 text-center text-[11px] text-zinc-500">
             <div className="text-2xl">✨</div>
             <div className="font-medium text-zinc-400">AI Music Assistant</div>
-            <div>Ask about production techniques, effects, mixing tips, or how to use DAW features.</div>
-            <div className="space-y-1.5 mt-4">
-              <SuggestionChip text="How do I make my drums punch harder?" onClick={(t) => { setInput(t); }} />
-              <SuggestionChip text="Suggest effects for vocals" onClick={(t) => { setInput(t); }} />
-              <SuggestionChip text="What BPM is good for lo-fi hip hop?" onClick={(t) => { setInput(t); }} />
+            <div>Ask about production techniques, mixing, effects, or ACE-Step workflows in the current session.</div>
+            <div className="mt-4 space-y-1.5">
+              {suggestions.map((suggestion) => (
+                <SuggestionChip key={suggestion} text={suggestion} onClick={setInput} />
+              ))}
             </div>
           </div>
         )}
-        {messages.map((msg) => (
-          <MessageBubble key={msg.id} message={msg} />
+
+        {messages.map((message) => (
+          <MessageBubble key={message.id} message={message} />
         ))}
-        {streaming && (
-          <div className="flex justify-start mb-2">
-            <div className="bg-[#2a2a2a] border border-[#3a3a3a] px-3 py-2 rounded-lg">
-              <div className="flex gap-1">
-                <span className="w-1.5 h-1.5 bg-zinc-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-                <span className="w-1.5 h-1.5 bg-zinc-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-                <span className="w-1.5 h-1.5 bg-zinc-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
-              </div>
-            </div>
+
+        {error && (
+          <div className="mb-2 rounded-md border border-red-500/30 bg-red-950/30 px-3 py-2 text-[11px] text-red-300">
+            {error}
           </div>
         )}
+
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Input area */}
       <div className="shrink-0 border-t border-[#333] p-2">
         <div className="flex gap-2">
           <textarea
             ref={inputRef}
             value={input}
-            onChange={(e) => setInput(e.target.value)}
+            onChange={(event) => setInput(event.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Ask about music production..."
-            className="flex-1 bg-[#2a2a2a] border border-[#444] rounded-lg px-3 py-2 text-[12px] text-zinc-200 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent/50 transition-colors"
+            className="flex-1 resize-none rounded-lg border border-[#444] bg-[#2a2a2a] px-3 py-2 text-[12px] text-zinc-200 transition-colors placeholder:text-zinc-600 focus:border-daw-accent/50 focus:outline-none"
             rows={2}
             disabled={streaming}
             aria-label="Chat input"
           />
           <button
-            onClick={handleSend}
+            onClick={() => void handleSend()}
             disabled={!input.trim() || streaming}
-            className="self-end px-3 py-2 bg-daw-accent/80 hover:bg-daw-accent text-white text-[11px] font-medium rounded-lg disabled:opacity-30 disabled:hover:bg-daw-accent/80 transition-colors"
+            className="self-end rounded-lg bg-daw-accent/80 px-3 py-2 text-[11px] font-medium text-white transition-colors hover:bg-daw-accent disabled:opacity-30 disabled:hover:bg-daw-accent/80"
             aria-label="Send message"
           >
             Send
           </button>
         </div>
-        <div className="text-[10px] text-zinc-600 mt-1 px-1">
-          Shift+Enter for new line · Phase 1: built-in knowledge
+        <div className="mt-1 px-1 text-[10px] text-zinc-600">
+          Shift+Enter for new line · Replies stream from live DAW context
         </div>
       </div>
     </div>
@@ -210,68 +162,9 @@ function SuggestionChip({ text, onClick }: { text: string; onClick: (text: strin
   return (
     <button
       onClick={() => onClick(text)}
-      className="block w-full text-left px-3 py-1.5 text-[11px] text-zinc-400 hover:text-zinc-200 bg-[#2a2a2a] hover:bg-[#333] border border-[#3a3a3a] rounded-md transition-colors"
+      className="block w-full rounded-md border border-[#3a3a3a] bg-[#2a2a2a] px-3 py-1.5 text-left text-[11px] text-zinc-400 transition-colors hover:bg-[#333] hover:text-zinc-200"
     >
       {text}
     </button>
   );
-}
-
-/**
- * Phase 1: Local knowledge-based response generation.
- * Matches keywords from the user's question against a built-in knowledge base.
- * Phase 2 will replace this with actual LLM API streaming.
- */
-function generateLocalResponse(question: string, context: string): string {
-  const q = question.toLowerCase();
-
-  // Context-aware responses
-  if (context.includes('No project loaded')) {
-    return 'It looks like you don\'t have a project open yet. Create a new project first, then I can help you with production tips specific to your setup!';
-  }
-
-  // Effects & mixing
-  if (q.includes('reverb')) {
-    return 'Reverb adds space and depth to your sound. In ACE-Step DAW:\n\n1. Select the track you want to add reverb to\n2. Open the Effect Chain (click the FX button or use the mixer)\n3. Add a Reverb effect\n4. Adjust Decay (room size), Pre-Delay (space before reverb starts), and Wet mix\n\nTips:\n- Vocals: Use a medium room (decay 1.5-2.5s) with 20-30% wet\n- Drums: Short room reverb (0.5-1s) to add body without muddiness\n- Use pre-delay (20-50ms) to keep the original sound clear';
-  }
-
-  if (q.includes('compressor') || q.includes('compression')) {
-    return 'Compression controls dynamic range — it makes loud parts quieter and quiet parts louder.\n\nKey parameters:\n- **Threshold**: Level where compression starts (lower = more compression)\n- **Ratio**: How much to compress (4:1 is a good starting point)\n- **Attack**: How fast compression kicks in (fast = tighter, slow = more punch)\n- **Release**: How fast compression lets go\n\nQuick settings:\n- Vocals: Threshold -18dB, Ratio 3:1, Attack 10ms, Release 100ms\n- Drums: Threshold -12dB, Ratio 4:1, Attack 1ms, Release 50ms\n- Bass: Threshold -15dB, Ratio 4:1, Attack 5ms, Release 80ms';
-  }
-
-  if (q.includes('eq') || q.includes('equaliz')) {
-    return 'EQ shapes the tonal balance of your tracks.\n\nACE-Step DAW has a 3-band EQ and a parametric EQ on each track.\n\nCommon EQ moves:\n- **Cut muddy frequencies**: Reduce 200-400 Hz on non-bass instruments\n- **Add vocal presence**: Boost 2-5 kHz slightly\n- **Air and brightness**: Gentle boost at 10-12 kHz\n- **Kick drum punch**: Boost 60-80 Hz, cut 300 Hz, boost 3-5 kHz for click\n- **High-pass everything except kick/bass**: Set a filter at 80-100 Hz to remove rumble';
-  }
-
-  if (q.includes('effect') && q.includes('vocal')) {
-    return 'Essential vocal effects chain:\n\n1. **EQ** — High-pass at 80 Hz, cut 200-300 Hz if muddy, boost 3-5 kHz for presence\n2. **Compressor** — Ratio 3:1, threshold to catch -6dB peaks, fast attack\n3. **Reverb** — Medium room, 20-30% wet, 30ms pre-delay\n4. **Delay** — Optional, 1/4 note, 15-20% wet for depth\n\nIn ACE-Step: Select the vocal track → open Effect Chain → add effects in this order.';
-  }
-
-  // BPM & genre
-  if (q.includes('bpm') || q.includes('tempo')) {
-    return 'Common BPM ranges by genre:\n\n- **Lo-fi Hip Hop**: 70-90 BPM\n- **Hip Hop / Trap**: 130-160 BPM (half-time feel)\n- **Pop**: 100-130 BPM\n- **House / EDM**: 120-130 BPM\n- **Drum & Bass**: 160-180 BPM\n- **Dubstep**: 140 BPM (half-time)\n- **R&B**: 60-80 BPM\n- **Rock**: 110-140 BPM\n\nYou can change BPM in the Settings dialog (Cmd+,) or click the BPM display in the toolbar.';
-  }
-
-  // Drums
-  if (q.includes('drum') && (q.includes('punch') || q.includes('hard') || q.includes('hit'))) {
-    return 'To make drums punch harder:\n\n1. **Compression**: Use fast attack (1-5ms) and medium release. Ratio 4:1-6:1\n2. **Transient shaping**: Boost the attack of kick and snare\n3. **EQ**: Boost kick at 60-80 Hz and 3-5 kHz (beater click). Boost snare at 200 Hz (body) and 5-7 kHz (crack)\n4. **Parallel compression**: Mix heavily compressed drums with the original\n5. **Saturation/Distortion**: Light distortion adds harmonics and perceived loudness\n6. **Sidechain**: Use the kick to duck other elements slightly\n\nIn ACE-Step: Add Compressor and Distortion effects to your drum track from the Effect Chain panel.';
-  }
-
-  // Mixing
-  if (q.includes('mix') && (q.includes('tip') || q.includes('better') || q.includes('how'))) {
-    return 'Mixing fundamentals:\n\n1. **Gain staging**: Keep individual tracks around -12 to -6 dBFS before summing\n2. **Start with the faders**: Set relative levels before adding effects\n3. **EQ to separate**: Give each instrument its own frequency space\n4. **Pan for width**: Spread instruments across the stereo field\n5. **Use high-pass filters**: On everything except kick and bass\n6. **Reference tracks**: Compare against professional mixes frequently\n7. **Take breaks**: Your ears fatigue — rest every 30-45 minutes\n\nACE-Step Mixer (X key) gives you faders, pan, and EQ for every track.';
-  }
-
-  // DAW-specific features
-  if (q.includes('shortcut') || q.includes('keyboard')) {
-    return 'Essential ACE-Step DAW shortcuts:\n\n- **Space**: Play/Pause\n- **Enter**: Stop/Return to start\n- **R**: Toggle recording\n- **X**: Toggle mixer\n- **B**: Smart controls\n- **Y**: Library panel\n- **N**: Toggle snap\n- **?**: Show all shortcuts\n- **Cmd+G**: Generate (batch)\n- **Cmd+Shift+G**: Context generation\n- **Cmd+Enter**: Generate selected clip\n- **Cmd+Z / Cmd+Shift+Z**: Undo/Redo';
-  }
-
-  if (q.includes('generate') || q.includes('ai') && q.includes('music')) {
-    return 'ACE-Step AI music generation:\n\n1. **Add a track** (Cmd+Shift+I) — choose instrument type\n2. **Add a clip** — click on the timeline lane\n3. **Write a prompt** — describe the sound (e.g., "groovy bass line, funky, 120bpm")\n4. **Generate** — Cmd+Enter to generate the selected clip\n5. **Batch generate** — Cmd+G to generate multiple clips at once\n\nTips:\n- Be specific in prompts: genre, mood, tempo, instrument style\n- Use context generation (Cmd+Shift+G) to make new clips that match existing ones\n- Use "repaint" to partially regenerate sections you want to change';
-  }
-
-  // Fallback — still context-aware
-  const trackInfo = context.includes('Selected track') ? '\n\nI can see you have a track selected — feel free to ask specific questions about it!' : '';
-  return `I can help with music production questions! Here are some things I know about:\n\n- **Effects**: Reverb, compression, EQ, delay, distortion\n- **Mixing tips**: Gain staging, panning, frequency separation\n- **BPM/Genre guidance**: Tempo ranges for different genres\n- **ACE-Step features**: Shortcuts, AI generation, effects chain\n- **Music theory**: Chord progressions, scales, arrangement\n\nTry asking something specific like "How do I add reverb to vocals?" or "What BPM for lo-fi?"${trackInfo}`;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import { generateProjectSummary, generateProjectStructure } from './utils/dawSta
 // Agents can call: window.__store.getState() / window.__store.setState(...)
 (window as unknown as Record<string, unknown>).__store = useProjectStore;
 (window as unknown as Record<string, unknown>).__uiStore = useUIStore;
+(window as unknown as Record<string, unknown>).__assistantStore = useUIStore;
 (window as unknown as Record<string, unknown>).__transportStore = useTransportStore;
 (window as unknown as Record<string, unknown>).__collaborationStore = useCollaborationStore;
 

--- a/src/services/aiAssistantService.ts
+++ b/src/services/aiAssistantService.ts
@@ -1,0 +1,140 @@
+import type { AIChatContext } from '../utils/aiAssistantContext';
+
+const DEFAULT_STREAM_DELAY_MS = 18;
+
+export function getAssistantSuggestions(context: AIChatContext): string[] {
+  if (!context.hasProject) {
+    return [
+      'How do I start a new song in ACE-Step?',
+      'What track should I add first for a lo-fi beat?',
+      'Show me the most useful ACE-Step shortcuts.',
+    ];
+  }
+
+  if (context.focusedTrack?.trackType === 'sequencer' || /drum/i.test(context.focusedTrack?.displayName ?? '')) {
+    return [
+      'How do I make this drum track punch harder?',
+      'What compressor settings fit this drum track?',
+      'How should I balance kick, snare, and hats?',
+    ];
+  }
+
+  if (/vocal/i.test(context.focusedTrack?.displayName ?? '')) {
+    return [
+      'Suggest an effects chain for this vocal track.',
+      'How can I keep this vocal clear in the mix?',
+      'What reverb and delay settings fit this vocal?',
+    ];
+  }
+
+  return [
+    'How should I balance this mix?',
+    'What should I work on next in this project?',
+    'Show shortcuts for the panels I have open.',
+  ];
+}
+
+export function generateAssistantResponse(question: string, context: AIChatContext): string {
+  const q = question.toLowerCase();
+  const intro = buildIntro(context);
+
+  if (!context.hasProject) {
+    return `${intro}\n\nStart by creating a project, then add one track with Cmd+Shift+I. Once the project exists, I can give track-specific advice, explain panels, and recommend settings based on your actual session.`;
+  }
+
+  if (q.includes('drum') && (q.includes('punch') || q.includes('hard') || q.includes('hit'))) {
+    const focused = context.focusedTrack?.displayName ?? 'your drum track';
+    return `${intro}\n\nFor ${focused}, start with transient-first cleanup before adding loudness.\n\n1. Keep the kick peak clear. Cut 200-350 Hz if it feels boxy, then add a small 3-5 kHz boost for click.\n2. Use compression with a medium attack so the transient survives. A practical starting point is threshold around -12 dB, ratio 4:1, attack 10-20 ms, release 60-120 ms.\n3. Keep reverb short or off on the main kick/snare path. Long tails soften impact.\n4. If the groove still feels flat, add light saturation after compression.\n\nInside ACE-Step, open the Mixer with X or the Effect Chain from the focused track and adjust compressor, EQ, and saturation in that order.`;
+  }
+
+  if (q.includes('compressor') || q.includes('compression')) {
+    return `${intro}\n\nCompression is most useful when you decide what you want first: peak control, sustain, or glue.\n\n- Peak control: fast attack, medium release, moderate ratio.\n- Punch: slower attack so the transient gets through.\n- Glue on a bus: low ratio, 1-3 dB of gain reduction.\n\nFor this session, start with threshold low enough to see consistent gain reduction, then tune attack/release by ear against the groove at ${context.projectBpm ?? 'the current'} BPM.`;
+  }
+
+  if (q.includes('effect') && q.includes('vocal')) {
+    return `${intro}\n\nA safe starting vocal chain is EQ -> compression -> de-ess if needed -> delay/reverb sends.\n\n- High-pass around 80-100 Hz.\n- Cut a little 200-350 Hz if the vocal sounds cloudy.\n- Use 3:1 compression with 3-6 dB of gain reduction.\n- Add short plate or room reverb with pre-delay so the vocal stays forward.\n- Use tempo-synced delay sparingly for depth.\n\nIf you focus the vocal track first, I can tailor the advice to its current effects and level.`;
+  }
+
+  if (q.includes('eq') || q.includes('equaliz')) {
+    return `${intro}\n\nUse EQ to create separation, not to make every track sound big in solo.\n\n- Remove low-end rumble from non-bass parts.\n- Cut muddy low-mids before boosting highs.\n- Make kick and bass complement each other instead of boosting both in the same range.\n- Compare with the full mix playing, not only the isolated track.\n\nIf you tell me which track you are shaping, I can suggest likely problem ranges for that source.`;
+  }
+
+  if (q.includes('bpm') || q.includes('tempo')) {
+    return `${intro}\n\nCommon tempo ranges:\n\n- Lo-fi hip hop: 70-90 BPM\n- Pop: 100-130 BPM\n- House: 120-130 BPM\n- Trap: 130-160 BPM with half-time feel\n- Drum and bass: 160-180 BPM\n\nYour project is currently at ${context.projectBpm ?? 'an unset'} BPM, so choose whether you want the song to feel more laid back or more driving before you move it.`;
+  }
+
+  if (q.includes('mix') || q.includes('balance')) {
+    const trackCount = context.trackCount ?? 0;
+    return `${intro}\n\nFor this ${trackCount}-track session, balance in this order:\n\n1. Set fader relationships before adding more processing.\n2. Keep kick, bass, lead vocal, or main hook as the anchor.\n3. Pan supporting parts away from the center to open space.\n4. Use EQ cuts to reduce masking before boosting presence.\n5. Check the mixer while the full arrangement plays, not clip-by-clip.\n\nIf you want, ask me for a per-track balance pass and I’ll prioritize the current arrangement.`;
+  }
+
+  if (q.includes('shortcut') || q.includes('keyboard')) {
+    const panels = context.activePanels.length > 0 ? context.activePanels.join(', ') : 'no extra panels';
+    return `${intro}\n\nUseful shortcuts for the current workspace:\n\n- Cmd+/ opens this assistant\n- X toggles Mixer\n- Y toggles Library\n- O toggles Loop Browser\n- B toggles Smart Controls\n- ? opens the full shortcuts dialog\n- Cmd+G opens batch generation\n- Cmd+Enter generates the selected clip\n\nRight now you have ${panels} open, so X, Y, O, and B are the quickest panel-navigation keys.`;
+  }
+
+  if (q.includes('generate') || (q.includes('ai') && q.includes('music'))) {
+    return `${intro}\n\nFor ACE-Step generation, keep the prompt concrete: genre, motion, instrument role, and energy. Then generate against the right context.\n\n- Use Cmd+Enter for a selected clip.\n- Use Cmd+G for a broader batch pass.\n- Use context generation when you want a new part to match the existing arrangement.\n\nIf you tell me the role you need next, like bass, pad, or drums, I can help write the prompt.`;
+  }
+
+  return `${intro}\n\nI can answer production, arrangement, mixing, sound-design, and ACE-Step workflow questions. Try asking about the focused track, a specific effect chain, or how to improve the current arrangement based on the visible panels and project tempo.`;
+}
+
+export async function* streamAssistantResponse(
+  question: string,
+  context: AIChatContext,
+  delayMs = DEFAULT_STREAM_DELAY_MS,
+): AsyncGenerator<string> {
+  const response = generateAssistantResponse(question, context);
+  const chunks = chunkResponse(response);
+
+  for (const chunk of chunks) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    yield chunk;
+  }
+}
+
+function buildIntro(context: AIChatContext): string {
+  if (!context.hasProject) {
+    return 'No project is loaded yet, so I can only give generic startup guidance.';
+  }
+
+  const parts = [
+    `I’m looking at "${context.projectName}"`,
+    context.projectBpm ? `running at ${context.projectBpm} BPM` : null,
+    context.focusedTrack ? `with ${context.focusedTrack.displayName} in focus` : null,
+  ].filter(Boolean);
+
+  const panels = context.activePanels.length > 0
+    ? ` Active panels: ${context.activePanels.join(', ')}.`
+    : '';
+
+  return `${parts.join(' ')}.${panels}`;
+}
+
+function chunkResponse(response: string): string[] {
+  const paragraphs = response.split('\n');
+  const chunks: string[] = [];
+
+  for (const paragraph of paragraphs) {
+    if (paragraph === '') {
+      chunks.push('\n');
+      continue;
+    }
+
+    const words = paragraph.split(' ');
+    for (let index = 0; index < words.length; index += 8) {
+      const slice = words.slice(index, index + 8).join(' ');
+      chunks.push(index + 8 < words.length ? `${slice} ` : slice);
+    }
+    chunks.push('\n');
+  }
+
+  if (chunks[chunks.length - 1] === '\n') {
+    chunks.pop();
+  }
+
+  return chunks;
+}

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,6 +1,20 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import type { AIChatMessage } from '../types/aiAssistant';
+import { useProjectStore } from './projectStore';
+import { useTransportStore } from './transportStore';
+import type { AIChatContext } from '../utils/aiAssistantContext';
+import { buildAssistantContext } from '../utils/aiAssistantContext';
+import { getAssistantSuggestions, streamAssistantResponse } from '../services/aiAssistantService';
+
+function createAssistantMessage(role: AIChatMessage['role'], content: string): AIChatMessage {
+  return {
+    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    role,
+    content,
+    timestamp: Date.now(),
+  };
+}
 
 interface UIState {
   pixelsPerSecond: number;
@@ -81,6 +95,8 @@ interface UIState {
   showAIAssistant: boolean;
   aiChatMessages: AIChatMessage[];
   aiAssistantStreaming: boolean;
+  aiAssistantSuggestions: string[];
+  aiAssistantError: string | null;
 
   setPixelsPerSecond: (pps: number) => void;
   toggleSnap: () => void;
@@ -158,13 +174,16 @@ interface UIState {
   addAIChatMessage: (msg: AIChatMessage) => void;
   clearAIChatMessages: () => void;
   setAIAssistantStreaming: (v: boolean) => void;
+  updateAIChatMessage: (id: string, updater: (message: AIChatMessage) => AIChatMessage) => void;
+  refreshAIAssistantSuggestions: () => void;
+  askAIAssistant: (question: string, options?: { delayMs?: number }) => Promise<void>;
 }
 
 const ZOOM_LEVELS = [10, 25, 50, 100, 200, 500];
 
 export const useUIStore = create<UIState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
   pixelsPerSecond: 50,
   snapEnabled: true,
   scrollX: 0,
@@ -227,6 +246,8 @@ export const useUIStore = create<UIState>()(
   showAIAssistant: false,
   aiChatMessages: [],
   aiAssistantStreaming: false,
+  aiAssistantSuggestions: [],
+  aiAssistantError: null,
 
   setPixelsPerSecond: (pps) => set({ pixelsPerSecond: pps }),
   toggleSnap: () => set((s) => ({ snapEnabled: !s.snapEnabled })),
@@ -329,11 +350,83 @@ export const useUIStore = create<UIState>()(
   setShowGeneratePatternDialog: (v) => set(v ? { showGeneratePatternDialog: v } : { showGeneratePatternDialog: false, generatePatternClipId: null }),
   openGeneratePatternDialog: (clipId) => set({ showGeneratePatternDialog: true, generatePatternClipId: clipId }),
 
-  toggleAIAssistant: () => set((s) => ({ showAIAssistant: !s.showAIAssistant })),
-  setShowAIAssistant: (v) => set({ showAIAssistant: v }),
+  toggleAIAssistant: () => set((state) => {
+    const nextShow = !state.showAIAssistant;
+    return nextShow
+      ? {
+          showAIAssistant: true,
+          aiAssistantSuggestions: getAssistantSuggestions(getAssistantContext(state)),
+          aiAssistantError: null,
+        }
+      : { showAIAssistant: false };
+  }),
+  setShowAIAssistant: (v) => set((state) => (
+    v
+      ? {
+          showAIAssistant: true,
+          aiAssistantSuggestions: getAssistantSuggestions(getAssistantContext(state)),
+          aiAssistantError: null,
+        }
+      : { showAIAssistant: false }
+  )),
   addAIChatMessage: (msg) => set((s) => ({ aiChatMessages: [...s.aiChatMessages, msg] })),
-  clearAIChatMessages: () => set({ aiChatMessages: [] }),
+  clearAIChatMessages: () => set((state) => ({
+    aiChatMessages: [],
+    aiAssistantError: null,
+    aiAssistantSuggestions: getAssistantSuggestions(getAssistantContext(state)),
+  })),
   setAIAssistantStreaming: (v) => set({ aiAssistantStreaming: v }),
+  updateAIChatMessage: (id, updater) => set((state) => ({
+    aiChatMessages: state.aiChatMessages.map((message) => (
+      message.id === id ? updater(message) : message
+    )),
+  })),
+  refreshAIAssistantSuggestions: () => set((state) => ({
+    aiAssistantSuggestions: getAssistantSuggestions(getAssistantContext(state)),
+  })),
+  askAIAssistant: async (question, options) => {
+    const trimmed = question.trim();
+    if (!trimmed) return;
+
+    const userMessage = createAssistantMessage('user', trimmed);
+    const assistantMessage = createAssistantMessage('assistant', '');
+    const context = getAssistantContext(get());
+
+    set((state) => ({
+      showAIAssistant: true,
+      aiAssistantStreaming: true,
+      aiAssistantError: null,
+      aiChatMessages: [...state.aiChatMessages, userMessage, assistantMessage],
+      aiAssistantSuggestions: getAssistantSuggestions(context),
+    }));
+
+    try {
+      for await (const chunk of streamAssistantResponse(trimmed, context, options?.delayMs)) {
+        set((state) => ({
+          aiChatMessages: state.aiChatMessages.map((message) => (
+            message.id === assistantMessage.id
+              ? { ...message, content: `${message.content}${chunk}` }
+              : message
+          )),
+        }));
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Assistant response failed.';
+      set((state) => ({
+        aiAssistantError: message,
+        aiChatMessages: state.aiChatMessages.map((item) => (
+          item.id === assistantMessage.id
+            ? { ...item, content: 'I ran into an error while preparing the reply. Please try again.' }
+            : item
+        )),
+      }));
+    } finally {
+      set((state) => ({
+        aiAssistantStreaming: false,
+        aiAssistantSuggestions: getAssistantSuggestions(getAssistantContext(state)),
+      }));
+    }
+  },
 }),
     {
       name: 'ace-step-daw-ui',
@@ -366,3 +459,7 @@ export const useUIStore = create<UIState>()(
     },
   ),
 );
+
+function getAssistantContext(state: UIState): AIChatContext {
+  return buildAssistantContext(useProjectStore.getState().project, state, useTransportStore.getState());
+}

--- a/src/utils/aiAssistantContext.ts
+++ b/src/utils/aiAssistantContext.ts
@@ -1,22 +1,59 @@
-/**
- * aiAssistantContext.ts — Build a context string for the AI assistant
- * that describes the current DAW project state, selected track, and effects.
- */
 import type { Project, Track } from '../types/project';
 
-/**
- * Build a context string summarizing the current DAW state for the AI assistant.
- * Includes project settings, track layout, selected track details, and effects.
- */
+interface AssistantUIContext {
+  expandedTrackId?: string | null;
+  openSequencerTrackId?: string | null;
+  openDrumMachineTrackId?: string | null;
+  openPianoRollTrackId?: string | null;
+  openEffectChainTrackId?: string | null;
+  openMidiEffectChainTrackId?: string | null;
+  selectedClipIds?: Set<string>;
+  showMixer?: boolean;
+  showLibrary?: boolean;
+  loopBrowserOpen?: boolean;
+  showSmartControls?: boolean;
+  showAIAssistant?: boolean;
+}
+
+interface AssistantTransportContext {
+  isPlaying?: boolean;
+  loopEnabled?: boolean;
+}
+
+export interface AIChatContext {
+  hasProject: boolean;
+  projectName: string | null;
+  projectBpm: number | null;
+  trackCount: number | null;
+  focusedTrack: Track | null;
+  selectedClipCount: number;
+  activePanels: string[];
+  summary: string;
+}
+
 export function buildAssistantContext(
   project: Project | null,
-  selectedTrackId: string | null,
-): string {
-  if (!project) return 'No project loaded.';
+  ui: AssistantUIContext = {},
+  transport: AssistantTransportContext = {},
+): AIChatContext {
+  if (!project) {
+    return {
+      hasProject: false,
+      projectName: null,
+      projectBpm: null,
+      trackCount: null,
+      focusedTrack: null,
+      selectedClipCount: 0,
+      activePanels: [],
+      summary: 'No project loaded.',
+    };
+  }
 
   const lines: string[] = [];
+  const focusedTrack = resolveFocusedTrack(project, ui);
+  const activePanels = getActivePanels(ui);
+  const selectedClipCount = ui.selectedClipIds?.size ?? 0;
 
-  // Project overview
   lines.push(`Project: "${project.name}"`);
   lines.push(`BPM: ${project.bpm} | Key: ${project.keyScale || 'none'} | Time Signature: ${project.timeSignature}/4`);
   lines.push(`Duration: ${fmtDur(project.totalDuration)} | Tracks: ${project.tracks.length}`);
@@ -25,7 +62,6 @@ export function buildAssistantContext(
     lines.push(`Description: ${project.globalCaption}`);
   }
 
-  // Track summary
   if (project.tracks.length > 0) {
     lines.push('');
     lines.push('Tracks:');
@@ -40,55 +76,108 @@ export function buildAssistantContext(
     }
   }
 
-  // Selected track detail
-  if (selectedTrackId) {
-    const track = project.tracks.find((t) => t.id === selectedTrackId);
-    if (track) {
-      lines.push('');
-      lines.push(`Selected track: ${track.displayName} (${track.trackType || 'stems'})`);
-      lines.push(`  Volume: ${Math.round(track.volume * 100)}% | Pan: ${track.pan ?? 0}`);
+  if (selectedClipCount > 0 || activePanels.length > 0 || transport.isPlaying || transport.loopEnabled) {
+    lines.push('');
+  }
 
-      if (track.localCaption) {
-        lines.push(`  Caption: ${track.localCaption}`);
-      }
+  if (selectedClipCount > 0) {
+    lines.push(`Selected clips: ${selectedClipCount}`);
+  }
 
-      // Effects
-      if (track.effects && track.effects.length > 0) {
-        const fxList = track.effects.map((e) => `${e.type}${e.enabled ? '' : ' (bypassed)'}`).join(', ');
-        lines.push(`  Effects: ${fxList}`);
-      }
+  if (activePanels.length > 0) {
+    lines.push(`Open panels: ${activePanels.join(', ')}`);
+  }
 
-      // MIDI effects
-      if (track.midiEffects && track.midiEffects.length > 0) {
-        const mfxList = track.midiEffects.map((e) => `${e.type}${e.enabled ? '' : ' (bypassed)'}`).join(', ');
-        lines.push(`  MIDI Effects: ${mfxList}`);
-      }
+  if (transport.isPlaying || transport.loopEnabled) {
+    const playback = [
+      transport.isPlaying ? 'playing' : 'stopped',
+      transport.loopEnabled ? 'loop enabled' : null,
+    ].filter(Boolean).join(', ');
+    lines.push(`Transport: ${playback}`);
+  }
 
-      // Synth/drum info
-      if (track.synthPreset) {
-        lines.push(`  Synth: ${track.synthPreset}`);
-      }
-      if (track.drumKit) {
-        lines.push(`  Drum Kit: ${track.drumKit}`);
-      }
+  if (focusedTrack) {
+    lines.push('');
+    lines.push(`Focused track: ${focusedTrack.displayName} (${focusedTrack.trackType || 'stems'})`);
+    lines.push(`  Volume: ${Math.round(focusedTrack.volume * 100)}% | Pan: ${focusedTrack.pan ?? 0}`);
 
-      // Clips detail
-      if (track.clips.length > 0) {
-        lines.push(`  Clips:`);
-        for (const clip of track.clips) {
-          const status = clip.generationStatus === 'ready' ? 'ready' : clip.generationStatus;
-          const type = clip.midiData ? `MIDI (${clip.midiData.notes.length} notes)` : (clip.prompt || 'audio');
-          lines.push(`    [${status}] ${fmtDur(clip.startTime)}-${fmtDur(clip.startTime + clip.duration)}: ${type}`);
-        }
+    if (focusedTrack.localCaption) {
+      lines.push(`  Caption: ${focusedTrack.localCaption}`);
+    }
+
+    if (focusedTrack.effects && focusedTrack.effects.length > 0) {
+      const fxList = focusedTrack.effects.map((effect) => `${effect.type}${effect.enabled ? '' : ' (bypassed)'}`).join(', ');
+      lines.push(`  Effects: ${fxList}`);
+    }
+
+    if (focusedTrack.midiEffects && focusedTrack.midiEffects.length > 0) {
+      const mfxList = focusedTrack.midiEffects.map((effect) => `${effect.type}${effect.enabled ? '' : ' (bypassed)'}`).join(', ');
+      lines.push(`  MIDI Effects: ${mfxList}`);
+    }
+
+    if (focusedTrack.synthPreset) {
+      lines.push(`  Synth: ${focusedTrack.synthPreset}`);
+    }
+
+    if (focusedTrack.drumKit) {
+      lines.push(`  Drum Kit: ${focusedTrack.drumKit}`);
+    }
+
+    if (focusedTrack.clips.length > 0) {
+      lines.push('  Clips:');
+      for (const clip of focusedTrack.clips) {
+        const status = clip.generationStatus === 'ready' ? 'ready' : clip.generationStatus;
+        const type = clip.midiData ? `MIDI (${clip.midiData.notes.length} notes)` : (clip.prompt || 'audio');
+        lines.push(`    [${status}] ${fmtDur(clip.startTime)}-${fmtDur(clip.startTime + clip.duration)}: ${type}`);
       }
     }
   }
 
-  return lines.join('\n');
+  return {
+    hasProject: true,
+    projectName: project.name,
+    projectBpm: project.bpm,
+    trackCount: project.tracks.length,
+    focusedTrack,
+    selectedClipCount,
+    activePanels,
+    summary: lines.join('\n'),
+  };
 }
 
 function fmtDur(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = Math.floor(seconds % 60);
   return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function resolveFocusedTrack(project: Project, ui: AssistantUIContext): Track | null {
+  const directTrackId = ui.expandedTrackId
+    ?? ui.openEffectChainTrackId
+    ?? ui.openMidiEffectChainTrackId
+    ?? ui.openPianoRollTrackId
+    ?? ui.openSequencerTrackId
+    ?? ui.openDrumMachineTrackId
+    ?? null;
+
+  if (directTrackId) {
+    return project.tracks.find((track) => track.id === directTrackId) ?? null;
+  }
+
+  const firstSelectedClipId = ui.selectedClipIds ? [...ui.selectedClipIds][0] : null;
+  if (firstSelectedClipId) {
+    return project.tracks.find((track) => track.clips.some((clip) => clip.id === firstSelectedClipId)) ?? null;
+  }
+
+  return project.tracks[0] ?? null;
+}
+
+function getActivePanels(ui: AssistantUIContext): string[] {
+  const panels: string[] = [];
+  if (ui.showMixer) panels.push('Mixer');
+  if (ui.showLibrary) panels.push('Library');
+  if (ui.loopBrowserOpen) panels.push('Loop Browser');
+  if (ui.showSmartControls) panels.push('Smart Controls');
+  if (ui.showAIAssistant) panels.push('AI Assistant');
+  return panels;
 }

--- a/tests/e2e/ai-assistant.spec.ts
+++ b/tests/e2e/ai-assistant.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('AI Assistant', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined');
+    await page.evaluate(() => {
+      const store = (window as any).__store;
+      store.getState().createProject({ name: 'Assistant Test', bpm: 128 });
+      const track = store.getState().addTrack('drums');
+      (window as any).__uiStore.getState().setExpandedTrackId(track.id);
+    });
+    await page.mouse.click(24, 24);
+  });
+
+  test('opens with Cmd+/ and streams a context-aware production reply', async ({ page }) => {
+    test.slow();
+
+    await page.keyboard.press('Meta+/');
+    await expect(page.getByRole('complementary', { name: 'AI Assistant' })).toBeVisible();
+
+    await page.getByLabel('Chat input').fill('How do I make my drums punch harder?');
+    await page.getByLabel('Send message').click();
+
+    await page.waitForFunction(() => (window as any).__uiStore.getState().aiAssistantStreaming === true);
+
+    await expect.poll(async () => (
+      page.evaluate(() => {
+        const messages = (window as any).__uiStore.getState().aiChatMessages;
+        return messages[messages.length - 1]?.content.length ?? 0;
+      })
+    )).toBeGreaterThan(20);
+
+    await page.waitForFunction(() => (window as any).__uiStore.getState().aiAssistantStreaming === false);
+
+    const assistantReply = await page.evaluate(() => {
+      const messages = (window as any).__uiStore.getState().aiChatMessages;
+      return messages[messages.length - 1]?.content ?? '';
+    });
+
+    expect(assistantReply).toContain('128 BPM');
+    expect(assistantReply.toLowerCase()).toContain('drum');
+  });
+
+  test('supports agent-driven questions through the exposed assistant store', async ({ page }) => {
+    await page.evaluate(async () => {
+      await (window as any).__assistantStore.getState().askAIAssistant(
+        'What shortcuts are useful in the current workspace?',
+        { delayMs: 0 },
+      );
+    });
+
+    const reply = await page.evaluate(() => {
+      const messages = (window as any).__assistantStore.getState().aiChatMessages;
+      return messages[messages.length - 1]?.content ?? '';
+    });
+
+    expect(reply).toContain('Cmd+/');
+    expect(reply).toContain('Mixer');
+  });
+});

--- a/tests/unit/aiAssistant.test.ts
+++ b/tests/unit/aiAssistant.test.ts
@@ -1,21 +1,23 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { useUIStore } from '../../src/store/uiStore';
 import { useProjectStore } from '../../src/store/projectStore';
+import { useTransportStore } from '../../src/store/transportStore';
 import { buildAssistantContext } from '../../src/utils/aiAssistantContext';
-import type { AIChatMessage } from '../../src/types/aiAssistant';
 
 describe('AI Assistant', () => {
   beforeEach(() => {
     localStorage.clear();
     useUIStore.setState(useUIStore.getInitialState(), true);
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useTransportStore.setState(useTransportStore.getInitialState(), true);
   });
 
-  describe('uiStore — assistant panel state', () => {
+  describe('uiStore assistant state', () => {
     it('assistant panel is closed by default', () => {
       expect(useUIStore.getState().showAIAssistant).toBe(false);
     });
 
-    it('toggles assistant panel open/closed', () => {
+    it('toggles assistant panel open and closed', () => {
       useUIStore.getState().toggleAIAssistant();
       expect(useUIStore.getState().showAIAssistant).toBe(true);
 
@@ -23,61 +25,37 @@ describe('AI Assistant', () => {
       expect(useUIStore.getState().showAIAssistant).toBe(false);
     });
 
-    it('sets assistant panel visibility directly', () => {
-      useUIStore.getState().setShowAIAssistant(true);
-      expect(useUIStore.getState().showAIAssistant).toBe(true);
-
-      useUIStore.getState().setShowAIAssistant(false);
-      expect(useUIStore.getState().showAIAssistant).toBe(false);
-    });
-
-    it('manages chat messages', () => {
-      expect(useUIStore.getState().aiChatMessages).toEqual([]);
-
-      const msg: AIChatMessage = {
+    it('tracks chat messages and streaming state', () => {
+      useUIStore.getState().addAIChatMessage({
         id: 'msg-1',
         role: 'user',
         content: 'How do I add reverb?',
         timestamp: Date.now(),
-      };
-      useUIStore.getState().addAIChatMessage(msg);
-      expect(useUIStore.getState().aiChatMessages).toHaveLength(1);
-      expect(useUIStore.getState().aiChatMessages[0].content).toBe('How do I add reverb?');
-
-      const reply: AIChatMessage = {
-        id: 'msg-2',
-        role: 'assistant',
-        content: 'You can add reverb from the effects chain.',
-        timestamp: Date.now(),
-      };
-      useUIStore.getState().addAIChatMessage(reply);
-      expect(useUIStore.getState().aiChatMessages).toHaveLength(2);
-    });
-
-    it('clears chat messages', () => {
-      useUIStore.getState().addAIChatMessage({
-        id: 'msg-1',
-        role: 'user',
-        content: 'test',
-        timestamp: Date.now(),
       });
-      useUIStore.getState().clearAIChatMessages();
-      expect(useUIStore.getState().aiChatMessages).toEqual([]);
-    });
 
-    it('tracks streaming state', () => {
-      expect(useUIStore.getState().aiAssistantStreaming).toBe(false);
+      expect(useUIStore.getState().aiChatMessages).toHaveLength(1);
 
       useUIStore.getState().setAIAssistantStreaming(true);
       expect(useUIStore.getState().aiAssistantStreaming).toBe(true);
 
+      useUIStore.getState().clearAIChatMessages();
       useUIStore.getState().setAIAssistantStreaming(false);
+
+      expect(useUIStore.getState().aiChatMessages).toEqual([]);
       expect(useUIStore.getState().aiAssistantStreaming).toBe(false);
+    });
+
+    it('seeds contextual suggestions when opened', () => {
+      useProjectStore.getState().createProject({ name: 'Suggestions', bpm: 124 });
+      useProjectStore.getState().addTrack('drums');
+
+      useUIStore.getState().setShowAIAssistant(true);
+
+      expect(useUIStore.getState().aiAssistantSuggestions.length).toBeGreaterThan(0);
     });
 
     it('persists assistant panel open state', () => {
       useUIStore.getState().setShowAIAssistant(true);
-      // Partialize should include showAIAssistant
       const persisted = JSON.parse(localStorage.getItem('ace-step-daw-ui') || '{}');
       expect(persisted.state.showAIAssistant).toBe(true);
     });
@@ -85,34 +63,66 @@ describe('AI Assistant', () => {
 
   describe('buildAssistantContext', () => {
     it('returns minimal context when no project is loaded', () => {
-      const ctx = buildAssistantContext(null, null);
-      expect(ctx).toContain('No project loaded');
+      const ctx = buildAssistantContext(null);
+      expect(ctx.summary).toContain('No project loaded');
     });
 
     it('includes project info in context', () => {
       useProjectStore.getState().createProject({ name: 'My Song', bpm: 128 });
-      const project = useProjectStore.getState().project;
-      const ctx = buildAssistantContext(project, null);
-      expect(ctx).toContain('My Song');
-      expect(ctx).toContain('128');
+      const ctx = buildAssistantContext(useProjectStore.getState().project);
+
+      expect(ctx.summary).toContain('My Song');
+      expect(ctx.summary).toContain('128');
     });
 
-    it('includes selected track details when provided', () => {
-      useProjectStore.getState().createProject({ name: 'Track Test' });
-      const track = useProjectStore.getState().addTrack('drums');
-      const project = useProjectStore.getState().project;
-      const ctx = buildAssistantContext(project, track.id);
-      expect(ctx).toContain('Drums');
-      expect(ctx).toContain('Selected track');
-    });
-
-    it('includes effect chain info for selected track', () => {
+    it('includes focused track details and effects', () => {
       useProjectStore.getState().createProject({ name: 'FX Test' });
       const track = useProjectStore.getState().addTrack('vocals');
       useProjectStore.getState().addTrackEffect(track.id, 'reverb');
-      const project = useProjectStore.getState().project;
-      const ctx = buildAssistantContext(project, track.id);
-      expect(ctx).toContain('reverb');
+
+      const ctx = buildAssistantContext(useProjectStore.getState().project, {
+        expandedTrackId: track.id,
+      });
+
+      expect(ctx.summary).toContain('Focused track');
+      expect(ctx.summary).toContain('reverb');
+    });
+
+    it('includes active panels and transport state', () => {
+      useProjectStore.getState().createProject({ name: 'Context Panels', bpm: 110 });
+      useTransportStore.getState().toggleLoop();
+
+      const ctx = buildAssistantContext(
+        useProjectStore.getState().project,
+        {
+          showMixer: true,
+          showLibrary: true,
+          showAIAssistant: true,
+        },
+        useTransportStore.getState(),
+      );
+
+      expect(ctx.summary).toContain('Open panels: Mixer, Library, AI Assistant');
+      expect(ctx.summary).toContain('loop enabled');
+    });
+  });
+
+  describe('askAIAssistant', () => {
+    it('streams a context-aware reply into store state', async () => {
+      useProjectStore.getState().createProject({ name: 'Beat Lab', bpm: 128 });
+      const track = useProjectStore.getState().addTrack('drums');
+      useProjectStore.getState().addTrackEffect(track.id, 'compressor');
+      useUIStore.getState().setExpandedTrackId(track.id);
+
+      await useUIStore.getState().askAIAssistant('How do I make my drums punch harder?', { delayMs: 0 });
+
+      const messages = useUIStore.getState().aiChatMessages;
+      expect(messages).toHaveLength(2);
+      expect(messages[0].role).toBe('user');
+      expect(messages[1].role).toBe('assistant');
+      expect(messages[1].content).toContain('128 BPM');
+      expect(messages[1].content.toLowerCase()).toContain('drum');
+      expect(useUIStore.getState().aiAssistantStreaming).toBe(false);
     });
   });
 });

--- a/tests/unit/aiAssistantService.test.ts
+++ b/tests/unit/aiAssistantService.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useProjectStore } from '../../src/store/projectStore';
+import { buildAssistantContext } from '../../src/utils/aiAssistantContext';
+import {
+  generateAssistantResponse,
+  getAssistantSuggestions,
+  streamAssistantResponse,
+} from '../../src/services/aiAssistantService';
+
+describe('aiAssistantService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+  });
+
+  it('generates drum-specific suggestions for a focused drum track', () => {
+    useProjectStore.getState().createProject({ name: 'Drum Context', bpm: 126 });
+    const track = useProjectStore.getState().addTrack('drums');
+
+    const context = buildAssistantContext(useProjectStore.getState().project, {
+      expandedTrackId: track.id,
+      showMixer: true,
+    });
+
+    expect(getAssistantSuggestions(context)[0]?.toLowerCase()).toContain('drum');
+  });
+
+  it('uses project context in the generated response', () => {
+    useProjectStore.getState().createProject({ name: 'Context Song', bpm: 122 });
+    const track = useProjectStore.getState().addTrack('drums');
+
+    const context = buildAssistantContext(useProjectStore.getState().project, {
+      expandedTrackId: track.id,
+      showMixer: true,
+      showAIAssistant: true,
+    });
+
+    const response = generateAssistantResponse('How should I balance this mix?', context);
+
+    expect(response).toContain('Context Song');
+    expect(response).toContain('122 BPM');
+    expect(response).toContain('Mixer');
+  });
+
+  it('streams replies in multiple chunks', async () => {
+    useProjectStore.getState().createProject({ name: 'Stream Song', bpm: 128 });
+    const track = useProjectStore.getState().addTrack('drums');
+
+    const context = buildAssistantContext(useProjectStore.getState().project, {
+      expandedTrackId: track.id,
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of streamAssistantResponse('How do I make my drums punch harder?', context, 0)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.length).toBeGreaterThan(2);
+    expect(chunks.join('')).toContain('128 BPM');
+    expect(chunks.join('').toLowerCase()).toContain('drum');
+  });
+});


### PR DESCRIPTION
## Summary
- add a real in-DAW AI assistant service with store-driven streaming responses and agent-callable API exposure
- upgrade assistant context synthesis so replies understand focused track, visible panels, transport state, and current project metadata
- add competitive research, executable plan docs, unit coverage, and Playwright coverage for human and agent assistant workflows

## What Changed
- moved assistant orchestration out of the panel component and into `uiStore` + `aiAssistantService`
- added `window.__assistantStore` so agents can call `askAIAssistant(...)` directly
- replaced delayed full-message replies with streamed message updates in the chat panel
- made empty-state prompts context-aware instead of static
- expanded assistant context building to cover focused track resolution, panel visibility, and loop/play transport state
- added issue-specific research and implementation plan docs under `docs/`

## Verification
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `E2E_PORT=5174 npx playwright test tests/e2e/ai-assistant.spec.ts --workers=1`

## User Stories
- As a human user, I want to press `Cmd+/`, ask how to improve my current track, and see a streamed reply that uses my current DAW context.
- As an AI agent, I want to call `window.__assistantStore.getState().askAIAssistant(question)` and inspect the streamed response in store state, so I can automate help workflows programmatically.
