### PR TITLE
fix: stabilize Playwright e2e web server startup (closes #315)

### DIFF
--- a/docs/plans/fix-playwright-e2e-startup.md
+++ b/docs/plans/fix-playwright-e2e-startup.md
@@ -1,0 +1,35 @@
+# Fix Playwright E2E Startup Regression
+
+## User Stories
+
+As a developer, I want `npx playwright test tests/e2e/` to launch the DAW on an isolated local port, so that e2e runs are deterministic even when another local dev server is already running.
+
+As an AI agent, I want the Playwright `webServer` lifecycle to own the app process it tests, so that CLI-driven verification does not accidentally reuse an unrelated process and fail before any workflow assertions run.
+
+## Problem
+
+Issue [#315](https://github.com/ace-step/ACE-Step-DAW/issues/315) reports that the Playwright regression suite exits with `ERR_CONNECTION_REFUSED` at `http://127.0.0.1:5274/` before any e2e assertions execute.
+
+## Root Cause
+
+[`playwright.config.ts`](/tmp/daw-worktrees/agent-315/playwright.config.ts) only injected `NO_PROXY` into the child `webServer` process. Playwright checks whether `http://127.0.0.1:5274/` is already available before it starts that child process, and that parent-side check was still running through the local HTTP proxy configured in the shell environment. The proxy returned `400`, which Playwright treated as "server available", so it skipped starting the DAW and the specs later failed on `page.goto('/')` with `ERR_CONNECTION_REFUSED`.
+
+## Solution
+
+Update [`playwright.config.ts`](/tmp/daw-worktrees/agent-315/playwright.config.ts) to:
+
+1. Normalize loopback bypass entries into `NO_PROXY`, `no_proxy`, and `GLOBAL_AGENT_NO_PROXY` before Playwright evaluates `webServer` availability.
+2. Keep `127.0.0.1` / `localhost` requests on the local machine instead of sending them to the configured HTTP proxy.
+3. Use a deterministic worktree-specific e2e port when `E2E_PORT` is not explicitly set, so concurrent local worktrees do not fight over the same Playwright/Vite port.
+4. Disable `reuseExistingServer` so Playwright always owns the server lifecycle for regression runs.
+
+## Verification
+
+1. `npm run build`
+2. `npx playwright test tests/e2e/project-lifecycle.spec.ts --reporter=line`
+3. `npx playwright test tests/e2e/ --reporter=line`
+
+## Files To Touch
+
+- [`playwright.config.ts`](/tmp/daw-worktrees/agent-315/playwright.config.ts)
+- [`docs/plans/fix-playwright-e2e-startup.md`](/tmp/daw-worktrees/agent-315/docs/plans/fix-playwright-e2e-startup.md)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,30 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const e2ePort = Number(process.env.E2E_PORT) || 5274;
+function mergeNoProxyValue(value: string | undefined) {
+  const entries = new Set(
+    (value ?? '')
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+  entries.add('127.0.0.1');
+  entries.add('localhost');
+  return Array.from(entries).join(',');
+}
+
+function deriveWorktreePort() {
+  return Array.from(process.cwd()).reduce((hash, character) => {
+    return (hash * 33 + character.charCodeAt(0)) % 200;
+  }, 0);
+}
+
+const noProxyValue = mergeNoProxyValue(process.env.NO_PROXY ?? process.env.no_proxy);
+
+process.env.NO_PROXY = noProxyValue;
+process.env.no_proxy = noProxyValue;
+process.env.GLOBAL_AGENT_NO_PROXY = noProxyValue;
+
+const e2ePort = Number(process.env.E2E_PORT) || 5274 + deriveWorktreePort();
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -22,7 +46,7 @@ export default defineConfig({
   webServer: {
     command: 'npm run dev',
     url: `http://127.0.0.1:${e2ePort}`,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: false,
     timeout: 60000,
     env: {
       VITE_PORT: String(e2ePort),


### PR DESCRIPTION
## Summary
- force Playwright's parent process to bypass the local HTTP proxy for `127.0.0.1` / `localhost`
- derive a deterministic worktree-specific e2e port when `E2E_PORT` is not explicitly set, avoiding local worktree collisions
- disable `reuseExistingServer` so the regression suite always starts and owns the Vite process it is testing
- add a user-story plan doc for issue #315 with problem, root cause, solution, and verification

## Root Cause
Playwright checks `config.webServer.url` before launching the app process. In this environment, that preflight check was still going through the shell's HTTP proxy, which returned a `400` for loopback URLs and made Playwright incorrectly conclude the app was already running. In shared local worktrees, the fixed port `5274` could also collide with another Vite server.

## Verification
- `npm run build`
- `npx tsc --noEmit`
- `npx playwright test tests/e2e/project-lifecycle.spec.ts --reporter=line`
- `npx playwright test tests/e2e/ --reporter=line`

## Notes
- The targeted e2e regression path from #315 is fixed: the app now starts and `project-lifecycle.spec.ts` passes.
- The full e2e directory still has unrelated pre-existing failures after startup is repaired, including a strict locator issue in `tests/e2e/mixer.spec.ts` and mid-suite server instability in `qa-full-workflow.spec.ts` / `real-user-scenarios.spec.ts`.
