### PR TITLE
fix: harden Playwright localhost proxy env

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,16 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
-function mergeNoProxyValue(value: string | undefined) {
-  const entries = new Set(
-    (value ?? '')
-      .split(',')
-      .map((entry) => entry.trim())
-      .filter(Boolean),
-  );
-  entries.add('127.0.0.1');
-  entries.add('localhost');
-  return Array.from(entries).join(',');
-}
+import {
+  applyPlaywrightProxySafeEnv,
+  createPlaywrightProxySafeEnv,
+} from './tests/support/playwrightProxyEnv';
 
 function deriveWorktreePort() {
   return Array.from(process.cwd()).reduce((hash, character) => {
@@ -18,13 +11,10 @@ function deriveWorktreePort() {
   }, 0);
 }
 
-const noProxyValue = mergeNoProxyValue(process.env.NO_PROXY ?? process.env.no_proxy);
-
-process.env.NO_PROXY = noProxyValue;
-process.env.no_proxy = noProxyValue;
-process.env.GLOBAL_AGENT_NO_PROXY = noProxyValue;
-
 const e2ePort = Number(process.env.E2E_PORT) || 5274 + deriveWorktreePort();
+const safeProcessEnv = createPlaywrightProxySafeEnv(process.env);
+
+applyPlaywrightProxySafeEnv(process.env);
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -36,6 +26,9 @@ export default defineConfig({
   use: {
     baseURL: `http://127.0.0.1:${e2ePort}`,
     trace: 'on-first-retry',
+    launchOptions: {
+      env: safeProcessEnv,
+    },
   },
   projects: [
     {
@@ -49,9 +42,8 @@ export default defineConfig({
     reuseExistingServer: false,
     timeout: 60000,
     env: {
+      ...safeProcessEnv,
       VITE_PORT: String(e2ePort),
-      NO_PROXY: '127.0.0.1,localhost',
-      no_proxy: '127.0.0.1,localhost',
     },
   },
 });

--- a/tests/support/playwrightProxyEnv.ts
+++ b/tests/support/playwrightProxyEnv.ts
@@ -1,0 +1,57 @@
+const LOCALHOST_BYPASS_HOSTS = ['127.0.0.1', 'localhost'] as const;
+const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'GLOBAL_AGENT_HTTP_PROXY',
+  'GLOBAL_AGENT_HTTPS_PROXY',
+] as const;
+
+export type ProxyEnvMap = Record<string, string | undefined>;
+
+function mergeNoProxyHosts(...values: Array<string | undefined>): string {
+  const merged = new Set<string>();
+
+  for (const value of values) {
+    if (!value) continue;
+
+    for (const entry of value.split(',')) {
+      const normalized = entry.trim();
+      if (normalized) merged.add(normalized);
+    }
+  }
+
+  for (const host of LOCALHOST_BYPASS_HOSTS) {
+    merged.add(host);
+  }
+
+  return Array.from(merged).join(',');
+}
+
+export function createPlaywrightProxySafeEnv(sourceEnv: ProxyEnvMap = process.env): ProxyEnvMap {
+  const env: ProxyEnvMap = { ...sourceEnv };
+  const noProxy = mergeNoProxyHosts(sourceEnv.NO_PROXY, sourceEnv.no_proxy);
+
+  env.NO_PROXY = noProxy;
+  env.no_proxy = noProxy;
+
+  for (const key of PROXY_ENV_KEYS) {
+    delete env[key];
+  }
+
+  return env;
+}
+
+export function applyPlaywrightProxySafeEnv(sourceEnv: ProxyEnvMap = process.env): void {
+  const safeEnv = createPlaywrightProxySafeEnv(sourceEnv);
+
+  for (const key of PROXY_ENV_KEYS) {
+    delete process.env[key];
+  }
+
+  process.env.NO_PROXY = safeEnv.NO_PROXY;
+  process.env.no_proxy = safeEnv.no_proxy;
+}

--- a/tests/unit/playwrightProxyEnv.test.ts
+++ b/tests/unit/playwrightProxyEnv.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyPlaywrightProxySafeEnv,
+  createPlaywrightProxySafeEnv,
+} from '../support/playwrightProxyEnv';
+
+describe('createPlaywrightProxySafeEnv', () => {
+  it('removes inherited proxy variables and preserves localhost bypass', () => {
+    const safeEnv = createPlaywrightProxySafeEnv({
+      HTTP_PROXY: 'http://127.0.0.1:10080',
+      HTTPS_PROXY: 'http://127.0.0.1:10080',
+      GLOBAL_AGENT_HTTP_PROXY: 'http://127.0.0.1:10080',
+      NO_PROXY: 'example.internal',
+    });
+
+    expect(safeEnv.HTTP_PROXY).toBeUndefined();
+    expect(safeEnv.HTTPS_PROXY).toBeUndefined();
+    expect(safeEnv.GLOBAL_AGENT_HTTP_PROXY).toBeUndefined();
+    expect(safeEnv.NO_PROXY).toBe('example.internal,127.0.0.1,localhost');
+    expect(safeEnv.no_proxy).toBe('example.internal,127.0.0.1,localhost');
+  });
+});
+
+describe('applyPlaywrightProxySafeEnv', () => {
+  it('updates process.env in place for Playwright child processes', () => {
+    const original = {
+      HTTP_PROXY: process.env.HTTP_PROXY,
+      HTTPS_PROXY: process.env.HTTPS_PROXY,
+      GLOBAL_AGENT_HTTP_PROXY: process.env.GLOBAL_AGENT_HTTP_PROXY,
+      GLOBAL_AGENT_HTTPS_PROXY: process.env.GLOBAL_AGENT_HTTPS_PROXY,
+      NO_PROXY: process.env.NO_PROXY,
+      no_proxy: process.env.no_proxy,
+    };
+
+    process.env.HTTP_PROXY = 'http://127.0.0.1:10080';
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:10080';
+    process.env.GLOBAL_AGENT_HTTP_PROXY = 'http://127.0.0.1:10080';
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+
+    applyPlaywrightProxySafeEnv();
+
+    expect(process.env.HTTP_PROXY).toBeUndefined();
+    expect(process.env.HTTPS_PROXY).toBeUndefined();
+    expect(process.env.GLOBAL_AGENT_HTTP_PROXY).toBeUndefined();
+    expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost');
+    expect(process.env.no_proxy).toBe('127.0.0.1,localhost');
+
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fix Playwright localhost connectivity by sanitizing inherited proxy environment variables before launching the browser and dev server
- add a regression helper and unit test covering localhost `NO_PROXY` handling
- keep the E2E base URL on `127.0.0.1:5274` while making local and CI runs resilient to proxy-heavy shells

## User story
As an AI agent running the regression suite from the CLI, I want Playwright to bypass shell proxy settings for the local app server, so that `page.goto('/')` can reliably reach `http://127.0.0.1:5274`.

Closes #319.

## Verification
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `npx vitest run tests/unit/playwrightProxyEnv.test.ts`
- `npx playwright test tests/e2e/project-lifecycle.spec.ts --workers=1`
- `npm run test:e2e` -> 131 passed, 3 failed

## Remaining E2E failures
These are no longer server-connectivity failures:
- `tests/e2e/midi-export.spec.ts` cannot find `Open Piano Roll`
- `tests/e2e/mixer.spec.ts` has a duplicate `Track level meter` accessible label
- `tests/e2e/sampler.spec.ts` times out waiting for the `Piano Roll` button
