### PR TITLE
feat: polish piano roll tool mode workflow (closes #325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A browser-based Digital Audio Workstation powered by [ACE-Step 1.5](https://gith
 ### DAW Capabilities
 - **Multi-Track Timeline** — Arrangement view with clip-based editing
 - **4 Track Types** — Stems (AI-generated), Sample (imported audio), Sequencer (step-based drums), Piano Roll (MIDI)
-- **Piano Roll Editor** — Canvas-based MIDI note editor with velocity lane, draw mode, grid snap
+- **Piano Roll Editor** — Canvas-based MIDI note editor with explicit tool modes, velocity lane, slide notes, and grid snap
 - **Step Sequencer** — FL Studio-inspired drum pattern editor with beat pads
 - **Effect Chain** — 6 built-in effects (EQ3, Compressor, Reverb, Delay, Distortion, Filter) with per-effect UI
 - **Mixer Panel** — Per-track volume, pan, mute, solo, channel strips

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -87,9 +87,13 @@ const SECTIONS: Section[] = [
   {
     title: 'Piano Roll',
     rows: [
+      { keys: ['1', '2', '3', '4', '5'],   description: 'Switch tools: Select, Pencil, Paint, Erase, Slide' },
+      { keys: ['B'],                        description: 'Toggle pencil tool' },
       { keys: ['Delete', 'Backspace'],  description: 'Delete selected notes' },
-      { keys: ['⇧', '↑'],               description: 'Transpose selected notes up 1 semitone' },
-      { keys: ['⇧', '↓'],               description: 'Transpose selected notes down 1 semitone' },
+      { keys: ['↑'],                    description: 'Transpose selected notes up 1 semitone' },
+      { keys: ['↓'],                    description: 'Transpose selected notes down 1 semitone' },
+      { keys: ['←'],                    description: 'Nudge selected notes earlier by one grid step' },
+      { keys: ['→'],                    description: 'Nudge selected notes later by one grid step' },
       { keys: ['Q'],                    description: 'Quantize selected notes to the current grid' },
       { keys: [`${mod}`, 'Q'],          description: 'Quantize with options (strength, swing, scope)' },
       { keys: [`${mod}`, 'A'],          description: 'Select all notes in the current clip' },

--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -10,6 +10,14 @@ import { TransformMenu } from './TransformMenu';
 import { getPianoRollToolShortcut, midiNoteToName, type PianoRollTool } from './PianoRollConstants';
 import { useAudioImport } from '../../hooks/useAudioImport';
 
+const PIANO_ROLL_TOOL_BUTTONS = [
+  { tool: 'select', label: 'Select', icon: '↖' },
+  { tool: 'pencil', label: 'Pencil', icon: '✏' },
+  { tool: 'paint', label: 'Paint', icon: '▦' },
+  { tool: 'erase', label: 'Erase', icon: '⌫' },
+  { tool: 'slide', label: 'Slide', icon: '⇢' },
+] as const satisfies ReadonlyArray<{ tool: PianoRollTool; label: string; icon: string }>;
+
 export function PianoRoll() {
   const [activeTool, setActiveTool] = useState<PianoRollTool>('select');
   const [showGhostNotes, setShowGhostNotes] = useState(false);
@@ -121,18 +129,15 @@ export function PianoRoll() {
       <div className="h-9 px-3 border-b border-[#2a2a2a] bg-[#0e0e24] flex items-center gap-2 shrink-0">
         <div className="text-xs font-medium text-zinc-200">{track.displayName}</div>
 
-        {([
-          { tool: 'select', label: 'Select', icon: '↖' },
-          { tool: 'pencil', label: 'Pencil', icon: '✏' },
-          { tool: 'paint', label: 'Paint', icon: '▦' },
-          { tool: 'erase', label: 'Erase', icon: '⌫' },
-          { tool: 'slide', label: 'Slide', icon: '⇢' },
-        ] as const).map(({ tool, label, icon }) => {
+        {PIANO_ROLL_TOOL_BUTTONS.map(({ tool, label, icon }) => {
           const active = activeTool === tool;
           return (
             <button
+              type="button"
               key={tool}
               aria-label={`Activate ${label.toLowerCase()} tool`}
+              aria-keyshortcuts={getPianoRollToolShortcut(tool)}
+              aria-pressed={active ? 'true' : 'false'}
               className={`px-2 py-1 rounded text-[10px] transition-colors ${
                 active ? 'bg-violet-600/50 text-violet-200' : 'bg-white/5 text-zinc-400 hover:bg-white/10'
               }`}
@@ -143,6 +148,15 @@ export function PianoRoll() {
             </button>
           );
         })}
+
+        <div
+          role="status"
+          aria-live="polite"
+          data-active-tool={activeTool}
+          className="px-2 py-1 rounded bg-black/20 border border-white/5 text-[10px] text-zinc-300"
+        >
+          Tool: <span className="text-zinc-100">{PIANO_ROLL_TOOL_BUTTONS.find(({ tool }) => tool === activeTool)?.label ?? 'Select'}</span>
+        </div>
 
         <button
           className={`px-2 py-1 rounded text-[10px] transition-colors ${

--- a/src/components/pianoroll/PianoRollCanvas.tsx
+++ b/src/components/pianoroll/PianoRollCanvas.tsx
@@ -943,6 +943,38 @@ export function PianoRollCanvas({
     quantizeMidiNotes(clip.id, Array.from(selectedNoteIds), gridBeats);
   }, [clip.id, selectedNoteIds, quantizeMidiNotes, gridBeats]);
 
+  useEffect(() => {
+    const globalWindow = window as Window & {
+      __pianoRollHelpers?: {
+        beatToX: (beat: number) => number;
+        xToBeat: (x: number) => number;
+        pitchToY: (pitch: number) => number;
+        yToPitch: (y: number) => number;
+        pixelsPerBeat: number;
+        keyHeight: number;
+        prScrollX: number;
+        prScrollY: number;
+        activeTool: PianoRollTool;
+      };
+    };
+
+    globalWindow.__pianoRollHelpers = {
+      beatToX,
+      xToBeat,
+      pitchToY,
+      yToPitch,
+      pixelsPerBeat,
+      keyHeight,
+      prScrollX,
+      prScrollY,
+      activeTool,
+    };
+
+    return () => {
+      delete globalWindow.__pianoRollHelpers;
+    };
+  }, [activeTool, beatToX, keyHeight, pitchToY, pixelsPerBeat, prScrollX, prScrollY, xToBeat, yToPitch]);
+
   return (
     <div ref={containerRef} className="flex-1 relative overflow-hidden">
       <canvas

--- a/tests/e2e/piano-roll.spec.ts
+++ b/tests/e2e/piano-roll.spec.ts
@@ -23,6 +23,19 @@ type PianoRollTestStore = {
   };
 };
 
+type PianoRollUIStore = {
+  getState(): {
+    setOpenPianoRoll: (trackId: string | null, clipId?: string | null) => void;
+  };
+};
+
+type PianoRollHelpers = {
+  beatToX: (beat: number) => number;
+  pitchToY: (pitch: number) => number;
+  keyHeight: number;
+  activeTool: 'select' | 'pencil' | 'paint' | 'erase' | 'slide';
+};
+
 test.describe('Piano Roll Workflow', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
@@ -113,5 +126,37 @@ test.describe('Piano Roll Workflow', () => {
     });
 
     expect(result).toEqual({ isSlide: true, pitch: 67 });
+  });
+
+  test('exposes tool mode state and coordinate helpers for agent-driven canvas testing', async ({ page }) => {
+    await page.evaluate(() => {
+      const store = (window as unknown as { __store: PianoRollTestStore }).__store;
+      const uiStore = (window as unknown as { __uiStore: PianoRollUIStore }).__uiStore;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = store.getState().ensureMidiClip(track.id);
+      uiStore.getState().setOpenPianoRoll(track.id, clip.id);
+    });
+
+    await expect(page.getByLabel('Piano roll editor')).toBeVisible();
+    await expect(page.getByText('Tool: Select')).toBeVisible();
+
+    await page.keyboard.press('5');
+    await expect(page.getByText('Tool: Slide')).toBeVisible();
+
+    const helperSnapshot = await page.evaluate(() => {
+      const helpers = (window as unknown as { __pianoRollHelpers?: PianoRollHelpers }).__pianoRollHelpers;
+      return helpers
+        ? {
+            activeTool: helpers.activeTool,
+            noteX: helpers.beatToX(2),
+            noteY: helpers.pitchToY(60) + helpers.keyHeight / 2,
+          }
+        : null;
+    });
+
+    expect(helperSnapshot).not.toBeNull();
+    expect(helperSnapshot?.activeTool).toBe('slide');
+    expect(helperSnapshot?.noteX).toBeGreaterThan(56);
+    expect(helperSnapshot?.noteY).toBeGreaterThan(0);
   });
 });

--- a/website/guide/piano-roll.md
+++ b/website/guide/piano-roll.md
@@ -16,14 +16,19 @@ The Piano Roll is a canvas-based MIDI editor for composing melodies, chords, and
 | **MIDI Keyboard** | 56px sidebar on the left showing note names (C, C#, D, etc.) with octave labels. Black keys are shaded. |
 | **Note Grid** | Main editing area. Notes appear as colored rectangles. |
 | **Velocity Lane** | 60px strip below the grid showing velocity bars for each note. Resizable via drag divider. |
-| **Toolbar** | Grid size selector, draw mode toggle, zoom controls. |
+| **Toolbar** | Explicit tool buttons, grid size selector, ghost-note toggle, synth controls, and zoom controls. |
 
-## Drawing Notes
+## Tool Modes
 
-1. Enable **Draw Mode** by pressing `B` or clicking the draw mode toggle
-2. Click on the grid to place a note
-3. Drag left/right while placing to set duration
-4. Notes snap to the selected grid size
+| Tool | Shortcut | Behavior |
+|---|---|---|
+| **Select** | `1` | Select, move, resize, and box-select notes |
+| **Pencil** | `2` or `B` | Click to place a note, then drag to set duration |
+| **Paint** | `3` | Drag across the grid to write repeated notes on snapped cells |
+| **Erase** | `4` | Click or drag across notes to delete them |
+| **Slide** | `5` | Create slide notes with a distinct color and playback behavior |
+
+The active tool is shown in the toolbar, and notes snap to the selected grid by default.
 
 ## Editing Notes
 
@@ -73,13 +78,17 @@ Each piano roll track includes 6 built-in synth presets:
 |---|---|
 | Zoom X/Y | Scroll wheel with `Cmd/Ctrl` |
 | Pan/Scroll | Scroll wheel |
-| Toggle draw mode | `B` |
+| Tool switching | `1` / `2` / `3` / `4` / `5` |
+| Pencil toggle | `B` |
+| Quantize | `Q` |
+| Quantize options | `Cmd/Ctrl + Q` |
 
 ## Tips
 
 - Use **1/16 grid** for detailed melodies, **1/4 grid** for chord pads
 - Lower velocities work well for ghost notes in drum programming
 - The velocity color gradient makes it easy to spot dynamic variation at a glance
+- Use **Paint** for hi-hat runs and **Slide** for expressive bass transitions
 - Combine with the [Effects Chain](/guide/effects) to shape your synth sound
 
 ::: warning Known Limitation

--- a/website/guide/shortcuts.md
+++ b/website/guide/shortcuts.md
@@ -36,7 +36,7 @@ A complete reference of all keyboard shortcuts in ACE-Step DAW.
 | Shortcut | Action |
 |---|---|
 | `X` | Toggle mixer |
-| `B` | Toggle smart controls / draw mode |
+| `B` | Toggle smart controls or the piano roll pencil tool |
 | `O` | Toggle loop browser / assets |
 | `Shift + /` (`?`) | Show shortcuts dialog |
 
@@ -81,8 +81,13 @@ Escape follows a priority order: clip editor → batch generate → dialogs → 
 
 | Shortcut | Action |
 |---|---|
-| `B` | Toggle draw mode |
+| `1` / `2` / `3` / `4` / `5` | Select tool: Select / Pencil / Paint / Erase / Slide |
+| `B` | Toggle the pencil tool |
 | `Delete` / `Backspace` | Delete selected notes |
+| `↑` / `↓` | Transpose selected notes by semitone |
+| `←` / `→` | Nudge selected notes by one grid step |
+| `Q` | Quantize selected notes to the active grid |
+| `Cmd/Ctrl + Q` | Open quantize options |
 | Scroll wheel | Scroll |
 | `Cmd/Ctrl` + scroll | Zoom |
 


### PR DESCRIPTION
## Summary
- make the piano roll’s active tool state visible and automation-friendly via toolbar status text and explicit tool metadata on the buttons
- expose `window.__pianoRollHelpers` from the canvas so agent/browser tests can map beats and pitches to canvas coordinates on the shipped tool-mode workflow
- update the shortcut/help/docs surfaces that still described the old draw-mode toggle instead of the explicit select/pencil/paint/erase/slide workflow

## User stories
As a user, I want the piano roll toolbar and shortcut docs to reflect the real tool-mode workflow, so that I can switch editing modes without guessing.

As an AI agent, I want the active piano roll tool and coordinate helpers exposed outside the canvas, so that browser automation can verify the same editing workflow that human users see.

## Verification
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `npm test -- tests/unit/pianoRollContextMenu.test.tsx`
- `E2E_PORT=5401 npx playwright test tests/e2e/piano-roll.spec.ts`
