### PR TITLE
feat: build mixer channel strips with inserts, sends, and accessibility (closes #326)

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -6,13 +6,28 @@ import { Knob } from '../ui/Knob';
 import { LevelMeter } from './LevelMeter';
 import { MasteringPanel } from './MasteringPanel';
 import { SpectrumAnalyzer } from './SpectrumAnalyzer';
-import type { Track } from '../../types/project';
+import type { Track, ReturnTrack, TrackEffectType } from '../../types/project';
 
 const MIXER_MIN_VISIBLE_HEIGHT = 360;
 const MIXER_RESIZE_HANDLE_HEIGHT = 6;
-const CHANNEL_STRIP_RESERVED_HEIGHT = 246;
+const CHANNEL_STRIP_RESERVED_HEIGHT = 346;
 const CHANNEL_STRIP_BOTTOM_PADDING = 12;
 const FADER_MIN_HEIGHT = 96;
+const MAX_INSERT_SLOTS = 4;
+const MAX_SEND_SLOTS = 2;
+
+const EFFECT_SHORT_NAMES: Record<string, string> = {
+  eq3: 'EQ3',
+  parametricEq: 'PEQ',
+  compressor: 'Comp',
+  reverb: 'Reverb',
+  delay: 'Delay',
+  distortion: 'Dist',
+  filter: 'Filter',
+  chorus: 'Chorus',
+  flanger: 'Flanger',
+  phaser: 'Phaser',
+};
 
 function volumeToDb(v: number): string {
   if (v <= 0) return '-inf';
@@ -23,11 +38,14 @@ function volumeToDb(v: number): string {
 interface ChannelStripProps {
   track: Track;
   faderHeight: number;
+  returnTracks: ReturnTrack[];
 }
 
-function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
+function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
   const updateTrack = useProjectStore((s) => s.updateTrack);
   const updateTrackMixer = useProjectStore((s) => s.updateTrackMixer);
+  const addTrackEffect = useProjectStore((s) => s.addTrackEffect);
+  const updateTrackSend = useProjectStore((s) => s.updateTrackSend);
 
   const vol = track.volume;
   const pan = track.pan ?? 0;
@@ -38,9 +56,15 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
   const compThresh = track.compressorThreshold ?? -24;
   const compRatio = track.compressorRatio ?? 4;
   const isFrozen = track.frozen ?? false;
+  const effects = track.effects ?? [];
+  const sends = track.sends ?? [];
 
   return (
-    <div className={`flex h-full min-h-0 min-w-[120px] flex-col border-r border-[#3a3a3a] bg-[#2a2a2a] px-3 py-2 ${isFrozen ? 'opacity-70' : ''}`}>
+    <div
+      data-testid="channel-strip"
+      data-track-id={track.id}
+      className={`flex h-full min-h-0 min-w-[120px] flex-col border-r border-[#3a3a3a] bg-[#2a2a2a] px-3 py-2 ${isFrozen ? 'opacity-70' : ''}`}
+    >
       <div className="flex min-h-0 flex-1 flex-col items-center gap-1.5 overflow-y-auto">
         <div className="w-full h-1.5 rounded-full mb-0.5" style={{ backgroundColor: track.color }} />
         <span className="text-xs text-zinc-300 font-medium leading-none truncate w-full text-center uppercase tracking-wide" title={track.displayName}>
@@ -51,6 +75,7 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
         <div className="flex gap-2 mt-0.5">
           <button
             onClick={() => updateTrack(track.id, { muted: !track.muted })}
+            aria-label={`Mute ${track.displayName}`}
             className={`text-xs font-bold px-2.5 py-1 rounded transition-colors ${
               track.muted ? 'bg-amber-500 text-black' : 'bg-[#444] text-zinc-400 hover:bg-[#484848]'
             }`}
@@ -59,6 +84,7 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
           </button>
           <button
             onClick={() => updateTrack(track.id, { soloed: !track.soloed })}
+            aria-label={`Solo ${track.displayName}`}
             className={`text-xs font-bold px-2.5 py-1 rounded transition-colors ${
               track.soloed ? 'bg-emerald-500 text-black' : 'bg-[#444] text-zinc-400 hover:bg-[#484848]'
             }`}
@@ -68,6 +94,76 @@ function ChannelStrip({ track, faderHeight }: ChannelStripProps) {
         </div>
 
         <Knob value={pan} min={-1} max={1} defaultValue={0} onChange={(v) => updateTrackMixer(track.id, { pan: v })} label="Pan" size={36} step={0.01} disabled={isFrozen} />
+
+        {/* Inserts section — 4 effect slots */}
+        <div data-testid="inserts-section" className="w-full mt-1">
+          <div className="text-[10px] text-zinc-500 uppercase tracking-widest mb-0.5">Inserts</div>
+          <div className="flex flex-col gap-0.5">
+            {Array.from({ length: MAX_INSERT_SLOTS }).map((_, i) => {
+              const effect = effects[i];
+              return (
+                <button
+                  key={i}
+                  data-testid={`insert-slot-${i}`}
+                  className={`text-[10px] w-full rounded px-1.5 py-0.5 text-left truncate transition-colors ${
+                    effect
+                      ? effect.enabled
+                        ? 'bg-[#3a3a3a] text-zinc-300 hover:bg-[#444]'
+                        : 'bg-[#3a3a3a] text-zinc-300 hover:bg-[#444] opacity-50'
+                      : 'bg-[#333] text-zinc-600 hover:bg-[#3a3a3a]'
+                  }`}
+                  title={effect ? `${EFFECT_SHORT_NAMES[effect.type] ?? effect.type}${effect.enabled ? '' : ' (bypassed)'}` : 'Add insert effect'}
+                  onClick={() => {
+                    if (!effect && !isFrozen) {
+                      addTrackEffect(track.id, 'reverb' as TrackEffectType);
+                    }
+                  }}
+                  disabled={isFrozen}
+                >
+                  {effect ? (EFFECT_SHORT_NAMES[effect.type] ?? effect.type) : '+'}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Sends section — 2 send slots */}
+        <div data-testid="sends-section" className="w-full mt-1">
+          <div className="text-[10px] text-zinc-500 uppercase tracking-widest mb-0.5">Sends</div>
+          <div className="flex flex-col gap-0.5">
+            {Array.from({ length: MAX_SEND_SLOTS }).map((_, i) => {
+              const rt = returnTracks[i];
+              const send = rt ? sends.find((s) => s.returnTrackId === rt.id) : undefined;
+              const amount = send?.amount ?? 0;
+              return (
+                <div
+                  key={i}
+                  data-testid={`send-slot-${i}`}
+                  className="flex items-center gap-1"
+                >
+                  {rt ? (
+                    <>
+                      <span className="text-[10px] text-zinc-400 truncate flex-1" title={rt.name}>{rt.name}</span>
+                      <input
+                        type="range"
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        value={amount}
+                        onChange={(e) => updateTrackSend(track.id, rt.id, parseFloat(e.target.value))}
+                        aria-label={`Send ${track.displayName} to ${rt.name}`}
+                        className="w-12 h-3 accent-blue-500"
+                        disabled={isFrozen}
+                      />
+                    </>
+                  ) : (
+                    <span className="text-[10px] text-zinc-600 w-full text-center">&mdash;</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
 
         <div className="text-[10px] text-zinc-500 uppercase tracking-widest mt-0.5">EQ</div>
         <div className="flex gap-1.5">
@@ -188,6 +284,7 @@ export function MixerPanel() {
 
   if (!showMixer || !project) return null;
 
+  const returnTracks = project.returnTracks ?? [];
   const visibleMixerHeight = Math.max(mixerHeight, MIXER_MIN_VISIBLE_HEIGHT);
   const faderHeight = Math.max(
     FADER_MIN_HEIGHT,
@@ -209,7 +306,7 @@ export function MixerPanel() {
             </div>
           )}
           {project.tracks.map((track) => (
-            <ChannelStrip key={track.id} track={track} faderHeight={faderHeight} />
+            <ChannelStrip key={track.id} track={track} faderHeight={faderHeight} returnTracks={returnTracks} />
           ))}
           <MasterStrip faderHeight={faderHeight} />
         </div>

--- a/tests/unit/channelStrip.test.tsx
+++ b/tests/unit/channelStrip.test.tsx
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { MixerPanel } from '../../src/components/mixer/MixerPanel';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useUIStore } from '../../src/store/uiStore';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    masterVolume: 1,
+    getMasterLevel: () => 0,
+    getTrackLevel: () => 0,
+    getMasterMeter: () => ({ level: 0, clipped: false }),
+    getTrackMeter: () => ({ level: 0, clipped: false }),
+    resetTrackClip: vi.fn(),
+    resetMasterClip: vi.fn(),
+  }),
+}));
+
+function setupProject() {
+  useProjectStore.getState().createProject({ name: 'Channel Strip Test' });
+  useProjectStore.getState().addTrack('drums');
+  useUIStore.getState().setShowMixer(true);
+  useUIStore.getState().setMixerHeight(500);
+}
+
+describe('ChannelStrip — Inserts section', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useUIStore.setState(useUIStore.getInitialState(), true);
+    setupProject();
+  });
+
+  it('renders 4 insert slots per channel strip', () => {
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    expect(strips.length).toBeGreaterThanOrEqual(1);
+    const insertsSection = within(strips[0]).getByTestId('inserts-section');
+    const slots = within(insertsSection).getAllByTestId(/^insert-slot-/);
+    expect(slots).toHaveLength(4);
+  });
+
+  it('shows effect name when an insert slot is populated', () => {
+    const tracks = useProjectStore.getState().project!.tracks;
+    useProjectStore.getState().addTrackEffect(tracks[0].id, 'reverb');
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const insertsSection = within(strips[0]).getByTestId('inserts-section');
+    const slots = within(insertsSection).getAllByTestId(/^insert-slot-/);
+    // First slot should show 'reverb'
+    expect(slots[0]).toHaveTextContent(/reverb/i);
+    // Remaining slots should show '+' or be empty
+    expect(slots[1]).toHaveTextContent('+');
+  });
+
+  it('shows bypass state when effect is disabled', () => {
+    const tracks = useProjectStore.getState().project!.tracks;
+    const effectId = useProjectStore.getState().addTrackEffect(tracks[0].id, 'delay');
+    useProjectStore.getState().updateTrackEffect(tracks[0].id, effectId!, { enabled: false });
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const insertsSection = within(strips[0]).getByTestId('inserts-section');
+    const slot = within(insertsSection).getByTestId('insert-slot-0');
+    expect(slot).toHaveClass('opacity-50');
+  });
+});
+
+describe('ChannelStrip — Sends section', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useUIStore.setState(useUIStore.getInitialState(), true);
+    setupProject();
+  });
+
+  it('renders 2 send slots per channel strip', () => {
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const sendsSection = within(strips[0]).getByTestId('sends-section');
+    const slots = within(sendsSection).getAllByTestId(/^send-slot-/);
+    expect(slots).toHaveLength(2);
+  });
+
+  it('shows send amount when a return track exists and send is active', () => {
+    const tracks = useProjectStore.getState().project!.tracks;
+    const rt = useProjectStore.getState().addReturnTrack('FX A');
+    useProjectStore.getState().updateTrackSend(tracks[0].id, rt.id, 0.5);
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const sendsSection = within(strips[0]).getByTestId('sends-section');
+    const slot = within(sendsSection).getByTestId('send-slot-0');
+    expect(slot).toHaveTextContent(/FX A/i);
+  });
+
+  it('shows empty send slots when no return tracks exist', () => {
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const sendsSection = within(strips[0]).getByTestId('sends-section');
+    const slots = within(sendsSection).getAllByTestId(/^send-slot-/);
+    expect(slots[0]).toHaveTextContent('—');
+    expect(slots[1]).toHaveTextContent('—');
+  });
+});
+
+describe('ChannelStrip — Accessibility & data attributes', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useUIStore.setState(useUIStore.getInitialState(), true);
+    setupProject();
+  });
+
+  it('each channel strip has data-track-id attribute', () => {
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const tracks = useProjectStore.getState().project!.tracks;
+    expect(strips[0]).toHaveAttribute('data-track-id', tracks[0].id);
+  });
+
+  it('mute and solo buttons have accessible names', () => {
+    render(<MixerPanel />);
+    expect(screen.getByRole('button', { name: /mute drums/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /solo drums/i })).toBeInTheDocument();
+  });
+
+  it('volume fader has accessible label', () => {
+    render(<MixerPanel />);
+    expect(screen.getByRole('slider', { name: 'Drums volume fader' })).toBeInTheDocument();
+  });
+
+  it('pan knob section is labeled', () => {
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    // Pan knob should exist
+    expect(within(strips[0]).getByText('Pan')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 insert effect slots per channel strip showing effect names and bypass state
- Add 2 send routing slots per channel strip with return track names and amount sliders
- Add `data-testid`, `data-track-id`, and `aria-label` attributes for E2E testing and keyboard accessibility
- Add comprehensive unit tests (10 tests covering inserts, sends, and accessibility)

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run tests/unit/` — all 489 tests pass (55 files)
- [x] `npm run build` — succeeds
- [ ] Manual: open mixer, verify 4 insert slots and 2 send slots visible per track
- [ ] Manual: add effects to a track, verify they appear in insert slots
- [ ] Manual: create return tracks and sends, verify send controls appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)