### PR TITLE
feat: multi-format audio export — OGG Opus + metadata embedding (closes #318)

### DIFF
--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -8,6 +8,7 @@ import { renderMidiTrackOffline, renderSamplerTrackOffline, renderSequencerTrack
 import { toastError, toastSuccess } from '../../hooks/useToast';
 import {
   type ExportFormat,
+  type ExportMetadata,
   type Mp3Bitrate,
   type SampleRateOption,
   type BitDepth,
@@ -21,6 +22,7 @@ const FORMAT_OPTIONS: { value: ExportFormat; label: string }[] = [
   { value: 'wav', label: 'WAV' },
   { value: 'mp3', label: 'MP3' },
   { value: 'flac', label: 'FLAC' },
+  { value: 'ogg', label: 'OGG (Opus)' },
 ];
 
 const BITRATE_OPTIONS: { value: Mp3Bitrate; label: string }[] = [
@@ -44,6 +46,7 @@ function fileExtension(format: ExportFormat): string {
   switch (format) {
     case 'mp3': return '.mp3';
     case 'flac': return '.flac';
+    case 'ogg': return '.ogg';
     default: return '.wav';
   }
 }
@@ -55,6 +58,10 @@ export function ExportDialog() {
   const [exporting, setExporting] = useState(false);
   const [exportOptions, setExportOptions] = useState<ExportOptions>(DEFAULT_EXPORT_OPTIONS);
   const [progress, setProgress] = useState(0);
+  const [metadata, setMetadata] = useState<ExportMetadata>({
+    title: project?.name ?? '',
+    artist: '',
+  });
 
   if (!show || !project) return null;
 
@@ -131,7 +138,11 @@ export function ExportDialog() {
       }
 
       setProgress(60);
-      const blob = await exportMix(clips, project.totalDuration, exportOptions);
+      const optionsWithMeta = {
+        ...exportOptions,
+        metadata: (metadata.title || metadata.artist) ? metadata : undefined,
+      };
+      const blob = await exportMix(clips, project.totalDuration, optionsWithMeta);
       setProgress(90);
 
       const url = URL.createObjectURL(blob);
@@ -227,7 +238,7 @@ export function ExportDialog() {
           </div>
 
           {/* Bit depth (WAV & FLAC only) */}
-          {exportOptions.format !== 'mp3' && (
+          {exportOptions.format !== 'mp3' && exportOptions.format !== 'ogg' && (
             <div>
               <label className="block text-xs text-zinc-400 mb-1">Bit Depth</label>
               <select
@@ -261,6 +272,55 @@ export function ExportDialog() {
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
                 ))}
               </select>
+            </div>
+          )}
+
+          {/* OGG quality (OGG only) */}
+          {exportOptions.format === 'ogg' && (
+            <div>
+              <label className="block text-xs text-zinc-400 mb-1">
+                Quality: {Math.round(exportOptions.oggQuality * 10)}/10
+              </label>
+              <input
+                data-testid="export-ogg-quality"
+                type="range"
+                min="0"
+                max="1"
+                step="0.1"
+                value={exportOptions.oggQuality}
+                onChange={(e) =>
+                  setExportOptions((prev) => ({ ...prev, oggQuality: Number(e.target.value) }))
+                }
+                className="w-full accent-daw-accent"
+              />
+              <div className="flex justify-between text-[10px] text-zinc-500 mt-0.5">
+                <span>Smaller</span>
+                <span>~{Math.round(32 + exportOptions.oggQuality * 288)} kbps</span>
+                <span>Better</span>
+              </div>
+            </div>
+          )}
+
+          {/* Metadata (MP3 & FLAC) */}
+          {(exportOptions.format === 'mp3' || exportOptions.format === 'flac') && (
+            <div className="space-y-2 pt-1 border-t border-daw-border">
+              <label className="block text-xs text-zinc-400">Metadata</label>
+              <input
+                data-testid="export-metadata-title"
+                type="text"
+                placeholder="Title"
+                value={metadata.title ?? ''}
+                onChange={(e) => setMetadata((prev) => ({ ...prev, title: e.target.value }))}
+                className="w-full bg-daw-surface-2 border border-daw-border rounded px-2 py-1 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-daw-accent"
+              />
+              <input
+                data-testid="export-metadata-artist"
+                type="text"
+                placeholder="Artist"
+                value={metadata.artist ?? ''}
+                onChange={(e) => setMetadata((prev) => ({ ...prev, artist: e.target.value }))}
+                className="w-full bg-daw-surface-2 border border-daw-border rounded px-2 py-1 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-daw-accent"
+              />
             </div>
           )}
 

--- a/src/engine/exportMix.ts
+++ b/src/engine/exportMix.ts
@@ -1,5 +1,5 @@
 import { audioBufferToWavBlob } from '../utils/wav';
-import { encodeToMp3, encodeToFlac } from '../utils/audioEncoders';
+import { encodeToMp3, encodeToFlac, encodeToOgg } from '../utils/audioEncoders';
 import type { ExportOptions } from '../utils/audioEncoders';
 import type { MasteringState, TrackEffect } from '../types/project';
 import { ensureMasteringState } from '../utils/mastering';
@@ -314,9 +314,11 @@ export async function exportMix(
 
   switch (options.format) {
     case 'mp3':
-      return encodeToMp3(rendered, options.mp3Bitrate);
+      return encodeToMp3(rendered, options.mp3Bitrate, options.metadata);
     case 'flac':
-      return encodeToFlac(rendered, options.bitDepth);
+      return encodeToFlac(rendered, options.bitDepth, options.metadata);
+    case 'ogg':
+      return encodeToOgg(rendered, options.oggQuality);
     case 'wav':
     default:
       return audioBufferToWavBlob(rendered, options.bitDepth);

--- a/src/utils/audioEncoders.ts
+++ b/src/utils/audioEncoders.ts
@@ -1,20 +1,31 @@
 /**
- * Audio encoding utilities for exporting to MP3 and FLAC formats.
+ * Audio encoding utilities for exporting to MP3, FLAC, and OGG formats.
  * WAV encoding lives in wav.ts (pre-existing).
  */
 
 import { Mp3Encoder } from '@breezystack/lamejs';
 
-export type ExportFormat = 'wav' | 'mp3' | 'flac';
+export type ExportFormat = 'wav' | 'mp3' | 'flac' | 'ogg';
 export type Mp3Bitrate = 128 | 192 | 256 | 320;
 export type SampleRateOption = 44100 | 48000;
 export type BitDepth = 16 | 24;
+
+export interface ExportMetadata {
+  title?: string;
+  artist?: string;
+  album?: string;
+  trackNumber?: number;
+  genre?: string;
+  year?: string;
+}
 
 export interface ExportOptions {
   format: ExportFormat;
   sampleRate: SampleRateOption;
   bitDepth: BitDepth;
   mp3Bitrate: Mp3Bitrate;
+  oggQuality: number; // 0.0 - 1.0
+  metadata?: ExportMetadata;
 }
 
 export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
@@ -22,6 +33,7 @@ export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
   sampleRate: 48000,
   bitDepth: 16,
   mp3Bitrate: 320,
+  oggQuality: 0.5,
 };
 
 /**
@@ -39,10 +51,12 @@ export function floatToInt16(samples: Float32Array): Int16Array {
 /**
  * Encode an AudioBuffer to MP3 using lamejs.
  * Returns a Blob with type audio/mpeg.
+ * Optionally prepends ID3v2 metadata tags.
  */
 export function encodeToMp3(
   buffer: AudioBuffer,
   bitrate: Mp3Bitrate = 320,
+  metadata?: ExportMetadata,
 ): Blob {
   const channels = buffer.numberOfChannels;
   const sampleRate = buffer.sampleRate;
@@ -53,6 +67,14 @@ export function encodeToMp3(
 
   const blockSize = 1152;
   const mp3Data: Uint8Array[] = [];
+
+  // Prepend ID3v2 tag if metadata is provided
+  if (metadata) {
+    const id3Tag = encodeId3v2Tag(metadata);
+    if (id3Tag.length > 0) {
+      mp3Data.push(id3Tag);
+    }
+  }
 
   for (let i = 0; i < left.length; i += blockSize) {
     const leftChunk = left.subarray(i, i + blockSize);
@@ -85,6 +107,7 @@ export function encodeToMp3(
 export function encodeToFlac(
   buffer: AudioBuffer,
   bitDepth: BitDepth = 16,
+  metadata?: ExportMetadata,
 ): Blob {
   const numChannels = buffer.numberOfChannels;
   const sampleRate = buffer.sampleRate;
@@ -116,7 +139,7 @@ export function encodeToFlac(
   // 1. Magic number: "fLaC"
   parts.push(new Uint8Array([0x66, 0x4c, 0x61, 0x43]));
 
-  // 2. STREAMINFO metadata block (last metadata block)
+  // 2. STREAMINFO metadata block
   const blockSize = 4096;
   const streaminfo = buildStreamInfo(
     blockSize,
@@ -128,9 +151,29 @@ export function encodeToFlac(
     bitDepth,
     totalSamples,
   );
-  // Block header: last-block flag (1) | type 0 (STREAMINFO) = 0x80, then 3-byte length = 34
-  parts.push(new Uint8Array([0x80, 0x00, 0x00, 0x22]));
-  parts.push(streaminfo);
+
+  // Build optional VORBIS_COMMENT block for metadata
+  const vorbisComment = metadata ? buildFlacVorbisComment(metadata) : null;
+
+  if (vorbisComment) {
+    // STREAMINFO is NOT last (0x00 | type 0)
+    parts.push(new Uint8Array([0x00, 0x00, 0x00, 0x22]));
+    parts.push(streaminfo);
+
+    // VORBIS_COMMENT is last (0x80 | type 4 = 0x84)
+    const vcLen = vorbisComment.length;
+    parts.push(new Uint8Array([
+      0x84,
+      (vcLen >> 16) & 0xff,
+      (vcLen >> 8) & 0xff,
+      vcLen & 0xff,
+    ]));
+    parts.push(vorbisComment);
+  } else {
+    // STREAMINFO is last (0x80 | type 0)
+    parts.push(new Uint8Array([0x80, 0x00, 0x00, 0x22]));
+    parts.push(streaminfo);
+  }
 
   // 3. Audio frames — verbatim subframes
   let sampleOffset = 0;
@@ -466,7 +509,7 @@ export function estimateFileSize(
   durationSeconds: number,
   sampleRate: SampleRateOption,
   channels: number,
-  options: Pick<ExportOptions, 'format' | 'bitDepth' | 'mp3Bitrate'>,
+  options: Pick<ExportOptions, 'format' | 'bitDepth' | 'mp3Bitrate' | 'oggQuality'>,
 ): number {
   const { format, bitDepth, mp3Bitrate } = options;
   switch (format) {
@@ -477,6 +520,12 @@ export function estimateFileSize(
     case 'flac':
       // Verbatim FLAC is similar size to WAV, estimate ~70% of WAV
       return Math.ceil(durationSeconds * sampleRate * channels * (bitDepth / 8) * 0.7);
+    case 'ogg': {
+      // OGG Opus: quality maps to bitrate (~32-320 kbps)
+      const quality = options.oggQuality ?? 0.5;
+      const oggBitrate = 32000 + quality * 288000; // 32-320 kbps range
+      return Math.ceil(durationSeconds * oggBitrate / 8);
+    }
   }
 }
 
@@ -487,4 +536,204 @@ export function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ── OGG Opus encoding via MediaRecorder ────────────────────────────────
+
+/**
+ * Encode an AudioBuffer to OGG Opus format using the browser's MediaRecorder API.
+ * Quality maps to audioBitsPerSecond (0.0 = 32kbps, 1.0 = 320kbps).
+ *
+ * Note: encoding takes approximately real-time duration since it uses MediaRecorder.
+ * Chrome produces WebM/Opus containers; Firefox produces OGG/Opus natively.
+ * Both are saved with audio/ogg MIME type for consistency.
+ */
+export async function encodeToOgg(
+  buffer: AudioBuffer,
+  quality: number = 0.5,
+): Promise<Blob> {
+  if (typeof globalThis.AudioContext === 'undefined') {
+    throw new Error('OGG export requires AudioContext (not available in this environment)');
+  }
+  if (typeof globalThis.MediaRecorder === 'undefined') {
+    throw new Error('OGG export requires MediaRecorder (not available in this environment)');
+  }
+
+  const clampedQuality = Math.max(0, Math.min(1, quality));
+  const bitsPerSecond = Math.round(32000 + clampedQuality * 288000);
+
+  // Determine best available MIME type
+  const oggSupported = MediaRecorder.isTypeSupported('audio/ogg;codecs=opus');
+  const webmSupported = MediaRecorder.isTypeSupported('audio/webm;codecs=opus');
+  if (!oggSupported && !webmSupported) {
+    throw new Error('Neither audio/ogg nor audio/webm Opus encoding is supported in this browser');
+  }
+  const mimeType = oggSupported ? 'audio/ogg;codecs=opus' : 'audio/webm;codecs=opus';
+
+  const ctx = new AudioContext({ sampleRate: buffer.sampleRate });
+  const dest = ctx.createMediaStreamDestination();
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+  source.connect(dest);
+
+  const recorder = new MediaRecorder(dest.stream, {
+    mimeType,
+    audioBitsPerSecond: bitsPerSecond,
+  });
+
+  const chunks: Blob[] = [];
+
+  return new Promise<Blob>((resolve, reject) => {
+    recorder.ondataavailable = (e: BlobEvent) => {
+      if (e.data.size > 0) chunks.push(e.data);
+    };
+
+    recorder.onstop = () => {
+      void ctx.close();
+      resolve(new Blob(chunks, { type: 'audio/ogg' }));
+    };
+
+    recorder.onerror = () => {
+      void ctx.close();
+      reject(new Error('OGG encoding failed'));
+    };
+
+    recorder.start();
+    source.start(0);
+
+    source.onended = () => {
+      // Small delay to ensure final audio data is captured
+      setTimeout(() => recorder.stop(), 100);
+    };
+  });
+}
+
+// ── ID3v2 Tag Encoding for MP3 ────────────────────────────────────────
+
+/**
+ * Encode metadata as an ID3v2.3 tag.
+ * Returns a Uint8Array that should be prepended to the MP3 data.
+ */
+export function encodeId3v2Tag(metadata: ExportMetadata): Uint8Array {
+  const frames: Uint8Array[] = [];
+
+  const addTextFrame = (id: string, value: string | undefined) => {
+    if (!value) return;
+    const encoder = new TextEncoder();
+    const textBytes = encoder.encode(value);
+    // Frame: 4-byte ID + 4-byte size + 2-byte flags + 1-byte encoding (3=UTF-8) + text
+    const frameSize = 1 + textBytes.length;
+    const frame = new Uint8Array(10 + frameSize);
+    const idBytes = encoder.encode(id);
+    frame.set(idBytes, 0);
+    // Size (big-endian, 4 bytes, NOT syncsafe for frame size in ID3v2.3)
+    frame[4] = (frameSize >> 24) & 0xff;
+    frame[5] = (frameSize >> 16) & 0xff;
+    frame[6] = (frameSize >> 8) & 0xff;
+    frame[7] = frameSize & 0xff;
+    // Flags: 0x00, 0x00
+    frame[8] = 0;
+    frame[9] = 0;
+    // Encoding: 3 = UTF-8
+    frame[10] = 3;
+    // Text data
+    frame.set(textBytes, 11);
+    frames.push(frame);
+  };
+
+  addTextFrame('TIT2', metadata.title);
+  addTextFrame('TPE1', metadata.artist);
+  addTextFrame('TALB', metadata.album);
+  addTextFrame('TCON', metadata.genre);
+  addTextFrame('TYER', metadata.year);
+  if (metadata.trackNumber !== undefined) {
+    addTextFrame('TRCK', String(metadata.trackNumber));
+  }
+
+  if (frames.length === 0) return new Uint8Array(0);
+
+  // Calculate total frames size
+  let totalFrameSize = 0;
+  for (const f of frames) totalFrameSize += f.length;
+
+  // ID3v2 header: "ID3" + version (2.3) + flags + syncsafe size
+  const header = new Uint8Array(10);
+  const enc = new TextEncoder();
+  header.set(enc.encode('ID3'), 0);
+  header[3] = 3; // Version 2.3
+  header[4] = 0; // Revision 0
+  header[5] = 0; // Flags
+
+  // Syncsafe integer: each byte uses 7 bits
+  const size = totalFrameSize;
+  header[6] = (size >> 21) & 0x7f;
+  header[7] = (size >> 14) & 0x7f;
+  header[8] = (size >> 7) & 0x7f;
+  header[9] = size & 0x7f;
+
+  // Combine header + frames
+  const result = new Uint8Array(10 + totalFrameSize);
+  result.set(header, 0);
+  let offset = 10;
+  for (const frame of frames) {
+    result.set(frame, offset);
+    offset += frame.length;
+  }
+
+  return result;
+}
+
+// ── FLAC VORBIS_COMMENT block ──────────────────────────────────────────
+
+/**
+ * Build a VORBIS_COMMENT data block for FLAC metadata.
+ * Returns the raw block data (without the metadata block header).
+ */
+export function buildFlacVorbisComment(metadata: ExportMetadata): Uint8Array {
+  const encoder = new TextEncoder();
+  const vendor = 'ACE-Step DAW';
+  const vendorBytes = encoder.encode(vendor);
+
+  const comments: Uint8Array[] = [];
+  const addComment = (key: string, value: string | undefined) => {
+    if (!value) return;
+    comments.push(encoder.encode(`${key}=${value}`));
+  };
+
+  addComment('TITLE', metadata.title);
+  addComment('ARTIST', metadata.artist);
+  addComment('ALBUM', metadata.album);
+  addComment('GENRE', metadata.genre);
+  addComment('DATE', metadata.year);
+  if (metadata.trackNumber !== undefined) {
+    addComment('TRACKNUMBER', String(metadata.trackNumber));
+  }
+
+  // Calculate total size
+  let totalSize = 4 + vendorBytes.length + 4; // vendor length + vendor + comment count
+  for (const c of comments) totalSize += 4 + c.length; // each comment: length + data
+
+  const buf = new Uint8Array(totalSize);
+  const view = new DataView(buf.buffer);
+  let offset = 0;
+
+  // Vendor string (little-endian length + UTF-8 string)
+  view.setUint32(offset, vendorBytes.length, true);
+  offset += 4;
+  buf.set(vendorBytes, offset);
+  offset += vendorBytes.length;
+
+  // Comment count (little-endian)
+  view.setUint32(offset, comments.length, true);
+  offset += 4;
+
+  // Comments (little-endian length + UTF-8 string each)
+  for (const c of comments) {
+    view.setUint32(offset, c.length, true);
+    offset += 4;
+    buf.set(c, offset);
+    offset += c.length;
+  }
+
+  return buf;
 }

--- a/tests/unit/audioEncoders.test.ts
+++ b/tests/unit/audioEncoders.test.ts
@@ -3,9 +3,12 @@ import {
   floatToInt16,
   encodeToMp3,
   encodeToFlac,
+  encodeId3v2Tag,
+  buildFlacVorbisComment,
   estimateFileSize,
   formatFileSize,
   type ExportOptions,
+  type ExportMetadata,
 } from '../../src/utils/audioEncoders';
 
 /**
@@ -149,6 +152,7 @@ describe('estimateFileSize', () => {
       format: 'wav',
       bitDepth: 16,
       mp3Bitrate: 320,
+      oggQuality: 0.5,
     });
 
     // 60s * 48000 * 2ch * 2 bytes + 44 header = 11,520,044
@@ -160,6 +164,7 @@ describe('estimateFileSize', () => {
       format: 'mp3',
       bitDepth: 16,
       mp3Bitrate: 320,
+      oggQuality: 0.5,
     });
 
     // 60s * 320000 bps / 8 = 2,400,000
@@ -171,14 +176,55 @@ describe('estimateFileSize', () => {
       format: 'wav',
       bitDepth: 16,
       mp3Bitrate: 320,
+      oggQuality: 0.5,
     });
     const flacSize = estimateFileSize(60, 48000, 2, {
       format: 'flac',
       bitDepth: 16,
       mp3Bitrate: 320,
+      oggQuality: 0.5,
     });
 
     expect(flacSize).toBeLessThan(wavSize);
+  });
+
+  it('estimates OGG size based on quality', () => {
+    const sizeLow = estimateFileSize(60, 48000, 2, {
+      format: 'ogg',
+      bitDepth: 16,
+      mp3Bitrate: 320,
+      oggQuality: 0.0,
+    });
+    const sizeHigh = estimateFileSize(60, 48000, 2, {
+      format: 'ogg',
+      bitDepth: 16,
+      mp3Bitrate: 320,
+      oggQuality: 1.0,
+    });
+
+    expect(sizeLow).toBeGreaterThan(0);
+    expect(sizeHigh).toBeGreaterThan(sizeLow);
+    // At quality 0.0: ~32kbps => 60s * 32000 / 8 = 240,000
+    expect(sizeLow).toBe(240000);
+    // At quality 1.0: ~320kbps => 60s * 320000 / 8 = 2,400,000
+    expect(sizeHigh).toBe(2400000);
+  });
+
+  it('estimates OGG size smaller than WAV', () => {
+    const wavSize = estimateFileSize(60, 48000, 2, {
+      format: 'wav',
+      bitDepth: 16,
+      mp3Bitrate: 320,
+      oggQuality: 0.5,
+    });
+    const oggSize = estimateFileSize(60, 48000, 2, {
+      format: 'ogg',
+      bitDepth: 16,
+      mp3Bitrate: 320,
+      oggQuality: 0.5,
+    });
+
+    expect(oggSize).toBeLessThan(wavSize);
   });
 
   it('24-bit WAV is larger than 16-bit', () => {
@@ -186,11 +232,13 @@ describe('estimateFileSize', () => {
       format: 'wav',
       bitDepth: 16,
       mp3Bitrate: 320,
+      oggQuality: 0.5,
     });
     const size24 = estimateFileSize(60, 48000, 2, {
       format: 'wav',
       bitDepth: 24,
       mp3Bitrate: 320,
+      oggQuality: 0.5,
     });
 
     expect(size24).toBeGreaterThan(size16);
@@ -212,5 +260,159 @@ describe('formatFileSize', () => {
 
   it('formats fractional megabytes', () => {
     expect(formatFileSize(1.5 * 1024 * 1024)).toBe('1.5 MB');
+  });
+});
+
+describe('encodeId3v2Tag', () => {
+  it('returns empty array when no metadata fields are set', () => {
+    const tag = encodeId3v2Tag({});
+    expect(tag.length).toBe(0);
+  });
+
+  it('starts with ID3 magic bytes', () => {
+    const tag = encodeId3v2Tag({ title: 'Test Song' });
+    expect(tag[0]).toBe(0x49); // I
+    expect(tag[1]).toBe(0x44); // D
+    expect(tag[2]).toBe(0x33); // 3
+  });
+
+  it('uses ID3v2.3 version', () => {
+    const tag = encodeId3v2Tag({ title: 'Test' });
+    expect(tag[3]).toBe(3); // version 2.3
+    expect(tag[4]).toBe(0); // revision 0
+  });
+
+  it('contains TIT2 frame for title', () => {
+    const tag = encodeId3v2Tag({ title: 'My Song' });
+    const str = new TextDecoder().decode(tag);
+    expect(str).toContain('TIT2');
+    expect(str).toContain('My Song');
+  });
+
+  it('contains TPE1 frame for artist', () => {
+    const tag = encodeId3v2Tag({ artist: 'Test Artist' });
+    const str = new TextDecoder().decode(tag);
+    expect(str).toContain('TPE1');
+    expect(str).toContain('Test Artist');
+  });
+
+  it('contains multiple frames for multiple fields', () => {
+    const tag = encodeId3v2Tag({
+      title: 'Song',
+      artist: 'Artist',
+      album: 'Album',
+      genre: 'Electronic',
+      year: '2026',
+      trackNumber: 3,
+    });
+    const str = new TextDecoder().decode(tag);
+    expect(str).toContain('TIT2');
+    expect(str).toContain('TPE1');
+    expect(str).toContain('TALB');
+    expect(str).toContain('TCON');
+    expect(str).toContain('TYER');
+    expect(str).toContain('TRCK');
+  });
+
+  it('has syncsafe integer size in header', () => {
+    const tag = encodeId3v2Tag({ title: 'Test' });
+    // Bytes 6-9 are syncsafe size (each byte uses 7 bits)
+    const size = (tag[6] << 21) | (tag[7] << 14) | (tag[8] << 7) | tag[9];
+    // Size should equal total length minus 10-byte header
+    expect(size).toBe(tag.length - 10);
+  });
+});
+
+describe('buildFlacVorbisComment', () => {
+  it('starts with vendor string length (little-endian)', () => {
+    const comment = buildFlacVorbisComment({ title: 'Test' });
+    const view = new DataView(comment.buffer);
+    const vendorLen = view.getUint32(0, true);
+    expect(vendorLen).toBe(new TextEncoder().encode('ACE-Step DAW').length);
+  });
+
+  it('contains vendor string', () => {
+    const comment = buildFlacVorbisComment({ title: 'Test' });
+    const vendorLen = new DataView(comment.buffer).getUint32(0, true);
+    const vendorBytes = comment.slice(4, 4 + vendorLen);
+    const vendor = new TextDecoder().decode(vendorBytes);
+    expect(vendor).toBe('ACE-Step DAW');
+  });
+
+  it('contains correct comment count', () => {
+    const comment = buildFlacVorbisComment({ title: 'Test', artist: 'Me' });
+    const vendorLen = new DataView(comment.buffer).getUint32(0, true);
+    const commentCount = new DataView(comment.buffer).getUint32(4 + vendorLen, true);
+    expect(commentCount).toBe(2);
+  });
+
+  it('encodes TITLE and ARTIST fields', () => {
+    const comment = buildFlacVorbisComment({ title: 'My Song', artist: 'Bob' });
+    const str = new TextDecoder().decode(comment);
+    expect(str).toContain('TITLE=My Song');
+    expect(str).toContain('ARTIST=Bob');
+  });
+
+  it('skips undefined fields', () => {
+    const comment = buildFlacVorbisComment({ title: 'Test' });
+    const vendorLen = new DataView(comment.buffer).getUint32(0, true);
+    const commentCount = new DataView(comment.buffer).getUint32(4 + vendorLen, true);
+    expect(commentCount).toBe(1);
+  });
+});
+
+describe('encodeToMp3 with metadata', () => {
+  it('prepends ID3v2 tag when metadata is provided', async () => {
+    const buffer = createMockAudioBuffer(4410, 44100, 2);
+    const blobWithMeta = encodeToMp3(buffer, 128, { title: 'Test', artist: 'Me' });
+    const blobWithout = encodeToMp3(buffer, 128);
+
+    // With metadata should be larger (ID3 tag prepended)
+    expect(blobWithMeta.size).toBeGreaterThan(blobWithout.size);
+
+    // Check for ID3 header
+    const bytes = new Uint8Array(await blobWithMeta.arrayBuffer());
+    expect(bytes[0]).toBe(0x49); // I
+    expect(bytes[1]).toBe(0x44); // D
+    expect(bytes[2]).toBe(0x33); // 3
+  });
+});
+
+describe('encodeToFlac with metadata', () => {
+  it('embeds VORBIS_COMMENT block when metadata is provided', async () => {
+    const buffer = createMockAudioBuffer(4410, 44100, 2);
+    const blobWithMeta = encodeToFlac(buffer, 16, { title: 'Test', artist: 'Me' });
+    const blobWithout = encodeToFlac(buffer, 16);
+
+    // With metadata should be larger
+    expect(blobWithMeta.size).toBeGreaterThan(blobWithout.size);
+  });
+
+  it('STREAMINFO is not marked as last when VORBIS_COMMENT follows', async () => {
+    const buffer = createMockAudioBuffer(4410, 44100, 2);
+    const blob = encodeToFlac(buffer, 16, { title: 'Test' });
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+
+    // After magic (4 bytes), STREAMINFO header byte should be 0x00 (not last, type 0)
+    expect(bytes[4]).toBe(0x00);
+  });
+
+  it('VORBIS_COMMENT block header has correct type', async () => {
+    const buffer = createMockAudioBuffer(4410, 44100, 2);
+    const blob = encodeToFlac(buffer, 16, { title: 'Test' });
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+
+    // VORBIS_COMMENT starts after magic(4) + STREAMINFO header(4) + STREAMINFO data(34) = offset 42
+    // Block header byte: 0x84 = last block (0x80) | type 4 (VORBIS_COMMENT)
+    expect(bytes[42]).toBe(0x84);
+  });
+
+  it('FLAC with no metadata keeps STREAMINFO as last block', async () => {
+    const buffer = createMockAudioBuffer(4410, 44100, 2);
+    const blob = encodeToFlac(buffer, 16);
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+
+    // STREAMINFO should be marked as last (0x80)
+    expect(bytes[4]).toBe(0x80);
   });
 });


### PR DESCRIPTION
## Summary

- Add **OGG (Opus)** as a fourth export format alongside WAV, MP3, and FLAC, using the browser's MediaRecorder API with configurable quality (0.0–1.0, mapping to 32–320 kbps)
- Add **ID3v2.3 metadata embedding** for MP3 exports (title, artist, album, genre, year, track number)
- Add **VORBIS_COMMENT metadata blocks** for FLAC exports (same fields)
- Add **metadata input fields** (title, artist) and **OGG quality slider** to the Export Dialog
- Update **file size estimates** for the OGG format

## Changes

| File | What changed |
|------|-------------|
| `src/utils/audioEncoders.ts` | Added `encodeToOgg()`, `encodeId3v2Tag()`, `buildFlacVorbisComment()`, OGG types, updated `estimateFileSize` |
| `src/engine/exportMix.ts` | Added OGG case to `exportMix()`, pass metadata to MP3/FLAC encoders |
| `src/components/dialogs/ExportDialog.tsx` | Added OGG format option, quality slider, metadata fields (title/artist) |
| `tests/unit/audioEncoders.test.ts` | 19 new tests covering OGG estimation, ID3v2 tags, VORBIS_COMMENT, metadata embedding |

## Test plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run` — 775 tests pass (85 files), including 19 new tests
- [x] `npm run build` — production build succeeds
- [ ] Manual: open Export Dialog → select OGG → verify quality slider appears
- [ ] Manual: select MP3 → enter title/artist → export → verify ID3 tags with `ffprobe`
- [ ] Manual: select FLAC → enter metadata → export → verify with `metaflac --list`
- [ ] Manual: verify file size estimate updates when switching formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)