### PR TITLE
feat: finish piano roll power tools for fast MIDI editing

### DIFF
--- a/docs/plans/feat-piano-roll-power-tools.md
+++ b/docs/plans/feat-piano-roll-power-tools.md
@@ -1,0 +1,57 @@
+# Plan: Piano Roll Power Tools
+
+Issue: #341
+
+## User Story
+
+As a composer, I want explicit pencil, paint, erase, resize, and slide-note tools in the piano roll, so that I can edit MIDI quickly without modal friction.
+
+As an AI agent, I want the note model and store API to support the same slide-note concept used in the UI, so that browser automation and store-driven composition can verify identical behavior.
+
+## Problem
+
+ACE-Step's piano roll already supports note creation, velocity editing, quantize, and basic selection, but the fast-edit workflow is still incomplete. The editor relies on a single draw toggle, only exposes right-edge resize, and has no durable note model for slide or portamento notes. That leaves the product short of the "power tools" bar defined in the design docs and issue scope.
+
+## Root Cause
+
+- The toolbar exposes only a draw toggle, so tool intent is not modeled explicitly in UI state: `src/components/pianoroll/PianoRoll.tsx`.
+- Canvas hit-testing only distinguishes note body vs right edge; there is no left-edge resize path or explicit paint/erase tool handling: `src/components/pianoroll/PianoRollCanvas.tsx`.
+- `MidiNote` has no field for slide/portamento semantics, so playback and rendering cannot distinguish normal notes from slide notes: `src/types/project.ts`.
+- Existing tests cover note creation and quantize, but not tool switching, slide-note data, or the new edit affordances: `tests/e2e/piano-roll.spec.ts`, `tests/unit/pianoRollContextMenu.test.tsx`.
+
+## Solution
+
+1. Extend the MIDI note model with slide metadata and keep the store actions compatible with agent usage.
+   - Add a boolean slide flag to `MidiNote`.
+   - Ensure add/update flows preserve the field.
+2. Replace the binary draw toggle with explicit piano roll tools.
+   - Add `select`, `pencil`, `paint`, `erase`, and `slide` tools.
+   - Wire number-key shortcuts and visible toolbar state.
+3. Upgrade the canvas interactions.
+   - Support left and right resize handles with snap behavior.
+   - Support paint drag creation and erase drag deletion.
+   - Support slide-note creation and a distinct visual treatment.
+   - Preserve current velocity-lane editing and keyboard workflows.
+4. Add regression coverage.
+   - Unit tests for slide-note store behavior.
+   - Component tests for the new tool UI.
+   - E2E coverage for agent-visible slide metadata and tool-driven editing flows.
+
+## Verification
+
+- `npm test`
+- `npx tsc --noEmit`
+- `npm run build`
+- `npx playwright test tests/e2e/piano-roll.spec.ts`
+
+## Files To Touch
+
+- `src/types/project.ts`
+- `src/store/projectStore.ts`
+- `src/components/pianoroll/PianoRoll.tsx`
+- `src/components/pianoroll/PianoRollCanvas.tsx`
+- `src/components/pianoroll/PianoRollConstants.ts`
+- `src/components/pianoroll/VelocityLane.tsx`
+- `src/store/__tests__/projectStore.test.ts`
+- `tests/unit/pianoRollContextMenu.test.tsx`
+- `tests/e2e/piano-roll.spec.ts`

--- a/docs/research-notes/piano-roll-power-tools-competitive-research-20260319.md
+++ b/docs/research-notes/piano-roll-power-tools-competitive-research-20260319.md
@@ -1,0 +1,45 @@
+# Piano Roll Power Tools Competitive Research
+
+Date: 2026-03-19
+Feature: Issue #341, piano roll power tools for fast MIDI editing
+
+## User Story
+
+As a composer, I want pencil, paint, erase, resize, and slide-note tools to behave predictably, so that dense MIDI editing feels immediate instead of mode-heavy.
+
+As an AI agent, I want the same edit primitives represented in the note data model and store actions, so that programmatic MIDI authoring matches what human users can do in the canvas.
+
+## Ableton Live 12 MIDI Editor Notes
+
+Source reviewed:
+
+- Ableton Live 12 Manual, `10. Editing MIDI`, especially sections `10.2`, `10.4`, and `10.5`
+
+Interaction details worth copying:
+
+- Draw mode is an explicit mode with a keyboard toggle (`B`), not an implicit side effect hidden inside other gestures.
+- In draw mode, dragging adds notes continuously and clicking an existing note removes it. That makes paint and erase part of one fast workflow instead of forcing toolbar detours.
+- Grid snapping is the default behavior for note creation and resize, with a temporary modifier to bypass snap. This preserves speed without blocking loose input.
+- The velocity lane is integrated directly below the note editor, resizable by dragging the divider, so note dynamics stay visible while editing pitch and timing.
+- Notes can be selected first and then moved or transposed with keyboard actions. The editor is selection-centric, not canvas-only.
+
+## ACE-Step Product Decision
+
+Copy from competitor:
+
+- Explicit tool model instead of a single draw toggle
+- Number-key tool switching for immediate editing
+- Draw/paint behavior that can also erase by acting directly on notes
+- Integrated velocity lane and snap-first editing
+
+Improve for ACE-Step:
+
+- Keep all note-edit primitives agent-usable by extending the `MidiNote` model with slide metadata instead of making slide notes a canvas-only visual trick.
+- Add left-edge resize, because the current editor already supports right-edge resize and selection-first workflows.
+- Make slide notes visually distinct in both the note body and velocity lane so they are readable in dense patterns.
+
+Skip for this issue:
+
+- MPE per-note expressions
+- Probability/chance lanes
+- Advanced FL-style stamp libraries beyond the existing chord/pattern foundations

--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import type { PianoRollGrid } from '../../types/project';
@@ -7,11 +7,11 @@ import { PianoRollEmptyState } from './PianoRollEmptyState';
 import { QuantizeDialog } from './QuantizeDialog';
 import { GeneratePatternDialog } from './GeneratePatternDialog';
 import { TransformMenu } from './TransformMenu';
