### PR TITLE
feat: #339 — upgrade sampler into one-step Quick Sampler workflow

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -62,6 +62,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const duplicateClip = useProjectStore((s) => s.duplicateClip);
   const consolidateClips = useProjectStore((s) => s.consolidateClips);
   const convertAudioToMidi = useProjectStore((s) => s.convertAudioToMidi);
+  const createQuickSamplerFromClip = useProjectStore((s) => s.createQuickSamplerFromClip);
   const exportMidiClip = useProjectStore((s) => s.exportMidiClip);
   const batchDuplicateClips = useProjectStore((s) => s.batchDuplicateClips);
   const batchMoveClips = useProjectStore((s) => s.batchMoveClips);
@@ -616,6 +617,13 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           onConvertToMidi={() => {
             closeCtxMenu();
             convertAudioToMidi(clip.id);
+          }}
+          onCreateQuickSampler={() => {
+            closeCtxMenu();
+            const samplerTrack = createQuickSamplerFromClip(track.id, clip.id);
+            if (samplerTrack) {
+              useUIStore.getState().setOpenPianoRoll(samplerTrack.id);
+            }
           }}
           onClose={closeCtxMenu}
           hasPrompt={!!clip.prompt}

--- a/src/components/timeline/ClipContextMenu.tsx
+++ b/src/components/timeline/ClipContextMenu.tsx
@@ -16,6 +16,7 @@ interface ClipContextMenuProps {
   onAnalyze: () => void;
   onSeparateStems: () => void;
   onConvertToMidi: () => void;
+  onCreateQuickSampler: () => void;
   onClose: () => void;
   hasPrompt: boolean;
   isReady: boolean;
@@ -43,6 +44,7 @@ export function ClipContextMenu({
   onAnalyze,
   onSeparateStems,
   onConvertToMidi,
+  onCreateQuickSampler,
   onClose,
   hasPrompt,
   isReady,
@@ -112,9 +114,14 @@ export function ClipContextMenu({
         )}
 
         {!isMidiClip && hasAudio && (
-          <button onClick={onConvertToMidi} className="w-full text-left px-3 py-1.5 text-[11px] text-violet-300 hover:bg-daw-accent hover:text-white transition-colors">
-            Convert to MIDI…
-          </button>
+          <>
+            <button onClick={onConvertToMidi} className="w-full text-left px-3 py-1.5 text-[11px] text-violet-300 hover:bg-daw-accent hover:text-white transition-colors">
+              Convert to MIDI…
+            </button>
+            <button onClick={onCreateQuickSampler} className="w-full text-left px-3 py-1.5 text-[11px] text-orange-300 hover:bg-daw-accent hover:text-white transition-colors">
+              Create Quick Sampler
+            </button>
+          </>
         )}
 
         <div className="my-1 border-t border-[#555]" />

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -84,7 +84,7 @@ export function Timeline() {
   const [normalDrag, setNormalDrag] = useState<DragRect | null>(null);
   const [fileDragOver, setFileDragOver] = useState(false);
   const dragCounterRef = useRef(0);
-  const { importMultipleFiles, importLoopToTrack, importAssetToTrack } = useAudioImport();
+  const { importMultipleFiles, importLoopToTrack, importAssetToTrack, importAudioFileAsNewQuickSampler, importAssetAsQuickSampler } = useAudioImport();
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer.types;
@@ -124,19 +124,25 @@ export function Timeline() {
       return;
     }
 
-    // Handle asset drop -> create new sample track
+    // Handle asset drop -> create Quick Sampler track
     const assetId = e.dataTransfer.getData('application/x-asset-id');
     if (assetId) {
-      const newTrack = addTrack('custom', 'sample');
-      await importAssetToTrack(assetId, newTrack.id, 0);
+      await importAssetAsQuickSampler(assetId);
       return;
     }
 
+    // Audio files -> Quick Sampler, MIDI files -> piano roll tracks
     const files = e.dataTransfer.files;
     if (files.length > 0) {
-      await importMultipleFiles(files);
+      for (const file of Array.from(files)) {
+        if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
+          await importAudioFileAsNewQuickSampler(file);
+        } else if (/\.(mid|midi)$/i.test(file.name)) {
+          await importMultipleFiles([file]);
+        }
+      }
     }
-  }, [addTrack, importMultipleFiles, importLoopToTrack, importAssetToTrack]);
+  }, [addTrack, importMultipleFiles, importLoopToTrack, importAssetToTrack, importAudioFileAsNewQuickSampler, importAssetAsQuickSampler]);
 
   // Safety net: if a child (e.g. TrackLane) stops propagation on drop,
   // the Timeline's own handleDrop never fires. Listen globally to clear the overlay.

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -187,6 +187,7 @@ interface ProjectState {
     rootNote?: number;
     trackId?: string;
   }) => Track | undefined;
