### PR TITLE
feat: add Session View clip launcher with MIDI capture (closes #329)

### DIFF
--- a/src/components/session/SessionClipSlotView.tsx
+++ b/src/components/session/SessionClipSlotView.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+import type { SessionClipSlot } from '../../types/session';
+import { useSessionStore } from '../../store/sessionStore';
+
+interface SessionClipSlotViewProps {
+  slot: SessionClipSlot;
+  trackColor: string;
+}
+
+export function SessionClipSlotView({ slot, trackColor }: SessionClipSlotViewProps) {
+  const launchSlot = useSessionStore((s) => s.launchSlot);
+  const stopSlot = useSessionStore((s) => s.stopSlot);
+
+  const handleClick = useCallback(() => {
+    if (slot.state === 'playing') {
+      stopSlot(slot.id);
+    } else if (slot.clipId) {
+      launchSlot(slot.id);
+    }
+  }, [slot.id, slot.clipId, slot.state, launchSlot, stopSlot]);
+
+  const isEmpty = !slot.clipId;
+  const isPlaying = slot.state === 'playing';
+  const bgColor = slot.color ?? trackColor;
+
+  return (
+    <button
+      className={`
+        w-full h-12 rounded border text-xs font-medium
+        transition-all duration-100 cursor-pointer
+        flex items-center justify-center gap-1
+        ${isEmpty
+          ? 'border-zinc-700 bg-zinc-800/50 text-zinc-600 hover:bg-zinc-700/50'
+          : isPlaying
+            ? 'border-green-500 text-white shadow-[0_0_8px_rgba(34,197,94,0.3)]'
+            : 'border-zinc-600 text-zinc-200 hover:brightness-110'
+        }
+      `}
+      style={!isEmpty ? { backgroundColor: `${bgColor}33` } : undefined}
+      onClick={handleClick}
+      data-testid={`session-slot-${slot.id}`}
+      data-slot-id={slot.id}
+      data-track-id={slot.trackId}
+      title={isEmpty ? 'Empty slot' : isPlaying ? 'Click to stop' : 'Click to launch'}
+      aria-label={
+        isEmpty
+          ? `Empty slot, scene ${slot.sceneIndex + 1}`
+          : isPlaying
+            ? `Stop clip in scene ${slot.sceneIndex + 1}`
+            : `Launch clip in scene ${slot.sceneIndex + 1}`
+      }
+    >
+      {isPlaying && (
+        <span className="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+      )}
+      {!isEmpty && !isPlaying && (
+        <span
+          className="inline-block w-0 h-0 border-l-[6px] border-t-[4px] border-b-[4px] border-l-current border-t-transparent border-b-transparent"
+        />
+      )}
+      {isEmpty && <span className="text-zinc-600">+</span>}
+    </button>
+  );
+}

--- a/src/components/session/SessionSceneStrip.tsx
+++ b/src/components/session/SessionSceneStrip.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useState } from 'react';
+import { useSessionStore } from '../../store/sessionStore';
+import type { SessionScene } from '../../types/session';
+
+interface SessionSceneStripProps {
+  scene: SessionScene;
+}
+
+export function SessionSceneStrip({ scene }: SessionSceneStripProps) {
+  const launchScene = useSessionStore((s) => s.launchScene);
+  const stopScene = useSessionStore((s) => s.stopScene);
+  const renameScene = useSessionStore((s) => s.renameScene);
+  const slots = useSessionStore((s) => s.slots);
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(scene.name);
+
+  const sceneSlots = slots.filter((s) => s.sceneIndex === scene.index);
+  const isPlaying = sceneSlots.some((s) => s.state === 'playing');
+
+  const handleLaunch = useCallback(() => {
+    if (isPlaying) {
+      stopScene(scene.index);
+    } else {
+      launchScene(scene.index);
+    }
+  }, [scene.index, isPlaying, launchScene, stopScene]);
+
+  const handleDoubleClick = useCallback(() => {
+    setEditValue(scene.name);
+    setEditing(true);
+  }, [scene.name]);
+
+  const handleBlur = useCallback(() => {
+    setEditing(false);
+    if (editValue.trim() && editValue !== scene.name) {
+      renameScene(scene.id, editValue.trim());
+    }
+  }, [scene.id, scene.name, editValue, renameScene]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      (e.target as HTMLInputElement).blur();
+    } else if (e.key === 'Escape') {
+      setEditing(false);
+      setEditValue(scene.name);
+    }
+  }, [scene.name]);
+
+  return (
+    <div
+      className="flex items-center gap-1 h-12"
+      data-testid={`session-scene-${scene.index}`}
+    >
+      <button
+        className={`
+          w-8 h-8 rounded flex items-center justify-center
+          transition-colors duration-100
+          ${isPlaying
+            ? 'bg-green-600 hover:bg-green-500 text-white'
+            : 'bg-zinc-700 hover:bg-zinc-600 text-zinc-300'
+          }
+        `}
+        onClick={handleLaunch}
+        title={isPlaying ? `Stop ${scene.name}` : `Launch ${scene.name}`}
+        aria-label={isPlaying ? `Stop ${scene.name}` : `Launch ${scene.name}`}
+      >
+        {isPlaying ? '■' : '▶'}
+      </button>
+      {editing ? (
+        <input
+          className="bg-zinc-800 text-xs text-zinc-200 px-1 py-0.5 rounded border border-zinc-600 w-16 outline-none focus:border-blue-500"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          autoFocus
+        />
+      ) : (
+        <span
+          className="text-xs text-zinc-400 cursor-default select-none truncate w-16"
+          onDoubleClick={handleDoubleClick}
+          title="Double-click to rename"
+        >
+          {scene.name}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import { useTransportStore } from './store/transportStore';
 import { useCollaborationStore } from './store/collaborationStore';
 import { useShortcutsStore } from './store/shortcutsStore';
 import { useGenerationStore } from './store/generationStore';
+import { useSessionStore } from './store/sessionStore';
 import { generateProjectSummary, generateProjectStructure } from './utils/dawStateSummary';
 import { getMidiCaptureService } from './services/midiCaptureService';
 
@@ -20,6 +21,7 @@ import { getMidiCaptureService } from './services/midiCaptureService';
 (window as unknown as Record<string, unknown>).__transportStore = useTransportStore;
 (window as unknown as Record<string, unknown>).__collaborationStore = useCollaborationStore;
 (window as unknown as Record<string, unknown>).__generationStore = useGenerationStore;
+(window as unknown as Record<string, unknown>).__sessionStore = useSessionStore;
 (window as unknown as Record<string, unknown>).__getAudioEngine = () => getAudioEngine();
 (window as unknown as Record<string, unknown>).__shortcutsStore = useShortcutsStore;
 (window as unknown as Record<string, unknown>).__commandPalette = {

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -1,0 +1,216 @@
+import { create } from 'zustand';
+import { v4 as uuidv4 } from 'uuid';
+import type { SessionClipSlot, SessionScene, BufferedMidiEvent } from '../types/session';
+import { MidiCaptureBuffer } from '../utils/midiCaptureBuffer';
+
+const DEFAULT_SCENE_COUNT = 8;
+const MIDI_BUFFER_DURATION = 30; // seconds
+const MIDI_BUFFER_MAX_EVENTS = 2000;
+
+/** A recorded session event for arrangement capture. */
+export interface SessionRecordedEvent {
+  slotId: string;
+  clipId: string;
+  trackId: string;
+  action: 'launch' | 'stop';
+  timestamp: number;
+}
+
+interface SessionState {
+  slots: SessionClipSlot[];
+  scenes: SessionScene[];
+  sceneCount: number;
+  recordingToArrangement: boolean;
+  recordedEvents: SessionRecordedEvent[];
+
+  // Actions
+  initSession: (trackIds: string[], sceneCount?: number) => void;
+  assignClipToSlot: (slotId: string, clipId: string) => void;
+  clearSlot: (slotId: string) => void;
+  launchSlot: (slotId: string) => void;
+  stopSlot: (slotId: string) => void;
+  launchScene: (sceneIndex: number) => void;
+  stopScene: (sceneIndex: number) => void;
+  stopAll: () => void;
+  renameScene: (sceneId: string, name: string) => void;
+  addScene: (trackIds: string[]) => void;
+  setRecordingToArrangement: (v: boolean) => void;
+  recordSessionEvent: (event: SessionRecordedEvent) => void;
+  clearRecordedEvents: () => void;
+
+  // MIDI capture
+  midiNoteOn: (pitch: number, velocity: number, timestamp: number) => void;
+  midiNoteOff: (pitch: number, timestamp: number) => void;
+  captureMidi: (startTime?: number, endTime?: number) => BufferedMidiEvent[];
+  clearMidiBuffer: () => void;
+}
+
+// Module-level MIDI buffer (not stored in Zustand to avoid serialization)
+const midiBuffer = new MidiCaptureBuffer({
+  maxDurationSeconds: MIDI_BUFFER_DURATION,
+  maxEvents: MIDI_BUFFER_MAX_EVENTS,
+});
+
+function createSlots(trackIds: string[], sceneCount: number): SessionClipSlot[] {
+  const slots: SessionClipSlot[] = [];
+  for (let sceneIdx = 0; sceneIdx < sceneCount; sceneIdx++) {
+    for (const trackId of trackIds) {
+      slots.push({
+        id: uuidv4(),
+        trackId,
+        sceneIndex: sceneIdx,
+        clipId: null,
+        state: 'stopped',
+        color: null,
+      });
+    }
+  }
+  return slots;
+}
+
+function createScenes(count: number): SessionScene[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: uuidv4(),
+    name: `Scene ${i + 1}`,
+    index: i,
+  }));
+}
+
+export const useSessionStore = create<SessionState>()((set, get) => ({
+  slots: [],
+  scenes: [],
+  sceneCount: 0,
+  recordingToArrangement: false,
+  recordedEvents: [],
+
+  initSession: (trackIds, sceneCount = DEFAULT_SCENE_COUNT) => {
+    set({
+      slots: createSlots(trackIds, sceneCount),
+      scenes: createScenes(sceneCount),
+      sceneCount,
+      recordedEvents: [],
+    });
+  },
+
+  assignClipToSlot: (slotId, clipId) => {
+    set((s) => ({
+      slots: s.slots.map((slot) =>
+        slot.id === slotId ? { ...slot, clipId } : slot,
+      ),
+    }));
+  },
+
+  clearSlot: (slotId) => {
+    set((s) => ({
+      slots: s.slots.map((slot) =>
+        slot.id === slotId ? { ...slot, clipId: null, state: 'stopped' } : slot,
+      ),
+    }));
+  },
+
+  launchSlot: (slotId) => {
+    set((s) => {
+      const target = s.slots.find((slot) => slot.id === slotId);
+      if (!target || !target.clipId) return s;
+      return {
+        slots: s.slots.map((slot) => {
+          if (slot.id === slotId) return { ...slot, state: 'playing' as const };
+          // Stop other playing slots on the same track
+          if (slot.trackId === target.trackId && slot.state === 'playing') {
+            return { ...slot, state: 'stopped' as const };
+          }
+          return slot;
+        }),
+      };
+    });
+  },
+
+  stopSlot: (slotId) => {
+    set((s) => ({
+      slots: s.slots.map((slot) =>
+        slot.id === slotId ? { ...slot, state: 'stopped' as const } : slot,
+      ),
+    }));
+  },
+
+  launchScene: (sceneIndex) => {
+    set((s) => ({
+      slots: s.slots.map((slot) => {
+        if (slot.sceneIndex === sceneIndex && slot.clipId) {
+          return { ...slot, state: 'playing' as const };
+        }
+        // Stop slots on same tracks that belong to other scenes
+        if (slot.sceneIndex !== sceneIndex && slot.state === 'playing') {
+          return { ...slot, state: 'stopped' as const };
+        }
+        return slot;
+      }),
+    }));
+  },
+
+  stopScene: (sceneIndex) => {
+    set((s) => ({
+      slots: s.slots.map((slot) =>
+        slot.sceneIndex === sceneIndex ? { ...slot, state: 'stopped' as const } : slot,
+      ),
+    }));
+  },
+
+  stopAll: () => {
+    set((s) => ({
+      slots: s.slots.map((slot) => ({ ...slot, state: 'stopped' as const })),
+    }));
+  },
+
+  renameScene: (sceneId, name) => {
+    set((s) => ({
+      scenes: s.scenes.map((scene) =>
+        scene.id === sceneId ? { ...scene, name } : scene,
+      ),
+    }));
+  },
+
+  addScene: (trackIds) => {
+    set((s) => {
+      const newIndex = s.sceneCount;
+      const newSlots: SessionClipSlot[] = trackIds.map((trackId) => ({
+        id: uuidv4(),
+        trackId,
+        sceneIndex: newIndex,
+        clipId: null,
+        state: 'stopped' as const,
+        color: null,
+      }));
+      return {
+        slots: [...s.slots, ...newSlots],
+        scenes: [...s.scenes, { id: uuidv4(), name: `Scene ${newIndex + 1}`, index: newIndex }],
+        sceneCount: newIndex + 1,
+      };
+    });
+  },
+
+  setRecordingToArrangement: (v) => set({ recordingToArrangement: v }),
+
+  recordSessionEvent: (event) => {
+    set((s) => ({ recordedEvents: [...s.recordedEvents, event] }));
+  },
+
+  clearRecordedEvents: () => set({ recordedEvents: [] }),
+
+  // MIDI capture (delegates to module-level buffer)
+  midiNoteOn: (pitch, velocity, timestamp) => {
+    midiBuffer.noteOn(pitch, velocity, timestamp);
+  },
+
+  midiNoteOff: (pitch, timestamp) => {
+    midiBuffer.noteOff(pitch, timestamp);
+  },
+
+  captureMidi: (startTime?: number, endTime?: number) => {
+    return midiBuffer.capture(startTime, endTime);
+  },
+
+  clearMidiBuffer: () => {
+    midiBuffer.clear();
+  },
+}));

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,0 +1,51 @@
+/**
+ * Session View types for clip launcher, scene management,
+ * and MIDI capture buffer.
+ */
+
+/** Playback state of a session clip slot. */
+export type SessionClipState = 'stopped' | 'playing' | 'queued' | 'recording';
+
+/** A single slot in the session clip grid. */
+export interface SessionClipSlot {
+  id: string;
+  trackId: string;
+  /** Index position in the track's session column (row). */
+  sceneIndex: number;
+  /** Reference to an arrangement clip id, or null if the slot is empty. */
+  clipId: string | null;
+  /** Current playback state. */
+  state: SessionClipState;
+  /** Color override (inherits track color when null). */
+  color: string | null;
+}
+
+/** A scene (horizontal row) that can trigger all slots at once. */
+export interface SessionScene {
+  id: string;
+  name: string;
+  /** Row index in the session grid. */
+  index: number;
+}
+
+/** A buffered MIDI event for retroactive capture. */
+export interface BufferedMidiEvent {
+  /** MIDI note number (0–127). */
+  pitch: number;
+  /** Velocity (0–1). */
+  velocity: number;
+  /** Timestamp in seconds (performance.now() / 1000 at capture time). */
+  timestamp: number;
+  /** Duration in seconds (filled on note-off). */
+  duration: number;
+}
+
+/** Session-level state stored on the project. */
+export interface SessionData {
+  /** All clip slots in the grid, keyed by slot id. */
+  slots: SessionClipSlot[];
+  /** Scene definitions (rows). */
+  scenes: SessionScene[];
+  /** Number of scene rows in the grid. */
+  sceneCount: number;
+}

--- a/src/utils/midiCaptureBuffer.ts
+++ b/src/utils/midiCaptureBuffer.ts
@@ -1,0 +1,100 @@
+import type { BufferedMidiEvent } from '../types/session';
+
+export interface MidiCaptureBufferOptions {
+  /** Maximum age (seconds) of events to keep in the buffer. */
+  maxDurationSeconds: number;
+  /** Maximum number of completed events to keep. */
+  maxEvents: number;
+}
+
+/**
+ * Always-on circular buffer that records MIDI note events for retroactive capture.
+ * Events older than `maxDurationSeconds` or exceeding `maxEvents` are evicted.
+ */
+export class MidiCaptureBuffer {
+  private events: BufferedMidiEvent[] = [];
+  /** Pending note-ons that haven't received a note-off yet, keyed by pitch. */
+  private pending = new Map<number, { velocity: number; timestamp: number }>();
+  private readonly maxDuration: number;
+  private readonly maxEvents: number;
+
+  constructor(options: MidiCaptureBufferOptions) {
+    this.maxDuration = options.maxDurationSeconds;
+    this.maxEvents = options.maxEvents;
+  }
+
+  /** Record a note-on event. */
+  noteOn(pitch: number, velocity: number, timestamp: number): void {
+    // If the same pitch is already pending, auto-close it (retrigger)
+    const existing = this.pending.get(pitch);
+    if (existing) {
+      this.events.push({
+        pitch,
+        velocity: existing.velocity,
+        timestamp: existing.timestamp,
+        duration: timestamp - existing.timestamp,
+      });
+    }
+    this.pending.set(pitch, { velocity, timestamp });
+    this.evict(timestamp);
+  }
+
+  /** Record a note-off event, completing the corresponding note-on. */
+  noteOff(pitch: number, timestamp: number): void {
+    const note = this.pending.get(pitch);
+    if (!note) return;
+    this.pending.delete(pitch);
+    this.events.push({
+      pitch,
+      velocity: note.velocity,
+      timestamp: note.timestamp,
+      duration: timestamp - note.timestamp,
+    });
+    this.evict(timestamp);
+  }
+
+  /** Get all completed events currently in the buffer (read-only copies). */
+  getEvents(): BufferedMidiEvent[] {
+    return this.events.map((e) => ({ ...e }));
+  }
+
+  /** Number of completed events in the buffer. */
+  getEventCount(): number {
+    return this.events.length;
+  }
+
+  /**
+   * Capture events within an optional time window.
+   * Returns copies with timestamps normalized to start at 0.
+   * If no window specified, captures all completed events.
+   */
+  capture(startTime?: number, endTime?: number): BufferedMidiEvent[] {
+    let filtered = this.events;
+    if (startTime !== undefined && endTime !== undefined) {
+      filtered = this.events.filter(
+        (e) => e.timestamp >= startTime && e.timestamp + e.duration <= endTime,
+      );
+    }
+    if (filtered.length === 0) return [];
+    const earliest = filtered[0].timestamp;
+    return filtered.map((e) => ({
+      ...e,
+      timestamp: e.timestamp - earliest,
+    }));
+  }
+
+  /** Remove all events and pending notes. */
+  clear(): void {
+    this.events = [];
+    this.pending.clear();
+  }
+
+  /** Evict events that are too old or exceed maxEvents. */
+  private evict(currentTime: number): void {
+    const cutoff = currentTime - this.maxDuration;
+    this.events = this.events.filter((e) => e.timestamp >= cutoff);
+    while (this.events.length > this.maxEvents) {
+      this.events.shift();
+    }
+  }
+}

--- a/tests/unit/midiCaptureBuffer.test.ts
+++ b/tests/unit/midiCaptureBuffer.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MidiCaptureBuffer } from '../../src/utils/midiCaptureBuffer';
+
+describe('MidiCaptureBuffer', () => {
+  let buffer: MidiCaptureBuffer;
+
+  beforeEach(() => {
+    buffer = new MidiCaptureBuffer({ maxDurationSeconds: 30, maxEvents: 1000 });
+  });
+
+  it('starts empty', () => {
+    expect(buffer.getEvents()).toEqual([]);
+    expect(buffer.getEventCount()).toBe(0);
+  });
+
+  it('records note-on and note-off as a single event with duration', () => {
+    buffer.noteOn(60, 0.8, 1.0);
+    buffer.noteOff(60, 1.5);
+    const events = buffer.getEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      pitch: 60,
+      velocity: 0.8,
+      timestamp: 1.0,
+      duration: 0.5,
+    });
+  });
+
+  it('handles multiple simultaneous notes', () => {
+    buffer.noteOn(60, 0.8, 1.0);
+    buffer.noteOn(64, 0.7, 1.0);
+    buffer.noteOff(60, 1.5);
+    buffer.noteOff(64, 2.0);
+    const events = buffer.getEvents();
+    expect(events).toHaveLength(2);
+    expect(events[0].pitch).toBe(60);
+    expect(events[0].duration).toBe(0.5);
+    expect(events[1].pitch).toBe(64);
+    expect(events[1].duration).toBe(1.0);
+  });
+
+  it('evicts events older than maxDurationSeconds', () => {
+    buffer.noteOn(60, 0.8, 1.0);
+    buffer.noteOff(60, 1.5);
+    // Add a note 31s later — should evict the first
+    buffer.noteOn(64, 0.7, 32.0);
+    buffer.noteOff(64, 32.5);
+    const events = buffer.getEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].pitch).toBe(64);
+  });
+
+  it('evicts oldest events when maxEvents is exceeded', () => {
+    const small = new MidiCaptureBuffer({ maxDurationSeconds: 60, maxEvents: 2 });
+    small.noteOn(60, 0.8, 1.0);
+    small.noteOff(60, 1.5);
+    small.noteOn(62, 0.8, 2.0);
+    small.noteOff(62, 2.5);
+    small.noteOn(64, 0.8, 3.0);
+    small.noteOff(64, 3.5);
+    const events = small.getEvents();
+    expect(events).toHaveLength(2);
+    expect(events[0].pitch).toBe(62);
+    expect(events[1].pitch).toBe(64);
+  });
+
+  it('capture() returns events within the given time window', () => {
+    buffer.noteOn(60, 0.8, 1.0);
+    buffer.noteOff(60, 1.5);
+    buffer.noteOn(62, 0.7, 3.0);
+    buffer.noteOff(62, 3.5);
+    buffer.noteOn(64, 0.9, 5.0);
+    buffer.noteOff(64, 5.5);
+
+    const captured = buffer.capture(2.0, 4.0);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].pitch).toBe(62);
+  });
+
+  it('capture() with no args returns all completed events', () => {
+    buffer.noteOn(60, 0.8, 1.0);
+    buffer.noteOff(60, 1.5);
+    buffer.noteOn(62, 0.7, 2.0);
+    buffer.noteOff(62, 2.5);
+    const captured = buffer.capture();
+    expect(captured).toHaveLength(2);
+  });
+
+  it('capture() normalizes timestamps to start at 0', () => {
+    buffer.noteOn(60, 0.8, 10.0);
+    buffer.noteOff(60, 10.5);
+    buffer.noteOn(62, 0.7, 12.0);
+    buffer.noteOff(62, 12.5);
+    const captured = buffer.capture(9.0, 13.0);
+    expect(captured[0].timestamp).toBe(0);
+    expect(captured[1].timestamp).toBeCloseTo(2.0);
+  });
+
+  it('clear() removes all events and pending notes', () => {
+    buffer.noteOn(60, 0.8, 1.0);
+    buffer.noteOff(60, 1.5);
+    buffer.noteOn(62, 0.7, 2.0); // pending, no noteOff yet
+    buffer.clear();
+    expect(buffer.getEvents()).toEqual([]);
+    expect(buffer.getEventCount()).toBe(0);
+  });
+
+  it('ignores noteOff for notes that were never started', () => {
+    buffer.noteOff(60, 1.5);
+    expect(buffer.getEvents()).toEqual([]);
+  });
+
+  it('handles repeated noteOn for same pitch (retrigger)', () => {
+    buffer.noteOn(60, 0.8, 1.0);
+    // Retrigger same note before noteOff — first note gets auto-closed
+    buffer.noteOn(60, 0.9, 2.0);
+    buffer.noteOff(60, 2.5);
+    const events = buffer.getEvents();
+    expect(events).toHaveLength(2);
+    expect(events[0].duration).toBe(1.0); // auto-closed at retrigger time
+    expect(events[1].velocity).toBe(0.9);
+    expect(events[1].duration).toBe(0.5);
+  });
+});

