### PR TITLE
feat: upgrade sampler into one-step Quick Sampler workflow

### DIFF
--- a/docs/design/UX_IMPROVEMENT_CHECKLIST.md
+++ b/docs/design/UX_IMPROVEMENT_CHECKLIST.md
@@ -148,7 +148,7 @@
 - ⬜ **Modulators** — Bitwig-style drag-modulator-onto-parameter system. LFO, step sequencer, envelope follower.
 - ⬜ **Nested devices** — Effects and instruments can contain sub-chains.
 - ⬜ **Capture MIDI** — Retroactive MIDI recording (Ableton-style). Always-on MIDI buffer, "Capture" saves last N bars.
-- ⬜ **Quick Sampler** — Drag any audio → instant playable instrument (Logic-style).
+- ✅ **Quick Sampler** — Drag any audio → instant playable instrument (Logic-style).
 - ⬜ **Smart Controls** — Macro knobs that control multiple parameters. Beginner-friendly, mappable.
 - ⬜ **Per-note expressions** — Pitch bend, pressure, timbre per note (MPE data model).
 - ⬜ **Comping** — Record multiple takes, visually comp best sections.

--- a/docs/plans/feat-quick-sampler.md
+++ b/docs/plans/feat-quick-sampler.md
@@ -1,0 +1,43 @@
+# Plan: Quick Sampler Workflow
+
+## Problem
+
+ACE-Step already had sampler playback primitives, but no explicit “audio in, playable instrument out” Quick Sampler workflow. Users could load a sample onto a sampler track, but not through a first-class store action or an in-context sample editor.
+
+## Root Cause
+
+- `src/hooks/useAudioImport.ts` only loaded sample data into an existing sampler track.
+- `src/components/pianoroll/PianoRoll.tsx` exposed only load/clear/root-note controls.
+- `src/hooks/useTransport.ts` and `src/engine/offlineRender.ts` treated the sampler as a simple pitched playback path with no trim or playback mode state.
+
+## Solution
+
+- Extend `SamplerConfig` with trim, loop, and playback-mode fields.
+- Add a store action that creates or retargets a Quick Sampler track from an existing audio key.
+- Upgrade piano roll sampler UI into a lightweight Quick Sampler editor with drag target, root note, trim, loop, preview, and playback mode.
+- Route piano roll audio drops and asset drops into the Quick Sampler path instead of audio clip import.
+- Render and play sampler notes through the new config so Classic, One Shot, and Loop settings affect transport and offline bounce.
+
+## Verification
+
+- `npx tsc --noEmit`
+- `npm test`
+- `npm run build`
+- `npx playwright test tests/e2e/sampler.spec.ts`
+
+## Files To Touch
+
+- `src/types/project.ts`
+- `src/store/projectStore.ts`
+- `src/hooks/useAudioImport.ts`
+- `src/hooks/useTransport.ts`
+- `src/engine/SamplerEngine.ts`
+- `src/engine/offlineRender.ts`
+- `src/components/pianoroll/PianoRoll.tsx`
+- `src/components/timeline/TrackLane.tsx`
+- `src/components/dialogs/InstrumentPicker.tsx`
+- `src/components/dialogs/ExportDialog.tsx`
+- `src/services/freezeTrack.ts`
+- `src/store/__tests__/projectStore.test.ts`
+- `tests/unit/samplerEngine.test.ts`
+- `tests/e2e/sampler.spec.ts`

--- a/docs/research-notes/quick-sampler-competitive-research-20260319.md
+++ b/docs/research-notes/quick-sampler-competitive-research-20260319.md
@@ -1,0 +1,28 @@
+# Quick Sampler Competitive Research — 2026-03-19
+
+## User Story
+
+As a beatmaker, I want to drop audio into a sampler and immediately play it chromatically, so that found sounds become musical material without setup friction.
+
+## Reference Product
+
+- Logic Pro Quick Sampler
+  - Apple Support: https://support.apple.com/en-us/102041
+  - Apple User Guide overview: https://support.apple.com/is-is/guide/logicpro/lgcp5af33756/10.7/mac/11.0
+
+## Interaction-Level Findings
+
+- Dragging a file or region into Quick Sampler is the primary entry path, not a secondary utility flow.
+- The loaded sample is immediately mapped across the keyboard around a root note, so pitch audition starts as soon as the sample lands.
+- Classic mode is the “held key / loop-capable” mode.
+- One Shot mode ignores key length and plays the sample through from start to end.
+- The waveform view exposes sample start, end, and loop points in the same context as playback.
+- Root key preview is visible directly in the sampler context instead of hidden behind a separate editor.
+
+## ACE-Step Decisions
+
+- Copy: one-step audio-to-instrument flow.
+- Copy: root note, trim start/end, loop start/end, and playback mode in the same editor context.
+- Copy: Classic and One Shot as first-class playback modes.
+- Improve: expose creation through `window.__store` and drag/drop on piano roll tracks so agents can script the same workflow.
+- Skip for this issue: Logic-style Optimized/Original analysis modes, Recorder mode, Slice mode, and deeper modulation pages.

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -5,6 +5,7 @@ import { getAudioEngine } from '../../hooks/useAudioEngine';
 import { loadAudioBlobByKey } from '../../services/audioFileManager';
 import { exportMix, type ExportClip } from '../../engine/exportMix';
 import { renderMidiTrackOffline, renderSamplerTrackOffline, renderSequencerTrackOffline } from '../../engine/offlineRender';
+import { createSamplerConfig } from '../../engine/SamplerEngine';
 import { toastError, toastSuccess } from '../../hooks/useToast';
 import {
   type ExportFormat,
@@ -88,7 +89,11 @@ export function ExportDialog() {
                   clip.startTime,
                   project.bpm,
                   sampleBuffer,
-                  track.sampler.rootNote,
+                  track.samplerConfig ?? createSamplerConfig(track.sampler.audioKey, {
+                    rootNote: track.sampler.rootNote,
+                    trimEnd: track.sampler.sampleDuration,
+                    loopEnd: track.sampler.sampleDuration,
+                  }),
                   project.totalDuration,
                 );
               }