-import { midiNoteToName } from './PianoRollConstants';
+import { getPianoRollToolShortcut, midiNoteToName, type PianoRollTool } from './PianoRollConstants';
 import { useAudioImport } from '../../hooks/useAudioImport';
 
 export function PianoRoll() {
-  const [drawMode, setDrawMode] = useState(false);
+  const [activeTool, setActiveTool] = useState<PianoRollTool>('select');
   const [showGhostNotes, setShowGhostNotes] = useState(false);
   const [gridSize, setGridSize] = useState<PianoRollGrid>('1/16');
   const [prZoomX, setPrZoomX] = useState(1);
@@ -29,6 +29,29 @@ export function PianoRoll() {
   const setPianoRollHeight = useUIStore((s) => s.setPianoRollHeight);
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
   const openGeneratePatternDialog = useUIStore((s) => s.openGeneratePatternDialog);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tagName = target?.tagName;
+      if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') return;
+
+      if (event.key === 'b' || event.key === 'B') {
+        event.preventDefault();
+        setActiveTool((tool) => (tool === 'pencil' ? 'select' : 'pencil'));
+        return;
+      }
+
+      if (event.key === '1') setActiveTool('select');
+      if (event.key === '2') setActiveTool('pencil');
+      if (event.key === '3') setActiveTool('paint');
+      if (event.key === '4') setActiveTool('erase');
+      if (event.key === '5') setActiveTool('slide');
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   const track = useMemo(
     () => project?.tracks.find((candidate) => candidate.id === openTrackId) ?? null,
@@ -98,16 +121,28 @@ export function PianoRoll() {
       <div className="h-9 px-3 border-b border-[#2a2a2a] bg-[#0e0e24] flex items-center gap-2 shrink-0">
         <div className="text-xs font-medium text-zinc-200">{track.displayName}</div>
 
-        <button
-          aria-label="Toggle piano roll draw mode"
-          className={`px-2 py-1 rounded text-[10px] transition-colors ${
-            drawMode ? 'bg-violet-600/50 text-violet-200' : 'bg-white/5 text-zinc-400 hover:bg-white/10'
-          }`}
-          onClick={() => setDrawMode((mode) => !mode)}
-          title="Toggle draw mode (B)"
-        >
-          ✏ Draw
-        </button>
+        {([
+          { tool: 'select', label: 'Select', icon: '↖' },
+          { tool: 'pencil', label: 'Pencil', icon: '✏' },
+          { tool: 'paint', label: 'Paint', icon: '▦' },
+          { tool: 'erase', label: 'Erase', icon: '⌫' },
+          { tool: 'slide', label: 'Slide', icon: '⇢' },
+        ] as const).map(({ tool, label, icon }) => {
+          const active = activeTool === tool;
+          return (
+            <button
+              key={tool}
+              aria-label={`Activate ${label.toLowerCase()} tool`}
+              className={`px-2 py-1 rounded text-[10px] transition-colors ${
+                active ? 'bg-violet-600/50 text-violet-200' : 'bg-white/5 text-zinc-400 hover:bg-white/10'
+              }`}
+              onClick={() => setActiveTool(tool)}
+              title={`${label} tool (${getPianoRollToolShortcut(tool)})`}
+            >
+              {icon} {label}
+            </button>
+          );
+        })}
 
         <button
           className={`px-2 py-1 rounded text-[10px] transition-colors ${
@@ -228,7 +263,7 @@ export function PianoRoll() {
         <PianoRollCanvas
           clip={clip}
           track={track}
-          drawMode={drawMode}
+          activeTool={activeTool}
           gridSize={gridSize}
           prZoomX={prZoomX}
           onZoomXChange={setPrZoomX}

--- a/src/components/pianoroll/PianoRollCanvas.tsx
+++ b/src/components/pianoroll/PianoRollCanvas.tsx
@@ -9,17 +9,19 @@ import { drawPianoRollKeyboard } from './PianoRollKeyboard';
 import { drawVelocityLane } from './VelocityLane';
 import {
   generateNoteId,
+  getPianoRollToolShortcut,
   gridSizeToBeats,
   isBlackKey,
   MIDI_MAX_NOTE,
   midiNoteToName,
   PIANO_KEYBOARD_WIDTH,
   PIANO_ROLL_KEY_HEIGHT,
+  type PianoRollTool,
   velocityToColor,
   VELOCITY_LANE_HEIGHT,
 } from './PianoRollConstants';
 
-type NoteDragMode = null | 'move' | 'resize-right' | 'velocity';
+type NoteDragMode = null | 'move' | 'resize-left' | 'resize-right' | 'velocity';
 
 interface NoteDragState {
   mode: NoteDragMode;
@@ -45,7 +47,7 @@ export interface GhostNote {
 interface PianoRollCanvasProps {
   clip: Clip;
   track: Track;
-  drawMode: boolean;
+  activeTool: PianoRollTool;
   gridSize: PianoRollGrid;
   prZoomX: number;
   onZoomXChange: React.Dispatch<React.SetStateAction<number>>;
@@ -57,7 +59,7 @@ interface PianoRollCanvasProps {
 export function PianoRollCanvas({
   clip,
   track,
-  drawMode,
+  activeTool,
   gridSize,
   prZoomX,
   onZoomXChange,
@@ -70,6 +72,10 @@ export function PianoRollCanvas({
   const animRef = useRef<number>(0);
   const dragRef = useRef<NoteDragState | null>(null);
   const dividerDragRef = useRef<{ startY: number; startHeight: number } | null>(null);
+  const toolStrokeRef = useRef<{
+    noteIds: Set<string>;
+    cells: Set<string>;
+  }>({ noteIds: new Set(), cells: new Set() });
 
   const [velocityHeight, setVelocityHeight] = useState(VELOCITY_LANE_HEIGHT);
   const [prZoomY, setPrZoomY] = useState(1);
@@ -130,8 +136,49 @@ export function PianoRollCanvas({
     [gridBeats],
   );
 
+  const getCellKey = useCallback(
+    (beat: number, pitch: number) => `${Math.round(beat / gridBeats)}:${pitch}`,
+    [gridBeats],
+  );
+
+  const createNoteAt = useCallback(
+    (x: number, y: number, options?: { isSlide?: boolean; select?: boolean; velocity?: number }) => {
+      const beat = snapBeat(xToBeat(x), false);
+      const pitch = yToPitch(y);
+      if (pitch < 0 || pitch > MIDI_MAX_NOTE) return null;
+
+      const newNote: MidiNote = {
+        id: generateNoteId(),
+        pitch,
+        startBeat: Math.max(0, beat),
+        durationBeats: gridBeats,
+        velocity: options?.velocity ?? 100,
+        isSlide: options?.isSlide,
+      };
+      addMidiNote(clip.id, newNote);
+      if (options?.select !== false) {
+        setSelectedNoteIds(new Set([newNote.id]));
+      }
+      if (previewEnabled) previewNoteAtPitch(pitch, newNote.velocity, 0.3);
+      return newNote;
+    },
+    [addMidiNote, clip.id, gridBeats, previewEnabled, previewNoteAtPitch, setSelectedNoteIds, snapBeat, xToBeat, yToPitch],
+  );
+
+  const deleteNoteById = useCallback(
+    (noteId: string) => {
+      removeMidiNote(clip.id, noteId);
+      setSelectedNoteIds((prev) => {
+        const next = new Set(prev);
+        next.delete(noteId);
+        return next;
+      });
+    },
+    [clip.id, removeMidiNote, setSelectedNoteIds],
+  );
+
   const findNoteAt = useCallback(
-    (x: number, y: number): { note: MidiNote; edge: 'body' | 'right' } | null => {
+    (x: number, y: number): { note: MidiNote; edge: 'body' | 'left' | 'right' } | null => {
       for (let i = notes.length - 1; i >= 0; i--) {
         const note = notes[i];
         const noteX = beatToX(note.startBeat);
@@ -140,9 +187,11 @@ export function PianoRollCanvas({
         const noteHeight = keyHeight - 1;
 
         if (x >= noteX && x <= noteX + noteWidth && y >= noteY && y <= noteY + noteHeight) {
+          const nearLeft = x < noteX + 8 && noteWidth > 10;
+          const nearRight = x > noteX + noteWidth - 8 && noteWidth > 10;
           return {
             note,
-            edge: x > noteX + noteWidth - 8 && noteWidth > 10 ? 'right' : 'body',
+            edge: nearLeft ? 'left' : nearRight ? 'right' : 'body',
           };
         }
       }
@@ -260,29 +309,41 @@ export function PianoRollCanvas({
       if (noteY + noteHeight < 0 || noteY > noteAreaHeight) continue;
 
       const isSelected = selectedNoteIds.has(note.id);
+      const isSlide = note.isSlide === true;
 
-      ctx.fillStyle = velocityToColor(note.velocity);
+      ctx.fillStyle = isSlide ? 'rgba(251, 191, 36, 0.92)' : velocityToColor(note.velocity);
       ctx.globalAlpha = isSelected ? 1.0 : 0.8;
       ctx.beginPath();
       ctx.roundRect(noteX, noteY, Math.max(noteWidth, 3), noteHeight, 2);
       ctx.fill();
 
-      ctx.strokeStyle = isSelected ? '#fff' : 'rgba(255,255,255,0.3)';
+      ctx.strokeStyle = isSlide ? (isSelected ? '#fff7d6' : 'rgba(251,191,36,0.9)') : (isSelected ? '#fff' : 'rgba(255,255,255,0.3)');
       ctx.lineWidth = isSelected ? 1.5 : 0.5;
       ctx.beginPath();
       ctx.roundRect(noteX, noteY, Math.max(noteWidth, 3), noteHeight, 2);
       ctx.stroke();
       ctx.globalAlpha = 1.0;
 
+      if (isSlide && noteWidth > 10) {
+        ctx.strokeStyle = 'rgba(24,24,27,0.75)';
+        ctx.lineWidth = 1.25;
+        ctx.beginPath();
+        ctx.moveTo(noteX + 3, noteY + noteHeight - 3);
+        ctx.lineTo(noteX + noteWidth - 6, noteY + 3);
+        ctx.lineTo(noteX + noteWidth - 3, noteY + 6);
+        ctx.stroke();
+      }
+
       if (noteWidth > 30 && noteHeight > 8) {
-        ctx.fillStyle = 'rgba(0,0,0,0.6)';
+        ctx.fillStyle = isSlide ? 'rgba(24,24,27,0.85)' : 'rgba(0,0,0,0.6)';
         ctx.font = `${Math.min(9, noteHeight * 0.7)}px "Geist Mono", monospace`;
         ctx.textBaseline = 'middle';
-        ctx.fillText(midiNoteToName(note.pitch), noteX + 3, noteY + noteHeight / 2);
+        ctx.fillText(isSlide ? `${midiNoteToName(note.pitch)} SL` : midiNoteToName(note.pitch), noteX + 3, noteY + noteHeight / 2);
       }
 
       if (isSelected && noteWidth > 10) {
         ctx.fillStyle = 'rgba(255,255,255,0.4)';
+        ctx.fillRect(noteX + 1, noteY + 2, 3, noteHeight - 4);
         ctx.fillRect(noteX + noteWidth - 4, noteY + 2, 3, noteHeight - 4);
       }
     }
@@ -333,19 +394,19 @@ export function PianoRollCanvas({
       pixelsPerBeat,
     });
 
-    if (drawMode) {
+    if (activeTool !== 'select') {
       ctx.fillStyle = 'rgba(139, 92, 246, 0.3)';
-      ctx.fillRect(width - 60, 4, 56, 16);
+      ctx.fillRect(width - 86, 4, 82, 16);
       ctx.fillStyle = 'rgba(255,255,255,0.7)';
       ctx.font = '9px "Geist", sans-serif';
       ctx.textBaseline = 'middle';
-      ctx.fillText('✏ Draw', width - 55, 12);
+      ctx.fillText(`${activeTool.toUpperCase()} ${getPianoRollToolShortcut(activeTool)}`, width - 80, 12);
     }
   }, [
+    activeTool,
     beatToX,
     bpm,
     clip,
-    drawMode,
     gridBeats,
     keyHeight,
     notes,
@@ -419,40 +480,38 @@ export function PianoRollCanvas({
 
       const hit = findNoteAt(x, y);
 
-      if (drawMode) {
+      if (activeTool === 'erase') {
         if (hit) {
-          removeMidiNote(clip.id, hit.note.id);
-          setSelectedNoteIds((prev) => {
-            const next = new Set(prev);
-            next.delete(hit.note.id);
-            return next;
-          });
+          toolStrokeRef.current.noteIds.add(hit.note.id);
+          deleteNoteById(hit.note.id);
+        }
+        return;
+      }
+
+      if (activeTool === 'pencil' || activeTool === 'paint' || activeTool === 'slide') {
+        if (hit && activeTool !== 'slide') {
+          deleteNoteById(hit.note.id);
+          if (activeTool === 'paint') {
+            toolStrokeRef.current.noteIds.add(hit.note.id);
+          }
           return;
         }
 
-        const beat = snapBeat(xToBeat(x), e.altKey);
-        const pitch = yToPitch(y);
-        if (pitch < 0 || pitch > MIDI_MAX_NOTE) return;
+        const newNote = createNoteAt(x, y, { isSlide: activeTool === 'slide' });
+        if (!newNote) return;
 
-        const newNote = {
-          id: generateNoteId(),
-          pitch,
-          startBeat: Math.max(0, beat),
-          durationBeats: gridBeats,
-          velocity: 100,
-        };
-        addMidiNote(clip.id, newNote);
-        if (previewEnabled) previewNoteAtPitch(pitch, 100, 0.3);
         beginDrag();
+        toolStrokeRef.current.noteIds.add(newNote.id);
+        toolStrokeRef.current.cells.add(getCellKey(newNote.startBeat, newNote.pitch));
         dragRef.current = {
           mode: 'resize-right',
           noteId: newNote.id,
           startMouseX: x,
           startMouseY: y,
-          originalPitch: pitch,
+          originalPitch: newNote.pitch,
           originalStartBeat: newNote.startBeat,
           originalDurationBeats: newNote.durationBeats,
-          originalVelocity: 100,
+          originalVelocity: newNote.velocity,
         };
         return;
       }
@@ -471,7 +530,7 @@ export function PianoRollCanvas({
 
         beginDrag();
         dragRef.current = {
-          mode: hit.edge === 'right' ? 'resize-right' : 'move',
+          mode: hit.edge === 'right' ? 'resize-right' : hit.edge === 'left' ? 'resize-left' : 'move',
           noteId: hit.note.id,
           startMouseX: x,
           startMouseY: y,
@@ -503,54 +562,23 @@ export function PianoRollCanvas({
         return;
       }
 
-      // Single click on empty = create note (regardless of draw mode)
-      {
-        const beat = snapBeat(xToBeat(x), e.altKey);
-        const pitch = yToPitch(y);
-        if (pitch < 0 || pitch > MIDI_MAX_NOTE) return;
-
-        const newNote = {
-          id: generateNoteId(),
-          pitch,
-          startBeat: Math.max(0, beat),
-          durationBeats: gridBeats,
-          velocity: 100,
-        };
-        addMidiNote(clip.id, newNote);
-        setSelectedNoteIds(new Set([newNote.id]));
-        if (previewEnabled) previewNoteAtPitch(pitch, 100, 0.3);
-
-        beginDrag();
-        dragRef.current = {
-          mode: 'resize-right',
-          noteId: newNote.id,
-          startMouseX: x,
-          startMouseY: y,
-          originalPitch: pitch,
-          originalStartBeat: newNote.startBeat,
-          originalDurationBeats: newNote.durationBeats,
-          originalVelocity: 100,
-        };
-      }
+      setSelectedNoteIds(new Set());
     },
     [
-      addMidiNote,
+      activeTool,
       beatToX,
       beginDrag,
-      clip.id,
-      drawMode,
+      createNoteAt,
+      deleteNoteById,
       findNoteAt,
-      gridBeats,
+      getCellKey,
       notes,
       pixelsPerBeat,
       previewEnabled,
       previewNoteAtPitch,
-      removeMidiNote,
       selectedNoteIds,
-      snapBeat,
       updateMidiNote,
       velocityHeight,
-      xToBeat,
       yToPitch,
     ],
   );
@@ -558,7 +586,7 @@ export function PianoRollCanvas({
   const handleDoubleClick = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
       const canvas = canvasRef.current;
-      if (!canvas || drawMode) return;
+      if (!canvas || activeTool !== 'select') return;
 
       const rect = canvas.getBoundingClientRect();
       const x = e.clientX - rect.left;
@@ -569,43 +597,18 @@ export function PianoRollCanvas({
 
       const hit = findNoteAt(x, y);
       if (hit) {
-        removeMidiNote(clip.id, hit.note.id);
-        setSelectedNoteIds((prev) => {
-          const next = new Set(prev);
-          next.delete(hit.note.id);
-          return next;
-        });
+        deleteNoteById(hit.note.id);
         return;
       }
 
-      const beat = snapBeat(xToBeat(x), e.altKey);
-      const pitch = yToPitch(y);
-      if (pitch < 0 || pitch > MIDI_MAX_NOTE) return;
-
-      const newNote = {
-        id: generateNoteId(),
-        pitch,
-        startBeat: Math.max(0, beat),
-        durationBeats: gridBeats,
-        velocity: 100,
-      };
-      addMidiNote(clip.id, newNote);
-      setSelectedNoteIds(new Set([newNote.id]));
-      if (previewEnabled) previewNoteAtPitch(pitch, 100, 0.3);
+      createNoteAt(x, y);
     },
     [
-      addMidiNote,
-      clip.id,
-      drawMode,
+      activeTool,
+      createNoteAt,
+      deleteNoteById,
       findNoteAt,
-      gridBeats,
-      previewEnabled,
-      previewNoteAtPitch,
-      removeMidiNote,
-      snapBeat,
       velocityHeight,
-      xToBeat,
-      yToPitch,
     ],
   );
 
@@ -617,15 +620,40 @@ export function PianoRollCanvas({
         return;
       }
 
-      const drag = dragRef.current;
-      if (!drag) return;
-
       const canvas = canvasRef.current;
       if (!canvas) return;
 
       const rect = canvas.getBoundingClientRect();
       const x = e.clientX - rect.left;
       const y = e.clientY - rect.top;
+      const noteAreaHeight = rect.height - velocityHeight;
+      const drag = dragRef.current;
+
+      if (!drag && y <= noteAreaHeight && x >= PIANO_KEYBOARD_WIDTH) {
+        if (activeTool === 'erase') {
+          const hit = findNoteAt(x, y);
+          if (hit && !toolStrokeRef.current.noteIds.has(hit.note.id)) {
+            toolStrokeRef.current.noteIds.add(hit.note.id);
+            deleteNoteById(hit.note.id);
+          }
+        }
+        if (activeTool === 'paint') {
+          const pitch = yToPitch(y);
+          if (pitch >= 0 && pitch <= MIDI_MAX_NOTE) {
+            const beat = Math.max(0, snapBeat(xToBeat(x), e.altKey));
+            const cellKey = getCellKey(beat, pitch);
+            const hit = findNoteAt(x, y);
+            if (!hit && !toolStrokeRef.current.cells.has(cellKey)) {
+              const newNote = createNoteAt(x, y, { select: false });
+              if (newNote) {
+                toolStrokeRef.current.noteIds.add(newNote.id);
+                toolStrokeRef.current.cells.add(cellKey);
+              }
+            }
+          }
+        }
+      }
+      if (!drag) return;
 
       if (drag.isBoxSelect) {
         drag.startMouseX = x;
@@ -650,7 +678,6 @@ export function PianoRollCanvas({
       }
 
       if (drag.mode === 'velocity') {
-        const noteAreaHeight = rect.height - velocityHeight;
         const velAreaTop = noteAreaHeight + 3;
         const velAreaHeight = velocityHeight - 6;
         updateMidiNote(clip.id, drag.noteId, {
@@ -671,6 +698,19 @@ export function PianoRollCanvas({
         return;
       }
 
+      if (drag.mode === 'resize-left') {
+        const beatDelta = (x - drag.startMouseX) / pixelsPerBeat;
+        const snappedStart = Math.max(0, snapBeat(drag.originalStartBeat + beatDelta, e.altKey));
+        const originalEnd = drag.originalStartBeat + drag.originalDurationBeats;
+        const maxStart = originalEnd - gridBeats * 0.5;
+        const newStartBeat = Math.min(snappedStart, maxStart);
+        updateMidiNote(clip.id, drag.noteId, {
+          startBeat: newStartBeat,
+          durationBeats: Math.max(gridBeats * 0.5, originalEnd - newStartBeat),
+        });
+        return;
+      }
+
       if (drag.mode === 'resize-right') {
         const beatDelta = (x - drag.startMouseX) / pixelsPerBeat;
         const endBeat = snapBeat(drag.originalStartBeat + drag.originalDurationBeats + beatDelta, e.altKey);
@@ -683,6 +723,7 @@ export function PianoRollCanvas({
     const handleGlobalUp = () => {
       dividerDragRef.current = null;
       if (dragRef.current) endDrag();
+      toolStrokeRef.current = { noteIds: new Set(), cells: new Set() };
       dragRef.current = null;
     };
 
@@ -693,9 +734,14 @@ export function PianoRollCanvas({
       window.removeEventListener('mouseup', handleGlobalUp);
     };
   }, [
+    activeTool,
     beatToX,
     clip.id,
+    createNoteAt,
+    deleteNoteById,
     endDrag,
+    findNoteAt,
+    getCellKey,
     gridBeats,
     keyHeight,
     notes,
@@ -706,6 +752,7 @@ export function PianoRollCanvas({
     snapBeat,
     updateMidiNote,
     velocityHeight,
+    xToBeat,
     yToPitch,
   ]);
 
@@ -902,7 +949,16 @@ export function PianoRollCanvas({
         ref={canvasRef}
         aria-label="Piano roll editor"
         className="absolute inset-0"
-        style={{ cursor: drawMode ? 'crosshair' : 'default' }}
+        style={{
+          cursor:
+            activeTool === 'select'
+              ? 'default'
+              : activeTool === 'erase'
+                ? 'not-allowed'
+                : activeTool === 'slide'
+                  ? 'alias'
+                  : 'crosshair',
+        }}
         onMouseDown={handleMouseDown}
         onDoubleClick={handleDoubleClick}
         onWheel={handleWheel}

--- a/src/components/pianoroll/PianoRollConstants.ts
+++ b/src/components/pianoroll/PianoRollConstants.ts
@@ -1,5 +1,7 @@
 import type { PianoRollGrid } from '../../types/project';
 
+export type PianoRollTool = 'select' | 'pencil' | 'paint' | 'erase' | 'slide';
+
 export const MIDI_MAX_NOTE = 127;
 export const PIANO_ROLL_KEY_HEIGHT = 14;
 export const PIANO_KEYBOARD_WIDTH = 56;
@@ -43,6 +45,21 @@ export function velocityToBarColor(velocity: number): string {
   const g = Math.round(80 + t * 40);
   const b = Math.round(200 - t * 100);
   return `rgba(${r},${g},${b},0.8)`;
+}
+
+export function getPianoRollToolShortcut(tool: PianoRollTool): string {
+  switch (tool) {
+    case 'select':
+      return '1';
+    case 'pencil':
+      return '2';
+    case 'paint':
+      return '3';
+    case 'erase':
+      return '4';
+    case 'slide':
+      return '5';
+  }
 }
 
 export function generateNoteId(): string {

--- a/src/components/pianoroll/VelocityLane.tsx
+++ b/src/components/pianoroll/VelocityLane.tsx
@@ -46,10 +46,20 @@ export function drawVelocityLane({
     const barHeight = (note.velocity / 127) * velAreaHeight;
     const barY = velAreaTop + velAreaHeight - barHeight;
     const isSelected = selectedNoteIds.has(note.id);
+    const isSlide = note.isSlide === true;
 
-    ctx.fillStyle = velocityToBarColor(note.velocity);
+    ctx.fillStyle = isSlide ? 'rgba(251,191,36,0.85)' : velocityToBarColor(note.velocity);
     ctx.globalAlpha = isSelected ? 1.0 : 0.6;
     ctx.fillRect(x, barY, Math.max(widthPx - 1, 3), barHeight);
+
+    if (isSlide) {
+      ctx.strokeStyle = 'rgba(24,24,27,0.9)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(x + 1, barY + barHeight - 2);
+      ctx.lineTo(x + Math.max(widthPx - 2, 3), barY + 2);
+      ctx.stroke();
+    }
 
     if (isSelected) {
       ctx.strokeStyle = '#fff';

--- a/src/engine/SynthEngine.ts
+++ b/src/engine/SynthEngine.ts
@@ -107,6 +107,30 @@ class SynthEngine {
     synth.triggerAttackRelease(freq, duration, undefined, velocity / 127);
   }
 
+  async playSlideNote(
+    trackId: string,
+    fromPitch: number,
+    toPitch: number,
+    velocity: number,
+    duration: number,
+    preset: SynthPreset,
+  ) {
+    await this.ensureStarted();
+    const synth = this.ensureTrackSynth(trackId, preset) as unknown as {
+      set: (options: Record<string, unknown>) => void;
+      triggerAttack: (note: number, time?: string | number, velocity?: number) => void;
+      triggerRelease: (note: number, time?: string | number) => void;
+      triggerAttackRelease: (note: number, duration: number, time?: string | number, velocity?: number) => void;
+    };
+    const glideTime = Math.max(0.03, Math.min(0.12, duration * 0.35));
+    const fromFreq = Tone.Frequency(fromPitch, 'midi').toFrequency();
+    const toFreq = Tone.Frequency(toPitch, 'midi').toFrequency();
+    synth.set({ portamento: glideTime });
+    synth.triggerAttack(fromFreq, undefined, velocity / 127);
+    synth.triggerRelease(fromFreq, `+${glideTime}`);
+    synth.triggerAttackRelease(toFreq, Math.max(0.04, duration), `+${glideTime}`, velocity / 127);
+  }
+
   /** Trigger note on for a track synth (for live playing / recording). */
   noteOn(trackId: string, pitch: number, velocity = 100) {
     const instance = this.synths.get(trackId);

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -228,10 +228,11 @@ export function useTransport() {
         }
 
         for (const clip of track.clips) {
-          const notes = clip.midiData?.notes ?? [];
+          const notes = [...(clip.midiData?.notes ?? [])].sort((a, b) => a.startBeat - b.startBeat);
           if (notes.length === 0) continue;
 
-          for (const note of notes) {
+          for (let noteIndex = 0; noteIndex < notes.length; noteIndex++) {
+            const note = notes[noteIndex];
             const noteStart = clip.startTime + beatToTime(note.startBeat, tempoMap, fallbackBpm);
             const noteDuration = Math.max(0, beatToTime(note.startBeat + note.durationBeats, tempoMap, fallbackBpm) - beatToTime(note.startBeat, tempoMap, fallbackBpm));
             const noteEnd = noteStart + noteDuration;
@@ -252,7 +253,24 @@ export function useTransport() {
               });
             } else {
               const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
+              const previousOverlap = note.isSlide
+                ? [...notes]
+                    .slice(0, noteIndex)
+                    .reverse()
+                    .find((candidate) => candidate.startBeat + candidate.durationBeats >= note.startBeat)
+                : undefined;
               engine.scheduleMidiEvent(scheduledStart, () => {
+                if (previousOverlap) {
+                  void synthEngine.playSlideNote(
+                    trackId,
+                    previousOverlap.pitch,
+                    note.pitch,
+                    Math.max(1, Math.round(velocity * 127)),
+                    scheduledDuration,
+                    preset,
+                  );
+                  return;
+                }
                 const synth = synthEngine.getSynth(trackId);
                 if (synth) {
                   synth.triggerAttackRelease(freq, scheduledDuration, undefined, velocity);

--- a/src/store/__tests__/projectStore.test.ts
+++ b/src/store/__tests__/projectStore.test.ts
@@ -498,6 +498,18 @@ describe('projectStore', () => {
       const clip = useProjectStore.getState().getClipById(clipId);
       expect(clip!.midiData!.notes[0].pitch).toBe(72);
     });
+
+    it('stores slide-note metadata', () => {
+      const noteId = useProjectStore.getState().addMidiNote(clipId, {
+        pitch: 67,
+        startBeat: 1,
+        durationBeats: 0.5,
+        velocity: 96,
+        isSlide: true,
+      });
+      const clip = useProjectStore.getState().getClipById(clipId);
+      expect(clip!.midiData!.notes.find((note) => note.id === noteId)?.isSlide).toBe(true);
+    });
   });
 
   describe('effects', () => {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -58,6 +58,7 @@ export interface MidiNote {
   startBeat: number;
   durationBeats: number;
   velocity: number;
+  isSlide?: boolean;
 }
 
 export interface MidiClipData {

--- a/tests/e2e/piano-roll.spec.ts
+++ b/tests/e2e/piano-roll.spec.ts
@@ -1,19 +1,42 @@
 import { test, expect } from '@playwright/test';
 
+type PianoRollTestStore = {
+  getState(): {
+    createProject: (input: { name: string }) => void;
+    addTrack: (name: string, type: 'pianoRoll') => { id: string; trackType: string; displayName: string };
+    ensureMidiClip: (trackId: string) => { id: string; midiData?: { notes?: Array<{ id: string; startBeat?: number; isSlide?: boolean; pitch?: number }> } };
+    addMidiNote: (
+      clipId: string,
+      note: { pitch: number; startBeat: number; durationBeats: number; velocity: number; isSlide?: boolean },
+    ) => string | undefined;
+    quantizeMidiNotes: (clipId: string, noteIds: Array<string | undefined>, gridBeats: number) => void;
+    removeMidiNote: (clipId: string, noteId: string | undefined) => void;
+    project?: {
+      tracks?: Array<{
+        clips?: Array<{
+          midiData?: {
+            notes?: Array<{ id: string; startBeat?: number; isSlide?: boolean; pitch?: number }>;
+          };
+        }>;
+      }>;
+    };
+  };
+};
+
 test.describe('Piano Roll Workflow', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
+    await page.waitForFunction(() => typeof (window as unknown as { __store?: unknown }).__store !== 'undefined', null, { timeout: 10000 });
     await page.evaluate(() => {
-      const store = (window as any).__store;
+      const store = (window as unknown as { __store: PianoRollTestStore }).__store;
       store.getState().createProject({ name: 'Piano Roll Test' });
     });
   });
 
   test('can add a keyboard track with pianoRoll type', async ({ page }) => {
     const result = await page.evaluate(() => {
-      const store = (window as any).__store;
+      const store = (window as unknown as { __store: PianoRollTestStore }).__store;
       const track = store.getState().addTrack('keyboard', 'pianoRoll');
       return { trackType: track.trackType, displayName: track.displayName };
     });
@@ -22,7 +45,7 @@ test.describe('Piano Roll Workflow', () => {
 
   test('can create a MIDI clip via ensureMidiClip', async ({ page }) => {
     const result = await page.evaluate(() => {
-      const store = (window as any).__store;
+      const store = (window as unknown as { __store: PianoRollTestStore }).__store;
       const track = store.getState().addTrack('keyboard', 'pianoRoll');
       const clip = store.getState().ensureMidiClip(track.id);
       return {
@@ -36,7 +59,7 @@ test.describe('Piano Roll Workflow', () => {
 
   test('can add MIDI notes via store API', async ({ page }) => {
     const noteCount = await page.evaluate(() => {
-      const store = (window as any).__store;
+      const store = (window as unknown as { __store: PianoRollTestStore }).__store;
       const track = store.getState().addTrack('keyboard', 'pianoRoll');
       const clip = store.getState().ensureMidiClip(track.id);
       store.getState().addMidiNote(clip.id, { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 100 });
@@ -49,7 +72,7 @@ test.describe('Piano Roll Workflow', () => {
 
   test('can quantize MIDI notes via store API', async ({ page }) => {
     const result = await page.evaluate(() => {
-      const store = (window as any).__store;
+      const store = (window as unknown as { __store: PianoRollTestStore }).__store;
       const track = store.getState().addTrack('keyboard', 'pianoRoll');
       const clip = store.getState().ensureMidiClip(track.id);
       const noteId = store.getState().addMidiNote(clip.id, { pitch: 60, startBeat: 0.3, durationBeats: 1, velocity: 100 });
@@ -62,7 +85,7 @@ test.describe('Piano Roll Workflow', () => {
 
   test('can remove a MIDI note', async ({ page }) => {
     const noteCount = await page.evaluate(() => {
-      const store = (window as any).__store;
+      const store = (window as unknown as { __store: PianoRollTestStore }).__store;
       const track = store.getState().addTrack('keyboard', 'pianoRoll');
       const clip = store.getState().ensureMidiClip(track.id);
       const noteId = store.getState().addMidiNote(clip.id, { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 100 });
@@ -71,5 +94,24 @@ test.describe('Piano Roll Workflow', () => {
       return store.getState().project?.tracks[0]?.clips[0]?.midiData?.notes?.length ?? 0;
     });
     expect(noteCount).toBe(1);
+  });
+
+  test('can persist slide-note metadata via store API', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const store = (window as unknown as { __store: PianoRollTestStore }).__store;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = store.getState().ensureMidiClip(track.id);
+      const noteId = store.getState().addMidiNote(clip.id, {
+        pitch: 67,
+        startBeat: 1,
+        durationBeats: 1,
+        velocity: 96,
+        isSlide: true,
+      });
+      const note = store.getState().project?.tracks?.[0]?.clips?.[0]?.midiData?.notes?.find((n) => n.id === noteId);
+      return { isSlide: note?.isSlide, pitch: note?.pitch };
+    });
+
+    expect(result).toEqual({ isSlide: true, pitch: 67 });
   });
 });

--- a/tests/unit/pianoRollContextMenu.test.tsx
+++ b/tests/unit/pianoRollContextMenu.test.tsx
@@ -4,16 +4,24 @@ import '@testing-library/jest-dom';
 import { PianoRollCanvas } from '../../src/components/pianoroll/PianoRollCanvas';
 import type { Clip, MidiNote, Track } from '../../src/types/project';
 
+const mockAddMidiNote = vi.fn();
+const mockRemoveMidiNote = vi.fn();
+const mockUpdateMidiNote = vi.fn();
+const mockQuantizeMidiNotes = vi.fn();
+const mockBeginDrag = vi.fn();
+const mockEndDrag = vi.fn();
+const mockOpenQuantizeDialog = vi.fn();
+
 // Mock stores
 vi.mock('../../src/store/projectStore', () => ({
   useProjectStore: vi.fn((selector) => {
     const state: Record<string, unknown> = {
-      addMidiNote: vi.fn(),
-      removeMidiNote: vi.fn(),
-      updateMidiNote: vi.fn(),
-      quantizeMidiNotes: vi.fn(),
-      beginDrag: vi.fn(),
-      endDrag: vi.fn(),
+      addMidiNote: mockAddMidiNote,
+      removeMidiNote: mockRemoveMidiNote,
+      updateMidiNote: mockUpdateMidiNote,
+      quantizeMidiNotes: mockQuantizeMidiNotes,
+      beginDrag: mockBeginDrag,
+      endDrag: mockEndDrag,
       project: { bpm: 120 },
     };
     return selector(state);
@@ -23,7 +31,7 @@ vi.mock('../../src/store/projectStore', () => ({
 vi.mock('../../src/store/uiStore', () => ({
   useUIStore: vi.fn((selector) => {
     const state: Record<string, unknown> = {
-      openQuantizeDialog: vi.fn(),
+      openQuantizeDialog: mockOpenQuantizeDialog,
     };
     return selector(state);
   }),
@@ -120,6 +128,13 @@ describe('PianoRollCanvas — context menu accessibility (#298)', () => {
   let setSelectedNoteIds: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    mockAddMidiNote.mockReset();
+    mockRemoveMidiNote.mockReset();
+    mockUpdateMidiNote.mockReset();
+    mockQuantizeMidiNotes.mockReset();
+    mockBeginDrag.mockReset();
+    mockEndDrag.mockReset();
+    mockOpenQuantizeDialog.mockReset();
     setSelectedNoteIds = vi.fn();
     // Mock getBoundingClientRect on all elements so canvas has real dimensions
     Element.prototype.getBoundingClientRect = vi.fn().mockReturnValue({
@@ -142,7 +157,7 @@ describe('PianoRollCanvas — context menu accessibility (#298)', () => {
       <PianoRollCanvas
         clip={clip}
         track={makeTrack()}
-        drawMode={false}
+        activeTool="select"
         gridSize="1/4"
         prZoomX={1}
         onZoomXChange={vi.fn()}
@@ -171,7 +186,7 @@ describe('PianoRollCanvas — context menu accessibility (#298)', () => {
       <PianoRollCanvas
         clip={clip}
         track={makeTrack()}
-        drawMode={false}
+        activeTool="select"
         gridSize="1/4"
         prZoomX={1}
         onZoomXChange={vi.fn()}
@@ -202,7 +217,7 @@ describe('PianoRollCanvas — context menu accessibility (#298)', () => {
       <PianoRollCanvas
         clip={clip}
         track={makeTrack()}
-        drawMode={false}
+        activeTool="select"
         gridSize="1/4"
         prZoomX={1}
         onZoomXChange={vi.fn()}
@@ -224,5 +239,36 @@ describe('PianoRollCanvas — context menu accessibility (#298)', () => {
       b.textContent?.includes('Quantize'),
     );
     expect(quantizeButton).toBeFalsy();
+  });
+
+  it('creates slide notes through the explicit slide tool', () => {
+    const clip = makeClip([]);
+
+    const { container } = render(
+      <PianoRollCanvas
+        clip={clip}
+        track={makeTrack()}
+        activeTool="slide"
+        gridSize="1/4"
+        prZoomX={1}
+        onZoomXChange={vi.fn()}
+        selectedNoteIds={new Set<string>()}
+        onSelectedNoteIdsChange={setSelectedNoteIds}
+      />,
+    );
+
+    const canvas = container.querySelector('canvas')!;
+    fireEvent.mouseDown(canvas, {
+      clientX: 120,
+      clientY: NOTE_HIT_CLIENT_Y,
+    });
+
+    expect(mockAddMidiNote).toHaveBeenCalledTimes(1);
+    const [, note] = mockAddMidiNote.mock.calls[0];
+    expect(note).toMatchObject({
+      isSlide: true,
+      durationBeats: 1,
+      velocity: 100,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- finish the piano roll tool model with explicit `select`, `pencil`, `paint`, `erase`, and `slide` tools plus number-key shortcuts
- add left-edge note resize, paint/erase drag behavior, slide-note visuals, and a lightweight slide playback handoff for synth tracks
- extend MIDI note data with slide metadata and add plan/research docs plus regression coverage for store/UI/E2E flows

## User Stories
- As a composer, I want explicit pencil, paint, erase, resize, and slide-note tools in the piano roll, so that I can edit MIDI quickly without modal friction.
- As an AI agent, I want the note model and store API to support the same slide-note concept used in the UI, so that browser automation and store-driven composition can verify identical behavior.

## Files Changed
- `docs/plans/feat-piano-roll-power-tools.md`
- `docs/research-notes/piano-roll-power-tools-competitive-research-20260319.md`
- `src/components/pianoroll/PianoRoll.tsx`
- `src/components/pianoroll/PianoRollCanvas.tsx`
- `src/components/pianoroll/PianoRollConstants.ts`
- `src/components/pianoroll/VelocityLane.tsx`
- `src/engine/SynthEngine.ts`
- `src/hooks/useTransport.ts`
- `src/store/__tests__/projectStore.test.ts`
- `src/types/project.ts`
- `tests/e2e/piano-roll.spec.ts`
- `tests/unit/pianoRollContextMenu.test.tsx`

## Verification
- `npm test`
- `npx tsc --noEmit`
- `npm run build`
- `npx playwright test tests/e2e/piano-roll.spec.ts`

## Notes
- Playwright passed, but the dev server still logs existing `/health` proxy `ECONNREFUSED 127.0.0.1:8001` noise during the run; it did not fail the piano-roll spec.
- Closes #341