--- a/tests/unit/sessionStore.test.ts
+++ b/tests/unit/sessionStore.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSessionStore } from '../../src/store/sessionStore';
+import { useProjectStore } from '../../src/store/projectStore';
+
+function resetStores() {
+  useSessionStore.setState(useSessionStore.getInitialState());
+  useProjectStore.setState(useProjectStore.getInitialState());
+}
+
+describe('sessionStore', () => {
+  beforeEach(() => {
+    resetStores();
+    // Create a project with 2 tracks
+    useProjectStore.getState().createProject({ name: 'Test', bpm: 120 });
+    useProjectStore.getState().addTrack('drums', 'stems');
+    useProjectStore.getState().addTrack('bass', 'pianoRoll');
+  });
+
+  describe('initialization', () => {
+    it('initializes session grid for all tracks', () => {
+      const project = useProjectStore.getState().project!;
+      useSessionStore.getState().initSession(project.tracks.map((t) => t.id));
+      const state = useSessionStore.getState();
+      expect(state.scenes).toHaveLength(8); // default 8 scenes
+      // Each track should have 8 slots
+      const trackIds = project.tracks.map((t) => t.id);
+      for (const trackId of trackIds) {
+        const trackSlots = state.slots.filter((s) => s.trackId === trackId);
+        expect(trackSlots).toHaveLength(8);
+      }
+    });
+
+    it('initializes with custom scene count', () => {
+      const project = useProjectStore.getState().project!;
+      useSessionStore.getState().initSession(
+        project.tracks.map((t) => t.id),
+        4,
+      );
+      expect(useSessionStore.getState().scenes).toHaveLength(4);
+    });
+  });
+
+  describe('clip slot management', () => {
+    beforeEach(() => {
+      const project = useProjectStore.getState().project!;
+      useSessionStore.getState().initSession(project.tracks.map((t) => t.id));
+    });
+
+    it('assigns a clip to a slot', () => {
+      const state = useSessionStore.getState();
+      const slot = state.slots[0];
+      useSessionStore.getState().assignClipToSlot(slot.id, 'clip-123');
+      const updated = useSessionStore.getState().slots.find((s) => s.id === slot.id)!;
+      expect(updated.clipId).toBe('clip-123');
+    });
+
+    it('clears a clip from a slot', () => {
+      const state = useSessionStore.getState();
+      const slot = state.slots[0];
+      useSessionStore.getState().assignClipToSlot(slot.id, 'clip-123');
+      useSessionStore.getState().clearSlot(slot.id);
+      const updated = useSessionStore.getState().slots.find((s) => s.id === slot.id)!;
+      expect(updated.clipId).toBeNull();
+      expect(updated.state).toBe('stopped');
+    });
+  });
+
+  describe('clip launching', () => {
+    beforeEach(() => {
+      const project = useProjectStore.getState().project!;
+      useSessionStore.getState().initSession(project.tracks.map((t) => t.id));
+      // Assign a clip to first slot
+      const slot = useSessionStore.getState().slots[0];
+      useSessionStore.getState().assignClipToSlot(slot.id, 'clip-1');
+    });
+
+    it('launches a clip slot (sets state to playing)', () => {
+      const slot = useSessionStore.getState().slots[0];
+      useSessionStore.getState().launchSlot(slot.id);
+      const updated = useSessionStore.getState().slots.find((s) => s.id === slot.id)!;
+      expect(updated.state).toBe('playing');
+    });
+
+    it('stops all other slots on the same track when launching', () => {
+      const state = useSessionStore.getState();
+      const trackId = state.slots[0].trackId;
+      // Assign and launch slot at index 0
+      useSessionStore.getState().launchSlot(state.slots[0].id);
+
+      // Assign and launch a different slot on the same track
+      const otherSlot = state.slots.find(
+        (s) => s.trackId === trackId && s.id !== state.slots[0].id,
+      )!;
+      useSessionStore.getState().assignClipToSlot(otherSlot.id, 'clip-2');
+      useSessionStore.getState().launchSlot(otherSlot.id);
+
+      const slots = useSessionStore.getState().slots.filter((s) => s.trackId === trackId);
+      const playing = slots.filter((s) => s.state === 'playing');
+      expect(playing).toHaveLength(1);
+      expect(playing[0].id).toBe(otherSlot.id);
+    });
+
+    it('stops a playing slot', () => {
+      const slot = useSessionStore.getState().slots[0];
+      useSessionStore.getState().launchSlot(slot.id);
+      useSessionStore.getState().stopSlot(slot.id);
+      const updated = useSessionStore.getState().slots.find((s) => s.id === slot.id)!;
+      expect(updated.state).toBe('stopped');
+    });
+
+    it('does not launch an empty slot', () => {
+      // Find an empty slot
+      const emptySlot = useSessionStore.getState().slots.find((s) => s.clipId === null)!;
+      useSessionStore.getState().launchSlot(emptySlot.id);
+      const updated = useSessionStore.getState().slots.find((s) => s.id === emptySlot.id)!;
+      expect(updated.state).toBe('stopped');
+    });
+  });
+
+  describe('scene launching', () => {
+    beforeEach(() => {
+      const project = useProjectStore.getState().project!;
+      useSessionStore.getState().initSession(project.tracks.map((t) => t.id));
+      // Assign clips to all slots in scene 0
+      const scene0Slots = useSessionStore.getState().slots.filter((s) => s.sceneIndex === 0);
+      scene0Slots.forEach((slot, i) => {
+        useSessionStore.getState().assignClipToSlot(slot.id, `clip-scene0-${i}`);
+      });
+    });
+
+    it('launches all slots in a scene', () => {
+      useSessionStore.getState().launchScene(0);
+      const scene0Slots = useSessionStore.getState().slots.filter((s) => s.sceneIndex === 0);
+      for (const slot of scene0Slots) {
+        expect(slot.state).toBe('playing');
+      }
+    });
+
+    it('stops all other scenes when launching a scene', () => {
+      // Also assign clips to scene 1
+      const scene1Slots = useSessionStore.getState().slots.filter((s) => s.sceneIndex === 1);
+      scene1Slots.forEach((slot, i) => {
+        useSessionStore.getState().assignClipToSlot(slot.id, `clip-scene1-${i}`);
+      });
+
+      useSessionStore.getState().launchScene(0);
+      useSessionStore.getState().launchScene(1);
+
+      const scene0Slots = useSessionStore.getState().slots.filter((s) => s.sceneIndex === 0);
+      for (const slot of scene0Slots) {
+        expect(slot.state).toBe('stopped');
+      }
+      const scene1Playing = useSessionStore.getState().slots.filter(
+        (s) => s.sceneIndex === 1 && s.state === 'playing',
+      );
+      expect(scene1Playing).toHaveLength(scene1Slots.length);
+    });
+
+    it('stops all clips in a scene', () => {
+      useSessionStore.getState().launchScene(0);
+      useSessionStore.getState().stopScene(0);
+      const scene0Slots = useSessionStore.getState().slots.filter((s) => s.sceneIndex === 0);
+      for (const slot of scene0Slots) {
+        expect(slot.state).toBe('stopped');
+      }
+    });
+  });
+
+  describe('stopAll', () => {
+    it('stops all playing slots', () => {
+      const project = useProjectStore.getState().project!;
+      useSessionStore.getState().initSession(project.tracks.map((t) => t.id));
+      const slots = useSessionStore.getState().slots;
+      useSessionStore.getState().assignClipToSlot(slots[0].id, 'clip-1');
+      useSessionStore.getState().assignClipToSlot(slots[1].id, 'clip-2');
+      useSessionStore.getState().launchSlot(slots[0].id);
+      useSessionStore.getState().launchSlot(slots[1].id);
+      useSessionStore.getState().stopAll();
+      const allStopped = useSessionStore.getState().slots.every((s) => s.state === 'stopped');
+      expect(allStopped).toBe(true);
+    });
+  });
+
+  describe('scene management', () => {
+    beforeEach(() => {
+      const project = useProjectStore.getState().project!;
+      useSessionStore.getState().initSession(project.tracks.map((t) => t.id));
+    });
+
+    it('renames a scene', () => {
+      const scene = useSessionStore.getState().scenes[0];
+      useSessionStore.getState().renameScene(scene.id, 'Intro');
+      const updated = useSessionStore.getState().scenes.find((s) => s.id === scene.id)!;
+      expect(updated.name).toBe('Intro');
+    });
+
+    it('adds a new scene row', () => {
+      const project = useProjectStore.getState().project!;
+      const initialCount = useSessionStore.getState().scenes.length;
+      useSessionStore.getState().addScene(project.tracks.map((t) => t.id));
+      expect(useSessionStore.getState().scenes).toHaveLength(initialCount + 1);
+      // Should also add new slots for each track
+      const newSceneIndex = initialCount;
+      const newSlots = useSessionStore.getState().slots.filter((s) => s.sceneIndex === newSceneIndex);
+      expect(newSlots).toHaveLength(project.tracks.length);
+    });
+  });
+
+  describe('record to arrangement', () => {
+    it('toggles recording state', () => {
+      useSessionStore.getState().setRecordingToArrangement(true);
+      expect(useSessionStore.getState().recordingToArrangement).toBe(true);
+      useSessionStore.getState().setRecordingToArrangement(false);
+      expect(useSessionStore.getState().recordingToArrangement).toBe(false);
+    });
+
+    it('records a session event', () => {
+      useSessionStore.getState().setRecordingToArrangement(true);
+      useSessionStore.getState().recordSessionEvent({
+        slotId: 'slot-1',
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        action: 'launch',
+        timestamp: 1.5,
+      });
+      const events = useSessionStore.getState().recordedEvents;
+      expect(events).toHaveLength(1);
+      expect(events[0].action).toBe('launch');
+    });
+
+    it('clears recorded events', () => {
+      useSessionStore.getState().recordSessionEvent({
+        slotId: 'slot-1',
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        action: 'launch',
+        timestamp: 1.5,
+      });
+      useSessionStore.getState().clearRecordedEvents();
+      expect(useSessionStore.getState().recordedEvents).toHaveLength(0);
+    });
+  });
+
+  describe('MIDI capture', () => {
+    it('records and captures MIDI events', () => {
+      useSessionStore.getState().midiNoteOn(60, 0.8, 1.0);
+      useSessionStore.getState().midiNoteOff(60, 1.5);
+      const captured = useSessionStore.getState().captureMidi();
+      expect(captured).toHaveLength(1);
+      expect(captured[0].pitch).toBe(60);
+      expect(captured[0].duration).toBe(0.5);
+    });
+
+    it('clears MIDI buffer', () => {
+      useSessionStore.getState().midiNoteOn(60, 0.8, 1.0);
+      useSessionStore.getState().midiNoteOff(60, 1.5);
+      useSessionStore.getState().clearMidiBuffer();
+      expect(useSessionStore.getState().captureMidi()).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a **Session View** clip launcher grid alongside the existing Arrangement timeline, enabling non-linear, improvisational workflows
- Implements **scene launching** (trigger all clips in a row), per-slot launch/stop, and record-to-Arrangement mode for capturing live performances
- Adds an always-on **MIDI capture buffer** (30s circular buffer) for retroactive take recovery — ideas played before hitting record are not lost
- View toggle via **Tab key** or toolbar button; session store exposed on `window.__sessionStore` for full scriptability

## Changes
- **New files**: `src/types/session.ts`, `src/utils/midiCaptureBuffer.ts`, `src/store/sessionStore.ts`, `src/components/session/` (3 components)
- **Modified**: `uiStore` (view toggle), `AppShell` (conditional view rendering), `Toolbar` (toggle button), `useKeyboardShortcuts` (Tab), `KeyboardShortcutsDialog`, `main.tsx`
- **Tests**: 30 new unit tests across `midiCaptureBuffer.test.ts` and `sessionStore.test.ts`

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run` — 786 tests pass (87 files)
- [x] `npm run build` — successful production build
- [ ] Manual: Toggle Session/Arrangement view via Tab key
- [ ] Manual: Launch/stop clip slots and scenes in Session View
- [ ] Manual: Verify record-to-Arrangement toggle
- [ ] Manual: Verify MIDI capture buffer via `window.__sessionStore.getState().captureMidi()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)