--- a/src/components/dialogs/InstrumentPicker.tsx
+++ b/src/components/dialogs/InstrumentPicker.tsx
@@ -14,9 +14,10 @@ export function InstrumentPicker() {
   const addTrack = useProjectStore((s) => s.addTrack);
   const updateTrack = useProjectStore((s) => s.updateTrack);
   const setTrackSampler = useProjectStore((s) => s.setTrackSampler);
+  const createQuickSamplerTrack = useProjectStore((s) => s.createQuickSamplerTrack);
   const applyTrackPreset = useProjectStore((s) => s.applyTrackPreset);
   const project = useProjectStore((s) => s.project);
-  const { openFilePicker, openSamplerFilePicker } = useAudioImport();
+  const { openFilePicker, openQuickSamplerFilePicker } = useAudioImport();
 
   const [step, setStep] = useState<PickerStep>('type');
   const [selectedType, setSelectedType] = useState<TrackType>('stems');
@@ -245,7 +246,7 @@ export function InstrumentPicker() {
             <button
               onClick={() => {
                 const track = addTrack('keyboard', 'pianoRoll');
-                updateTrack(track.id, { displayName: 'Sampler', synthPreset: 'sampler' });
+                updateTrack(track.id, { displayName: 'Quick Sampler', synthPreset: 'sampler' });
                 setTrackSampler(track.id, { rootNote: 60 });
                 close();
                 setOpenPianoRoll(track.id);
@@ -261,20 +262,16 @@ export function InstrumentPicker() {
             </button>
             <button
               onClick={() => {
-                const track = addTrack('keyboard', 'pianoRoll');
-                updateTrack(track.id, { displayName: 'Sampler', synthPreset: 'sampler' });
-                setTrackSampler(track.id, { rootNote: 60 });
                 close();
-                setOpenPianoRoll(track.id);
-                openSamplerFilePicker(track.id);
+                openQuickSamplerFilePicker();
               }}
               className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-[#484848] transition-colors text-left"
               style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.pianoRoll.color}` }}
             >
               <span className="text-xl">📥</span>
               <div>
-                <div className="text-sm font-medium">Sampler From Audio File</div>
-                <div className="text-[11px] text-zinc-400">Create a sampler track and load a source sample immediately.</div>
+                <div className="text-sm font-medium">Quick Sampler From Audio File</div>
+                <div className="text-[11px] text-zinc-400">Create a playable instrument and open the sample editor in one step.</div>
               </div>
             </button>
             <button

--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -1,14 +1,19 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { samplerEngine } from '../../engine/SamplerEngine';
+import { useAudioImport } from '../../hooks/useAudioImport';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
-import type { PianoRollGrid } from '../../types/project';
+import type { PianoRollGrid, SamplerConfig, SamplerPlaybackMode } from '../../types/project';
+import { GeneratePatternDialog } from './GeneratePatternDialog';
 import { PianoRollCanvas } from './PianoRollCanvas';
 import { PianoRollEmptyState } from './PianoRollEmptyState';
 import { QuantizeDialog } from './QuantizeDialog';
-import { GeneratePatternDialog } from './GeneratePatternDialog';
 import { TransformMenu } from './TransformMenu';
 import { getPianoRollToolShortcut, midiNoteToName, type PianoRollTool } from './PianoRollConstants';
-import { useAudioImport } from '../../hooks/useAudioImport';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
 
 export function PianoRoll() {
   const [activeTool, setActiveTool] = useState<PianoRollTool>('select');
@@ -16,12 +21,18 @@ export function PianoRoll() {
   const [gridSize, setGridSize] = useState<PianoRollGrid>('1/16');
   const [prZoomX, setPrZoomX] = useState(1);
   const [selectedNoteIds, setSelectedNoteIds] = useState<Set<string>>(new Set());
+  const [samplerDropActive, setSamplerDropActive] = useState(false);
 
   const project = useProjectStore((s) => s.project);
   const updateTrack = useProjectStore((s) => s.updateTrack);
   const setTrackSampler = useProjectStore((s) => s.setTrackSampler);
   const clearTrackSampler = useProjectStore((s) => s.clearTrackSampler);
-  const { openSamplerFilePicker } = useAudioImport();
+  const updateSamplerConfig = useProjectStore((s) => s.updateSamplerConfig);
+  const {
+    importAudioFileAsSampler,
+    importAssetAsQuickSampler,
+    openSamplerFilePicker,
+  } = useAudioImport();
 
   const openTrackId = useUIStore((s) => s.openPianoRollTrackId);
   const openClipId = useUIStore((s) => s.openPianoRollClipId);
@@ -67,7 +78,6 @@ export function PianoRoll() {
     return track.clips.find((candidate) => candidate.midiData) ?? null;
   }, [openClipId, track]);
 
-  // Ghost notes from other tracks' MIDI clips
   const ghostNotes = useMemo(() => {
     if (!showGhostNotes || !project || !track) return [];
     const notes: Array<{ pitch: number; startBeat: number; durationBeats: number; color: string }> = [];
@@ -83,6 +93,28 @@ export function PianoRoll() {
     }
     return notes;
   }, [showGhostNotes, project, track]);
+
+  const samplerConfig = track?.samplerConfig ?? null;
+  const sampleDuration = Math.max(0.01, track?.sampler?.sampleDuration ?? samplerConfig?.trimEnd ?? 1);
+
+  const applySamplerConfig = useCallback((updates: Partial<SamplerConfig>) => {
+    if (!track?.sampler?.audioKey || !samplerConfig) return;
+
+    const trimStart = clamp(updates.trimStart ?? samplerConfig.trimStart, 0, sampleDuration - 0.01);
+    const trimEnd = clamp(updates.trimEnd ?? samplerConfig.trimEnd, trimStart + 0.01, sampleDuration);
+    const loopStart = clamp(updates.loopStart ?? samplerConfig.loopStart, trimStart, trimEnd - 0.01);
+    const loopEnd = clamp(updates.loopEnd ?? samplerConfig.loopEnd, loopStart + 0.01, trimEnd);
+
+    updateSamplerConfig(track.id, {
+      ...samplerConfig,
+      ...updates,
+      rootNote: updates.rootNote ?? samplerConfig.rootNote,
+      trimStart,
+      trimEnd,
+      loopStart,
+      loopEnd,
+    });
+  }, [sampleDuration, samplerConfig, track, updateSamplerConfig]);
 
   const handleResizeMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -105,6 +137,32 @@ export function PianoRoll() {
     [pianoRollHeight, setPianoRollHeight],
   );
 
+  const handleSamplerDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    const types = e.dataTransfer.types;
+    if (types.includes('Files') || types.includes('application/x-asset-id')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+      setSamplerDropActive(true);
+    }
+  }, []);
+
+  const handleSamplerDrop = useCallback(async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setSamplerDropActive(false);
+    if (!track) return;
+
+    const assetId = e.dataTransfer.getData('application/x-asset-id');
+    if (assetId) {
+      await importAssetAsQuickSampler(assetId, track.id);
+      return;
+    }
+
+    const file = e.dataTransfer.files?.[0];
+    if (file && (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name))) {
+      await importAudioFileAsSampler(file, track.id);
+    }
+  }, [importAssetAsQuickSampler, importAudioFileAsSampler, track]);
+
   if (!track) return null;
 
   return (
@@ -118,7 +176,7 @@ export function PianoRoll() {
         onMouseDown={handleResizeMouseDown}
       />
 
-      <div className="h-9 px-3 border-b border-[#2a2a2a] bg-[#0e0e24] flex items-center gap-2 shrink-0">
+      <div className="px-3 py-2 border-b border-[#2a2a2a] bg-[#0e0e24] flex items-center gap-2 shrink-0 flex-wrap">
         <div className="text-xs font-medium text-zinc-200">{track.displayName}</div>
 
         {([
@@ -151,7 +209,7 @@ export function PianoRoll() {
           onClick={() => setShowGhostNotes((v) => !v)}
           title="Show notes from other tracks"
         >
-          👻 Ghost
+          Ghost
         </button>
 
         <select
@@ -178,42 +236,8 @@ export function PianoRoll() {
           <option value="lead">Lead</option>
           <option value="bass">Bass</option>
           <option value="organ">Organ</option>
-          <option value="sampler">Sampler</option>
+          <option value="sampler">Quick Sampler</option>
         </select>
-
-        {track.synthPreset === 'sampler' && (
-          <>
-            <button
-              aria-label={`Load sampler source for ${track.displayName}`}
-              className="px-2 py-1 rounded text-[10px] bg-amber-500/15 text-amber-200 hover:bg-amber-500/25 transition-colors"
-              onClick={() => openSamplerFilePicker(track.id)}
-            >
-              {track.sampler?.audioKey ? 'Swap Sample' : 'Load Sample'}
-            </button>
-            <label className="text-[10px] text-zinc-400 flex items-center gap-1">
-              Root
-              <input
-                aria-label="Sampler root note"
-                type="number"
-                min="0"
-                max="127"
-                value={track.sampler?.rootNote ?? 60}
-                onChange={(e) => setTrackSampler(track.id, { rootNote: Number(e.target.value) })}
-                className="w-14 bg-[#111] border border-[#333] rounded px-1.5 py-1 text-[11px] text-zinc-200"
-              />
-              <span className="text-zinc-500">{midiNoteToName(track.sampler?.rootNote ?? 60)}</span>
-            </label>
-            {track.sampler?.audioKey && (
-              <button
-                aria-label={`Clear sampler source for ${track.displayName}`}
-                className="px-2 py-1 rounded text-[10px] bg-white/5 text-zinc-400 hover:bg-white/10"
-                onClick={() => clearTrackSampler(track.id)}
-              >
-                Clear
-              </button>
-            )}
-          </>
-        )}
 
         {clip && <TransformMenu clipId={clip.id} selectedNoteIds={selectedNoteIds} />}
 
@@ -228,11 +252,6 @@ export function PianoRoll() {
         )}
 
         {clip && <span className="text-[10px] text-zinc-500 ml-1 truncate max-w-[200px]">{clip.prompt}</span>}
-        {track.synthPreset === 'sampler' && (
-          <span className={`text-[10px] truncate max-w-[200px] ${track.sampler?.audioKey ? 'text-amber-200/80' : 'text-rose-300/80'}`}>
-            {track.sampler?.sampleName ? `Sample: ${track.sampler.sampleName}` : 'Load an audio sample to play this track'}
-          </span>
-        )}
 
         <div className="ml-auto flex items-center gap-2">
           <button
@@ -240,7 +259,7 @@ export function PianoRoll() {
             className="text-[9px] text-zinc-400 hover:text-zinc-200 px-1"
             onClick={() => setPrZoomX((zoom) => Math.max(0.25, zoom - 0.25))}
           >
-            −H
+            -H
           </button>
           <button
             aria-label="Zoom in piano roll horizontally"
@@ -258,6 +277,155 @@ export function PianoRoll() {
           </button>
         </div>
       </div>
+
+      {track.synthPreset === 'sampler' && (
+        <div
+          aria-label="Quick Sampler target"
+          className={`grid grid-cols-[minmax(220px,1.2fr)_minmax(180px,1fr)] gap-3 px-3 py-3 border-b border-[#1f2536] bg-[#0b1220] shrink-0 ${samplerDropActive ? 'ring-1 ring-cyan-400/70' : ''}`}
+          onDragOver={handleSamplerDragOver}
+          onDragLeave={() => setSamplerDropActive(false)}
+          onDrop={handleSamplerDrop}
+        >
+          <div className={`rounded-xl border px-3 py-3 ${track.sampler?.audioKey ? 'border-amber-400/25 bg-amber-300/[0.08]' : 'border-cyan-400/25 bg-cyan-300/[0.06]'}`}>
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Quick Sampler</div>
+                <div className="text-sm text-zinc-100">{track.sampler?.sampleName ?? 'Drop audio here to build an instrument'}</div>
+              </div>
+              <button
+                aria-label={`Load sampler source for ${track.displayName}`}
+                className="px-2 py-1 rounded text-[10px] bg-amber-500/15 text-amber-200 hover:bg-amber-500/25 transition-colors"
+                onClick={() => openSamplerFilePicker(track.id)}
+              >
+                {track.sampler?.audioKey ? 'Swap Sample' : 'Load Sample'}
+              </button>
+            </div>
+            <div className="mt-2 text-[11px] text-zinc-400">
+              {track.sampler?.audioKey
+                ? `Drag an imported asset here to remap it instantly. Current range: ${sampleDuration.toFixed(2)}s`
+                : 'Drop an audio file or imported asset here to create a playable instrument in one step.'}
+            </div>
+            {track.sampler?.audioKey && samplerConfig && (
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <label className="text-[10px] text-zinc-400 flex items-center gap-1">
+                  Root
+                  <input
+                    aria-label="Sampler root note"
+                    type="number"
+                    min="0"
+                    max="127"
+                    value={track.sampler?.rootNote ?? 60}
+                    onChange={(e) => {
+                      const rootNote = Number(e.target.value);
+                      setTrackSampler(track.id, { rootNote });
+                      applySamplerConfig({ rootNote });
+                    }}
+                    className="w-14 bg-[#111] border border-[#333] rounded px-1.5 py-1 text-[11px] text-zinc-200"
+                  />
+                  <span className="text-zinc-500">{midiNoteToName(track.sampler?.rootNote ?? 60)}</span>
+                </label>
+                <label className="text-[10px] text-zinc-400 flex items-center gap-1">
+                  Mode
+                  <select
+                    aria-label="Quick Sampler playback mode"
+                    value={samplerConfig.playbackMode}
+                    onChange={(e) => applySamplerConfig({ playbackMode: e.target.value as SamplerPlaybackMode })}
+                    className="bg-[#111] border border-[#333] rounded px-2 py-1 text-[11px] text-zinc-200"
+                  >
+                    <option value="classic">Classic</option>
+                    <option value="oneShot">One Shot</option>
+                    <option value="loop">Loop</option>
+                  </select>
+                </label>
+                <button
+                  aria-label="Preview quick sampler root note"
+                  className="px-2 py-1 rounded text-[10px] bg-cyan-500/15 text-cyan-200 hover:bg-cyan-500/25 transition-colors"
+                  onClick={() => void samplerEngine.previewTrackNote(track, track.sampler?.rootNote ?? 60, 110, 0.6)}
+                >
+                  Preview
+                </button>
+                <button
+                  aria-label={`Clear sampler source for ${track.displayName}`}
+                  className="px-2 py-1 rounded text-[10px] bg-white/5 text-zinc-400 hover:bg-white/10"
+                  onClick={() => clearTrackSampler(track.id)}
+                >
+                  Clear
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-white/8 bg-white/[0.03] px-3 py-3">
+            {samplerConfig ? (
+              <div className="space-y-2">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Sample Editor</div>
+                <label className="block text-[10px] text-zinc-400">
+                  Trim Start
+                  <input
+                    aria-label="Quick Sampler trim start"
+                    type="range"
+                    min="0"
+                    max={sampleDuration}
+                    step="0.01"
+                    value={samplerConfig.trimStart}
+                    onChange={(e) => applySamplerConfig({ trimStart: Number(e.target.value) })}
+                    className="w-full"
+                  />
+                  <span className="text-zinc-500">{samplerConfig.trimStart.toFixed(2)}s</span>
+                </label>
+                <label className="block text-[10px] text-zinc-400">
+                  Trim End
+                  <input
+                    aria-label="Quick Sampler trim end"
+                    type="range"
+                    min="0.01"
+                    max={sampleDuration}
+                    step="0.01"
+                    value={samplerConfig.trimEnd}
+                    onChange={(e) => applySamplerConfig({ trimEnd: Number(e.target.value) })}
+                    className="w-full"
+                  />
+                  <span className="text-zinc-500">{samplerConfig.trimEnd.toFixed(2)}s</span>
+                </label>
+                {samplerConfig.playbackMode === 'loop' && (
+                  <>
+                    <label className="block text-[10px] text-zinc-400">
+                      Loop Start
+                      <input
+                        aria-label="Quick Sampler loop start"
+                        type="range"
+                        min={samplerConfig.trimStart}
+                        max={samplerConfig.trimEnd - 0.01}
+                        step="0.01"
+                        value={samplerConfig.loopStart}
+                        onChange={(e) => applySamplerConfig({ loopStart: Number(e.target.value) })}
+                        className="w-full"
+                      />
+                      <span className="text-zinc-500">{samplerConfig.loopStart.toFixed(2)}s</span>
+                    </label>
+                    <label className="block text-[10px] text-zinc-400">
+                      Loop End
+                      <input
+                        aria-label="Quick Sampler loop end"
+                        type="range"
+                        min={samplerConfig.loopStart + 0.01}
+                        max={samplerConfig.trimEnd}
+                        step="0.01"
+                        value={samplerConfig.loopEnd}
+                        onChange={(e) => applySamplerConfig({ loopEnd: Number(e.target.value) })}
+                        className="w-full"
+                      />
+                      <span className="text-zinc-500">{samplerConfig.loopEnd.toFixed(2)}s</span>
+                    </label>
+                  </>
+                )}
+              </div>
+            ) : (
+              <div className="text-[11px] text-zinc-500">Load a sample to reveal trim and loop controls.</div>
+            )}
+          </div>
+        </div>
+      )}
 
       {clip ? (
         <PianoRollCanvas

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -89,7 +89,14 @@ export function TrackLane({ track }: TrackLaneProps) {
     startTime: number; duration: number;
   } | null>(null);
 
-  const { importAudioToTrack, importMidiFile, importLoopToTrack, importAssetToTrack } = useAudioImport();
+  const {
+    importAssetAsQuickSampler,
+    importAudioFileAsSampler,
+    importAudioToTrack,
+    importMidiFile,
+    importLoopToTrack,
+    importAssetToTrack,
+  } = useAudioImport();
   const [fileDragOver, setFileDragOver] = useState(false);
 
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
@@ -221,6 +228,10 @@ export function TrackLane({ track }: TrackLaneProps) {
     // Handle asset drop
     const assetId = e.dataTransfer.getData('application/x-asset-id');
     if (assetId) {
+      if (track.trackType === 'pianoRoll') {
+        await importAssetAsQuickSampler(assetId, track.id);
+        return;
+      }
       await importAssetToTrack(assetId, track.id, startTime);
       return;
     }
@@ -230,12 +241,16 @@ export function TrackLane({ track }: TrackLaneProps) {
     if (!files.length) return;
     for (const file of Array.from(files)) {
       if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
-        await importAudioToTrack(file, track.id, startTime);
+        if (track.trackType === 'pianoRoll') {
+          await importAudioFileAsSampler(file, track.id);
+        } else {
+          await importAudioToTrack(file, track.id, startTime);
+        }
       } else if (/\.(mid|midi)$/i.test(file.name)) {
         await importMidiFile(file, startTime);
       }
     }
-  }, [project, pixelsPerSecond, track.id, importAudioToTrack, importMidiFile, importLoopToTrack, importAssetToTrack]);
+  }, [project, pixelsPerSecond, track.id, track.trackType, importAssetAsQuickSampler, importAssetToTrack, importAudioFileAsSampler, importAudioToTrack, importMidiFile, importLoopToTrack]);
 
   const hasClips = track.clips.length > 0;
   const automationLanes = (project?.automationLanes ?? []).filter((l) => l.trackId === track.id);

--- a/src/engine/SamplerEngine.ts
+++ b/src/engine/SamplerEngine.ts
@@ -3,15 +3,30 @@ import type { SamplerConfig, Track } from '../types/project';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { getAudioEngine } from '../hooks/useAudioEngine';
 
-interface SamplerInstance {
-  sampler: Tone.Sampler;
+interface SamplerVoice {
   gain: Tone.Gain;
+  pitch: number;
+  releaseTimeoutId: number | null;
+  source: Tone.ToneBufferSource;
+}
+
+interface SamplerInstance {
+  audioBuffer: AudioBuffer;
   audioKey: string;
+  buffer: Tone.ToneAudioBuffer;
+  config: SamplerConfig;
+  output: Tone.Gain;
+  voices: Map<number, SamplerVoice[]>;
 }
 
 /** Default ADSR values for new sampler configs. */
 export const DEFAULT_SAMPLER_CONFIG: Omit<SamplerConfig, 'audioKey'> = {
   rootNote: 60,
+  trimStart: 0,
+  trimEnd: 1,
+  playbackMode: 'classic',
+  loopStart: 0,
+  loopEnd: 1,
   attack: 0.005,
   decay: 0.1,
   sustain: 1,
@@ -22,11 +37,25 @@ export const DEFAULT_SAMPLER_CONFIG: Omit<SamplerConfig, 'audioKey'> = {
  * Create a SamplerConfig with sensible defaults.
  */
 export function createSamplerConfig(audioKey: string, overrides?: Partial<SamplerConfig>): SamplerConfig {
+  const sampleDuration = Math.max(0.01, overrides?.trimEnd ?? overrides?.loopEnd ?? 1);
+  const trimStart = clamp(overrides?.trimStart ?? 0, 0, Math.max(0, sampleDuration - 0.01));
+  const trimEnd = clamp(overrides?.trimEnd ?? sampleDuration, trimStart + 0.01, sampleDuration);
+  const loopStart = clamp(overrides?.loopStart ?? trimStart, trimStart, Math.max(trimStart, trimEnd - 0.01));
+  const loopEnd = clamp(overrides?.loopEnd ?? trimEnd, loopStart + 0.01, trimEnd);
+
   return {
     ...DEFAULT_SAMPLER_CONFIG,
     audioKey,
+    trimStart,
+    trimEnd,
+    loopStart,
+    loopEnd,
     ...overrides,
   };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
 function getTrackSamplerConfig(track: Track): SamplerConfig | null {
@@ -34,18 +63,27 @@ function getTrackSamplerConfig(track: Track): SamplerConfig | null {
   if (!track.sampler?.audioKey) return null;
   return createSamplerConfig(track.sampler.audioKey, {
     rootNote: track.sampler.rootNote ?? DEFAULT_SAMPLER_CONFIG.rootNote,
+    trimEnd: track.sampler.sampleDuration ?? DEFAULT_SAMPLER_CONFIG.trimEnd,
+    loopEnd: track.sampler.sampleDuration ?? DEFAULT_SAMPLER_CONFIG.loopEnd,
+  });
+}
+
+function buildPlaybackConfig(config: SamplerConfig, sampleDuration: number): SamplerConfig {
+  return createSamplerConfig(config.audioKey, {
+    ...config,
+    trimStart: clamp(config.trimStart, 0, Math.max(0, sampleDuration - 0.01)),
+    trimEnd: clamp(config.trimEnd, 0.01, sampleDuration),
+    loopStart: clamp(config.loopStart, 0, Math.max(0, sampleDuration - 0.01)),
+    loopEnd: clamp(config.loopEnd, 0.01, sampleDuration),
   });
 }
 
 /**
- * Engine that manages Tone.js Sampler instances per track.
- * A sampler loads an audio buffer and pitch-shifts playback based on
- * the MIDI note relative to the configured root note.
+ * Engine that manages one-sample chromatic playback per track.
  */
 class SamplerEngine {
   private samplers = new Map<string, SamplerInstance>();
-  private previewSampler: Tone.Sampler | null = null;
-  private previewGain: Tone.Gain | null = null;
+  private previewVoices: SamplerVoice[] = [];
   private readonly bufferCache = new Map<string, AudioBuffer>();
 
   async ensureStarted() {
@@ -54,49 +92,42 @@ class SamplerEngine {
     }
   }
 
-  /**
-   * Create or update a Tone.js Sampler for a track.
-   * If the audioKey hasn't changed, returns the existing sampler.
-   */
   ensureTrackSampler(
     trackId: string,
     config: SamplerConfig,
     audioBuffer: AudioBuffer,
     connectTo?: Tone.InputNode,
-  ): Tone.Sampler {
+  ) {
+    const nextConfig = buildPlaybackConfig(config, audioBuffer.duration);
     const existing = this.samplers.get(trackId);
     if (existing && existing.audioKey === config.audioKey) {
-      this._applyEnvelope(existing.sampler, config);
-      return existing.sampler;
+      existing.audioBuffer = audioBuffer;
+      existing.buffer = new Tone.ToneAudioBuffer(audioBuffer);
+      existing.config = nextConfig;
+      this.bufferCache.set(config.audioKey, audioBuffer);
+      return;
     }
 
     if (existing) {
       this._disposeInstance(existing);
     }
 
-    const toneBuffer = new Tone.ToneAudioBuffer(audioBuffer);
-    const noteName = Tone.Frequency(config.rootNote, 'midi').toNote();
-    const sampler = new Tone.Sampler({
-      urls: { [noteName]: toneBuffer },
-      attack: config.attack,
-      release: config.release,
-    });
-
-    const gain = new Tone.Gain(0.55);
-    sampler.connect(gain);
+    const output = new Tone.Gain(0.55);
     if (connectTo) {
-      gain.connect(connectTo);
+      output.connect(connectTo);
     } else {
-      gain.toDestination();
+      output.toDestination();
     }
 
-    this.samplers.set(trackId, { sampler, gain, audioKey: config.audioKey });
+    this.samplers.set(trackId, {
+      audioBuffer,
+      audioKey: config.audioKey,
+      buffer: new Tone.ToneAudioBuffer(audioBuffer),
+      config: nextConfig,
+      output,
+      voices: new Map(),
+    });
     this.bufferCache.set(config.audioKey, audioBuffer);
-    return sampler;
-  }
-
-  getSampler(trackId: string): Tone.Sampler | null {
-    return this.samplers.get(trackId)?.sampler ?? null;
   }
 
   async getTrackBuffer(track: Track): Promise<AudioBuffer | null> {
@@ -119,29 +150,6 @@ class SamplerEngine {
   /**
    * Preview a sample at a given pitch (for audition / piano roll click).
    */
-  async previewNote(
-    audioBuffer: AudioBuffer,
-    rootNote: number,
-    pitch: number,
-    velocity = 100,
-    duration = 0.3,
-  ) {
-    await this.ensureStarted();
-    if (this.previewSampler) {
-      this.previewSampler.dispose();
-      this.previewGain?.dispose();
-    }
-
-    const toneBuffer = new Tone.ToneAudioBuffer(audioBuffer);
-    const noteName = Tone.Frequency(rootNote, 'midi').toNote();
-    this.previewSampler = new Tone.Sampler({ urls: { [noteName]: toneBuffer } });
-    this.previewGain = new Tone.Gain(0.3).toDestination();
-    this.previewSampler.connect(this.previewGain);
-
-    const freq = Tone.Frequency(pitch, 'midi').toNote();
-    this.previewSampler.triggerAttackRelease(freq, duration, undefined, velocity / 127);
-  }
-
   async previewTrackNote(
     track: Track,
     pitch: number,
@@ -153,30 +161,65 @@ class SamplerEngine {
 
     const buffer = await this.getTrackBuffer(track);
     if (!buffer) return;
-    await this.previewNote(buffer, config.rootNote, pitch, velocity, duration);
+
+    await this.ensureStarted();
+    this._disposeVoices(this.previewVoices);
+    this.previewVoices = [];
+
+    const previewConfig = buildPlaybackConfig(config, buffer.duration);
+    const voice = this._createVoice(new Tone.ToneAudioBuffer(buffer), previewConfig, pitch, velocity / 127);
+    voice.gain.connect(Tone.getDestination());
+    this.previewVoices.push(voice);
+    this._startVoice(voice, previewConfig, duration);
+  }
+
+  triggerAttackRelease(trackId: string, pitch: number, duration: number, velocity = 1) {
+    const instance = this.samplers.get(trackId);
+    if (!instance) return;
+    const voice = this._createVoice(instance.buffer, instance.config, pitch, velocity);
+    this._registerVoice(instance, voice);
+    this._startVoice(voice, instance.config, duration);
   }
 
   /** Trigger note on for a track sampler (for live playing / recording). */
   noteOn(trackId: string, pitch: number, velocity = 100) {
     const instance = this.samplers.get(trackId);
     if (!instance) return;
-    const note = Tone.Frequency(pitch, 'midi').toNote();
-    instance.sampler.triggerAttack(note, undefined, velocity / 127);
+
+    if (instance.config.playbackMode === 'oneShot') {
+      this.triggerAttackRelease(trackId, pitch, 0, velocity / 127);
+      return;
+    }
+
+    const voice = this._createVoice(instance.buffer, instance.config, pitch, velocity / 127);
+    this._registerVoice(instance, voice);
+    this._startVoice(voice, instance.config, Number.POSITIVE_INFINITY);
   }
 
   /** Trigger note off for a track sampler. */
   noteOff(trackId: string, pitch: number) {
     const instance = this.samplers.get(trackId);
     if (!instance) return;
-    const note = Tone.Frequency(pitch, 'midi').toNote();
-    instance.sampler.triggerRelease(note);
+
+    const voices = instance.voices.get(pitch) ?? [];
+    for (const voice of voices) {
+      this._releaseVoice(voice, instance.config.release);
+    }
+    instance.voices.delete(pitch);
   }
 
   /** Release all currently sounding notes on all track samplers. */
   releaseAll() {
     for (const instance of this.samplers.values()) {
-      instance.sampler.releaseAll();
+      for (const voices of instance.voices.values()) {
+        for (const voice of voices) {
+          this._releaseVoice(voice, instance.config.release);
+        }
+      }
+      instance.voices.clear();
     }
+    this._disposeVoices(this.previewVoices);
+    this.previewVoices = [];
   }
 
   removeTrackSampler(trackId: string) {
@@ -198,21 +241,114 @@ class SamplerEngine {
     for (const trackId of this.samplers.keys()) {
       this.removeTrackSampler(trackId);
     }
-    this.previewSampler?.dispose();
-    this.previewGain?.dispose();
-    this.previewSampler = null;
-    this.previewGain = null;
+    this._disposeVoices(this.previewVoices);
+    this.previewVoices = [];
   }
 
-  private _applyEnvelope(sampler: Tone.Sampler, config: SamplerConfig) {
-    sampler.attack = config.attack;
-    sampler.release = config.release;
+  private _createVoice(
+    buffer: Tone.ToneAudioBuffer,
+    config: SamplerConfig,
+    pitch: number,
+    velocity: number,
+  ): SamplerVoice {
+    const trimmedDuration = Math.max(0.01, config.trimEnd - config.trimStart);
+    const playbackRate = Math.pow(2, (pitch - config.rootNote) / 12);
+    const source = new Tone.BufferSource({
+      url: buffer,
+      loop: config.playbackMode === 'loop',
+      loopStart: config.loopStart,
+      loopEnd: config.loopEnd,
+      playbackRate,
+    });
+    const gain = new Tone.Gain(0);
+    source.connect(gain);
+
+    const now = Tone.now();
+    const attackEnd = now + Math.max(0.001, config.attack);
+    const sustainLevel = clamp(velocity * config.sustain, 0, 1);
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.linearRampToValueAtTime(Math.max(0.0001, velocity), attackEnd);
+    gain.gain.linearRampToValueAtTime(Math.max(0.0001, sustainLevel), attackEnd + Math.max(0, config.decay));
+
+    return {
+      gain,
+      pitch,
+      releaseTimeoutId: null,
+      source,
+    };
+  }
+
+  private _registerVoice(instance: SamplerInstance, voice: SamplerVoice) {
+    voice.gain.connect(instance.output);
+    const existing = instance.voices.get(voice.pitch) ?? [];
+    instance.voices.set(voice.pitch, existing.concat(voice));
+  }
+
+  private _startVoice(voice: SamplerVoice, config: SamplerConfig, requestedDuration: number) {
+    const startTime = Tone.now();
+    const trimmedDuration = Math.max(0.01, config.trimEnd - config.trimStart);
+    const playbackRate = Math.max(0.001, voice.source.playbackRate.value);
+    const naturalDuration = trimmedDuration / playbackRate;
+
+    if (config.playbackMode === 'loop') {
+      voice.source.start(startTime, config.trimStart);
+      if (Number.isFinite(requestedDuration)) {
+        this._scheduleRelease(voice, Math.max(0.02, requestedDuration), config.release);
+      }
+      return;
+    }
+
+    const playbackDuration = config.playbackMode === 'oneShot'
+      ? naturalDuration
+      : Number.isFinite(requestedDuration)
+        ? Math.max(0.02, Math.min(naturalDuration, requestedDuration))
+        : naturalDuration;
+    const sourceDuration = Math.min(trimmedDuration, playbackDuration * playbackRate);
+    voice.source.start(startTime, config.trimStart, sourceDuration);
+    this._scheduleRelease(voice, playbackDuration, config.release);
+  }
+
+  private _scheduleRelease(voice: SamplerVoice, holdDuration: number, release: number) {
+    const totalDuration = Math.max(0.02, holdDuration);
+    voice.releaseTimeoutId = globalThis.setTimeout(() => {
+      this._releaseVoice(voice, release);
+    }, totalDuration * 1000);
+  }
+
+  private _releaseVoice(voice: SamplerVoice, release: number) {
+    if (voice.releaseTimeoutId !== null) {
+      globalThis.clearTimeout(voice.releaseTimeoutId);
+      voice.releaseTimeoutId = null;
+    }
+
+    const now = Tone.now();
+    const releaseEnd = now + Math.max(0.01, release);
+    voice.gain.gain.cancelScheduledValues(now);
+    voice.gain.gain.setValueAtTime(Math.max(0.0001, voice.gain.gain.value), now);
+    voice.gain.gain.linearRampToValueAtTime(0.0001, releaseEnd);
+    voice.source.stop(releaseEnd + 0.005);
+    globalThis.setTimeout(() => {
+      voice.source.dispose();
+      voice.gain.dispose();
+    }, Math.max(20, Math.ceil((release + 0.05) * 1000)));
+  }
+
+  private _disposeVoices(voices: SamplerVoice[]) {
+    for (const voice of voices) {
+      if (voice.releaseTimeoutId !== null) {
+        globalThis.clearTimeout(voice.releaseTimeoutId);
+      }
+      voice.source.dispose();
+      voice.gain.dispose();
+    }
   }
 
   private _disposeInstance(instance: SamplerInstance) {
-    instance.sampler.releaseAll();
-    instance.sampler.dispose();
-    instance.gain.dispose();
+    for (const voices of instance.voices.values()) {
+      this._disposeVoices(voices);
+    }
+    instance.voices.clear();
+    instance.output.dispose();
   }
 }
 

--- a/src/engine/offlineRender.ts
+++ b/src/engine/offlineRender.ts
@@ -2,7 +2,7 @@ import * as Tone from 'tone';
 import type { ToneAudioBuffer } from 'tone';
 import { createDrumVoicesForKit } from './DrumEngine';
 import { createSynthForPreset } from './SynthEngine';
-import type { DrumKitName, MidiNote, SequencerPattern, SynthPreset } from '../types/project';
+import type { DrumKitName, MidiNote, SamplerConfig, SequencerPattern, SynthPreset } from '../types/project';
 
 const DRUM_PAD_INDEX_BY_SAMPLE_KEY: Record<string, number> = {
   kick: 0,
@@ -76,7 +76,7 @@ export async function renderSamplerTrackOffline(
   clipStartTime: number,
   bpm: number,
   sampleBuffer: AudioBuffer,
-  rootNote: number,
+  config: SamplerConfig,
   totalDuration: number,
   sampleRate: number = 48000,
 ): Promise<AudioBuffer> {
@@ -90,17 +90,30 @@ export async function renderSamplerTrackOffline(
     const noteEnd = noteStart + noteDuration;
     if (noteDuration <= 0 || noteEnd <= 0 || noteStart >= totalDuration) continue;
 
-    const playbackRate = Math.pow(2, (note.pitch - rootNote) / 12);
+    const trimStart = Math.max(0, Math.min(config.trimStart, sampleBuffer.duration - 0.01));
+    const trimEnd = Math.max(trimStart + 0.01, Math.min(config.trimEnd, sampleBuffer.duration));
+    const loopStart = Math.max(trimStart, Math.min(config.loopStart, trimEnd - 0.01));
+    const loopEnd = Math.max(loopStart + 0.01, Math.min(config.loopEnd, trimEnd));
+    const trimmedSpan = trimEnd - trimStart;
+    const playbackRate = Math.pow(2, (note.pitch - config.rootNote) / 12);
     const source = offlineCtx.createBufferSource();
     source.buffer = sampleBuffer;
     source.playbackRate.value = playbackRate;
+    source.loop = config.playbackMode === 'loop';
+    source.loopStart = loopStart;
+    source.loopEnd = loopEnd;
 
     const gain = offlineCtx.createGain();
     const velocity = Math.max(0, Math.min(1, note.velocity));
-    const attack = 0.005;
-    const release = 0.03;
-    const naturalDuration = sampleBuffer.duration / Math.max(playbackRate, 0.001);
-    const stopTime = Math.min(totalDuration, noteStart + Math.min(naturalDuration, noteDuration + release));
+    const attack = Math.max(0.001, config.attack);
+    const release = Math.max(0.01, config.release);
+    const naturalDuration = trimmedSpan / Math.max(playbackRate, 0.001);
+    const holdDuration = config.playbackMode === 'oneShot'
+      ? naturalDuration
+      : config.playbackMode === 'loop'
+        ? Math.max(0.02, noteDuration)
+        : Math.min(naturalDuration, Math.max(0.02, noteDuration));
+    const stopTime = Math.min(totalDuration, noteStart + holdDuration + release);
 
     gain.gain.setValueAtTime(0.0001, noteStart);
     gain.gain.linearRampToValueAtTime(velocity, Math.min(stopTime, noteStart + attack));
@@ -109,7 +122,11 @@ export async function renderSamplerTrackOffline(
 
     source.connect(gain);
     gain.connect(offlineCtx.destination);
-    source.start(noteStart);
+    if (config.playbackMode === 'loop') {
+      source.start(noteStart, trimStart);
+    } else {
+      source.start(noteStart, trimStart, Math.min(trimmedSpan, holdDuration * playbackRate));
+    }
     source.stop(stopTime);
   }
 

--- a/src/hooks/useAudioImport.ts
+++ b/src/hooks/useAudioImport.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useProjectStore } from '../store/projectStore';
+import { useUIStore } from '../store/uiStore';
 import { getAudioEngine } from './useAudioEngine';
 import { saveAudioBlob, loadAudioBlobByKey } from '../services/audioFileManager';
 import { computeWaveformPeaks } from '../utils/waveformPeaks';
@@ -38,7 +39,7 @@ export function useAudioImport() {
   const addClip = useProjectStore((s) => s.addClip);
   const updateProject = useProjectStore((s) => s.updateProject);
   const updateTrack = useProjectStore((s) => s.updateTrack);
-  const setTrackSampler = useProjectStore((s) => s.setTrackSampler);
+  const createQuickSamplerTrack = useProjectStore((s) => s.createQuickSamplerTrack);
   const updateClipStatus = useProjectStore((s) => s.updateClipStatus);
 
   const maybeApplyImportedMidiMetadata = useCallback((fileName: string, bpm?: number, timeSignature?: number) => {
@@ -194,19 +195,40 @@ export function useAudioImport() {
     const wavBlob = audioBufferToWavBlob(audioBuffer);
     const audioKey = await saveAudioBlob(project.id, `sampler-${trackId}`, 'isolated', wavBlob);
     const sampleName = file.name.replace(/\.[^.]+$/, '');
-
-    updateTrack(trackId, {
-      trackType: 'pianoRoll',
-      synthPreset: 'sampler',
-    });
-    setTrackSampler(trackId, {
+    const track = createQuickSamplerTrack({
+      trackId,
       audioKey,
       sampleName,
       sampleDuration: audioBuffer.duration,
     });
-
+    if (track) {
+      useUIStore.getState().setOpenPianoRoll(track.id);
+    }
     toastSuccess(`Loaded sampler source: ${sampleName}`);
-  }, [setTrackSampler, updateTrack]);
+  }, [createQuickSamplerTrack]);
+
+  const importAudioFileAsNewQuickSampler = useCallback(async (file: File) => {
+    const project = useProjectStore.getState().project;
+    if (!project) return;
+
+    const engine = getAudioEngine();
+    await engine.resume();
+
+    const arrayBuffer = await file.arrayBuffer();
+    const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
+    const wavBlob = audioBufferToWavBlob(audioBuffer);
+    const sampleName = file.name.replace(/\.[^.]+$/, '');
+    const audioKey = await saveAudioBlob(project.id, `sampler-${sampleName}-${crypto.randomUUID()}`, 'isolated', wavBlob);
+    const track = createQuickSamplerTrack({
+      audioKey,
+      sampleName,
+      sampleDuration: audioBuffer.duration,
+    });
+    if (track) {
+      useUIStore.getState().setOpenPianoRoll(track.id);
+    }
+    toastSuccess(`Created Quick Sampler: ${sampleName}`);
+  }, [createQuickSamplerTrack]);
 
   const importMidiFile = useCallback(async (file: File, startTime: number = 0) => {
     const project = useProjectStore.getState().project;
@@ -294,6 +316,19 @@ export function useAudioImport() {
     input.click();
   }, [importAudioFileAsSampler]);
 
+  const openQuickSamplerFilePicker = useCallback(() => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'audio/*';
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (file) {
+        await importAudioFileAsNewQuickSampler(file);
+      }
+    };
+    input.click();
+  }, [importAudioFileAsNewQuickSampler]);
+
   const importLoopToTrack = useCallback(async (loopId: string, trackId: string, startTime: number) => {
     const project = useProjectStore.getState().project;
     if (!project) return;
@@ -368,15 +403,47 @@ export function useAudioImport() {
     });
   }, [addClip, updateClipStatus]);
 
+  const importAssetAsQuickSampler = useCallback(async (assetId: string, trackId?: string) => {
+    const project = useProjectStore.getState().project;
+    if (!project) return;
+
+    const asset = (project.assets ?? []).find((candidate) => candidate.id === assetId);
+    if (!asset) return;
+
+    const audioKey = asset.isolatedAudioKey ?? asset.cumulativeMixKey;
+    if (!audioKey) return;
+
+    const blob = await loadAudioBlobByKey(audioKey);
+    if (!blob) return;
+
+    const engine = getAudioEngine();
+    await engine.resume();
+    const audioBuffer = await engine.decodeAudioData(blob);
+    const track = createQuickSamplerTrack({
+      trackId,
+      audioKey,
+      sampleName: asset.prompt || asset.trackDisplayName,
+      sampleDuration: audioBuffer.duration,
+    });
+    if (track) {
+      useUIStore.getState().setOpenPianoRoll(track.id);
+    }
+    toastSuccess(`Created Quick Sampler: ${asset.prompt || asset.trackDisplayName}`);
+  }, [createQuickSamplerTrack]);
+
   return {
     importAudioFile,
     importAudioBufferToTrack,
     importAudioToTrack,
+    importAudioFileAsSampler,
+    importAudioFileAsNewQuickSampler,
     importMidiFile,
     importMultipleFiles,
     openFilePicker,
     openSamplerFilePicker,
+    openQuickSamplerFilePicker,
     importLoopToTrack,
     importAssetToTrack,
+    importAssetAsQuickSampler,
   };
 }

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -5,7 +5,7 @@ import { useProjectStore } from '../store/projectStore';
 import { getAudioEngine } from './useAudioEngine';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { synthEngine } from '../engine/SynthEngine';
-import { samplerEngine } from '../engine/SamplerEngine';
+import { createSamplerConfig, samplerEngine } from '../engine/SamplerEngine';
 import { drumEngine } from '../engine/DrumEngine';
 import { automationEngine } from '../engine/AutomationEngine';
 import { useRecording } from './useRecording';
@@ -199,14 +199,11 @@ export function useTransport() {
         const preset = track.synthPreset ?? 'piano';
         const samplerConfig = track.samplerConfig
           ?? (preset === 'sampler' && track.sampler?.audioKey
-            ? {
-                audioKey: track.sampler.audioKey,
+            ? createSamplerConfig(track.sampler.audioKey, {
                 rootNote: track.sampler.rootNote ?? 60,
-                attack: 0.005,
-                decay: 0.1,
-                sustain: 1,
-                release: 0.3,
-              }
+                trimEnd: track.sampler.sampleDuration,
+                loopEnd: track.sampler.sampleDuration,
+              })
             : null);
         const useSampler = !!samplerConfig;
 
@@ -244,12 +241,8 @@ export function useTransport() {
             const trackId = track.id;
 
             if (useSampler) {
-              const noteName = Tone.Frequency(note.pitch, 'midi').toNote();
               engine.scheduleMidiEvent(scheduledStart, () => {
-                const sampler = samplerEngine.getSampler(trackId);
-                if (sampler) {
-                  sampler.triggerAttackRelease(noteName, scheduledDuration, undefined, velocity);
-                }
+                samplerEngine.triggerAttackRelease(trackId, note.pitch, scheduledDuration, velocity);
               });
             } else {
               const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();

--- a/src/services/freezeTrack.ts
+++ b/src/services/freezeTrack.ts
@@ -1,6 +1,7 @@
 import { useProjectStore } from '../store/projectStore';
 import { loadAudioBlobByKey, saveAudioBlob } from './audioFileManager';
 import { renderMidiTrackOffline, renderSamplerTrackOffline, renderSequencerTrackOffline } from '../engine/offlineRender';
+import { createSamplerConfig } from '../engine/SamplerEngine';
 import { audioBufferToWavBlob } from '../utils/wav';
 import { computeWaveformPeaks } from '../utils/waveformPeaks';
 import { getAudioEngine } from '../hooks/useAudioEngine';
@@ -39,7 +40,11 @@ export async function freezeTrackToAudio(trackId: string): Promise<void> {
             0,
             project.bpm,
             sampleBuffer,
-            track.sampler.rootNote,
+            track.samplerConfig ?? createSamplerConfig(track.sampler.audioKey, {
+              rootNote: track.sampler.rootNote,
+              trimEnd: track.sampler.sampleDuration,
+              loopEnd: track.sampler.sampleDuration,
+            }),
             project.totalDuration,
           );
         }

--- a/src/store/__tests__/projectStore.test.ts
+++ b/src/store/__tests__/projectStore.test.ts
@@ -118,6 +118,44 @@ describe('projectStore', () => {
         rootNote: 48,
         sampleDuration: 1.25,
       });
+      expect(updated.samplerConfig).toMatchObject({
+        audioKey: 'audio:test:sampler',
+        rootNote: 48,
+        trimStart: 0,
+        trimEnd: 1.25,
+        playbackMode: 'classic',
+        loopStart: 0,
+        loopEnd: 1.25,
+      });
+    });
+
+    it('creates a quick sampler track from an audio key via store API', () => {
+      const store = useProjectStore.getState();
+      const track = store.createQuickSamplerTrack({
+        audioKey: 'audio:test:quick-sampler',
+        sampleName: 'Quick Vox',
+        sampleDuration: 2.75,
+        rootNote: 57,
+      });
+
+      expect(track).toBeDefined();
+      expect(track?.trackType).toBe('pianoRoll');
+      expect(track?.synthPreset).toBe('sampler');
+      expect(track?.sampler).toMatchObject({
+        audioKey: 'audio:test:quick-sampler',
+        sampleName: 'Quick Vox',
+        sampleDuration: 2.75,
+        rootNote: 57,
+      });
+      expect(track?.samplerConfig).toMatchObject({
+        audioKey: 'audio:test:quick-sampler',
+        rootNote: 57,
+        trimStart: 0,
+        trimEnd: 2.75,
+        playbackMode: 'classic',
+        loopStart: 0,
+        loopEnd: 2.75,
+      });
     });
 
     it('increments order for each new track', () => {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -70,6 +70,7 @@ import { generatePattern, type PatternOptions } from '../utils/midiPatternGenera
 import { loadAudioBlobByKey, saveAudioBlob } from '../services/audioFileManager';
 import { getAudioEngine } from '../hooks/useAudioEngine';
 import { renderMidiTrackOffline, renderSamplerTrackOffline, renderSequencerTrackOffline } from '../engine/offlineRender';
+import { createSamplerConfig } from '../engine/SamplerEngine';
 import { convertClipAudioToMidi } from '../services/audioToMidi';
 import { createDefaultParametricEqBands } from '../utils/parametricEq';
 import type { StemCount } from '../types/api';
@@ -170,6 +171,13 @@ interface ProjectState {
   clearTrackSampler: (trackId: string) => void;
   /** Set or clear the sampler config on a pianoRoll track. Pass null to remove. */
   updateSamplerConfig: (trackId: string, config: SamplerConfig | null) => void;
+  createQuickSamplerTrack: (input: {
+    audioKey: string;
+    sampleName?: string;
+    sampleDuration?: number;
+    rootNote?: number;
+    trackId?: string;
+  }) => Track | undefined;
   saveTrackPreset: (trackId: string, presetName: string) => TrackPreset;
   applyTrackPreset: (presetId: string) => Track | undefined;
   deleteTrackPreset: (presetId: string) => void;
@@ -545,9 +553,19 @@ function createDefaultSamplerSettings(overrides?: Partial<SamplerSettings>): Sam
 }
 
 function createDefaultSamplerConfig(audioKey: string, overrides?: Partial<SamplerConfig>): SamplerConfig {
+  const sampleDuration = Math.max(0.01, overrides?.trimEnd ?? overrides?.loopEnd ?? 1);
+  const trimStart = Math.max(0, Math.min(overrides?.trimStart ?? 0, sampleDuration - 0.01));
+  const trimEnd = Math.max(trimStart + 0.01, Math.min(overrides?.trimEnd ?? sampleDuration, sampleDuration));
+  const loopStart = Math.max(trimStart, Math.min(overrides?.loopStart ?? trimStart, trimEnd - 0.01));
+  const loopEnd = Math.max(loopStart + 0.01, Math.min(overrides?.loopEnd ?? trimEnd, trimEnd));
   return {
     audioKey,
     rootNote: 60,
+    trimStart,
+    trimEnd,
+    playbackMode: 'classic',
+    loopStart,
+    loopEnd,
     attack: 0.005,
     decay: 0.1,
     sustain: 1,
@@ -572,6 +590,7 @@ function syncSamplerState(
         ...(nextSampler ?? {}),
         audioKey: nextConfig.audioKey,
         rootNote: nextConfig.rootNote,
+        sampleDuration: nextSampler?.sampleDuration ?? nextConfig.trimEnd,
       }),
       samplerConfig: createDefaultSamplerConfig(nextConfig.audioKey, nextConfig),
     };
@@ -582,6 +601,8 @@ function syncSamplerState(
       sampler: createDefaultSamplerSettings(nextSampler),
       samplerConfig: createDefaultSamplerConfig(nextSampler.audioKey, {
         rootNote: nextSampler.rootNote,
+        trimEnd: nextSampler.sampleDuration,
+        loopEnd: nextSampler.sampleDuration,
       }),
     };
   }
@@ -680,6 +701,7 @@ function createTrackPresetSnapshot(track: Track, name: string): TrackPreset {
     laneHeight: track.laneHeight,
     synthPreset: track.synthPreset,
     sampler: track.sampler ? createDefaultSamplerSettings(track.sampler) : undefined,
+    samplerConfig: track.samplerConfig ? createDefaultSamplerConfig(track.samplerConfig.audioKey, track.samplerConfig) : undefined,
     drumKit: track.drumKit,
     pan: track.pan,
     panMode: track.panMode,
@@ -1173,6 +1195,74 @@ export const useProjectStore = create<ProjectState>()(
         ...preset.settings,
         effects: preset.effects,
         midiEffects: preset.midiEffects,
+      },
+    );
+
+    const newTracks = [...state.project.tracks, track];
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature),
+        tracks: newTracks,
+      },
+    });
+    return track;
+  },
+
+  createQuickSamplerTrack: (input) => {
+    const state = get();
+    if (!state.project) return undefined;
+
+    const rootNote = input.rootNote ?? 60;
+    const sampleDuration = Math.max(0.01, input.sampleDuration ?? 1);
+    const sampler = createDefaultSamplerSettings({
+      audioKey: input.audioKey,
+      sampleName: input.sampleName,
+      rootNote,
+      sampleDuration,
+    });
+    const samplerConfig = createDefaultSamplerConfig(input.audioKey, {
+      rootNote,
+      trimEnd: sampleDuration,
+      loopEnd: sampleDuration,
+    });
+
+    _pushHistory(state.project);
+
+    if (input.trackId) {
+      let updatedTrack: Track | undefined;
+      const tracks = state.project.tracks.map((candidate) => {
+        if (candidate.id !== input.trackId) return candidate;
+        updatedTrack = {
+          ...candidate,
+          trackType: 'pianoRoll',
+          synthPreset: 'sampler',
+          displayName: input.sampleName || 'Quick Sampler',
+          ...syncSamplerState(candidate, { sampler, samplerConfig }),
+        };
+        return updatedTrack;
+      });
+      if (!updatedTrack) return undefined;
+      set({
+        project: {
+          ...state.project,
+          updatedAt: Date.now(),
+          tracks,
+        },
+      });
+      return updatedTrack;
+    }
+
+    const track = createTrackFromTemplate(
+      state.project.tracks,
+      'keyboard',
+      'pianoRoll',
+      {
+        displayName: input.sampleName || 'Quick Sampler',
+        synthPreset: 'sampler',
+        sampler,
+        samplerConfig,
       },
     );
 
@@ -3808,7 +3898,11 @@ export const useProjectStore = create<ProjectState>()(
                 clip.startTime,
                 project.bpm,
                 sampleBuffer,
-                track.sampler.rootNote,
+                track.samplerConfig ?? createSamplerConfig(track.sampler.audioKey, {
+                  rootNote: track.sampler.rootNote,
+                  trimEnd: track.sampler.sampleDuration,
+                  loopEnd: track.sampler.sampleDuration,
+                }),
                 totalDuration,
               );
             }

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -8,6 +8,7 @@ export type TrackType = 'stems' | 'sample' | 'sequencer' | 'pianoRoll' | 'drumMa
 export type InputMonitoringMode = 'off' | 'auto' | 'on';
 export type SynthPreset = 'piano' | 'strings' | 'pad' | 'lead' | 'bass' | 'organ' | 'sampler';
 export type DrumKitName = '808' | 'acoustic' | 'electronic' | 'lofi';
+export type SamplerPlaybackMode = 'classic' | 'oneShot' | 'loop';
 /** Time-stretch algorithm mode. 'repitch' uses playbackRate (changes pitch), 'slice' uses warp markers. */
 export type StretchMode = 'repitch' | 'slice';
 export type PianoRollGrid = '1/4' | '1/8' | '1/16' | '1/32';
@@ -18,6 +19,16 @@ export interface SamplerConfig {
   audioKey: string;
   /** MIDI note number the sample was recorded at (default 60 = C4). */
   rootNote: number;
+  /** Sample trim start in seconds. */
+  trimStart: number;
+  /** Sample trim end in seconds. */
+  trimEnd: number;
+  /** Playback mode inspired by Quick Sampler. */
+  playbackMode: SamplerPlaybackMode;
+  /** Loop region start in seconds. */
+  loopStart: number;
+  /** Loop region end in seconds. */
+  loopEnd: number;
   /** ADSR attack time in seconds. */
   attack: number;
   /** ADSR decay time in seconds. */
@@ -389,6 +400,7 @@ export interface TrackPresetSettings {
   laneHeight?: number;
   synthPreset?: SynthPreset;
   sampler?: SamplerSettings;
+  samplerConfig?: SamplerConfig;
   drumKit?: DrumKitName;
   pan?: number;
   panMode?: 'stereo' | 'dual-mono';

--- a/tests/e2e/sampler.spec.ts
+++ b/tests/e2e/sampler.spec.ts
@@ -33,7 +33,7 @@ function createTestWav(durationSeconds = 0.2, sampleRate = 44100): Buffer {
 }
 
 test.describe('Sampler Workflow', () => {
-  test('creates a sampler track from an audio file', async ({ page }, testInfo) => {
+  test('creates and edits a quick sampler from an audio file', async ({ page }, testInfo) => {
     const samplePath = testInfo.outputPath('sampler-test.wav');
     await fs.writeFile(samplePath, createTestWav());
 
@@ -46,12 +46,21 @@ test.describe('Sampler Workflow', () => {
     });
     await page.getByText('Click anywhere to enable audio').click();
 
-    await page.getByRole('button', { name: /track/i }).first().click();
-    await page.getByRole('button', { name: 'Piano Roll' }).click();
+    await page.evaluate(() => {
+      const store = (window as any).__store;
+      const uiStore = (window as any).__uiStore;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      store.getState().updateTrack(track.id, {
+        displayName: 'Quick Sampler',
+        synthPreset: 'sampler',
+      });
+      store.getState().setTrackSampler(track.id, { rootNote: 60 });
+      uiStore.getState().setOpenPianoRoll(track.id);
+    });
 
     const [chooser] = await Promise.all([
       page.waitForEvent('filechooser'),
-      page.getByRole('button', { name: 'Sampler From Audio File' }).click(),
+      page.getByRole('button', { name: /Load sampler source for Quick Sampler/i }).click(),
     ]);
     await chooser.setFiles(samplePath);
 
@@ -60,8 +69,27 @@ test.describe('Sampler Workflow', () => {
       return track?.synthPreset === 'sampler' && track?.sampler?.sampleName === 'sampler-test';
     });
 
-    await expect(page.getByText('Sample: sampler-test')).toBeVisible();
-    await expect(page.getByLabel('Sampler root note')).toHaveValue('60');
+    await expect(page.getByRole('button', { name: /Load sampler source for sampler-test/i })).toBeVisible();
+    await expect(page.getByRole('spinbutton', { name: 'Sampler root note' })).toHaveValue('60');
+    await expect(page.getByLabel('Quick Sampler playback mode')).toHaveValue('classic');
+
+    await page.evaluate(() => {
+      const store = (window as any).__store;
+      const track = store.getState().project?.tracks[0];
+      if (!track?.samplerConfig) return;
+      store.getState().updateSamplerConfig(track.id, {
+        ...track.samplerConfig,
+        playbackMode: 'loop',
+        trimEnd: 0.12,
+        loopEnd: 0.12,
+      });
+    });
+
+    await page.waitForFunction(() => {
+      const track = (window as any).__store.getState().project?.tracks[0];
+      return track?.samplerConfig?.playbackMode === 'loop'
+        && Math.abs((track?.samplerConfig?.trimEnd ?? 0) - 0.12) < 0.011;
+    });
 
     const samplerState = await page.evaluate(() => {
       const track = (window as any).__store.getState().project?.tracks[0];
@@ -79,6 +107,8 @@ test.describe('Sampler Workflow', () => {
         synthPreset: refreshedTrack.synthPreset,
         sampleName: refreshedTrack.sampler?.sampleName,
         rootNote: refreshedTrack.sampler?.rootNote,
+        playbackMode: refreshedTrack.samplerConfig?.playbackMode,
+        trimEnd: refreshedTrack.samplerConfig?.trimEnd,
         notes: refreshedClip?.midiData?.notes.length ?? 0,
       };
     });
@@ -88,7 +118,9 @@ test.describe('Sampler Workflow', () => {
       synthPreset: 'sampler',
       sampleName: 'sampler-test',
       rootNote: 60,
+      playbackMode: 'loop',
       notes: 1,
     });
+    expect(samplerState.trimEnd).toBeCloseTo(0.12, 2);
   });
 });

--- a/tests/unit/samplerEngine.test.ts
+++ b/tests/unit/samplerEngine.test.ts
@@ -16,6 +16,11 @@ describe('createSamplerConfig', () => {
     expect(config).toEqual({
       audioKey: 'audio:proj:clip:iso:123',
       rootNote: 60,
+      trimStart: 0,
+      trimEnd: 1,
+      playbackMode: 'classic',
+      loopStart: 0,
+      loopEnd: 1,
       attack: 0.005,
       decay: 0.1,
       sustain: 1,
@@ -63,6 +68,11 @@ describe('SamplerConfig type integration', () => {
     const config: SamplerConfig = {
       audioKey: 'test-key',
       rootNote: 60,
+      trimStart: 0,
+      trimEnd: 1,
+      playbackMode: 'classic',
+      loopStart: 0,
+      loopEnd: 1,
       attack: 0.01,
       decay: 0.1,
       sustain: 0.8,


### PR DESCRIPTION
## Summary\n- upgrade sampler tracks into a Quick Sampler workflow with trim, loop, preview, and playback modes\n- add a store API to create or retarget Quick Sampler tracks from audio keys, and route piano roll audio drops into that path\n- cover the new behavior with store/unit coverage and a targeted Playwright sampler workflow test\n\n## Verification\n- npx tsc --noEmit\n- npm test\n- npm run build\n- npx playwright test tests/e2e/sampler.spec.ts\n\nCloses #339