+  createQuickSamplerFromClip: (trackId: string, clipId: string) => Track | undefined;
   saveTrackPreset: (trackId: string, presetName: string) => TrackPreset;
   applyTrackPreset: (presetId: string) => Track | undefined;
   deleteTrackPreset: (presetId: string) => void;
@@ -1276,12 +1277,12 @@ export const useProjectStore = create<ProjectState>()(
       'keyboard',
       'pianoRoll',
       {
-        displayName: input.sampleName || 'Quick Sampler',
         synthPreset: 'sampler',
         sampler,
         samplerConfig,
       },
     );
+    track.displayName = input.sampleName || 'Quick Sampler';
 
     const newTracks = [...state.project.tracks, track];
     set({
@@ -1293,6 +1294,29 @@ export const useProjectStore = create<ProjectState>()(
       },
     });
     return track;
+  },
+
+  createQuickSamplerFromClip: (trackId, clipId) => {
+    const state = get();
+    if (!state.project) return undefined;
+
+    const sourceTrack = state.project.tracks.find((t) => t.id === trackId);
+    if (!sourceTrack) return undefined;
+
+    const clip = sourceTrack.clips.find((c) => c.id === clipId);
+    if (!clip) return undefined;
+
+    const audioKey = clip.isolatedAudioKey ?? clip.cumulativeMixKey;
+    if (!audioKey) return undefined;
+
+    const sampleDuration = clip.audioDuration ?? clip.duration;
+    const sampleName = clip.prompt?.replace(/^Imported:\s*/, '') || sourceTrack.displayName;
+
+    return get().createQuickSamplerTrack({
+      audioKey,
+      sampleName,
+      sampleDuration,
+    });
   },
 
   deleteTrackPreset: (presetId) => {

--- a/tests/unit/quickSamplerWorkflow.test.ts
+++ b/tests/unit/quickSamplerWorkflow.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../../src/store/projectStore';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('Quick Sampler workflow', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useProjectStore.getState().createProject();
+  });
+
+  describe('createQuickSamplerTrack', () => {
+    it('creates a new pianoRoll track with sampler preset', () => {
+      const track = useProjectStore.getState().createQuickSamplerTrack({
+        audioKey: 'audio:proj:qs-1',
+        sampleName: 'Kick',
+        sampleDuration: 0.5,
+      });
+
+      expect(track).toBeDefined();
+      expect(track!.trackType).toBe('pianoRoll');
+      expect(track!.synthPreset).toBe('sampler');
+      expect(track!.displayName).toBe('Kick');
+    });
+
+    it('uses default root note C4 (60) when not specified', () => {
+      const track = useProjectStore.getState().createQuickSamplerTrack({
+        audioKey: 'audio:proj:qs-default-root',
+      });
+
+      expect(track!.sampler!.rootNote).toBe(60);
+      expect(track!.samplerConfig!.rootNote).toBe(60);
+    });
+
+    it('uses custom root note when specified', () => {
+      const track = useProjectStore.getState().createQuickSamplerTrack({
+        audioKey: 'audio:proj:qs-custom-root',
+        rootNote: 48,
+      });
+
+      expect(track!.sampler!.rootNote).toBe(48);
+      expect(track!.samplerConfig!.rootNote).toBe(48);
+    });
+
+    it('sets trimEnd and loopEnd to sampleDuration', () => {
+      const track = useProjectStore.getState().createQuickSamplerTrack({
+        audioKey: 'audio:proj:qs-dur',
+        sampleDuration: 3.5,
+      });
+
+      expect(track!.samplerConfig!.trimEnd).toBe(3.5);
+      expect(track!.samplerConfig!.loopEnd).toBe(3.5);
+    });
+
+    it('defaults display name to "Quick Sampler" when no sampleName', () => {
+      const track = useProjectStore.getState().createQuickSamplerTrack({
+        audioKey: 'audio:proj:qs-noname',
+      });
+
+      expect(track!.displayName).toBe('Quick Sampler');
+    });
+
+    it('updates an existing track when trackId is provided', () => {
+      const original = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+
+      const updated = useProjectStore.getState().createQuickSamplerTrack({
+        trackId: original.id,
+        audioKey: 'audio:proj:qs-update',
+        sampleName: 'Updated Sampler',
+        sampleDuration: 2.0,
+      });
+
+      expect(updated).toBeDefined();
+      expect(updated!.id).toBe(original.id);
+      expect(updated!.synthPreset).toBe('sampler');
+      expect(updated!.displayName).toBe('Updated Sampler');
+      // Should not add a new track
+      expect(useProjectStore.getState().project!.tracks).toHaveLength(1);
+    });
+
+    it('returns undefined for nonexistent trackId', () => {
+      const result = useProjectStore.getState().createQuickSamplerTrack({
+        trackId: 'nonexistent-id',
+        audioKey: 'audio:proj:qs-missing',
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('pushes to undo history', () => {
+      const track = useProjectStore.getState().createQuickSamplerTrack({
+        audioKey: 'audio:proj:qs-undo',
+        sampleName: 'Undoable',
+      });
+
+      expect(track).toBeDefined();
+      useProjectStore.getState().undo();
+
+      const tracks = useProjectStore.getState().project!.tracks;
+      expect(tracks.find((t) => t.displayName === 'Undoable')).toBeUndefined();
+    });
+
+    it('syncs sampler and samplerConfig audioKey', () => {
+      const track = useProjectStore.getState().createQuickSamplerTrack({
+        audioKey: 'audio:proj:qs-sync',
+        sampleName: 'Synced',
+        sampleDuration: 1.5,
+        rootNote: 64,
+      });
+
+      expect(track!.sampler!.audioKey).toBe('audio:proj:qs-sync');
+      expect(track!.samplerConfig!.audioKey).toBe('audio:proj:qs-sync');
+    });
+  });
+
+  describe('createQuickSamplerFromClip', () => {
+    it('creates a Quick Sampler track from a clip with audio', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('custom', 'sample');
+      const clip = store.addClip(track.id, {
+        startTime: 0,
+        duration: 2.0,
+        prompt: 'Test clip',
+        lyrics: '',
+      });
+
+      store.updateClipStatus(clip.id, 'ready', {
+        isolatedAudioKey: 'audio:proj:clip-1:iso:v1',
+        audioDuration: 2.0,
+      });
+
+      const samplerTrack = store.createQuickSamplerFromClip(track.id, clip.id);
+
+      expect(samplerTrack).toBeDefined();
+      expect(samplerTrack!.trackType).toBe('pianoRoll');
+      expect(samplerTrack!.synthPreset).toBe('sampler');
+      expect(samplerTrack!.sampler!.audioKey).toBe('audio:proj:clip-1:iso:v1');
+      expect(samplerTrack!.samplerConfig!.audioKey).toBe('audio:proj:clip-1:iso:v1');
+      expect(samplerTrack!.samplerConfig!.trimEnd).toBe(2.0);
+    });
+
+    it('uses clip prompt as sample name', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('custom', 'sample');
+      const clip = store.addClip(track.id, {
+        startTime: 0,
+        duration: 1.0,
+        prompt: 'Cool Synth Lead',
+        lyrics: '',
+      });
+
+      store.updateClipStatus(clip.id, 'ready', {
+        isolatedAudioKey: 'audio:proj:clip-2:iso:v1',
+        audioDuration: 1.0,
+      });
+
+      const samplerTrack = store.createQuickSamplerFromClip(track.id, clip.id);
+      expect(samplerTrack!.displayName).toBe('Cool Synth Lead');
+    });
+
+    it('returns undefined when clip has no audio key', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('custom', 'sample');
+      const clip = store.addClip(track.id, {
+        startTime: 0,
+        duration: 1.0,
+        prompt: 'No audio',
+        lyrics: '',
+      });
+
+      const result = store.createQuickSamplerFromClip(track.id, clip.id);
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined for nonexistent clip', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('custom', 'sample');
+
+      const result = store.createQuickSamplerFromClip(track.id, 'nonexistent-clip');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined for nonexistent track', () => {
+      const store = useProjectStore.getState();
+      const result = store.createQuickSamplerFromClip('nonexistent-track', 'nonexistent-clip');
+      expect(result).toBeUndefined();
+    });
+
+    it('pushes to undo history', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('custom', 'sample');
+      const clip = store.addClip(track.id, {
+        startTime: 0,
+        duration: 1.0,
+        prompt: 'Undo test',
+        lyrics: '',
+      });
+
+      store.updateClipStatus(clip.id, 'ready', {
+        isolatedAudioKey: 'audio:proj:clip-undo:iso:v1',
+        audioDuration: 1.0,
+      });
+
+      const trackCountBefore = useProjectStore.getState().project!.tracks.length;
+      useProjectStore.getState().createQuickSamplerFromClip(track.id, clip.id);
+      expect(useProjectStore.getState().project!.tracks.length).toBe(trackCountBefore + 1);
+
+      useProjectStore.getState().undo();
+      expect(useProjectStore.getState().project!.tracks.length).toBe(trackCountBefore);
+    });
+
+    it('uses audioDuration for trimEnd/loopEnd', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('custom', 'sample');
+      const clip = store.addClip(track.id, {
+        startTime: 0,
+        duration: 5.0,
+        prompt: 'Long clip',
+        lyrics: '',
+      });
+
+      store.updateClipStatus(clip.id, 'ready', {
+        isolatedAudioKey: 'audio:proj:clip-long:iso:v1',
+        audioDuration: 4.8,
+      });
+
+      const samplerTrack = store.createQuickSamplerFromClip(track.id, clip.id);
+      expect(samplerTrack!.samplerConfig!.trimEnd).toBe(4.8);
+      expect(samplerTrack!.samplerConfig!.loopEnd).toBe(4.8);
+    });
+  });
+});


### PR DESCRIPTION
Closes #339

## Summary
- **Store action `createQuickSamplerFromClip`**: Converts any audio clip into a playable Quick Sampler instrument in one step — finds the clip's audio key, extracts metadata, and delegates to `createQuickSamplerTrack`
- **Timeline drop → Quick Sampler**: Dropping audio files onto the empty timeline area now creates Quick Sampler tracks (chromatic playable instruments) instead of plain sample tracks. Assets also create Quick Sampler tracks. MIDI files still create piano roll tracks.
- **Clip context menu**: Audio clips with audio data now show "Create Quick Sampler" in the right-click menu, which creates a new sampler track and opens its piano roll editor
- **displayName fix**: Fixed `createQuickSamplerTrack` where the display name was being silently discarded by `createTrackFromTemplate`'s destructuring

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run tests/unit/` — 602 tests pass (63 files), including 16 new Quick Sampler workflow tests
- [x] `npm run build` — succeeds
- [ ] E2E: Drop audio file onto empty timeline → verify Quick Sampler track is created with correct sampler config
- [ ] E2E: Right-click audio clip → "Create Quick Sampler" → verify new sampler track opens in piano roll
- [ ] E2E: Verify undo reverts Quick Sampler creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)