### PR TITLE
feat: add shortcut editor with DAW migration presets (closes #338)

### DIFF
--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -157,10 +157,19 @@ export function KeyboardShortcutsDialog() {
         </div>
 
         {/* Footer */}
-        <div className="px-5 py-2.5 border-t border-daw-border text-center">
+        <div className="flex items-center justify-between px-5 py-2.5 border-t border-daw-border">
           <p className="text-[10px] text-zinc-600">
             Shortcuts are disabled when typing in text fields. Press <Key label="Esc" /> or <Key label="?" /> to toggle this overlay.
           </p>
+          <button
+            onClick={() => {
+              setShow(false);
+              useUIStore.getState().setShowShortcutEditorDialog(true);
+            }}
+            className="ml-3 px-3 py-1 text-[10px] rounded bg-daw-accent text-white hover:brightness-110 transition-colors whitespace-nowrap flex-shrink-0"
+          >
+            Customize…
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/dialogs/ShortcutEditorDialog.tsx
+++ b/src/components/dialogs/ShortcutEditorDialog.tsx
@@ -1,0 +1,320 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useUIStore } from '../../store/uiStore';
+import { useShortcutsStore, comboEquals } from '../../store/shortcutsStore';
+import { SHORTCUT_ACTIONS, SHORTCUT_CATEGORIES, SHORTCUT_ACTION_MAP } from '../../constants/shortcutDefaults';
+import { SHORTCUT_PRESETS } from '../../constants/shortcutPresets';
+import type { KeyCombo, ShortcutCategory } from '../../types/shortcuts';
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function comboToDisplay(combo: KeyCombo): string {
+  const parts: string[] = [];
+  if (combo.mod) parts.push(isMac ? '⌘' : 'Ctrl');
+  if (combo.shift) parts.push(isMac ? '⇧' : 'Shift');
+  if (combo.alt) parts.push(isMac ? '⌥' : 'Alt');
+  parts.push(codeToLabel(combo.code));
+  return parts.join(' + ');
+}
+
+function codeToLabel(code: string): string {
+  const map: Record<string, string> = {
+    Space: 'Space', Enter: '↵', Backspace: '⌫', Delete: 'Del',
+    ArrowLeft: '←', ArrowRight: '→', ArrowUp: '↑', ArrowDown: '↓',
+    Home: 'Home', End: 'End', Escape: 'Esc',
+    Equal: '=', Minus: '-', Comma: ',', Period: '.', Slash: '/',
+    Digit0: '0', Digit1: '1', Digit2: '2', Digit3: '3', Digit4: '4',
+    Digit5: '5', Digit6: '6', Digit7: '7', Digit8: '8', Digit9: '9',
+    Numpad0: 'Num0', NumpadAdd: 'Num+', NumpadSubtract: 'Num-',
+    NumpadEnter: 'Num↵',
+    F1: 'F1', F2: 'F2', F3: 'F3', F4: 'F4', F5: 'F5', F6: 'F6',
+    F7: 'F7', F8: 'F8', F9: 'F9', F10: 'F10', F11: 'F11', F12: 'F12',
+  };
+  if (map[code]) return map[code];
+  if (code.startsWith('Key')) return code.slice(3);
+  return code;
+}
+
+function keyEventToCombo(e: KeyboardEvent): KeyCombo | null {
+  // Ignore bare modifier keys
+  if (['Meta', 'Control', 'Shift', 'Alt'].includes(e.key)) return null;
+  return {
+    code: e.code,
+    mod: e.metaKey || e.ctrlKey || undefined,
+    shift: e.shiftKey || undefined,
+    alt: e.altKey || undefined,
+  };
+}
+
+// ── Key Badge ────────────────────────────────────────────────────
+
+function KeyBadge({ label }: { label: string }) {
+  return (
+    <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded text-[10px] font-mono font-semibold bg-[#444] border border-zinc-600 text-zinc-200 shadow-sm">
+      {label}
+    </kbd>
+  );
+}
+
+// ── Shortcut Row ─────────────────────────────────────────────────
+
+interface RowProps {
+  actionId: string;
+  label: string;
+  combo: KeyCombo;
+  defaultCombo: KeyCombo;
+  isRecording: boolean;
+  conflictLabel: string | null;
+  onStartRecord: () => void;
+  onReset: () => void;
+}
+
+function ShortcutRow({ actionId, label, combo, defaultCombo, isRecording, conflictLabel, onStartRecord, onReset }: RowProps) {
+  const isCustom = !comboEquals(combo, defaultCombo);
+
+  return (
+    <div
+      className={`flex items-center gap-3 px-2 py-1.5 rounded ${
+        isRecording ? 'bg-daw-accent/20 ring-1 ring-daw-accent' : 'hover:bg-white/5'
+      }`}
+      data-action-id={actionId}
+    >
+      <span className="text-xs text-zinc-400 flex-1 truncate">{label}</span>
+
+      {conflictLabel && (
+        <span className="text-[10px] text-amber-400 truncate max-w-[120px]">
+          conflicts with {conflictLabel}
+        </span>
+      )}
+
+      <button
+        onClick={onStartRecord}
+        className={`flex items-center gap-1 flex-shrink-0 px-2 py-0.5 rounded border text-xs transition-colors ${
+          isRecording
+            ? 'border-daw-accent text-daw-accent animate-pulse'
+            : 'border-zinc-600 text-zinc-300 hover:border-zinc-400'
+        }`}
+        title="Click to rebind, then press a key combo"
+      >
+        {isRecording ? (
+          <span>Press a key…</span>
+        ) : (
+          <span>{comboToDisplay(combo)}</span>
+        )}
+      </button>
+
+      {isCustom && (
+        <button
+          onClick={onReset}
+          className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors"
+          title={`Reset to default: ${comboToDisplay(defaultCombo)}`}
+        >
+          ↺
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Main Dialog ──────────────────────────────────────────────────
+
+export function ShortcutEditorDialog() {
+  const show = useUIStore((s) => s.showShortcutEditorDialog);
+  const setShow = useUIStore((s) => s.setShowShortcutEditorDialog);
+
+  const overrides = useShortcutsStore((s) => s.overrides);
+  const activePresetId = useShortcutsStore((s) => s.activePresetId);
+  const getCombo = useShortcutsStore((s) => s.getCombo);
+  const setBinding = useShortcutsStore((s) => s.setBinding);
+  const clearBinding = useShortcutsStore((s) => s.clearBinding);
+  const applyPreset = useShortcutsStore((s) => s.applyPreset);
+  const resetAll = useShortcutsStore((s) => s.resetAll);
+  const findConflict = useShortcutsStore((s) => s.findConflict);
+
+  const [activeCategory, setActiveCategory] = useState<ShortcutCategory>('transport');
+  const [recordingId, setRecordingId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // ── Key capture while recording ────────────────────────────────
+  useEffect(() => {
+    if (!recordingId) return;
+
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.code === 'Escape') {
+        setRecordingId(null);
+        return;
+      }
+
+      const combo = keyEventToCombo(e);
+      if (!combo) return;
+
+      setBinding(recordingId, combo);
+      setRecordingId(null);
+    };
+
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [recordingId, setBinding]);
+
+  // Close dialog on Escape when not recording
+  useEffect(() => {
+    if (!show || recordingId) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.code === 'Escape') {
+        e.preventDefault();
+        setShow(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [show, recordingId, setShow]);
+
+  const handlePresetChange = useCallback(
+    (presetId: string) => {
+      if (presetId === 'ace-step') {
+        resetAll();
+      } else {
+        applyPreset(presetId);
+      }
+    },
+    [applyPreset, resetAll],
+  );
+
+  if (!show) return null;
+
+  const lowerQuery = searchQuery.toLowerCase();
+  const filteredActions = searchQuery
+    ? SHORTCUT_ACTIONS.filter((a) => a.label.toLowerCase().includes(lowerQuery))
+    : SHORTCUT_ACTIONS.filter((a) => a.category === activeCategory);
+
+  const customCount = Object.keys(overrides).length;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) {
+          setRecordingId(null);
+          setShow(false);
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className="w-[620px] max-h-[85vh] bg-daw-surface rounded-lg border border-daw-border shadow-2xl flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ── Header ──────────────────────────────────────────────── */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-daw-border">
+          <h2 className="text-sm font-semibold text-zinc-100">Shortcut Editor</h2>
+          <button
+            onClick={() => setShow(false)}
+            className="text-zinc-500 hover:text-zinc-200 transition-colors text-lg leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* ── Preset selector + search ────────────────────────────── */}
+        <div className="flex items-center gap-3 px-5 py-2.5 border-b border-daw-border">
+          <label className="text-[10px] uppercase tracking-widest text-zinc-500">Preset</label>
+          <select
+            value={activePresetId}
+            onChange={(e) => handlePresetChange(e.target.value)}
+            className="flex-1 bg-daw-bg border border-zinc-600 rounded px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-daw-accent"
+          >
+            {SHORTCUT_PRESETS.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+            {activePresetId === 'custom' && (
+              <option value="custom">Custom</option>
+            )}
+          </select>
+
+          <input
+            type="text"
+            placeholder="Search shortcuts…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-[160px] bg-daw-bg border border-zinc-600 rounded px-2 py-1 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-daw-accent"
+          />
+        </div>
+
+        {/* ── Category tabs (hidden when searching) ───────────────── */}
+        {!searchQuery && (
+          <div className="flex gap-1 px-5 pt-2 overflow-x-auto">
+            {SHORTCUT_CATEGORIES.map((cat) => (
+              <button
+                key={cat.id}
+                onClick={() => setActiveCategory(cat.id)}
+                className={`px-2.5 py-1 rounded text-[10px] font-semibold uppercase tracking-wide transition-colors whitespace-nowrap ${
+                  activeCategory === cat.id
+                    ? 'bg-daw-accent text-white'
+                    : 'text-zinc-500 hover:text-zinc-300 hover:bg-white/5'
+                }`}
+              >
+                {cat.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* ── Shortcut list ───────────────────────────────────────── */}
+        <div className="flex-1 overflow-y-auto min-h-0 px-5 py-3 space-y-0.5">
+          {filteredActions.length === 0 && (
+            <p className="text-xs text-zinc-500 text-center py-8">No shortcuts match your search.</p>
+          )}
+          {filteredActions.map((action) => {
+            const combo = getCombo(action.id);
+            const conflictId = findConflict(combo, action.id);
+            const conflictLabel = conflictId ? SHORTCUT_ACTION_MAP[conflictId]?.label ?? null : null;
+
+            return (
+              <ShortcutRow
+                key={action.id}
+                actionId={action.id}
+                label={action.label}
+                combo={combo}
+                defaultCombo={action.defaultCombo}
+                isRecording={recordingId === action.id}
+                conflictLabel={conflictLabel}
+                onStartRecord={() => setRecordingId(action.id)}
+                onReset={() => clearBinding(action.id)}
+              />
+            );
+          })}
+        </div>
+
+        {/* ── Footer ──────────────────────────────────────────────── */}
+        <div className="flex items-center justify-between px-5 py-2.5 border-t border-daw-border">
+          <p className="text-[10px] text-zinc-600">
+            {customCount > 0
+              ? `${customCount} custom binding${customCount > 1 ? 's' : ''}`
+              : 'All shortcuts at defaults'}
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={resetAll}
+              className="px-3 py-1 text-[10px] rounded border border-zinc-600 text-zinc-400 hover:text-zinc-200 hover:border-zinc-400 transition-colors"
+            >
+              Reset All
+            </button>
+            <button
+              onClick={() => setShow(false)}
+              className="px-3 py-1 text-[10px] rounded bg-daw-accent text-white hover:brightness-110 transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -15,6 +15,7 @@ import { ExportDialog } from '../dialogs/ExportDialog';
 import { SettingsDialog } from '../dialogs/SettingsDialog';
 import { ProjectListDialog } from '../dialogs/ProjectListDialog';
 import { KeyboardShortcutsDialog } from '../dialogs/KeyboardShortcutsDialog';
+import { ShortcutEditorDialog } from '../dialogs/ShortcutEditorDialog';
 import { ShareDialog } from '../dialogs/ShareDialog';
 import { AIAssistantPanel } from '../dialogs/AIAssistantPanel';
 import { MixerPanel } from '../mixer/MixerPanel';
@@ -103,6 +104,7 @@ export function AppShell() {
       <SettingsDialog />
       <ProjectListDialog />
       <KeyboardShortcutsDialog />
+      <ShortcutEditorDialog />
       <CoverModal />
       <RepaintModal />
       <Vocal2BGMModal />

--- a/src/constants/shortcutDefaults.ts
+++ b/src/constants/shortcutDefaults.ts
@@ -1,0 +1,80 @@
+import type { ShortcutAction, ShortcutCategory } from '../types/shortcuts';
+
+/**
+ * Canonical list of every re-bindable shortcut action in ACE-Step DAW.
+ *
+ * The `id` field is the stable key used in the shortcuts store; the
+ * `defaultCombo` is the factory-default binding that ships with ACE-Step.
+ */
+export const SHORTCUT_ACTIONS: ShortcutAction[] = [
+  // ── Transport ──────────────────────────────────────────────────
+  { id: 'transport.playPause',   category: 'transport', label: 'Play / Pause',            defaultCombo: { code: 'Space' } },
+  { id: 'transport.stop',        category: 'transport', label: 'Stop + Return to 0',      defaultCombo: { code: 'Enter' } },
+  { id: 'transport.loop',        category: 'transport', label: 'Toggle Loop',              defaultCombo: { code: 'KeyL' } },
+  { id: 'transport.metronome',   category: 'transport', label: 'Toggle Metronome',         defaultCombo: { code: 'KeyK' } },
+  { id: 'transport.record',      category: 'transport', label: 'Toggle Record',            defaultCombo: { code: 'KeyR' } },
+  { id: 'transport.home',        category: 'transport', label: 'Jump to Start',            defaultCombo: { code: 'Home' } },
+  { id: 'transport.end',         category: 'transport', label: 'Jump to End',              defaultCombo: { code: 'End' } },
+  { id: 'transport.nudgeLeft',   category: 'transport', label: 'Nudge Playhead Left',      defaultCombo: { code: 'ArrowLeft' } },
+  { id: 'transport.nudgeRight',  category: 'transport', label: 'Nudge Playhead Right',     defaultCombo: { code: 'ArrowRight' } },
+  { id: 'transport.punchIn',     category: 'transport', label: 'Set Punch-In Point',       defaultCombo: { code: 'KeyI' } },
+  { id: 'transport.punchOut',    category: 'transport', label: 'Set Punch-Out Point',      defaultCombo: { code: 'KeyO' } },
+
+  // ── Clips ──────────────────────────────────────────────────────
+  { id: 'clips.delete',          category: 'clips',     label: 'Delete Selected Clips',    defaultCombo: { code: 'Delete' } },
+  { id: 'clips.duplicate',       category: 'clips',     label: 'Duplicate Clip',           defaultCombo: { code: 'KeyD', mod: true } },
+  { id: 'clips.split',           category: 'clips',     label: 'Split Clip at Playhead',   defaultCombo: { code: 'KeyS' } },
+  { id: 'clips.selectAll',       category: 'clips',     label: 'Select All Clips',         defaultCombo: { code: 'KeyA', mod: true } },
+  { id: 'clips.edit',            category: 'clips',     label: 'Edit Selected Clip',       defaultCombo: { code: 'KeyE' } },
+  { id: 'clips.generate',        category: 'clips',     label: 'Generate Selected Clip',   defaultCombo: { code: 'Enter', mod: true } },
+
+  // ── View ───────────────────────────────────────────────────────
+  { id: 'view.zoomIn',           category: 'view',      label: 'Zoom In',                  defaultCombo: { code: 'Equal', mod: true } },
+  { id: 'view.zoomOut',          category: 'view',      label: 'Zoom Out',                 defaultCombo: { code: 'Minus', mod: true } },
+  { id: 'view.zoomReset',        category: 'view',      label: 'Reset Zoom',               defaultCombo: { code: 'Digit0', mod: true } },
+  { id: 'view.zoomToFit',        category: 'view',      label: 'Zoom to Fit Project',      defaultCombo: { code: 'KeyZ' } },
+  { id: 'view.toggleSnap',       category: 'view',      label: 'Toggle Snap',              defaultCombo: { code: 'KeyN' } },
+
+  // ── Generation ─────────────────────────────────────────────────
+  { id: 'generation.silence',    category: 'generation', label: 'Generate from Silence',   defaultCombo: { code: 'KeyG', mod: true } },
+  { id: 'generation.context',    category: 'generation', label: 'Generate from Context',   defaultCombo: { code: 'KeyG', mod: true, shift: true } },
+
+  // ── Panels ─────────────────────────────────────────────────────
+  { id: 'panels.mixer',          category: 'panels',    label: 'Toggle Mixer',              defaultCombo: { code: 'KeyX' } },
+  { id: 'panels.smartControls',  category: 'panels',    label: 'Toggle Smart Controls',     defaultCombo: { code: 'KeyB' } },
+  { id: 'panels.library',        category: 'panels',    label: 'Toggle Library',            defaultCombo: { code: 'KeyY' } },
+  { id: 'panels.tempoLane',      category: 'panels',    label: 'Toggle Tempo Lane',         defaultCombo: { code: 'KeyT' } },
+  { id: 'panels.aiAssistant',    category: 'panels',    label: 'Toggle AI Assistant',       defaultCombo: { code: 'Slash', mod: true } },
+
+  // ── Project ────────────────────────────────────────────────────
+  { id: 'project.new',           category: 'project',   label: 'New Project',               defaultCombo: { code: 'KeyN', mod: true } },
+  { id: 'project.open',          category: 'project',   label: 'Open Project List',         defaultCombo: { code: 'KeyO', mod: true } },
+  { id: 'project.settings',      category: 'project',   label: 'Settings',                  defaultCombo: { code: 'Comma', mod: true } },
+  { id: 'project.export',        category: 'project',   label: 'Export',                    defaultCombo: { code: 'KeyE', mod: true, shift: true } },
+  { id: 'project.addTrack',      category: 'project',   label: 'Add Track',                 defaultCombo: { code: 'KeyI', mod: true, shift: true } },
+  { id: 'project.help',          category: 'project',   label: 'Keyboard Shortcuts Help',   defaultCombo: { code: 'Slash', shift: true } },
+
+  // ── Piano Roll ─────────────────────────────────────────────────
+  { id: 'pianoRoll.delete',       category: 'pianoRoll', label: 'Delete Selected Notes',    defaultCombo: { code: 'Delete' } },
+  { id: 'pianoRoll.transposeUp',  category: 'pianoRoll', label: 'Transpose Up 1 Semitone',  defaultCombo: { code: 'ArrowUp', shift: true } },
+  { id: 'pianoRoll.transposeDown',category: 'pianoRoll', label: 'Transpose Down 1 Semitone',defaultCombo: { code: 'ArrowDown', shift: true } },
+  { id: 'pianoRoll.quantize',     category: 'pianoRoll', label: 'Quantize Selected Notes',  defaultCombo: { code: 'KeyQ' } },
+  { id: 'pianoRoll.quantizeOpts', category: 'pianoRoll', label: 'Quantize with Options',    defaultCombo: { code: 'KeyQ', mod: true } },
+  { id: 'pianoRoll.selectAll',    category: 'pianoRoll', label: 'Select All Notes',         defaultCombo: { code: 'KeyA', mod: true } },
+];
+
+/** Quick lookup: actionId → ShortcutAction */
+export const SHORTCUT_ACTION_MAP: Record<string, ShortcutAction> = Object.fromEntries(
+  SHORTCUT_ACTIONS.map((a) => [a.id, a]),
+);
+
+/** Ordered list of categories for UI display. */
+export const SHORTCUT_CATEGORIES: { id: ShortcutCategory; label: string }[] = [
+  { id: 'transport',  label: 'Transport' },
+  { id: 'clips',      label: 'Clips' },
+  { id: 'view',       label: 'View' },
+  { id: 'generation', label: 'Generation' },
+  { id: 'panels',     label: 'Panels' },
+  { id: 'project',    label: 'Project' },
+  { id: 'pianoRoll',  label: 'Piano Roll' },
+];

--- a/src/constants/shortcutPresets.ts
+++ b/src/constants/shortcutPresets.ts
@@ -1,0 +1,134 @@
+import type { ShortcutPreset, ShortcutMap } from '../types/shortcuts';
+
+/**
+ * DAW migration presets — each provides a partial ShortcutMap
+ * that overrides only the shortcuts that differ from the ACE-Step defaults.
+ * Actions not listed keep their default binding.
+ */
+
+const abletonMap: ShortcutMap = {
+  // Ableton Live-style bindings
+  'transport.playPause':  { code: 'Space' },
+  'transport.stop':       { code: 'Space' },           // Ableton: space toggles, no separate stop
+  'transport.loop':       { code: 'KeyL', mod: true },  // Ctrl/Cmd+L in Ableton
+  'transport.record':     { code: 'F9' },               // F9 = record in Ableton
+  'transport.nudgeLeft':  { code: 'ArrowLeft' },
+  'transport.nudgeRight': { code: 'ArrowRight' },
+  'clips.delete':         { code: 'Delete' },
+  'clips.duplicate':      { code: 'KeyD', mod: true },
+  'clips.split':          { code: 'KeyE', mod: true },  // Cmd+E = split in Ableton
+  'clips.selectAll':      { code: 'KeyA', mod: true },
+  'view.zoomIn':          { code: 'Equal', mod: true },
+  'view.zoomOut':         { code: 'Minus', mod: true },
+  'view.toggleSnap':      { code: 'KeyB', mod: true },  // Cmd+B = snap in Ableton
+  'panels.mixer':         { code: 'KeyM', mod: true },  // Cmd+M = mixer in Ableton
+  'panels.library':       { code: 'KeyL', mod: true, alt: true }, // Cmd+Alt+L
+  'project.new':          { code: 'KeyN', mod: true },
+  'project.export':       { code: 'KeyE', mod: true, shift: true },
+  'project.settings':     { code: 'Comma', mod: true },
+};
+
+const logicProMap: ShortcutMap = {
+  // Logic Pro-style bindings
+  'transport.playPause':    { code: 'Space' },
+  'transport.stop':         { code: 'Digit0' },           // 0 on numpad = stop in Logic
+  'transport.loop':         { code: 'KeyC' },              // C = cycle (loop) in Logic
+  'transport.metronome':    { code: 'KeyK' },
+  'transport.record':       { code: 'KeyR' },
+  'transport.home':         { code: 'Home' },
+  'clips.delete':           { code: 'Backspace' },
+  'clips.duplicate':        { code: 'KeyD', mod: true },
+  'clips.split':            { code: 'KeyT', mod: true },  // Cmd+T = split in Logic
+  'clips.selectAll':        { code: 'KeyA', mod: true },
+  'clips.edit':             { code: 'KeyE' },
+  'view.zoomIn':            { code: 'Equal', mod: true },
+  'view.zoomOut':           { code: 'Minus', mod: true },
+  'view.zoomToFit':         { code: 'KeyZ' },
+  'view.toggleSnap':        { code: 'KeyN' },
+  'panels.mixer':           { code: 'KeyX' },
+  'panels.smartControls':   { code: 'KeyB' },
+  'panels.library':         { code: 'KeyY' },
+  'project.new':            { code: 'KeyN', mod: true },
+  'project.settings':       { code: 'Comma', mod: true },
+  'project.export':         { code: 'KeyE', mod: true },  // Cmd+E = bounce in Logic
+};
+
+const flStudioMap: ShortcutMap = {
+  // FL Studio-style bindings
+  'transport.playPause':    { code: 'Space' },
+  'transport.stop':         { code: 'Space', mod: true },  // Ctrl+Space = stop in FL
+  'transport.loop':         { code: 'KeyL', mod: true },
+  'transport.metronome':    { code: 'KeyM', mod: true },   // Ctrl+M = metronome in FL
+  'transport.record':       { code: 'KeyR', mod: true },   // Ctrl+R = record mode in FL
+  'clips.delete':           { code: 'Delete' },
+  'clips.duplicate':        { code: 'KeyB', mod: true },   // Ctrl+B = duplicate in FL
+  'clips.split':            { code: 'KeyS', mod: true, shift: true },
+  'clips.selectAll':        { code: 'KeyA', mod: true },
+  'view.zoomIn':            { code: 'Equal', mod: true },
+  'view.zoomOut':           { code: 'Minus', mod: true },
+  'view.toggleSnap':        { code: 'KeyS', alt: true },   // Alt+S in FL
+  'panels.mixer':           { code: 'F9' },                // F9 = mixer in FL
+  'panels.library':         { code: 'F8' },                // F8 = plugin picker in FL
+  'project.new':            { code: 'KeyN', mod: true },
+  'project.export':         { code: 'KeyR', mod: true, shift: true },
+  'project.settings':       { code: 'F11' },
+};
+
+const proToolsMap: ShortcutMap = {
+  // Pro Tools-style bindings
+  'transport.playPause':    { code: 'Space' },
+  'transport.stop':         { code: 'Space' },              // Same key stops in Pro Tools
+  'transport.loop':         { code: 'Digit4', mod: true },  // Cmd+4 in Pro Tools (numpad)
+  'transport.metronome':    { code: 'Digit7' },             // 7 on numpad = click
+  'transport.record':       { code: 'F12' },                // F12 = record in Pro Tools
+  'transport.home':         { code: 'Enter' },              // Return = go to start in Pro Tools
+  'clips.delete':           { code: 'Delete' },
+  'clips.duplicate':        { code: 'KeyD', mod: true },
+  'clips.split':            { code: 'KeyB' },               // B = separate clip in Pro Tools
+  'clips.selectAll':        { code: 'KeyA', mod: true },
+  'view.zoomIn':            { code: 'KeyT' },               // T = zoom in on Pro Tools
+  'view.zoomOut':           { code: 'KeyR' },               // R = zoom out on Pro Tools
+  'view.zoomToFit':         { code: 'KeyA', alt: true },    // Alt+A = zoom to fit in Pro Tools
+  'view.toggleSnap':        { code: 'KeyN' },
+  'panels.mixer':           { code: 'Equal', mod: true },   // Cmd+= = mix window in PT
+  'project.new':            { code: 'KeyN', mod: true },
+  'project.export':         { code: 'KeyB', mod: true, shift: true, alt: true },
+  'project.settings':       { code: 'Comma', mod: true },
+};
+
+export const SHORTCUT_PRESETS: ShortcutPreset[] = [
+  {
+    id: 'ace-step',
+    name: 'ACE-Step (Default)',
+    description: 'Default ACE-Step DAW shortcuts',
+    map: {},  // Empty = all defaults
+  },
+  {
+    id: 'ableton-live',
+    name: 'Ableton Live',
+    description: 'Shortcuts inspired by Ableton Live',
+    map: abletonMap,
+  },
+  {
+    id: 'logic-pro',
+    name: 'Logic Pro',
+    description: 'Shortcuts inspired by Logic Pro',
+    map: logicProMap,
+  },
+  {
+    id: 'fl-studio',
+    name: 'FL Studio',
+    description: 'Shortcuts inspired by FL Studio',
+    map: flStudioMap,
+  },
+  {
+    id: 'pro-tools',
+    name: 'Pro Tools',
+    description: 'Shortcuts inspired by Pro Tools',
+    map: proToolsMap,
+  },
+];
+
+export const SHORTCUT_PRESET_MAP: Record<string, ShortcutPreset> = Object.fromEntries(
+  SHORTCUT_PRESETS.map((p) => [p.id, p]),
+);

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -4,8 +4,10 @@ import { useUIStore } from '../store/uiStore';
 import { useProjectStore } from '../store/projectStore';
 import { useTransportStore } from '../store/transportStore';
 import { useGenerationStore } from '../store/generationStore';
+import { useShortcutsStore } from '../store/shortcutsStore';
 import { generateSingleClip } from '../services/generationPipeline';
 import { useRecording } from './useRecording';
+import type { KeyCombo } from '../types/shortcuts';
 
 function isInputFocused(e: KeyboardEvent): boolean {
   return (
@@ -18,6 +20,17 @@ function isInputFocused(e: KeyboardEvent): boolean {
 const NUDGE_SECONDS = 5;
 const DEFAULT_PIXELS_PER_SECOND = 50;
 
+/** Check whether a keyboard event matches a KeyCombo binding. */
+function eventMatchesCombo(e: KeyboardEvent, combo: KeyCombo): boolean {
+  const mod = e.metaKey || e.ctrlKey;
+  return (
+    e.code === combo.code &&
+    mod === !!combo.mod &&
+    e.shiftKey === !!combo.shift &&
+    e.altKey === !!combo.alt
+  );
+}
+
 export function useKeyboardShortcuts() {
   const { play, pause, stop, seek } = useTransport();
   const { toggleRecord } = useRecording();
@@ -25,10 +38,10 @@ export function useKeyboardShortcuts() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
+      const getCombo = useShortcutsStore.getState().getCombo;
 
       // Undo/Redo are always available — even when an input field is focused
       if (mod && e.code === 'KeyZ' && !e.altKey) {
-        // Only intercept if we're not in a native text field that handles its own undo
         if (!isInputFocused(e)) {
           e.preventDefault();
           if (e.shiftKey) {
@@ -47,8 +60,11 @@ export function useKeyboardShortcuts() {
       const transport = useTransportStore.getState();
       const gen = useGenerationStore.getState();
 
+      // ─── Helper: check if event matches a given action's binding ───
+      const matches = (actionId: string) => eventMatchesCombo(e, getCombo(actionId));
+
       // -----------------------------------------------------------------------
-      // Escape — close topmost modal in priority order
+      // Escape — close topmost modal in priority order (not rebindable)
       // -----------------------------------------------------------------------
       if (e.code === 'Escape') {
         if (ui.showAIAssistant) {
@@ -63,6 +79,9 @@ export function useKeyboardShortcuts() {
         } else if (ui.showKeyboardShortcutsDialog) {
           e.preventDefault();
           ui.setShowKeyboardShortcutsDialog(false);
+        } else if (ui.showShortcutEditorDialog) {
+          e.preventDefault();
+          ui.setShowShortcutEditorDialog(false);
         } else if (ui.showInstrumentPicker) {
           e.preventDefault();
           ui.setShowInstrumentPicker(false);
@@ -92,6 +111,7 @@ export function useKeyboardShortcuts() {
         ui.editingClipId !== null ||
         ui.batchGenerateMode !== null ||
         ui.showKeyboardShortcutsDialog ||
+        ui.showShortcutEditorDialog ||
         ui.showInstrumentPicker ||
         ui.showSettingsDialog ||
         ui.showExportDialog ||
@@ -99,266 +119,165 @@ export function useKeyboardShortcuts() {
         ui.showNewProjectDialog;
 
       // -----------------------------------------------------------------------
-      // Mod + key shortcuts (work even with modals closed)
+      // Mod shortcuts — zoom always works, others check anyModalOpen
       // -----------------------------------------------------------------------
-      if (mod) {
-        switch (e.code) {
-          // Zoom
-          case 'Equal':   // Cmd/Ctrl + =  (also +)
-          case 'NumpadAdd':
-            e.preventDefault();
-            ui.zoomIn();
-            return;
-          case 'Minus':
-          case 'NumpadSubtract':
-            e.preventDefault();
-            ui.zoomOut();
-            return;
-          case 'Digit0':
-          case 'Numpad0':
-            e.preventDefault();
-            ui.setPixelsPerSecond(DEFAULT_PIXELS_PER_SECOND);
-            return;
 
-          // Project
-          case 'Comma':   // Cmd+,  → Settings
-            e.preventDefault();
-            if (!anyModalOpen) ui.setShowSettingsDialog(true);
-            return;
-          case 'KeyN':
-            e.preventDefault();
-            if (!anyModalOpen) ui.setShowNewProjectDialog(true);
-            return;
-          case 'KeyO':
-            e.preventDefault();
-            if (!anyModalOpen) ui.setShowProjectListDialog(true);
-            return;
+      // Zoom (always)
+      if (matches('view.zoomIn')) { e.preventDefault(); ui.zoomIn(); return; }
+      if (matches('view.zoomOut')) { e.preventDefault(); ui.zoomOut(); return; }
+      if (matches('view.zoomReset')) { e.preventDefault(); ui.setPixelsPerSecond(DEFAULT_PIXELS_PER_SECOND); return; }
 
-          // Generation
-          case 'KeyG':
-            e.preventDefault();
-            if (!anyModalOpen && !gen.isGenerating) {
-              if (e.shiftKey) {
-                ui.setBatchGenerateMode('context');
-              } else {
-                ui.setBatchGenerateMode('silence');
-              }
-            }
-            return;
+      // Project shortcuts (require no modal)
+      if (matches('project.settings')) { e.preventDefault(); if (!anyModalOpen) ui.setShowSettingsDialog(true); return; }
+      if (matches('project.new')) { e.preventDefault(); if (!anyModalOpen) ui.setShowNewProjectDialog(true); return; }
+      if (matches('project.open')) { e.preventDefault(); if (!anyModalOpen) ui.setShowProjectListDialog(true); return; }
+      if (matches('project.export')) { e.preventDefault(); if (!anyModalOpen) ui.setShowExportDialog(true); return; }
+      if (matches('project.addTrack')) { e.preventDefault(); if (!anyModalOpen) ui.setShowInstrumentPicker(true); return; }
+      if (matches('project.help')) { e.preventDefault(); if (!anyModalOpen) ui.setShowKeyboardShortcutsDialog(true); return; }
 
-          // AI Assistant toggle (Cmd+/)
-          case 'Slash':
-            e.preventDefault();
-            ui.toggleAIAssistant();
-            return;
-
-          // Export
-          case 'KeyE':
-            if (e.shiftKey) {
-              e.preventDefault();
-              if (!anyModalOpen) ui.setShowExportDialog(true);
-            }
-            return;
-
-          // Add Track
-          case 'KeyI':
-            if (e.shiftKey) {
-              e.preventDefault();
-              if (!anyModalOpen) ui.setShowInstrumentPicker(true);
-            }
-            return;
-
-          // Clips
-          case 'KeyA':
-            e.preventDefault();
-            if (!anyModalOpen && project.project) {
-              const allClips = project.project.tracks.flatMap((t) => t.clips);
-              if (allClips.length > 0) {
-                const firstId = allClips[0].id;
-                ui.selectClip(firstId, false);
-                for (let i = 1; i < allClips.length; i++) {
-                  ui.selectClip(allClips[i].id, true);
-                }
-              }
-            }
-            return;
-          case 'KeyD':
-            e.preventDefault();
-            if (!anyModalOpen) {
-              const [firstSelected] = ui.selectedClipIds;
-              if (firstSelected) {
-                project.duplicateClip(firstSelected);
-              }
-            }
-            return;
-          case 'Enter':
-          case 'NumpadEnter':
-            // Cmd+Return → generate selected clip
-            e.preventDefault();
-            if (!anyModalOpen && !gen.isGenerating) {
-              const [clipId] = ui.selectedClipIds;
-              if (clipId) {
-                generateSingleClip(clipId);
-              }
-            }
-            return;
-        }
-        // Let other Cmd combos pass through (browser copy/paste etc.)
+      // Generation
+      if (matches('generation.context')) {
+        e.preventDefault();
+        if (!anyModalOpen && !gen.isGenerating) ui.setBatchGenerateMode('context');
         return;
       }
+      if (matches('generation.silence')) {
+        e.preventDefault();
+        if (!anyModalOpen && !gen.isGenerating) ui.setBatchGenerateMode('silence');
+        return;
+      }
+
+      // AI Assistant
+      if (matches('panels.aiAssistant')) { e.preventDefault(); ui.toggleAIAssistant(); return; }
+
+      // Clip actions with mod
+      if (matches('clips.selectAll')) {
+        e.preventDefault();
+        if (!anyModalOpen && project.project) {
+          const allClips = project.project.tracks.flatMap((t) => t.clips);
+          if (allClips.length > 0) {
+            const firstId = allClips[0].id;
+            ui.selectClip(firstId, false);
+            for (let i = 1; i < allClips.length; i++) {
+              ui.selectClip(allClips[i].id, true);
+            }
+          }
+        }
+        return;
+      }
+      if (matches('clips.duplicate')) {
+        e.preventDefault();
+        if (!anyModalOpen) {
+          const [firstSelected] = ui.selectedClipIds;
+          if (firstSelected) project.duplicateClip(firstSelected);
+        }
+        return;
+      }
+      if (matches('clips.generate')) {
+        e.preventDefault();
+        if (!anyModalOpen && !gen.isGenerating) {
+          const [clipId] = ui.selectedClipIds;
+          if (clipId) generateSingleClip(clipId);
+        }
+        return;
+      }
+
+      // If event uses mod and hasn't matched anything above, let it pass through
+      if (mod) return;
 
       // -----------------------------------------------------------------------
       // Non-mod shortcuts — skip if any modal is open
       // -----------------------------------------------------------------------
       if (anyModalOpen) return;
 
-      switch (e.code) {
-        // Transport
-        case 'Space':
-          e.preventDefault();
-          if (transport.isPlaying) pause();
-          else play();
-          break;
-
-        case 'Enter':
-        case 'NumpadEnter':
-          e.preventDefault();
-          stop();
-          break;
-
-        case 'KeyL':
-          e.preventDefault();
-          transport.toggleLoop();
-          break;
-
-        case 'KeyK':
-          e.preventDefault();
-          transport.toggleMetronome();
-          break;
-
-        case 'KeyR':
-          e.preventDefault();
-          void toggleRecord();
-          break;
-
-        case 'Home':
-          e.preventDefault();
-          seek(0);
-          break;
-
-        case 'End':
-          e.preventDefault();
-          if (project.project) seek(project.project.totalDuration);
-          break;
-
-        case 'ArrowLeft':
-          e.preventDefault();
-          seek(Math.max(0, transport.currentTime - NUDGE_SECONDS));
-          break;
-
-        case 'ArrowRight':
-          e.preventDefault();
-          seek(transport.currentTime + NUDGE_SECONDS);
-          break;
-
-        // Clips — require selection
-        case 'Delete':
-        case 'Backspace':
-          e.preventDefault();
-          if (ui.selectedClipIds.size > 0) {
-            const ids = [...ui.selectedClipIds];
-            ui.deselectAll();
-            ids.forEach((id) => project.removeClip(id));
-          }
-          break;
-
-        case 'KeyE': {
-          // Open editor for single selected clip
-          const selected = [...ui.selectedClipIds];
-          if (selected.length === 1) {
-            e.preventDefault();
-            ui.setEditingClip(selected[0]);
-          }
-          break;
-        }
-
-        // Split clip at playhead
-        case 'KeyS': {
-          const selected = [...ui.selectedClipIds];
-          if (selected.length === 1) {
-            e.preventDefault();
-            project.splitClip(selected[0], transport.currentTime);
-          }
-          break;
-        }
-
-        // Zoom to fit project (Z)
-        case 'KeyZ':
-          if (!e.shiftKey) {
-            e.preventDefault();
-            if (project.project && project.project.totalDuration > 0) {
-              // Calculate pixels per second to fit the entire project in the viewport
-              const viewportWidth = window.innerWidth - 200; // approximate sidebar width
-              const fitPps = Math.max(10, Math.min(500, viewportWidth / project.project.totalDuration));
-              ui.setPixelsPerSecond(fitPps);
-            }
-          }
-          break;
-
-        // Snap toggle (N for snap oN/off)
-        case 'KeyN':
-          e.preventDefault();
-          ui.toggleSnap();
-          break;
-
-        // Mixer toggle (X like GarageBand)
-        case 'KeyX':
-          e.preventDefault();
-          ui.setShowMixer(!ui.showMixer);
-          break;
-
-        // Smart Controls toggle (B like GarageBand)
-        case 'KeyB':
-          e.preventDefault();
-          ui.setShowSmartControls(!ui.showSmartControls);
-          break;
-
-        // Punch In — set punch-in point at playhead (I)
-        case 'KeyI':
-          e.preventDefault();
-          transport.setPunchIn(transport.currentTime);
-          break;
-
-        // Punch Out — set punch-out point at playhead (O)
-        case 'KeyO':
-          e.preventDefault();
-          transport.setPunchOut(transport.currentTime);
-          break;
-
-        // Library toggle (Y)
-        case 'KeyY':
-          e.preventDefault();
-          ui.setShowLibrary(!ui.showLibrary);
-          break;
-
-        // Tempo lane toggle (T)
-        case 'KeyT':
-          e.preventDefault();
-          ui.toggleTempoLane();
-          break;
-
-        // Help
-        case 'Slash':
-          // ? key (Shift+/ on most keyboards)
-          if (e.shiftKey) {
-            e.preventDefault();
-            ui.setShowKeyboardShortcutsDialog(true);
-          }
-          break;
+      // Transport
+      if (matches('transport.playPause')) {
+        e.preventDefault();
+        if (transport.isPlaying) pause(); else play();
+        return;
       }
+      if (matches('transport.stop')) {
+        e.preventDefault();
+        stop();
+        return;
+      }
+      if (matches('transport.loop')) { e.preventDefault(); transport.toggleLoop(); return; }
+      if (matches('transport.metronome')) { e.preventDefault(); transport.toggleMetronome(); return; }
+      if (matches('transport.record')) { e.preventDefault(); void toggleRecord(); return; }
+      if (matches('transport.home')) { e.preventDefault(); seek(0); return; }
+      if (matches('transport.end')) {
+        e.preventDefault();
+        if (project.project) seek(project.project.totalDuration);
+        return;
+      }
+      if (matches('transport.nudgeLeft')) {
+        e.preventDefault();
+        seek(Math.max(0, transport.currentTime - NUDGE_SECONDS));
+        return;
+      }
+      if (matches('transport.nudgeRight')) {
+        e.preventDefault();
+        seek(transport.currentTime + NUDGE_SECONDS);
+        return;
+      }
+      if (matches('transport.punchIn')) {
+        e.preventDefault();
+        transport.setPunchIn(transport.currentTime);
+        return;
+      }
+      if (matches('transport.punchOut')) {
+        e.preventDefault();
+        transport.setPunchOut(transport.currentTime);
+        return;
+      }
+
+      // Clips
+      if (matches('clips.delete')) {
+        e.preventDefault();
+        if (ui.selectedClipIds.size > 0) {
+          const ids = [...ui.selectedClipIds];
+          ui.deselectAll();
+          ids.forEach((id) => project.removeClip(id));
+        }
+        return;
+      }
+      if (matches('clips.edit')) {
+        const selected = [...ui.selectedClipIds];
+        if (selected.length === 1) {
+          e.preventDefault();
+          ui.setEditingClip(selected[0]);
+        }
+        return;
+      }
+      if (matches('clips.split')) {
+        const selected = [...ui.selectedClipIds];
+        if (selected.length === 1) {
+          e.preventDefault();
+          project.splitClip(selected[0], transport.currentTime);
+        }
+        return;
+      }
+
+      // View
+      if (matches('view.zoomToFit')) {
+        e.preventDefault();
+        if (project.project && project.project.totalDuration > 0) {
+          const viewportWidth = window.innerWidth - 200;
+          const fitPps = Math.max(10, Math.min(500, viewportWidth / project.project.totalDuration));
+          ui.setPixelsPerSecond(fitPps);
+        }
+        return;
+      }
+      if (matches('view.toggleSnap')) { e.preventDefault(); ui.toggleSnap(); return; }
+
+      // Panels
+      if (matches('panels.mixer')) { e.preventDefault(); ui.setShowMixer(!ui.showMixer); return; }
+      if (matches('panels.smartControls')) { e.preventDefault(); ui.setShowSmartControls(!ui.showSmartControls); return; }
+      if (matches('panels.library')) { e.preventDefault(); ui.setShowLibrary(!ui.showLibrary); return; }
+      if (matches('panels.tempoLane')) { e.preventDefault(); ui.toggleTempoLane(); return; }
     };
 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [play, pause, stop, seek]);
+  }, [play, pause, stop, seek, toggleRecord]);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { useProjectStore } from './store/projectStore';
 import { useUIStore } from './store/uiStore';
 import { useTransportStore } from './store/transportStore';
 import { useCollaborationStore } from './store/collaborationStore';
+import { useShortcutsStore } from './store/shortcutsStore';
 import { generateProjectSummary, generateProjectStructure } from './utils/dawStateSummary';
 
 // Expose stores globally for agent/automation access
@@ -17,6 +18,7 @@ import { generateProjectSummary, generateProjectStructure } from './utils/dawSta
 (window as unknown as Record<string, unknown>).__transportStore = useTransportStore;
 (window as unknown as Record<string, unknown>).__collaborationStore = useCollaborationStore;
 (window as unknown as Record<string, unknown>).__getAudioEngine = () => getAudioEngine();
+(window as unknown as Record<string, unknown>).__shortcutsStore = useShortcutsStore;
 
 // Expose DAW state summary for LLM agents
 // Agents can call: window.__dawSummary() for natural language, window.__dawStructure() for JSON

--- a/src/store/shortcutsStore.ts
+++ b/src/store/shortcutsStore.ts
@@ -1,0 +1,95 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { KeyCombo, ShortcutMap } from '../types/shortcuts';
+import { SHORTCUT_ACTIONS, SHORTCUT_ACTION_MAP } from '../constants/shortcutDefaults';
+import { SHORTCUT_PRESET_MAP } from '../constants/shortcutPresets';
+
+interface ShortcutsState {
+  /** User overrides keyed by actionId. Missing keys fall back to defaults. */
+  overrides: ShortcutMap;
+  /** The currently active preset id (for display purposes). */
+  activePresetId: string;
+
+  // ── Actions ──────────────────────────────────────────────────
+  /** Resolve the effective combo for an action, falling back to the default. */
+  getCombo: (actionId: string) => KeyCombo;
+  /** Set a single shortcut override. */
+  setBinding: (actionId: string, combo: KeyCombo) => void;
+  /** Remove a single override (revert to default). */
+  clearBinding: (actionId: string) => void;
+  /** Apply a preset — replaces all overrides with the preset's map. */
+  applyPreset: (presetId: string) => void;
+  /** Reset all overrides to factory defaults. */
+  resetAll: () => void;
+  /** Check whether a combo is already used by another action. */
+  findConflict: (combo: KeyCombo, excludeActionId?: string) => string | null;
+}
+
+function comboEquals(a: KeyCombo, b: KeyCombo): boolean {
+  return (
+    a.code === b.code &&
+    !!a.mod === !!b.mod &&
+    !!a.shift === !!b.shift &&
+    !!a.alt === !!b.alt
+  );
+}
+
+export { comboEquals };
+
+export const useShortcutsStore = create<ShortcutsState>()(
+  persist(
+    (set, get) => ({
+      overrides: {},
+      activePresetId: 'ace-step',
+
+      getCombo: (actionId: string): KeyCombo => {
+        const state = get();
+        if (state.overrides[actionId]) return state.overrides[actionId];
+        const action = SHORTCUT_ACTION_MAP[actionId];
+        if (action) return action.defaultCombo;
+        return { code: '' };
+      },
+
+      setBinding: (actionId, combo) =>
+        set((s) => ({
+          overrides: { ...s.overrides, [actionId]: combo },
+          activePresetId: 'custom',
+        })),
+
+      clearBinding: (actionId) =>
+        set((s) => {
+          const next = { ...s.overrides };
+          delete next[actionId];
+          return { overrides: next };
+        }),
+
+      applyPreset: (presetId) => {
+        const preset = SHORTCUT_PRESET_MAP[presetId];
+        if (!preset) return;
+        set({ overrides: { ...preset.map }, activePresetId: presetId });
+      },
+
+      resetAll: () => set({ overrides: {}, activePresetId: 'ace-step' }),
+
+      findConflict: (combo, excludeActionId) => {
+        const state = get();
+        for (const action of SHORTCUT_ACTIONS) {
+          if (action.id === excludeActionId) continue;
+          const effective = state.overrides[action.id] ?? action.defaultCombo;
+          if (comboEquals(combo, effective)) {
+            return action.id;
+          }
+        }
+        return null;
+      },
+    }),
+    {
+      name: 'ace-step-daw-shortcuts',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        overrides: state.overrides,
+        activePresetId: state.activePresetId,
+      }),
+    },
+  ),
+);

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -33,6 +33,7 @@ interface UIState {
   /** Optional time range pre-filled into BatchGenerateModal when opened from a lane drag-select or context menu. */
   batchGenerateInitialRange: { startTime: number; duration: number } | null;
   showKeyboardShortcutsDialog: boolean;
+  showShortcutEditorDialog: boolean;
   showMixer: boolean;
   mixerHeight: number;
   showAssetsPanel: boolean;
@@ -116,6 +117,7 @@ interface UIState {
   setBatchGenerateMode: (mode: 'silence' | 'context' | null) => void;
   setBatchGenerateInitialRange: (v: { startTime: number; duration: number } | null) => void;
   setShowKeyboardShortcutsDialog: (v: boolean) => void;
+  setShowShortcutEditorDialog: (v: boolean) => void;
   setShowMixer: (v: boolean) => void;
   setMixerHeight: (v: number) => void;
   setShowAssetsPanel: (v: boolean) => void;
@@ -198,6 +200,7 @@ export const useUIStore = create<UIState>()(
   batchGenerateMode: null,
   batchGenerateInitialRange: null,
   showKeyboardShortcutsDialog: false,
+  showShortcutEditorDialog: false,
   showMixer: false,
   mixerHeight: 420,
   showAssetsPanel: false,
@@ -295,6 +298,7 @@ export const useUIStore = create<UIState>()(
     : { batchGenerateMode: mode }),
   setBatchGenerateInitialRange: (v) => set({ batchGenerateInitialRange: v }),
   setShowKeyboardShortcutsDialog: (v) => set({ showKeyboardShortcutsDialog: v }),
+  setShowShortcutEditorDialog: (v) => set({ showShortcutEditorDialog: v }),
   setShowMixer: (v) => set({ showMixer: v }),
   setMixerHeight: (v) => set({ mixerHeight: Math.min(500, Math.max(160, v)) }),
   setShowAssetsPanel: (v) => set({ showAssetsPanel: v }),

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -1,0 +1,50 @@
+/**
+ * Keyboard shortcut binding types for the shortcut editor.
+ *
+ * Each shortcut is identified by a unique `actionId` (e.g. "transport.playPause").
+ * A `ShortcutBinding` maps that action to a physical key combo expressed as a
+ * `KeyboardEvent.code` value plus modifier flags.
+ */
+
+/** A single key combination (e.g. Cmd+Shift+G). */
+export interface KeyCombo {
+  code: string;          // KeyboardEvent.code — e.g. "KeyG", "Space", "Digit0"
+  mod?: boolean;         // Cmd/Ctrl
+  shift?: boolean;
+  alt?: boolean;
+}
+
+/** One shortcut binding — maps an action id to a key combo. */
+export interface ShortcutBinding {
+  actionId: string;
+  combo: KeyCombo;
+}
+
+/** Metadata about a shortcut action (for display in the editor). */
+export interface ShortcutAction {
+  id: string;
+  category: ShortcutCategory;
+  label: string;
+  /** Default combo shipped with ACE-Step. */
+  defaultCombo: KeyCombo;
+}
+
+export type ShortcutCategory =
+  | 'transport'
+  | 'clips'
+  | 'view'
+  | 'generation'
+  | 'panels'
+  | 'project'
+  | 'pianoRoll';
+
+/** A complete set of overrides keyed by actionId. */
+export type ShortcutMap = Record<string, KeyCombo>;
+
+/** A named preset that provides a full ShortcutMap override. */
+export interface ShortcutPreset {
+  id: string;
+  name: string;
+  description: string;
+  map: ShortcutMap;
+}

--- a/tests/unit/shortcutsStore.test.ts
+++ b/tests/unit/shortcutsStore.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useShortcutsStore, comboEquals } from '../../src/store/shortcutsStore';
+import { SHORTCUT_ACTIONS, SHORTCUT_ACTION_MAP } from '../../src/constants/shortcutDefaults';
+import { SHORTCUT_PRESETS, SHORTCUT_PRESET_MAP } from '../../src/constants/shortcutPresets';
+import type { KeyCombo } from '../../src/types/shortcuts';
+
+beforeEach(() => {
+  useShortcutsStore.setState({ overrides: {}, activePresetId: 'ace-step' });
+});
+
+// ── comboEquals ──────────────────────────────────────────────────
+
+describe('comboEquals', () => {
+  it('matches identical combos', () => {
+    const a: KeyCombo = { code: 'KeyG', mod: true, shift: true };
+    const b: KeyCombo = { code: 'KeyG', mod: true, shift: true };
+    expect(comboEquals(a, b)).toBe(true);
+  });
+
+  it('treats undefined and false the same for modifier flags', () => {
+    const a: KeyCombo = { code: 'Space' };
+    const b: KeyCombo = { code: 'Space', mod: false, shift: false, alt: false };
+    expect(comboEquals(a, b)).toBe(true);
+  });
+
+  it('returns false when codes differ', () => {
+    expect(comboEquals({ code: 'KeyA' }, { code: 'KeyB' })).toBe(false);
+  });
+
+  it('returns false when modifiers differ', () => {
+    expect(comboEquals({ code: 'KeyA', mod: true }, { code: 'KeyA' })).toBe(false);
+  });
+});
+
+// ── getCombo ─────────────────────────────────────────────────────
+
+describe('getCombo', () => {
+  it('returns the default combo when no override is set', () => {
+    const combo = useShortcutsStore.getState().getCombo('transport.playPause');
+    const action = SHORTCUT_ACTION_MAP['transport.playPause'];
+    expect(combo).toEqual(action.defaultCombo);
+  });
+
+  it('returns the override when one is set', () => {
+    const custom: KeyCombo = { code: 'KeyP', mod: true };
+    useShortcutsStore.getState().setBinding('transport.playPause', custom);
+    expect(useShortcutsStore.getState().getCombo('transport.playPause')).toEqual(custom);
+  });
+
+  it('returns empty combo for unknown action ids', () => {
+    expect(useShortcutsStore.getState().getCombo('nonexistent.action')).toEqual({ code: '' });
+  });
+});
+
+// ── setBinding / clearBinding ────────────────────────────────────
+
+describe('setBinding / clearBinding', () => {
+  it('adds an override and sets activePresetId to custom', () => {
+    const custom: KeyCombo = { code: 'F5' };
+    useShortcutsStore.getState().setBinding('transport.record', custom);
+
+    const state = useShortcutsStore.getState();
+    expect(state.overrides['transport.record']).toEqual(custom);
+    expect(state.activePresetId).toBe('custom');
+  });
+
+  it('clearBinding removes the override', () => {
+    useShortcutsStore.getState().setBinding('transport.record', { code: 'F5' });
+    useShortcutsStore.getState().clearBinding('transport.record');
+    expect(useShortcutsStore.getState().overrides['transport.record']).toBeUndefined();
+  });
+});
+
+// ── applyPreset ──────────────────────────────────────────────────
+
+describe('applyPreset', () => {
+  it('applies a named preset and updates activePresetId', () => {
+    useShortcutsStore.getState().applyPreset('ableton-live');
+
+    const state = useShortcutsStore.getState();
+    expect(state.activePresetId).toBe('ableton-live');
+    // Ableton sets clips.split to Cmd+E
+    const splitCombo = state.overrides['clips.split'];
+    expect(splitCombo).toBeDefined();
+    expect(splitCombo.code).toBe('KeyE');
+    expect(splitCombo.mod).toBe(true);
+  });
+
+  it('does nothing for an unknown preset id', () => {
+    useShortcutsStore.getState().applyPreset('nonexistent');
+    expect(useShortcutsStore.getState().activePresetId).toBe('ace-step');
+  });
+});
+
+// ── resetAll ─────────────────────────────────────────────────────
+
+describe('resetAll', () => {
+  it('clears all overrides and resets preset to ace-step', () => {
+    useShortcutsStore.getState().setBinding('transport.record', { code: 'F5' });
+    useShortcutsStore.getState().resetAll();
+
+    const state = useShortcutsStore.getState();
+    expect(Object.keys(state.overrides)).toHaveLength(0);
+    expect(state.activePresetId).toBe('ace-step');
+  });
+});
+
+// ── findConflict ─────────────────────────────────────────────────
+
+describe('findConflict', () => {
+  it('returns null when no conflict exists', () => {
+    const combo: KeyCombo = { code: 'F20' }; // not used by anything
+    expect(useShortcutsStore.getState().findConflict(combo)).toBeNull();
+  });
+
+  it('detects conflict with a default binding', () => {
+    // Space is bound to transport.playPause by default
+    const conflict = useShortcutsStore.getState().findConflict({ code: 'Space' }, 'some.other.action');
+    expect(conflict).toBe('transport.playPause');
+  });
+
+  it('excludes the specified action from conflict detection', () => {
+    const conflict = useShortcutsStore.getState().findConflict({ code: 'Space' }, 'transport.playPause');
+    expect(conflict).toBeNull();
+  });
+
+  it('detects conflict with an overridden binding', () => {
+    useShortcutsStore.getState().setBinding('transport.record', { code: 'F5' });
+    const conflict = useShortcutsStore.getState().findConflict({ code: 'F5' }, 'some.action');
+    expect(conflict).toBe('transport.record');
+  });
+});
+
+// ── SHORTCUT_ACTIONS ─────────────────────────────────────────────
+
+describe('SHORTCUT_ACTIONS', () => {
+  it('contains at least 30 actions', () => {
+    expect(SHORTCUT_ACTIONS.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('every action has a unique id', () => {
+    const ids = SHORTCUT_ACTIONS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every action has a non-empty label and code', () => {
+    for (const action of SHORTCUT_ACTIONS) {
+      expect(action.label.length).toBeGreaterThan(0);
+      expect(action.defaultCombo.code.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── SHORTCUT_PRESETS ─────────────────────────────────────────────
+
+describe('SHORTCUT_PRESETS', () => {
+  it('includes ace-step, ableton-live, logic-pro, fl-studio, pro-tools', () => {
+    const ids = SHORTCUT_PRESETS.map((p) => p.id);
+    expect(ids).toContain('ace-step');
+    expect(ids).toContain('ableton-live');
+    expect(ids).toContain('logic-pro');
+    expect(ids).toContain('fl-studio');
+    expect(ids).toContain('pro-tools');
+  });
+
+  it('ace-step preset has an empty map (all defaults)', () => {
+    expect(Object.keys(SHORTCUT_PRESET_MAP['ace-step'].map)).toHaveLength(0);
+  });
+
+  it('each preset only references valid action ids', () => {
+    for (const preset of SHORTCUT_PRESETS) {
+      for (const actionId of Object.keys(preset.map)) {
+        expect(SHORTCUT_ACTION_MAP[actionId]).toBeDefined();
+      }
+    }
+  });
+
+  it('each preset entry has a non-empty code for every binding', () => {
+    for (const preset of SHORTCUT_PRESETS) {
+      for (const [, combo] of Object.entries(preset.map)) {
+        expect(combo.code.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Shortcut Editor Dialog** — new modal (`ShortcutEditorDialog`) lets users rebind any of 40+ keyboard shortcuts via key capture. Includes search, category tabs, conflict detection, and a reset-to-default button per binding.
- **DAW Migration Presets** — ship 5 presets: ACE-Step (default), Ableton Live, Logic Pro, FL Studio, and Pro Tools. Users switching from another DAW can apply a familiar layout in one click.
- **Store-driven bindings** — new `shortcutsStore` (Zustand + localStorage persistence) replaces hardcoded key checks in `useKeyboardShortcuts`. Every action resolves via `getCombo()` which respects overrides → preset → default fallback chain.
- **"Customize…" entry point** — added button to the existing Keyboard Shortcuts Help dialog footer, opening the editor directly.
- **23 unit tests** covering store operations, preset validation, and conflict detection.

## Test plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 772/772 pass (23 new)
- [x] `npm run build` — success
- [ ] Manual: press `?` to open help overlay, click "Customize…", verify editor opens
- [ ] Manual: rebind Space to a different key, verify transport responds to new key
- [ ] Manual: apply Ableton Live preset, confirm shortcuts change (e.g. Cmd+E = split)
- [ ] Manual: reset all, confirm factory defaults restored
- [ ] Manual: reload page, confirm custom bindings persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)