### PR TITLE
feat: groove pool — extract and apply timing/velocity templates (closes #331)

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -80,6 +80,8 @@ import { separateClipAudioToStems } from '../services/stemSeparation';
 import { beatToTime, getBeatAtBar } from '../utils/tempoMap';
 import { encodeMidiFile } from '../utils/midi';
 import { clampClipFadeDurations } from '../utils/clipFade';
+import { extractGroove, applyGroove, type ExtractGrooveOptions, type ApplyGrooveOptions } from '../utils/groovePool';
+import type { GrooveTemplate } from '../types/project';
 import { toastError, toastSuccess } from '../hooks/useToast';
 import { buildConsolidatedMidiClipData, renderConsolidatedAudioClip, validateClipConsolidation } from '../services/clipConsolidation';
 
@@ -350,6 +352,13 @@ interface ProjectState {
   /** Create a new project from a template. */
   createProjectFromTemplate: (template: ProjectTemplate, projectName?: string) => void;
   exportMidiClip: (clipId: string) => void;
+
+  // Groove pool
+  extractGrooveFromClip: (clipId: string, name: string, options: ExtractGrooveOptions) => GrooveTemplate | undefined;
+  applyGrooveToClip: (clipId: string, noteIds: string[], grooveId: string, options: ApplyGrooveOptions) => void;
+  addGrooveTemplate: (template: GrooveTemplate) => void;
+  deleteGrooveTemplate: (grooveId: string) => void;
+  renameGrooveTemplate: (grooveId: string, name: string) => void;
 }
 
 function computeTotalDuration(
@@ -4334,6 +4343,112 @@ export const useProjectStore = create<ProjectState>()(
       `${fileName}.mid`,
     );
     toastSuccess(`Exported MIDI clip from ${track.displayName}`);
+  },
+
+  // ── Groove Pool ─────────────────────────────────────────────────────────
+
+  extractGrooveFromClip: (clipId, name, options) => {
+    const state = get();
+    if (!state.project) return undefined;
+
+    let notes: MidiNote[] | undefined;
+    for (const track of state.project.tracks) {
+      const clip = track.clips.find((c) => c.id === clipId);
+      if (clip?.midiData) {
+        notes = clip.midiData.notes;
+        break;
+      }
+    }
+    if (!notes || notes.length === 0) return undefined;
+
+    const extracted = extractGroove(notes, options);
+    const template: GrooveTemplate = {
+      id: uuidv4(),
+      name,
+      ...extracted,
+      createdAt: Date.now(),
+    };
+
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        groovePool: [...(state.project.groovePool ?? []), template],
+      },
+    });
+    return template;
+  },
+
+  applyGrooveToClip: (clipId, noteIds, grooveId, options) => {
+    const state = get();
+    if (!state.project) return;
+
+    const groove = state.project.groovePool?.find((g) => g.id === grooveId);
+    if (!groove) return;
+
+    const noteIdSet = new Set(noteIds);
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) => ({
+          ...track,
+          clips: track.clips.map((clip) => {
+            if (clip.id !== clipId || !clip.midiData) return clip;
+            const selected = clip.midiData.notes.filter((n) => noteIdSet.has(n.id));
+            const unselected = clip.midiData.notes.filter((n) => !noteIdSet.has(n.id));
+            const grooved = applyGroove(selected, groove, options);
+            return {
+              ...clip,
+              midiData: { ...clip.midiData, notes: [...unselected, ...grooved] },
+            };
+          }),
+        })),
+      },
+    });
+  },
+
+  addGrooveTemplate: (template) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        groovePool: [...(state.project.groovePool ?? []), template],
+      },
+    });
+  },
+
+  deleteGrooveTemplate: (grooveId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        groovePool: (state.project.groovePool ?? []).filter((g) => g.id !== grooveId),
+      },
+    });
+  },
+
+  renameGrooveTemplate: (grooveId, name) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        groovePool: (state.project.groovePool ?? []).map((g) =>
+          g.id === grooveId ? { ...g, name } : g,
+        ),
+      },
+    });
   },
 }),
     {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -77,6 +77,21 @@ export interface MidiClipData {
   grid: PianoRollGrid;
 }
 
+/** A timing/velocity groove template extracted from a MIDI clip. */
+export interface GrooveTemplate {
+  id: string;
+  name: string;
+  /** Normalized timing offsets per grid position (beat delta from quantized grid). */
+  timingOffsets: number[];
+  /** Normalized velocity multipliers per grid position (1.0 = original). */
+  velocityPattern: number[];
+  /** Grid size in beats used when extracting this groove. */
+  gridBeats: number;
+  /** Number of beats this groove pattern spans before looping. */
+  lengthBeats: number;
+  createdAt: number;
+}
+
 export interface EffectBase<T extends string, P> {
   id: string;
   type: T;
@@ -577,6 +592,8 @@ export interface Project {
   trackPresets?: TrackPreset[];
   /** Timeline markers (sorted by time). */
   markers?: Marker[];
+  /** Reusable groove templates (extracted timing/velocity patterns). */
+  groovePool?: GrooveTemplate[];
   /** Tempo map: discrete tempo changes sorted by beat. Empty = use project.bpm everywhere. */
   tempoMap?: TempoEvent[];
   /** Time signature map: changes sorted by bar. Empty = use project.timeSignature everywhere. */

--- a/src/utils/groovePool.ts
+++ b/src/utils/groovePool.ts
@@ -1,0 +1,117 @@
+import type { MidiNote, GrooveTemplate } from '../types/project';
+
+export interface ExtractGrooveOptions {
+  /** Grid size in beats (e.g. 0.25 = 16th note, 0.5 = 8th). */
+  gridBeats: number;
+  /** Total length in beats to analyze (e.g. 4 = one bar of 4/4). */
+  lengthBeats: number;
+}
+
+export interface ApplyGrooveOptions {
+  /** How strongly to apply the groove (0–100). 0 = no change, 100 = full groove. */
+  strength: number;
+  /** Apply timing offsets. Default true. */
+  applyTiming?: boolean;
+  /** Apply velocity pattern. Default true. */
+  applyVelocity?: boolean;
+}
+
+/**
+ * Extract a groove template from MIDI notes by analyzing their timing
+ * deviation from the quantized grid and their velocity pattern.
+ *
+ * The groove is expressed as arrays of timing offsets and velocity multipliers,
+ * one entry per grid position within `lengthBeats`.
+ */
+export function extractGroove(
+  notes: MidiNote[],
+  options: ExtractGrooveOptions,
+): Pick<GrooveTemplate, 'timingOffsets' | 'velocityPattern' | 'gridBeats' | 'lengthBeats'> {
+  const { gridBeats, lengthBeats } = options;
+  const slotCount = Math.round(lengthBeats / gridBeats);
+
+  // Accumulate per-slot: sum of offsets, sum of velocities, count
+  const slotOffsetSums = new Array<number>(slotCount).fill(0);
+  const slotVelocitySums = new Array<number>(slotCount).fill(0);
+  const slotCounts = new Array<number>(slotCount).fill(0);
+
+  // Average velocity of all notes for normalization
+  const avgVelocity = notes.length > 0
+    ? notes.reduce((s, n) => s + n.velocity, 0) / notes.length
+    : 80;
+
+  for (const note of notes) {
+    // Wrap the note position within the groove length
+    const posInLoop = ((note.startBeat % lengthBeats) + lengthBeats) % lengthBeats;
+    // Find nearest grid slot
+    const slotIndex = Math.round(posInLoop / gridBeats) % slotCount;
+    const quantizedBeat = slotIndex * gridBeats;
+    const offset = posInLoop - quantizedBeat;
+
+    slotOffsetSums[slotIndex] += offset;
+    slotVelocitySums[slotIndex] += note.velocity;
+    slotCounts[slotIndex] += 1;
+  }
+
+  const timingOffsets: number[] = [];
+  const velocityPattern: number[] = [];
+
+  for (let i = 0; i < slotCount; i++) {
+    if (slotCounts[i] > 0) {
+      timingOffsets.push(slotOffsetSums[i] / slotCounts[i]);
+      velocityPattern.push((slotVelocitySums[i] / slotCounts[i]) / avgVelocity);
+    } else {
+      timingOffsets.push(0);
+      velocityPattern.push(1);
+    }
+  }
+
+  return { timingOffsets, velocityPattern, gridBeats, lengthBeats };
+}
+
+/**
+ * Apply a groove template to MIDI notes. Returns new note objects (non-mutating).
+ *
+ * Each note is shifted toward the groove's timing offset for its nearest grid
+ * position, and its velocity is scaled by the groove's velocity multiplier.
+ * The `strength` parameter (0–100) controls interpolation.
+ */
+export function applyGroove(
+  notes: MidiNote[],
+  groove: Pick<GrooveTemplate, 'timingOffsets' | 'velocityPattern' | 'gridBeats' | 'lengthBeats'>,
+  options: ApplyGrooveOptions,
+): MidiNote[] {
+  const { strength, applyTiming = true, applyVelocity = true } = options;
+  if (strength === 0) return notes.map((n) => ({ ...n }));
+
+  const factor = strength / 100;
+  const slotCount = groove.timingOffsets.length;
+
+  return notes.map((note) => {
+    // Find the groove slot for this note
+    const posInLoop = ((note.startBeat % groove.lengthBeats) + groove.lengthBeats) % groove.lengthBeats;
+    const slotIndex = Math.round(posInLoop / groove.gridBeats) % slotCount;
+
+    let newStart = note.startBeat;
+    if (applyTiming) {
+      const currentOffset = posInLoop - slotIndex * groove.gridBeats;
+      const targetOffset = groove.timingOffsets[slotIndex];
+      const delta = targetOffset - currentOffset;
+      newStart = Math.max(0, note.startBeat + delta * factor);
+    }
+
+    let newVelocity = note.velocity;
+    if (applyVelocity) {
+      const velMultiplier = groove.velocityPattern[slotIndex];
+      const targetVelocity = note.velocity * velMultiplier;
+      newVelocity = note.velocity + (targetVelocity - note.velocity) * factor;
+      newVelocity = Math.max(1, Math.min(127, Math.round(newVelocity)));
+    }
+
+    return {
+      ...note,
+      startBeat: newStart,
+      velocity: newVelocity,
+    };
+  });
+}

--- a/tests/unit/groovePool.test.ts
+++ b/tests/unit/groovePool.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import type { MidiNote } from '../../src/types/project';
+import { extractGroove, applyGroove } from '../../src/utils/groovePool';
+
+function makeNote(overrides: Partial<MidiNote> & { id: string }): MidiNote {
+  return { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 80, ...overrides };
+}
+
+// ── extractGroove ─────────────────────────────────────────────────────────
+
+describe('extractGroove', () => {
+  it('extracts zero offsets from perfectly quantized notes', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0, velocity: 80 }),
+      makeNote({ id: 'b', startBeat: 0.5, velocity: 80 }),
+      makeNote({ id: 'c', startBeat: 1.0, velocity: 80 }),
+      makeNote({ id: 'd', startBeat: 1.5, velocity: 80 }),
+    ];
+    const groove = extractGroove(notes, { gridBeats: 0.5, lengthBeats: 2 });
+    expect(groove.timingOffsets).toHaveLength(4);
+    expect(groove.timingOffsets.every((o) => Math.abs(o) < 1e-10)).toBe(true);
+    expect(groove.velocityPattern.every((v) => Math.abs(v - 1) < 1e-10)).toBe(true);
+  });
+
+  it('captures timing offsets from swung notes', () => {
+    // Notes on 8th-note grid with swing: odd positions shifted +0.1 beats
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0, velocity: 80 }),
+      makeNote({ id: 'b', startBeat: 0.6, velocity: 80 }), // 0.5 + 0.1
+      makeNote({ id: 'c', startBeat: 1.0, velocity: 80 }),
+      makeNote({ id: 'd', startBeat: 1.6, velocity: 80 }), // 1.5 + 0.1
+    ];
+    const groove = extractGroove(notes, { gridBeats: 0.5, lengthBeats: 2 });
+    expect(groove.timingOffsets[0]).toBeCloseTo(0, 5);
+    expect(groove.timingOffsets[1]).toBeCloseTo(0.1, 5);
+    expect(groove.timingOffsets[2]).toBeCloseTo(0, 5);
+    expect(groove.timingOffsets[3]).toBeCloseTo(0.1, 5);
+  });
+
+  it('captures velocity variations', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0, velocity: 100 }),
+      makeNote({ id: 'b', startBeat: 0.5, velocity: 60 }),
+      makeNote({ id: 'c', startBeat: 1.0, velocity: 100 }),
+      makeNote({ id: 'd', startBeat: 1.5, velocity: 60 }),
+    ];
+    const groove = extractGroove(notes, { gridBeats: 0.5, lengthBeats: 2 });
+    // avg velocity = 80
+    expect(groove.velocityPattern[0]).toBeCloseTo(100 / 80, 5);
+    expect(groove.velocityPattern[1]).toBeCloseTo(60 / 80, 5);
+  });
+
+  it('averages multiple notes on the same grid slot', () => {
+    // Two notes near beat 0, one early one late
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0.04, velocity: 80 }),
+      makeNote({ id: 'b', startBeat: -0.02 + 2, velocity: 100 }), // startBeat 1.98, wraps to slot 0 in lengthBeats=2
+    ];
+    // Note a: pos 0.04, slot 0, offset 0.04
+    // Note b: pos 1.98, nearest slot = round(1.98/0.5) = 4 % 4 = 0, offset = 1.98 - 0 = 1.98 ... no
+    // Let's use notes that clearly land on the same slot
+    const notes2 = [
+      makeNote({ id: 'a', startBeat: 0.04, velocity: 80 }),
+      makeNote({ id: 'b', startBeat: 0.06, velocity: 100 }),
+    ];
+    // Both on slot 0 (nearest to 0). Offsets: 0.04 and 0.06. avg = 0.05
+    const groove = extractGroove(notes2, { gridBeats: 0.5, lengthBeats: 2 });
+    expect(groove.timingOffsets[0]).toBeCloseTo(0.05, 5);
+    // avg velocity = 90, slot 0 avg vel = 90 → pattern = 1.0
+    expect(groove.velocityPattern[0]).toBeCloseTo(1.0, 5);
+  });
+
+  it('fills empty grid slots with 0 offset and 1.0 velocity', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 0, velocity: 80 })];
+    const groove = extractGroove(notes, { gridBeats: 0.5, lengthBeats: 2 });
+    // Slots 1, 2, 3 should be defaults
+    expect(groove.timingOffsets[1]).toBe(0);
+    expect(groove.velocityPattern[1]).toBe(1);
+  });
+
+  it('returns correct gridBeats and lengthBeats', () => {
+    const groove = extractGroove([], { gridBeats: 0.25, lengthBeats: 4 });
+    expect(groove.gridBeats).toBe(0.25);
+    expect(groove.lengthBeats).toBe(4);
+    expect(groove.timingOffsets).toHaveLength(16);
+  });
+});
+
+// ── applyGroove ───────────────────────────────────────────────────────────
+
+describe('applyGroove', () => {
+  const swungGroove = {
+    timingOffsets: [0, 0.1, 0, 0.1],
+    velocityPattern: [1.25, 0.75, 1.25, 0.75],
+    gridBeats: 0.5,
+    lengthBeats: 2,
+  };
+
+  it('applies timing offsets at full strength', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0 }),
+      makeNote({ id: 'b', startBeat: 0.5 }),
+      makeNote({ id: 'c', startBeat: 1.0 }),
+      makeNote({ id: 'd', startBeat: 1.5 }),
+    ];
+    const result = applyGroove(notes, swungGroove, { strength: 100 });
+    expect(result[0].startBeat).toBeCloseTo(0, 5);
+    expect(result[1].startBeat).toBeCloseTo(0.6, 5);
+    expect(result[2].startBeat).toBeCloseTo(1.0, 5);
+    expect(result[3].startBeat).toBeCloseTo(1.6, 5);
+  });
+
+  it('applies velocity pattern at full strength', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0, velocity: 80 }),
+      makeNote({ id: 'b', startBeat: 0.5, velocity: 80 }),
+    ];
+    const result = applyGroove(notes, swungGroove, { strength: 100 });
+    expect(result[0].velocity).toBe(Math.round(80 * 1.25)); // 100
+    expect(result[1].velocity).toBe(Math.round(80 * 0.75)); // 60
+  });
+
+  it('does nothing at 0 strength', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0.5, velocity: 80 }),
+    ];
+    const result = applyGroove(notes, swungGroove, { strength: 0 });
+    expect(result[0].startBeat).toBe(0.5);
+    expect(result[0].velocity).toBe(80);
+  });
+
+  it('interpolates at partial strength', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 0.5, velocity: 80 })];
+    const result = applyGroove(notes, swungGroove, { strength: 50 });
+    // Slot 1: offset = 0.1, current offset = 0, delta = 0.1, factor = 0.5 → +0.05
+    expect(result[0].startBeat).toBeCloseTo(0.55, 5);
+  });
+
+  it('can apply only timing without velocity', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 0, velocity: 80 })];
+    const result = applyGroove(notes, swungGroove, {
+      strength: 100,
+      applyTiming: true,
+      applyVelocity: false,
+    });
+    expect(result[0].velocity).toBe(80);
+  });
+
+  it('can apply only velocity without timing', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 0, velocity: 80 })];
+    const result = applyGroove(notes, swungGroove, {
+      strength: 100,
+      applyTiming: false,
+      applyVelocity: true,
+    });
+    expect(result[0].startBeat).toBe(0);
+    expect(result[0].velocity).toBe(100);
+  });
+
+  it('clamps velocity to 1–127', () => {
+    const loudGroove = {
+      timingOffsets: [0],
+      velocityPattern: [2.0],
+      gridBeats: 1,
+      lengthBeats: 1,
+    };
+    const notes = [makeNote({ id: 'a', startBeat: 0, velocity: 120 })];
+    const result = applyGroove(notes, loudGroove, { strength: 100 });
+    expect(result[0].velocity).toBeLessThanOrEqual(127);
+    expect(result[0].velocity).toBeGreaterThanOrEqual(1);
+  });
+
+  it('clamps startBeat to >= 0', () => {
+    const negGroove = {
+      timingOffsets: [-1],
+      velocityPattern: [1],
+      gridBeats: 1,
+      lengthBeats: 1,
+    };
+    const notes = [makeNote({ id: 'a', startBeat: 0.2 })];
+    const result = applyGroove(notes, negGroove, { strength: 100 });
+    expect(result[0].startBeat).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not mutate original notes', () => {
+    const notes = [makeNote({ id: 'a', startBeat: 0.5, velocity: 80 })];
+    const original = { ...notes[0] };
+    applyGroove(notes, swungGroove, { strength: 100 });
+    expect(notes[0].startBeat).toBe(original.startBeat);
+    expect(notes[0].velocity).toBe(original.velocity);
+  });
+
+  it('wraps notes longer than groove length', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 2.5 }), // wraps to 0.5 in a 2-beat groove → slot 1
+    ];
+    const result = applyGroove(notes, swungGroove, { strength: 100 });
+    // Slot 1 has offset +0.1, note is at 2.5 which is already at offset 0 from slot 1
+    expect(result[0].startBeat).toBeCloseTo(2.6, 5);
+  });
+});
+
+// ── Round-trip: extract then apply ────────────────────────────────────────
+
+describe('round-trip', () => {
+  it('applying an extracted groove reproduces the original timing', () => {
+    // Original swung notes
+    const original = [
+      makeNote({ id: 'a', startBeat: 0, velocity: 100 }),
+      makeNote({ id: 'b', startBeat: 0.6, velocity: 60 }),
+      makeNote({ id: 'c', startBeat: 1.0, velocity: 100 }),
+      makeNote({ id: 'd', startBeat: 1.6, velocity: 60 }),
+    ];
+
+    // Extract groove
+    const groove = extractGroove(original, { gridBeats: 0.5, lengthBeats: 2 });
+
+    // Apply to straight notes
+    const straight = [
+      makeNote({ id: 'e', startBeat: 0, velocity: 80 }),
+      makeNote({ id: 'f', startBeat: 0.5, velocity: 80 }),
+      makeNote({ id: 'g', startBeat: 1.0, velocity: 80 }),
+      makeNote({ id: 'h', startBeat: 1.5, velocity: 80 }),
+    ];
+
+    const result = applyGroove(straight, groove, { strength: 100 });
+    expect(result[0].startBeat).toBeCloseTo(0, 5);
+    expect(result[1].startBeat).toBeCloseTo(0.6, 5);
+    expect(result[2].startBeat).toBeCloseTo(1.0, 5);
+    expect(result[3].startBeat).toBeCloseTo(1.6, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `GrooveTemplate` type to project model with timing offsets, velocity patterns, and grid metadata
- Create `src/utils/groovePool.ts` with `extractGroove()` and `applyGroove()` pure functions for extracting timing/velocity groove templates from MIDI clips and applying them to other clips
- Add 5 store actions: `extractGrooveFromClip`, `applyGrooveToClip`, `addGrooveTemplate`, `deleteGrooveTemplate`, `renameGrooveTemplate` — all with undo support
- Add `groovePool` array to Project interface for persistent storage of groove templates

## Test plan
- [x] 17 unit tests covering extract, apply, round-trip, edge cases (clamping, immutability, wrapping)
- [x] `npx tsc --noEmit` — 0 type errors
- [x] All 496 unit tests pass
- [x] `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)