### PR TITLE
feat: add shortcut editor with DAW migration presets

### DIFF
--- a/docs/research-notes/shortcut-editor-daw-migration-competitive-research-20260319.md
+++ b/docs/research-notes/shortcut-editor-daw-migration-competitive-research-20260319.md
@@ -1,0 +1,39 @@
+# Shortcut Editor + DAW Migration Competitive Research
+
+Date: 2026-03-19
+
+## User stories
+
+- As a migrating DAW user, I want shortcut presets that preserve familiar letter positions, so that I can move into ACE-Step without re-learning every muscle-memory path.
+- As a browser-based DAW user, I want reserved browser shortcuts to be identified before they interrupt my session, so that I do not lose focus or unsaved work.
+
+## Competitive observations
+
+### Ableton Live 12
+
+- Heavily relies on single-key transport (`Space`) and timeline editing keys (`E`, `B`, `0`, `Cmd/Ctrl+L`).
+- The desktop app can safely use `Cmd/Ctrl+L` for loop because there is no browser address-bar conflict.
+- Migration implication for ACE-Step browser DAW: preserve the letter target where possible, but avoid browser-reserved modifiers. `Shift+L` is a safer browser analogue than `Cmd/Ctrl+L`.
+
+### Logic Pro
+
+- Uses single-key transport and editing shortcuts extensively (`C` cycle, `R` record, `K` metronome, `X` mixer, `Y` library).
+- The migration value is mostly in keeping the same letter, not in preserving every modifier stack.
+- Browser implication: letter-only shortcuts migrate cleanly; project/file shortcuts need safe alternatives.
+
+### FL Studio
+
+- Uses function keys (`F8`, `F9`, `F11`) and modifier-heavy clip commands (`Ctrl/Cmd+B`, `Ctrl/Cmd+R`).
+- Function-key mappings are naturally safer in the browser and make good migration anchors.
+
+### Pro Tools
+
+- Depends on single-letter editing (`B`, `R`, `T`) and function/numpad transport conventions (`F12`, numpad transport).
+- Browser implication: single-letter edit actions can map well, but file/window commands should not reuse browser ownership.
+
+## Product decisions for ACE-Step
+
+- Ship migration presets that preserve the original action letters where reasonable.
+- Flag or block browser-owned shortcuts before they are saved or imported.
+- Provide browser-safe defaults for file/project actions (`Shift+N`, `Shift+O`, `Alt/Option+,`) so the web DAW remains operable without accidental browser takeovers.
+- Keep import/export JSON-based so users can share or version-control shortcut layouts outside the app.

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -1,111 +1,42 @@
 import { useUIStore } from '../../store/uiStore';
+import { useShortcutsStore } from '../../store/shortcutsStore';
+import { SHORTCUT_ACTIONS, SHORTCUT_CATEGORIES } from '../../constants/shortcutDefaults';
+import type { KeyCombo } from '../../types/shortcuts';
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
-const mod = isMac ? '⌘' : 'Ctrl';
-const opt = isMac ? '⌥' : 'Alt';
 
-interface ShortcutRow {
-  keys: string[];
-  description: string;
+function comboToLabels(combo: KeyCombo): string[] {
+  const labels: string[] = [];
+  if (combo.mod) labels.push(isMac ? '⌘' : 'Ctrl');
+  if (combo.shift) labels.push('⇧');
+  if (combo.alt) labels.push(isMac ? '⌥' : 'Alt');
+
+  const codeMap: Record<string, string> = {
+    Space: 'Space',
+    Enter: 'Enter',
+    Backspace: 'Backspace',
+    Delete: 'Delete',
+    ArrowLeft: '←',
+    ArrowRight: '→',
+    ArrowUp: '↑',
+    ArrowDown: '↓',
+    Home: 'Home',
+    End: 'End',
+    Escape: 'Esc',
+    Equal: '=',
+    Minus: '−',
+    Comma: ',',
+    Period: '.',
+    Slash: '/',
+  };
+
+  labels.push(codeMap[combo.code] ?? (combo.code.startsWith('Key') ? combo.code.slice(3) : combo.code));
+  return labels;
 }
-
-interface Section {
-  title: string;
-  rows: ShortcutRow[];
-}
-
-const SECTIONS: Section[] = [
-  {
-    title: 'Transport',
-    rows: [
-      { keys: ['Space'],          description: 'Play / Pause' },
-      { keys: ['Enter'],          description: 'Stop + return to 0' },
-      { keys: ['L'],              description: 'Toggle Loop' },
-      { keys: ['←', '→'],        description: 'Nudge playhead ±5 s' },
-    ],
-  },
-  {
-    title: 'Clips',
-    rows: [
-      { keys: ['Delete', 'Backspace'],  description: 'Delete selected clips' },
-      { keys: [`${mod}`, 'D'],          description: 'Duplicate selected clip' },
-      { keys: [`${mod}`, 'J'],          description: 'Consolidate selected clips' },
-      { keys: ['S'],                    description: 'Split clip at playhead' },
-      { keys: [`${mod}`, 'A'],          description: 'Select all clips' },
-      { keys: ['E'],                    description: 'Edit selected clip' },
-      { keys: [`${mod}`, 'Enter'],      description: 'Generate selected clip' },
-      { keys: ['Esc'],                  description: 'Close modal / deselect all' },
-    ],
-  },
-  {
-    title: 'Timeline Selection',
-    rows: [
-      { keys: ['Drag'],                   description: 'Rubber-band select clips' },
-      { keys: [`${mod}`, 'Drag'],         description: 'Select window (generation target)' },
-      { keys: [opt, 'Drag'],              description: 'Context window (audio context)' },
-      { keys: [`${mod}`, 'Click'],        description: 'Toggle clip multi-select' },
-      { keys: ['⇧', 'Drag clip'],        description: 'Copy clip(s) — works with multi-select' },
-      { keys: [`${mod}`, 'Drag clip'],   description: 'Fine-move clip (bypass grid snap)' },
-    ],
-  },
-  {
-    title: 'View',
-    rows: [
-      { keys: [`${mod}`, '='],  description: 'Zoom in' },
-      { keys: [`${mod}`, '−'],  description: 'Zoom out' },
-      { keys: [`${mod}`, '0'],  description: 'Reset zoom' },
-    ],
-  },
-  {
-    title: 'Generation',
-    rows: [
-      { keys: [`${mod}`, 'G'],         description: 'Generate from Silence' },
-      { keys: [`${mod}`, '⇧', 'G'],    description: 'Generate from Context' },
-    ],
-  },
-  {
-    title: 'Panels',
-    rows: [
-      { keys: ['Y'],                    description: 'Toggle Library' },
-      { keys: ['X'],                    description: 'Toggle Mixer' },
-      { keys: ['B'],                    description: 'Toggle Smart Controls' },
-      { keys: ['O'],                    description: 'Toggle Loop Browser' },
-      { keys: ['T'],                    description: 'Toggle Tempo Lane' },
-      { keys: [`${mod}`, '/'],           description: 'Toggle AI Assistant' },
-    ],
-  },
-  {
-    title: 'Project',
-    rows: [
-      { keys: [`${mod}`, 'K'],         description: 'Open command palette' },
-      { keys: [`${mod}`, 'N'],         description: 'New project' },
-      { keys: [`${mod}`, 'O'],         description: 'Open project list' },
-      { keys: [`${mod}`, ','],         description: 'Settings' },
-      { keys: [`${mod}`, '⇧', 'E'],    description: 'Export' },
-      { keys: [`${mod}`, '⇧', 'I'],    description: 'Add Track' },
-      { keys: ['?'],                    description: 'This help overlay' },
-    ],
-  },
-  {
-    title: 'Piano Roll',
-    rows: [
-      { keys: ['1', '2', '3', '4', '5'],   description: 'Switch tools: Select, Pencil, Paint, Erase, Slide' },
-      { keys: ['B'],                        description: 'Toggle pencil tool' },
-      { keys: ['Delete', 'Backspace'],  description: 'Delete selected notes' },
-      { keys: ['↑'],                    description: 'Transpose selected notes up 1 semitone' },
-      { keys: ['↓'],                    description: 'Transpose selected notes down 1 semitone' },
-      { keys: ['←'],                    description: 'Nudge selected notes earlier by one grid step' },
-      { keys: ['→'],                    description: 'Nudge selected notes later by one grid step' },
-      { keys: ['Q'],                    description: 'Quantize selected notes to the current grid' },
-      { keys: [`${mod}`, 'Q'],          description: 'Quantize with options (strength, swing, scope)' },
-      { keys: [`${mod}`, 'A'],          description: 'Select all notes in the current clip' },
-    ],
-  },
-];
 
 function Key({ label }: { label: string }) {
   return (
-    <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded text-[10px] font-mono font-semibold bg-[#444] border border-zinc-600 text-zinc-200 shadow-sm">
+    <kbd className="inline-flex min-w-[1.5rem] items-center justify-center rounded border border-zinc-600 bg-[#444] px-1.5 py-0.5 text-[10px] font-mono font-semibold text-zinc-200 shadow-sm">
       {label}
     </kbd>
   );
@@ -114,6 +45,7 @@ function Key({ label }: { label: string }) {
 export function KeyboardShortcutsDialog() {
   const show = useUIStore((s) => s.showKeyboardShortcutsDialog);
   const setShow = useUIStore((s) => s.setShowKeyboardShortcutsDialog);
+  const getCombo = useShortcutsStore((s) => s.getCombo);
 
   if (!show) return null;
 
@@ -123,57 +55,82 @@ export function KeyboardShortcutsDialog() {
       onMouseDown={(e) => e.target === e.currentTarget && setShow(false)}
     >
       <div
-        className="w-[540px] max-h-[85vh] bg-daw-surface rounded-lg border border-daw-border shadow-2xl flex flex-col"
+        className="flex max-h-[85vh] w-[640px] flex-col rounded-lg border border-daw-border bg-daw-surface shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-3 border-b border-daw-border">
-          <h2 className="text-sm font-semibold text-zinc-100">Keyboard Shortcuts</h2>
+        <div className="flex items-center justify-between border-b border-daw-border px-5 py-3">
+          <div>
+            <h2 className="text-sm font-semibold text-zinc-100">Keyboard Shortcuts</h2>
+            <p className="mt-1 text-[11px] text-zinc-500">
+              This overlay reflects your current active shortcut preset and custom overrides.
+            </p>
+          </div>
           <button
             onClick={() => setShow(false)}
             aria-label="Close keyboard shortcuts"
-            className="text-zinc-500 hover:text-zinc-200 transition-colors text-lg leading-none"
+            className="text-lg leading-none text-zinc-500 transition-colors hover:text-zinc-200"
           >
             ×
           </button>
         </div>
 
-        {/* Body */}
-        <div className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
           <div className="grid grid-cols-2 gap-x-8 gap-y-5">
-          {SECTIONS.map((section) => (
-            <div key={section.title}>
-              <h3 className="text-[10px] font-bold uppercase tracking-widest text-zinc-500 mb-2">
-                {section.title}
+            {SHORTCUT_CATEGORIES.map((category) => (
+              <div key={category.id}>
+                <h3 className="mb-2 text-[10px] font-bold uppercase tracking-widest text-zinc-500">
+                  {category.label}
+                </h3>
+                <div className="space-y-1.5">
+                  {SHORTCUT_ACTIONS.filter((action) => action.category === category.id).map((action) => (
+                    <div key={action.id} className="flex items-center justify-between gap-3">
+                      <span className="flex-1 text-xs text-zinc-400">{action.label}</span>
+                      <div className="flex flex-shrink-0 items-center gap-1">
+                        {comboToLabels(getCombo(action.id)).map((label, index) => (
+                          <Key key={`${action.id}-${label}-${index}`} label={label} />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+
+            <div>
+              <h3 className="mb-2 text-[10px] font-bold uppercase tracking-widest text-zinc-500">
+                Timeline Selection
               </h3>
               <div className="space-y-1.5">
-                {section.rows.map((row, i) => (
-                  <div key={i} className="flex items-center justify-between gap-3">
-                    <span className="text-xs text-zinc-400 flex-1">{row.description}</span>
-                    <div className="flex items-center gap-1 flex-shrink-0">
-                      {row.keys.map((k, ki) => (
-                        <Key key={ki} label={k} />
+                {[
+                  { labels: [isMac ? '⌘' : 'Ctrl', 'Drag'], text: 'Set generation target window' },
+                  { labels: [isMac ? '⌥' : 'Alt', 'Drag'], text: 'Set context audio window' },
+                  { labels: [isMac ? '⌘' : 'Ctrl', 'Click'], text: 'Toggle clip multi-select' },
+                  { labels: ['⇧', 'Drag'], text: 'Duplicate dragged clip selection' },
+                ].map((row) => (
+                  <div key={row.text} className="flex items-center justify-between gap-3">
+                    <span className="flex-1 text-xs text-zinc-400">{row.text}</span>
+                    <div className="flex flex-shrink-0 items-center gap-1">
+                      {row.labels.map((label) => (
+                        <Key key={`${row.text}-${label}`} label={label} />
                       ))}
                     </div>
                   </div>
                 ))}
               </div>
             </div>
-          ))}
           </div>
         </div>
 
-        {/* Footer */}
-        <div className="flex items-center justify-between px-5 py-2.5 border-t border-daw-border">
+        <div className="flex items-center justify-between border-t border-daw-border px-5 py-2.5">
           <p className="text-[10px] text-zinc-600">
-            Shortcuts are disabled when typing in text fields. Press <Key label="Esc" /> or <Key label="?" /> to toggle this overlay.
+            Shortcuts are paused while typing in text fields. Press <Key label="Esc" /> to close this overlay.
           </p>
           <button
             onClick={() => {
               setShow(false);
               useUIStore.getState().setShowShortcutEditorDialog(true);
             }}
-            className="ml-3 px-3 py-1 text-[10px] rounded bg-daw-accent text-white hover:brightness-110 transition-colors whitespace-nowrap flex-shrink-0"
+            className="ml-3 flex-shrink-0 whitespace-nowrap rounded bg-daw-accent px-3 py-1 text-[10px] text-white transition-colors hover:brightness-110"
           >
             Customize…
           </button>

--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
+import { useShortcutsStore } from '../../store/shortcutsStore';
 import { KEY_SCALES, TIME_SIGNATURES } from '../../constants/tracks';
+import { SHORTCUT_PRESETS } from '../../constants/shortcutPresets';
 import {
   DEFAULT_BPM,
   DEFAULT_KEY_SCALE,
@@ -63,12 +65,16 @@ export function NewProjectDialog() {
   const createProject = useProjectStore((s) => s.createProject);
   const setProject = useProjectStore((s) => s.setProject);
   const createProjectFromTemplate = useProjectStore((s) => s.createProjectFromTemplate);
+  const activeShortcutPresetId = useShortcutsStore((s) => s.activePresetId);
+  const applyShortcutPreset = useShortcutsStore((s) => s.applyPreset);
+  const resetShortcuts = useShortcutsStore((s) => s.resetAll);
 
   const [name, setName] = useState(DEFAULT_PROJECT_NAME);
   const [bpm, setBpm] = useState(DEFAULT_BPM);
   const [bpmText, setBpmText] = useState(String(DEFAULT_BPM));
   const [keyScale, setKeyScale] = useState(DEFAULT_KEY_SCALE);
   const [timeSignature, setTimeSignature] = useState(DEFAULT_TIME_SIGNATURE);
+  const [shortcutPresetId, setShortcutPresetId] = useState('ace-step');
 
   const [recentProjects, setRecentProjects] = useState<ProjectSummary[]>([]);
   const [templates, setTemplates] = useState<TemplateSummary[]>([]);
@@ -81,14 +87,20 @@ export function NewProjectDialog() {
       setBpmText(String(DEFAULT_BPM));
       setKeyScale(DEFAULT_KEY_SCALE);
       setTimeSignature(DEFAULT_TIME_SIGNATURE);
+      setShortcutPresetId(activeShortcutPresetId === 'custom' ? 'ace-step' : activeShortcutPresetId);
       listProjects().then((list) => setRecentProjects(list));
       listTemplates().then((list) => setTemplates(list));
     }
-  }, [show]);
+  }, [activeShortcutPresetId, show]);
 
   if (!show) return null;
 
   const handleCreate = () => {
+    if (shortcutPresetId === 'ace-step') {
+      resetShortcuts();
+    } else {
+      applyShortcutPreset(shortcutPresetId);
+    }
     createProject({ name, bpm, keyScale, timeSignature });
     setShow(false);
   };
@@ -247,6 +259,25 @@ export function NewProjectDialog() {
                   ))}
                 </select>
               </div>
+            </div>
+
+            <div>
+              <label className="block text-xs text-zinc-400 mb-1">Shortcut Migration Preset</label>
+              <select
+                value={shortcutPresetId}
+                onChange={(e) => setShortcutPresetId(e.target.value)}
+                aria-label="Shortcut migration preset"
+                className="w-full px-3 py-1.5 text-sm bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
+              >
+                {SHORTCUT_PRESETS.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.name}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-[10px] text-zinc-500">
+                Choose the closest DAW muscle-memory map now, then fine-tune it later in Settings → Shortcut Editor.
+              </p>
             </div>
 
             <p className="text-[10px] text-zinc-500">

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
+import { useShortcutsStore } from '../../store/shortcutsStore';
 import { listModels, initModel, getBackendUrl, setBackendUrl } from '../../services/aceStepApi';
 import { DEFAULT_GENERATION, DEFAULT_MEASURES } from '../../constants/defaults';
+import { SHORTCUT_PRESETS } from '../../constants/shortcutPresets';
 import type { ModelEntry, LmModelEntry } from '../../types/api';
 
 function modelSupportsThinking(modelName: string): boolean {
@@ -12,7 +14,11 @@ function modelSupportsThinking(modelName: string): boolean {
 export function SettingsDialog() {
   const show = useUIStore((s) => s.showSettingsDialog);
   const setShow = useUIStore((s) => s.setShowSettingsDialog);
+  const setShowShortcutEditorDialog = useUIStore((s) => s.setShowShortcutEditorDialog);
   const project = useProjectStore((s) => s.project);
+  const activeShortcutPresetId = useShortcutsStore((s) => s.activePresetId);
+  const applyShortcutPreset = useShortcutsStore((s) => s.applyPreset);
+  const resetShortcuts = useShortcutsStore((s) => s.resetAll);
 
   const [bpm, setBpm] = useState(120);
   const [bpmText, setBpmText] = useState('120');
@@ -66,6 +72,7 @@ export function SettingsDialog() {
   const [selectedLmModel, setSelectedLmModel] = useState('');
   const [initMessage, setInitMessage] = useState('');
   const [initError, setInitError] = useState('');
+  const [shortcutPresetId, setShortcutPresetId] = useState('ace-step');
   const prevShow = useRef(false);
 
   const handleModelChange = (newModel: string) => {
@@ -138,10 +145,11 @@ export function SettingsDialog() {
       setInitMessage('');
       setInitError('');
       setSelectedLmModel('');
+      setShortcutPresetId(activeShortcutPresetId === 'custom' ? 'ace-step' : activeShortcutPresetId);
       void refreshModels(gen.model);
     }
     prevShow.current = show;
-  }, [show, project]);
+  }, [activeShortcutPresetId, show, project]);
 
   if (!show) return null;
 
@@ -163,6 +171,11 @@ export function SettingsDialog() {
           },
         },
       });
+    }
+    if (shortcutPresetId === 'ace-step') {
+      resetShortcuts();
+    } else {
+      applyShortcutPreset(shortcutPresetId);
     }
     setBackendUrl(backendUrl);
     setShow(false);
@@ -438,6 +451,38 @@ export function SettingsDialog() {
           {initMessage && !initError && (
             <p className="text-[10px] text-emerald-400">{initMessage}</p>
           )}
+
+          <h3 className="text-xs font-medium text-zinc-300 pt-2">Keyboard Shortcuts</h3>
+          <div>
+            <label className="block text-xs text-zinc-400 mb-1">Migration Preset</label>
+            <select
+              value={shortcutPresetId}
+              onChange={(e) => setShortcutPresetId(e.target.value)}
+              aria-label="Shortcut migration preset"
+              className="w-full px-3 py-1.5 text-sm text-zinc-200 bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent"
+            >
+              {SHORTCUT_PRESETS.map((preset) => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.name}
+                </option>
+              ))}
+            </select>
+            <div className="mt-2 flex items-center justify-between gap-2">
+              <p className="text-[10px] text-zinc-500">
+                Presets remap the global keyboard handler. Import/export and per-action rebinding live in the Shortcut Editor.
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  setShow(false);
+                  setShowShortcutEditorDialog(true);
+                }}
+                className="shrink-0 px-2.5 py-1 text-[10px] font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
+              >
+                Open Editor
+              </button>
+            </div>
+          </div>
 
           {/* Custom Models inventory */}
           {availableModels.length > 0 && (

--- a/src/components/dialogs/ShortcutEditorDialog.tsx
+++ b/src/components/dialogs/ShortcutEditorDialog.tsx
@@ -1,43 +1,73 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, type ChangeEvent } from 'react';
 import { useUIStore } from '../../store/uiStore';
 import { useShortcutsStore, comboEquals } from '../../store/shortcutsStore';
 import { SHORTCUT_ACTIONS, SHORTCUT_CATEGORIES, SHORTCUT_ACTION_MAP } from '../../constants/shortcutDefaults';
 import { SHORTCUT_PRESETS } from '../../constants/shortcutPresets';
-import type { KeyCombo, ShortcutCategory } from '../../types/shortcuts';
+import type { BrowserShortcutRule, KeyCombo, ShortcutCategory } from '../../types/shortcuts';
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
 
-// ── Helpers ──────────────────────────────────────────────────────
-
-function comboToDisplay(combo: KeyCombo): string {
-  const parts: string[] = [];
-  if (combo.mod) parts.push(isMac ? '⌘' : 'Ctrl');
-  if (combo.shift) parts.push(isMac ? '⇧' : 'Shift');
-  if (combo.alt) parts.push(isMac ? '⌥' : 'Alt');
-  parts.push(codeToLabel(combo.code));
-  return parts.join(' + ');
-}
-
 function codeToLabel(code: string): string {
   const map: Record<string, string> = {
-    Space: 'Space', Enter: '↵', Backspace: '⌫', Delete: 'Del',
-    ArrowLeft: '←', ArrowRight: '→', ArrowUp: '↑', ArrowDown: '↓',
-    Home: 'Home', End: 'End', Escape: 'Esc',
-    Equal: '=', Minus: '-', Comma: ',', Period: '.', Slash: '/',
-    Digit0: '0', Digit1: '1', Digit2: '2', Digit3: '3', Digit4: '4',
-    Digit5: '5', Digit6: '6', Digit7: '7', Digit8: '8', Digit9: '9',
-    Numpad0: 'Num0', NumpadAdd: 'Num+', NumpadSubtract: 'Num-',
-    NumpadEnter: 'Num↵',
-    F1: 'F1', F2: 'F2', F3: 'F3', F4: 'F4', F5: 'F5', F6: 'F6',
-    F7: 'F7', F8: 'F8', F9: 'F9', F10: 'F10', F11: 'F11', F12: 'F12',
+    Space: 'Space',
+    Enter: 'Enter',
+    Backspace: 'Backspace',
+    Delete: 'Delete',
+    ArrowLeft: 'Left',
+    ArrowRight: 'Right',
+    ArrowUp: 'Up',
+    ArrowDown: 'Down',
+    Home: 'Home',
+    End: 'End',
+    Escape: 'Esc',
+    Equal: '=',
+    Minus: '-',
+    Comma: ',',
+    Period: '.',
+    Slash: '/',
+    Digit0: '0',
+    Digit1: '1',
+    Digit2: '2',
+    Digit3: '3',
+    Digit4: '4',
+    Digit5: '5',
+    Digit6: '6',
+    Digit7: '7',
+    Digit8: '8',
+    Digit9: '9',
+    Numpad0: 'Num0',
+    NumpadAdd: 'Num+',
+    NumpadSubtract: 'Num-',
+    NumpadEnter: 'NumEnter',
+    F1: 'F1',
+    F2: 'F2',
+    F3: 'F3',
+    F4: 'F4',
+    F5: 'F5',
+    F6: 'F6',
+    F7: 'F7',
+    F8: 'F8',
+    F9: 'F9',
+    F10: 'F10',
+    F11: 'F11',
+    F12: 'F12',
   };
   if (map[code]) return map[code];
   if (code.startsWith('Key')) return code.slice(3);
   return code;
 }
 
+function comboToDisplay(combo: KeyCombo | undefined): string {
+  if (!combo?.code) return 'Unassigned';
+  const parts: string[] = [];
+  if (combo.mod) parts.push(isMac ? 'Cmd' : 'Ctrl');
+  if (combo.shift) parts.push('Shift');
+  if (combo.alt) parts.push(isMac ? 'Option' : 'Alt');
+  parts.push(codeToLabel(combo.code));
+  return parts.join(' + ');
+}
+
 function keyEventToCombo(e: KeyboardEvent): KeyCombo | null {
-  // Ignore bare modifier keys
   if (['Meta', 'Control', 'Shift', 'Alt'].includes(e.key)) return null;
   return {
     code: e.code,
@@ -47,17 +77,26 @@ function keyEventToCombo(e: KeyboardEvent): KeyCombo | null {
   };
 }
 
-// ── Key Badge ────────────────────────────────────────────────────
+function StatusPill({
+  tone,
+  text,
+}: {
+  tone: 'warning' | 'error' | 'custom';
+  text: string;
+}) {
+  const className =
+    tone === 'error'
+      ? 'border-red-500/40 bg-red-500/10 text-red-300'
+      : tone === 'warning'
+        ? 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+        : 'border-daw-accent/40 bg-daw-accent/10 text-daw-accent';
 
-function KeyBadge({ label }: { label: string }) {
   return (
-    <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded text-[10px] font-mono font-semibold bg-[#444] border border-zinc-600 text-zinc-200 shadow-sm">
-      {label}
-    </kbd>
+    <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${className}`}>
+      {text}
+    </span>
   );
 }
-
-// ── Shortcut Row ─────────────────────────────────────────────────
 
 interface RowProps {
   actionId: string;
@@ -65,59 +104,91 @@ interface RowProps {
   combo: KeyCombo;
   defaultCombo: KeyCombo;
   isRecording: boolean;
+  browserConflict: BrowserShortcutRule | null;
   conflictLabel: string | null;
   onStartRecord: () => void;
   onReset: () => void;
 }
 
-function ShortcutRow({ actionId, label, combo, defaultCombo, isRecording, conflictLabel, onStartRecord, onReset }: RowProps) {
+function ShortcutRow({
+  actionId,
+  label,
+  combo,
+  defaultCombo,
+  isRecording,
+  browserConflict,
+  conflictLabel,
+  onStartRecord,
+  onReset,
+}: RowProps) {
   const isCustom = !comboEquals(combo, defaultCombo);
+  const conflictTone = browserConflict?.severity === 'error' ? 'error' : 'warning';
 
   return (
     <div
-      className={`flex items-center gap-3 px-2 py-1.5 rounded ${
-        isRecording ? 'bg-daw-accent/20 ring-1 ring-daw-accent' : 'hover:bg-white/5'
+      className={`rounded-lg border px-3 py-2 transition-colors ${
+        isRecording
+          ? 'border-daw-accent bg-daw-accent/10'
+          : browserConflict?.severity === 'error'
+            ? 'border-red-500/30 bg-red-500/5'
+            : conflictLabel || browserConflict
+              ? 'border-amber-500/20 bg-amber-500/5'
+              : 'border-white/5 hover:border-white/10 hover:bg-white/5'
       }`}
       data-action-id={actionId}
     >
-      <span className="text-xs text-zinc-400 flex-1 truncate">{label}</span>
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-xs text-zinc-100">{label}</span>
+            {isCustom && <StatusPill tone="custom" text="Custom" />}
+            {conflictLabel && <StatusPill tone="warning" text="Conflict" />}
+            {browserConflict && <StatusPill tone={conflictTone} text={browserConflict.severity} />}
+          </div>
+          <div className="mt-1 space-y-1">
+            {conflictLabel && (
+              <p className="text-[11px] text-amber-300">
+                Shares {comboToDisplay(combo)} with {conflictLabel}.
+              </p>
+            )}
+            {browserConflict && (
+              <p className={`text-[11px] ${browserConflict.severity === 'error' ? 'text-red-300' : 'text-amber-300'}`}>
+                {browserConflict.reason}
+                {browserConflict.suggestion ? ` Try ${comboToDisplay(browserConflict.suggestion)} instead.` : ''}
+              </p>
+            )}
+          </div>
+        </div>
 
-      {conflictLabel && (
-        <span className="text-[10px] text-amber-400 truncate max-w-[120px]">
-          conflicts with {conflictLabel}
-        </span>
-      )}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onStartRecord}
+            aria-label={`Rebind ${label}`}
+            className={`min-w-[8rem] rounded border px-2 py-1 text-xs transition-colors ${
+              isRecording
+                ? 'border-daw-accent text-daw-accent'
+                : 'border-zinc-600 text-zinc-200 hover:border-zinc-400'
+            }`}
+            title="Click to rebind, then press a key combo"
+          >
+            {isRecording ? 'Press a key…' : comboToDisplay(combo)}
+          </button>
 
-      <button
-        onClick={onStartRecord}
-        className={`flex items-center gap-1 flex-shrink-0 px-2 py-0.5 rounded border text-xs transition-colors ${
-          isRecording
-            ? 'border-daw-accent text-daw-accent animate-pulse'
-            : 'border-zinc-600 text-zinc-300 hover:border-zinc-400'
-        }`}
-        title="Click to rebind, then press a key combo"
-      >
-        {isRecording ? (
-          <span>Press a key…</span>
-        ) : (
-          <span>{comboToDisplay(combo)}</span>
-        )}
-      </button>
-
-      {isCustom && (
-        <button
-          onClick={onReset}
-          className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors"
-          title={`Reset to default: ${comboToDisplay(defaultCombo)}`}
-        >
-          ↺
-        </button>
-      )}
+          {isCustom && (
+            <button
+              onClick={onReset}
+              aria-label={`Reset ${label}`}
+              className="rounded border border-zinc-700 px-2 py-1 text-[10px] text-zinc-400 transition-colors hover:border-zinc-500 hover:text-zinc-200"
+              title={`Reset to ${comboToDisplay(defaultCombo)}`}
+            >
+              Reset
+            </button>
+          )}
+        </div>
+      </div>
     </div>
   );
 }
-
-// ── Main Dialog ──────────────────────────────────────────────────
 
 export function ShortcutEditorDialog() {
   const show = useUIStore((s) => s.showShortcutEditorDialog);
@@ -131,13 +202,26 @@ export function ShortcutEditorDialog() {
   const applyPreset = useShortcutsStore((s) => s.applyPreset);
   const resetAll = useShortcutsStore((s) => s.resetAll);
   const findConflict = useShortcutsStore((s) => s.findConflict);
+  const findBrowserConflict = useShortcutsStore((s) => s.findBrowserConflict);
+  const exportBindings = useShortcutsStore((s) => s.exportBindings);
+  const importBindings = useShortcutsStore((s) => s.importBindings);
 
   const [activeCategory, setActiveCategory] = useState<ShortcutCategory>('transport');
   const [recordingId, setRecordingId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const dialogRef = useRef<HTMLDivElement>(null);
+  const [statusMessage, setStatusMessage] = useState<string>('');
+  const [statusTone, setStatusTone] = useState<'neutral' | 'warning' | 'error'>('neutral');
+  const importInputRef = useRef<HTMLInputElement>(null);
 
-  // ── Key capture while recording ────────────────────────────────
+  useEffect(() => {
+    if (!show) {
+      setRecordingId(null);
+      setSearchQuery('');
+      setStatusMessage('');
+      setStatusTone('neutral');
+    }
+  }, [show]);
+
   useEffect(() => {
     if (!recordingId) return;
 
@@ -147,21 +231,38 @@ export function ShortcutEditorDialog() {
 
       if (e.code === 'Escape') {
         setRecordingId(null);
+        setStatusMessage('Shortcut capture cancelled.');
+        setStatusTone('neutral');
         return;
       }
 
       const combo = keyEventToCombo(e);
       if (!combo) return;
 
+      const browserConflict = findBrowserConflict(combo);
+      if (browserConflict?.severity === 'error') {
+        setStatusMessage(`${comboToDisplay(combo)} is reserved by the browser. ${browserConflict.reason}`);
+        setStatusTone('error');
+        return;
+      }
+
       setBinding(recordingId, combo);
+      const suggestion = browserConflict?.suggestion
+        ? ` ${comboToDisplay(browserConflict.suggestion)} is usually safer in the browser.`
+        : '';
+      setStatusMessage(
+        browserConflict
+          ? `${comboToDisplay(combo)} saved with a browser warning.${suggestion}`
+          : `${SHORTCUT_ACTION_MAP[recordingId]?.label ?? 'Shortcut'} mapped to ${comboToDisplay(combo)}.`,
+      );
+      setStatusTone(browserConflict ? 'warning' : 'neutral');
       setRecordingId(null);
     };
 
     window.addEventListener('keydown', handler, true);
     return () => window.removeEventListener('keydown', handler, true);
-  }, [recordingId, setBinding]);
+  }, [findBrowserConflict, recordingId, setBinding]);
 
-  // Close dialog on Escape when not recording
   useEffect(() => {
     if (!show || recordingId) return;
     const handler = (e: KeyboardEvent) => {
@@ -181,16 +282,59 @@ export function ShortcutEditorDialog() {
       } else {
         applyPreset(presetId);
       }
+      setStatusMessage(`Applied ${SHORTCUT_PRESETS.find((preset) => preset.id === presetId)?.name ?? 'ACE-Step (Default)'}.`);
+      setStatusTone('neutral');
     },
     [applyPreset, resetAll],
   );
+
+  const handleExport = useCallback(() => {
+    const payload = exportBindings();
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `ace-step-shortcuts-${payload.presetId}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+    setStatusMessage('Shortcut preset exported as JSON.');
+    setStatusTone('neutral');
+  }, [exportBindings]);
+
+  const handleImport = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+
+    try {
+      const parsed = JSON.parse(await file.text());
+      const result = importBindings(parsed);
+      const blockedCount = result.blockedActionIds.length;
+      const skippedCount = result.skippedActionIds.length;
+      const suffix = [
+        blockedCount > 0 ? `${blockedCount} browser-blocked` : '',
+        skippedCount > 0 ? `${skippedCount} skipped` : '',
+      ]
+        .filter(Boolean)
+        .join(', ');
+      setStatusMessage(
+        suffix
+          ? `Imported ${result.importedCount} shortcut overrides (${suffix}).`
+          : `Imported ${result.importedCount} shortcut overrides.`,
+      );
+      setStatusTone(blockedCount > 0 ? 'warning' : 'neutral');
+    } catch {
+      setStatusMessage('Shortcut import failed. Expected a valid ACE-Step shortcut JSON file.');
+      setStatusTone('error');
+    }
+  }, [importBindings]);
 
   if (!show) return null;
 
   const lowerQuery = searchQuery.toLowerCase();
   const filteredActions = searchQuery
-    ? SHORTCUT_ACTIONS.filter((a) => a.label.toLowerCase().includes(lowerQuery))
-    : SHORTCUT_ACTIONS.filter((a) => a.category === activeCategory);
+    ? SHORTCUT_ACTIONS.filter((action) => action.label.toLowerCase().includes(lowerQuery))
+    : SHORTCUT_ACTIONS.filter((action) => action.category === activeCategory);
 
   const customCount = Object.keys(overrides).length;
 
@@ -205,77 +349,111 @@ export function ShortcutEditorDialog() {
       }}
     >
       <div
-        ref={dialogRef}
-        className="w-[620px] max-h-[85vh] bg-daw-surface rounded-lg border border-daw-border shadow-2xl flex flex-col"
+        className="flex max-h-[88vh] w-[760px] flex-col rounded-lg border border-daw-border bg-daw-surface shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* ── Header ──────────────────────────────────────────────── */}
-        <div className="flex items-center justify-between px-5 py-3 border-b border-daw-border">
-          <h2 className="text-sm font-semibold text-zinc-100">Shortcut Editor</h2>
+        <div className="flex items-center justify-between border-b border-daw-border px-5 py-3">
+          <div>
+            <h2 className="text-sm font-semibold text-zinc-100">Shortcut Editor</h2>
+            <p className="mt-1 text-[11px] text-zinc-500">
+              Search, migrate from another DAW, and keep browser-reserved combos out of your live session.
+            </p>
+          </div>
           <button
             onClick={() => setShow(false)}
-            className="text-zinc-500 hover:text-zinc-200 transition-colors text-lg leading-none"
+            aria-label="Close shortcut editor"
+            className="text-lg leading-none text-zinc-500 transition-colors hover:text-zinc-200"
           >
             ×
           </button>
         </div>
 
-        {/* ── Preset selector + search ────────────────────────────── */}
-        <div className="flex items-center gap-3 px-5 py-2.5 border-b border-daw-border">
-          <label className="text-[10px] uppercase tracking-widest text-zinc-500">Preset</label>
+        <div className="flex flex-wrap items-center gap-3 border-b border-daw-border px-5 py-3">
+          <label className="text-[10px] uppercase tracking-widest text-zinc-500">Migration preset</label>
           <select
             value={activePresetId}
             onChange={(e) => handlePresetChange(e.target.value)}
-            className="flex-1 bg-daw-bg border border-zinc-600 rounded px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-daw-accent"
+            aria-label="Shortcut migration preset"
+            className="min-w-[220px] flex-1 rounded border border-zinc-600 bg-daw-bg px-2 py-1 text-xs text-zinc-200 focus:border-daw-accent focus:outline-none"
           >
-            {SHORTCUT_PRESETS.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
+            {SHORTCUT_PRESETS.map((preset) => (
+              <option key={preset.id} value={preset.id}>
+                {preset.name}
               </option>
             ))}
-            {activePresetId === 'custom' && (
-              <option value="custom">Custom</option>
-            )}
+            {activePresetId === 'custom' && <option value="custom">Custom</option>}
           </select>
 
           <input
             type="text"
             placeholder="Search shortcuts…"
+            aria-label="Search shortcuts"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-[160px] bg-daw-bg border border-zinc-600 rounded px-2 py-1 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-daw-accent"
+            className="w-[220px] rounded border border-zinc-600 bg-daw-bg px-2 py-1 text-xs text-zinc-200 placeholder:text-zinc-600 focus:border-daw-accent focus:outline-none"
+          />
+
+          <button
+            onClick={handleExport}
+            className="rounded border border-zinc-600 px-3 py-1 text-[11px] text-zinc-200 transition-colors hover:border-zinc-400"
+          >
+            Export JSON
+          </button>
+          <button
+            onClick={() => importInputRef.current?.click()}
+            className="rounded border border-zinc-600 px-3 py-1 text-[11px] text-zinc-200 transition-colors hover:border-zinc-400"
+          >
+            Import JSON
+          </button>
+          <input
+            ref={importInputRef}
+            type="file"
+            accept="application/json"
+            className="hidden"
+            onChange={handleImport}
           />
         </div>
 
-        {/* ── Category tabs (hidden when searching) ───────────────── */}
+        {statusMessage && (
+          <div
+            className={`border-b px-5 py-2 text-[11px] ${
+              statusTone === 'error'
+                ? 'border-red-500/30 bg-red-500/10 text-red-200'
+                : statusTone === 'warning'
+                  ? 'border-amber-500/30 bg-amber-500/10 text-amber-200'
+                  : 'border-daw-border bg-daw-surface-2 text-zinc-300'
+            }`}
+          >
+            {statusMessage}
+          </div>
+        )}
+
         {!searchQuery && (
-          <div className="flex gap-1 px-5 pt-2 overflow-x-auto">
-            {SHORTCUT_CATEGORIES.map((cat) => (
+          <div className="flex gap-1 overflow-x-auto px-5 pt-3">
+            {SHORTCUT_CATEGORIES.map((category) => (
               <button
-                key={cat.id}
-                onClick={() => setActiveCategory(cat.id)}
-                className={`px-2.5 py-1 rounded text-[10px] font-semibold uppercase tracking-wide transition-colors whitespace-nowrap ${
-                  activeCategory === cat.id
+                key={category.id}
+                onClick={() => setActiveCategory(category.id)}
+                className={`rounded px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide transition-colors ${
+                  activeCategory === category.id
                     ? 'bg-daw-accent text-white'
-                    : 'text-zinc-500 hover:text-zinc-300 hover:bg-white/5'
+                    : 'text-zinc-500 hover:bg-white/5 hover:text-zinc-300'
                 }`}
               >
-                {cat.label}
+                {category.label}
               </button>
             ))}
           </div>
         )}
 
-        {/* ── Shortcut list ───────────────────────────────────────── */}
-        <div className="flex-1 overflow-y-auto min-h-0 px-5 py-3 space-y-0.5">
+        <div className="min-h-0 flex-1 space-y-2 overflow-y-auto px-5 py-3">
           {filteredActions.length === 0 && (
-            <p className="text-xs text-zinc-500 text-center py-8">No shortcuts match your search.</p>
+            <p className="py-8 text-center text-xs text-zinc-500">No shortcuts match your search.</p>
           )}
           {filteredActions.map((action) => {
             const combo = getCombo(action.id);
             const conflictId = findConflict(combo, action.id);
-            const conflictLabel = conflictId ? SHORTCUT_ACTION_MAP[conflictId]?.label ?? null : null;
-
+            const browserConflict = findBrowserConflict(combo);
             return (
               <ShortcutRow
                 key={action.id}
@@ -284,31 +462,46 @@ export function ShortcutEditorDialog() {
                 combo={combo}
                 defaultCombo={action.defaultCombo}
                 isRecording={recordingId === action.id}
-                conflictLabel={conflictLabel}
-                onStartRecord={() => setRecordingId(action.id)}
-                onReset={() => clearBinding(action.id)}
+                browserConflict={browserConflict}
+                conflictLabel={conflictId ? SHORTCUT_ACTION_MAP[conflictId]?.label ?? null : null}
+                onStartRecord={() => {
+                  setRecordingId(action.id);
+                  setStatusMessage(`Press a new key combo for ${action.label}. Esc cancels.`);
+                  setStatusTone('neutral');
+                }}
+                onReset={() => {
+                  clearBinding(action.id);
+                  setStatusMessage(`${action.label} reset to ${comboToDisplay(action.defaultCombo)}.`);
+                  setStatusTone('neutral');
+                }}
               />
             );
           })}
         </div>
 
-        {/* ── Footer ──────────────────────────────────────────────── */}
-        <div className="flex items-center justify-between px-5 py-2.5 border-t border-daw-border">
-          <p className="text-[10px] text-zinc-600">
-            {customCount > 0
-              ? `${customCount} custom binding${customCount > 1 ? 's' : ''}`
-              : 'All shortcuts at defaults'}
-          </p>
+        <div className="flex items-center justify-between border-t border-daw-border px-5 py-3">
+          <div className="space-y-1 text-[10px] text-zinc-500">
+            <p>
+              {customCount > 0
+                ? `${customCount} custom binding${customCount > 1 ? 's' : ''} active`
+                : 'All shortcuts at ACE-Step defaults'}
+            </p>
+            <p>Conflicts are highlighted inline. Browser-reserved shortcuts are blocked or warned before import/remap.</p>
+          </div>
           <div className="flex items-center gap-2">
             <button
-              onClick={resetAll}
-              className="px-3 py-1 text-[10px] rounded border border-zinc-600 text-zinc-400 hover:text-zinc-200 hover:border-zinc-400 transition-colors"
+              onClick={() => {
+                resetAll();
+                setStatusMessage('Restored the ACE-Step default shortcut map.');
+                setStatusTone('neutral');
+              }}
+              className="rounded border border-zinc-600 px-3 py-1 text-[11px] text-zinc-300 transition-colors hover:border-zinc-400 hover:text-zinc-100"
             >
               Reset All
             </button>
             <button
               onClick={() => setShow(false)}
-              className="px-3 py-1 text-[10px] rounded bg-daw-accent text-white hover:brightness-110 transition-colors"
+              className="rounded bg-daw-accent px-3 py-1 text-[11px] text-white transition-colors hover:brightness-110"
             >
               Done
             </button>

--- a/src/constants/shortcutConflicts.ts
+++ b/src/constants/shortcutConflicts.ts
@@ -1,0 +1,94 @@
+import type {
+  BrowserShortcutRule,
+  KeyCombo,
+} from '../types/shortcuts';
+
+export function normalizeCombo(combo: KeyCombo): KeyCombo {
+  return {
+    code: combo.code,
+    mod: combo.mod || undefined,
+    shift: combo.shift || undefined,
+    alt: combo.alt || undefined,
+  };
+}
+
+export function comboEquals(a: KeyCombo, b: KeyCombo): boolean {
+  const left = normalizeCombo(a);
+  const right = normalizeCombo(b);
+  return (
+    left.code === right.code &&
+    left.mod === right.mod &&
+    left.shift === right.shift &&
+    left.alt === right.alt
+  );
+}
+
+export const BROWSER_RESERVED_SHORTCUTS: BrowserShortcutRule[] = [
+  {
+    id: 'browser.closeTab',
+    combo: { code: 'KeyW', mod: true },
+    severity: 'error',
+    reason: 'Browsers close the current tab before the DAW can safely respond.',
+    suggestion: { code: 'KeyW', shift: true },
+  },
+  {
+    id: 'browser.newTab',
+    combo: { code: 'KeyT', mod: true },
+    severity: 'error',
+    reason: 'Browsers open a new tab and steal focus from the project.',
+    suggestion: { code: 'KeyT', shift: true },
+  },
+  {
+    id: 'browser.newWindow',
+    combo: { code: 'KeyN', mod: true },
+    severity: 'error',
+    reason: 'Browsers open a new window instead of keeping focus in the DAW.',
+    suggestion: { code: 'KeyN', shift: true },
+  },
+  {
+    id: 'browser.openFile',
+    combo: { code: 'KeyO', mod: true },
+    severity: 'error',
+    reason: 'Browsers open the native file picker and interrupt the session.',
+    suggestion: { code: 'KeyO', shift: true },
+  },
+  {
+    id: 'browser.locationBar',
+    combo: { code: 'KeyL', mod: true },
+    severity: 'error',
+    reason: 'Browsers focus the address bar, so the shortcut never reaches the DAW.',
+    suggestion: { code: 'KeyL', shift: true },
+  },
+  {
+    id: 'browser.reload',
+    combo: { code: 'KeyR', mod: true },
+    severity: 'error',
+    reason: 'Browsers reload the page and can destroy unsaved context.',
+    suggestion: { code: 'KeyR', shift: true },
+  },
+  {
+    id: 'browser.hardReload',
+    combo: { code: 'KeyR', mod: true, shift: true },
+    severity: 'error',
+    reason: 'Browsers hard-reload the page and can wipe transient state.',
+    suggestion: { code: 'KeyR', alt: true, shift: true },
+  },
+  {
+    id: 'browser.print',
+    combo: { code: 'KeyP', mod: true },
+    severity: 'error',
+    reason: 'Browsers open the print dialog instead of dispatching the shortcut.',
+    suggestion: { code: 'KeyP', shift: true },
+  },
+  {
+    id: 'browser.preferences',
+    combo: { code: 'Comma', mod: true },
+    severity: 'warning',
+    reason: 'Some browsers capture this for preferences, so the shortcut can be unreliable.',
+    suggestion: { code: 'Comma', alt: true },
+  },
+];
+
+export function findBrowserShortcutConflict(combo: KeyCombo): BrowserShortcutRule | null {
+  return BROWSER_RESERVED_SHORTCUTS.find((rule) => comboEquals(rule.combo, combo)) ?? null;
+}

--- a/src/constants/shortcutDefaults.ts
+++ b/src/constants/shortcutDefaults.ts
@@ -47,9 +47,9 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   { id: 'panels.aiAssistant',    category: 'panels',    label: 'Toggle AI Assistant',       defaultCombo: { code: 'Slash', mod: true } },
 
   // ── Project ────────────────────────────────────────────────────
-  { id: 'project.new',           category: 'project',   label: 'New Project',               defaultCombo: { code: 'KeyN', mod: true } },
-  { id: 'project.open',          category: 'project',   label: 'Open Project List',         defaultCombo: { code: 'KeyO', mod: true } },
-  { id: 'project.settings',      category: 'project',   label: 'Settings',                  defaultCombo: { code: 'Comma', mod: true } },
+  { id: 'project.new',           category: 'project',   label: 'New Project',               defaultCombo: { code: 'KeyN', shift: true } },
+  { id: 'project.open',          category: 'project',   label: 'Open Project List',         defaultCombo: { code: 'KeyO', shift: true } },
+  { id: 'project.settings',      category: 'project',   label: 'Settings',                  defaultCombo: { code: 'Comma', alt: true } },
   { id: 'project.export',        category: 'project',   label: 'Export',                    defaultCombo: { code: 'KeyE', mod: true, shift: true } },
   { id: 'project.addTrack',      category: 'project',   label: 'Add Track',                 defaultCombo: { code: 'KeyI', mod: true, shift: true } },
   { id: 'project.help',          category: 'project',   label: 'Keyboard Shortcuts Help',   defaultCombo: { code: 'Slash', shift: true } },

--- a/src/constants/shortcutPresets.ts
+++ b/src/constants/shortcutPresets.ts
@@ -10,7 +10,7 @@ const abletonMap: ShortcutMap = {
   // Ableton Live-style bindings
   'transport.playPause':  { code: 'Space' },
   'transport.stop':       { code: 'Space' },           // Ableton: space toggles, no separate stop
-  'transport.loop':       { code: 'KeyL', mod: true },  // Ctrl/Cmd+L in Ableton
+  'transport.loop':       { code: 'KeyL', shift: true }, // Browser-safe alternative to Cmd/Ctrl+L
   'transport.record':     { code: 'F9' },               // F9 = record in Ableton
   'transport.nudgeLeft':  { code: 'ArrowLeft' },
   'transport.nudgeRight': { code: 'ArrowRight' },
@@ -23,9 +23,9 @@ const abletonMap: ShortcutMap = {
   'view.toggleSnap':      { code: 'KeyB', mod: true },  // Cmd+B = snap in Ableton
   'panels.mixer':         { code: 'KeyM', mod: true },  // Cmd+M = mixer in Ableton
   'panels.library':       { code: 'KeyL', mod: true, alt: true }, // Cmd+Alt+L
-  'project.new':          { code: 'KeyN', mod: true },
+  'project.new':          { code: 'KeyN', shift: true },
   'project.export':       { code: 'KeyE', mod: true, shift: true },
-  'project.settings':     { code: 'Comma', mod: true },
+  'project.settings':     { code: 'Comma', alt: true },
 };
 
 const logicProMap: ShortcutMap = {
@@ -38,7 +38,7 @@ const logicProMap: ShortcutMap = {
   'transport.home':         { code: 'Home' },
   'clips.delete':           { code: 'Backspace' },
   'clips.duplicate':        { code: 'KeyD', mod: true },
-  'clips.split':            { code: 'KeyT', mod: true },  // Cmd+T = split in Logic
+  'clips.split':            { code: 'KeyT', shift: true }, // Browser-safe analogue to Cmd+T
   'clips.selectAll':        { code: 'KeyA', mod: true },
   'clips.edit':             { code: 'KeyE' },
   'view.zoomIn':            { code: 'Equal', mod: true },
@@ -48,8 +48,8 @@ const logicProMap: ShortcutMap = {
   'panels.mixer':           { code: 'KeyX' },
   'panels.smartControls':   { code: 'KeyB' },
   'panels.library':         { code: 'KeyY' },
-  'project.new':            { code: 'KeyN', mod: true },
-  'project.settings':       { code: 'Comma', mod: true },
+  'project.new':            { code: 'KeyN', shift: true },
+  'project.settings':       { code: 'Comma', alt: true },
   'project.export':         { code: 'KeyE', mod: true },  // Cmd+E = bounce in Logic
 };
 
@@ -57,9 +57,9 @@ const flStudioMap: ShortcutMap = {
   // FL Studio-style bindings
   'transport.playPause':    { code: 'Space' },
   'transport.stop':         { code: 'Space', mod: true },  // Ctrl+Space = stop in FL
-  'transport.loop':         { code: 'KeyL', mod: true },
+  'transport.loop':         { code: 'KeyL', shift: true },
   'transport.metronome':    { code: 'KeyM', mod: true },   // Ctrl+M = metronome in FL
-  'transport.record':       { code: 'KeyR', mod: true },   // Ctrl+R = record mode in FL
+  'transport.record':       { code: 'KeyR', shift: true }, // Browser-safe analogue to Ctrl+R
   'clips.delete':           { code: 'Delete' },
   'clips.duplicate':        { code: 'KeyB', mod: true },   // Ctrl+B = duplicate in FL
   'clips.split':            { code: 'KeyS', mod: true, shift: true },
@@ -69,8 +69,8 @@ const flStudioMap: ShortcutMap = {
   'view.toggleSnap':        { code: 'KeyS', alt: true },   // Alt+S in FL
   'panels.mixer':           { code: 'F9' },                // F9 = mixer in FL
   'panels.library':         { code: 'F8' },                // F8 = plugin picker in FL
-  'project.new':            { code: 'KeyN', mod: true },
-  'project.export':         { code: 'KeyR', mod: true, shift: true },
+  'project.new':            { code: 'KeyN', shift: true },
+  'project.export':         { code: 'KeyR', alt: true, shift: true },
   'project.settings':       { code: 'F11' },
 };
 
@@ -91,9 +91,9 @@ const proToolsMap: ShortcutMap = {
   'view.zoomToFit':         { code: 'KeyA', alt: true },    // Alt+A = zoom to fit in Pro Tools
   'view.toggleSnap':        { code: 'KeyN' },
   'panels.mixer':           { code: 'Equal', mod: true },   // Cmd+= = mix window in PT
-  'project.new':            { code: 'KeyN', mod: true },
+  'project.new':            { code: 'KeyN', shift: true },
   'project.export':         { code: 'KeyB', mod: true, shift: true, alt: true },
-  'project.settings':       { code: 'Comma', mod: true },
+  'project.settings':       { code: 'Comma', alt: true },
 };
 
 export const SHORTCUT_PRESETS: ShortcutPreset[] = [

--- a/src/store/shortcutsStore.ts
+++ b/src/store/shortcutsStore.ts
@@ -1,8 +1,15 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-import type { KeyCombo, ShortcutMap } from '../types/shortcuts';
+import type {
+  BrowserShortcutRule,
+  KeyCombo,
+  ShortcutImportExportPayload,
+  ShortcutImportResult,
+  ShortcutMap,
+} from '../types/shortcuts';
 import { SHORTCUT_ACTIONS, SHORTCUT_ACTION_MAP } from '../constants/shortcutDefaults';
 import { SHORTCUT_PRESET_MAP } from '../constants/shortcutPresets';
+import { comboEquals, findBrowserShortcutConflict, normalizeCombo } from '../constants/shortcutConflicts';
 
 interface ShortcutsState {
   /** User overrides keyed by actionId. Missing keys fall back to defaults. */
@@ -23,18 +30,24 @@ interface ShortcutsState {
   resetAll: () => void;
   /** Check whether a combo is already used by another action. */
   findConflict: (combo: KeyCombo, excludeActionId?: string) => string | null;
-}
-
-function comboEquals(a: KeyCombo, b: KeyCombo): boolean {
-  return (
-    a.code === b.code &&
-    !!a.mod === !!b.mod &&
-    !!a.shift === !!b.shift &&
-    !!a.alt === !!b.alt
-  );
+  /** Check whether a combo clashes with a browser-reserved binding. */
+  findBrowserConflict: (combo: KeyCombo) => BrowserShortcutRule | null;
+  /** Export the current shortcuts as a portable JSON payload. */
+  exportBindings: () => ShortcutImportExportPayload;
+  /** Import shortcut bindings from a portable JSON payload. */
+  importBindings: (payload: unknown) => ShortcutImportResult;
 }
 
 export { comboEquals };
+
+function buildEffectiveBindings(overrides: ShortcutMap): ShortcutMap {
+  return Object.fromEntries(
+    SHORTCUT_ACTIONS.map((action) => [
+      action.id,
+      normalizeCombo(overrides[action.id] ?? action.defaultCombo),
+    ]),
+  );
+}
 
 export const useShortcutsStore = create<ShortcutsState>()(
   persist(
@@ -52,7 +65,7 @@ export const useShortcutsStore = create<ShortcutsState>()(
 
       setBinding: (actionId, combo) =>
         set((s) => ({
-          overrides: { ...s.overrides, [actionId]: combo },
+          overrides: { ...s.overrides, [actionId]: normalizeCombo(combo) },
           activePresetId: 'custom',
         })),
 
@@ -66,7 +79,13 @@ export const useShortcutsStore = create<ShortcutsState>()(
       applyPreset: (presetId) => {
         const preset = SHORTCUT_PRESET_MAP[presetId];
         if (!preset) return;
-        set({ overrides: { ...preset.map }, activePresetId: presetId });
+        const safeOverrides = Object.fromEntries(
+          Object.entries(preset.map).filter(([, combo]) => {
+            const browserConflict = findBrowserShortcutConflict(combo);
+            return browserConflict?.severity !== 'error';
+          }),
+        );
+        set({ overrides: safeOverrides, activePresetId: presetId });
       },
 
       resetAll: () => set({ overrides: {}, activePresetId: 'ace-step' }),
@@ -81,6 +100,94 @@ export const useShortcutsStore = create<ShortcutsState>()(
           }
         }
         return null;
+      },
+
+      findBrowserConflict: (combo) => findBrowserShortcutConflict(combo),
+
+      exportBindings: () => {
+        const state = get();
+        return {
+          version: 1,
+          presetId: state.activePresetId,
+          exportedAt: new Date().toISOString(),
+          overrides: { ...state.overrides },
+          bindings: buildEffectiveBindings(state.overrides),
+        };
+      },
+
+      importBindings: (payload) => {
+        const blockedActionIds: string[] = [];
+        const skippedActionIds: string[] = [];
+        const nextOverrides: ShortcutMap = {};
+
+        if (!payload || typeof payload !== 'object') {
+          return {
+            importedCount: 0,
+            blockedActionIds,
+            skippedActionIds: ['invalid-payload'],
+            activePresetId: get().activePresetId,
+          };
+        }
+
+        const data = payload as Partial<ShortcutImportExportPayload> & {
+          bindings?: ShortcutMap;
+          overrides?: ShortcutMap;
+        };
+        const source = data.overrides && typeof data.overrides === 'object'
+          ? data.overrides
+          : data.bindings && typeof data.bindings === 'object'
+            ? data.bindings
+            : null;
+
+        if (!source) {
+          return {
+            importedCount: 0,
+            blockedActionIds,
+            skippedActionIds: ['missing-bindings'],
+            activePresetId: get().activePresetId,
+          };
+        }
+
+        for (const [actionId, rawCombo] of Object.entries(source)) {
+          const action = SHORTCUT_ACTION_MAP[actionId];
+          if (!action || !rawCombo || typeof rawCombo !== 'object') {
+            skippedActionIds.push(actionId);
+            continue;
+          }
+
+          const combo = normalizeCombo(rawCombo as KeyCombo);
+          if (!combo.code) {
+            skippedActionIds.push(actionId);
+            continue;
+          }
+
+          const browserConflict = findBrowserShortcutConflict(combo);
+          if (browserConflict?.severity === 'error') {
+            blockedActionIds.push(actionId);
+            continue;
+          }
+
+          if (!comboEquals(combo, action.defaultCombo)) {
+            nextOverrides[actionId] = combo;
+          }
+        }
+
+        const importedPresetId =
+          typeof data.presetId === 'string' && data.presetId in SHORTCUT_PRESET_MAP
+            ? data.presetId
+            : 'custom';
+
+        set({
+          overrides: nextOverrides,
+          activePresetId: Object.keys(nextOverrides).length === 0 ? 'ace-step' : importedPresetId,
+        });
+
+        return {
+          importedCount: Object.keys(nextOverrides).length,
+          blockedActionIds,
+          skippedActionIds,
+          activePresetId: get().activePresetId,
+        };
       },
     }),
     {

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -48,3 +48,26 @@ export interface ShortcutPreset {
   description: string;
   map: ShortcutMap;
 }
+
+export interface BrowserShortcutRule {
+  id: string;
+  combo: KeyCombo;
+  reason: string;
+  severity: 'warning' | 'error';
+  suggestion?: KeyCombo;
+}
+
+export interface ShortcutImportExportPayload {
+  version: 1;
+  presetId: string;
+  exportedAt: string;
+  overrides: ShortcutMap;
+  bindings: ShortcutMap;
+}
+
+export interface ShortcutImportResult {
+  importedCount: number;
+  blockedActionIds: string[];
+  skippedActionIds: string[];
+  activePresetId: string;
+}

--- a/tests/e2e/qa-full-workflow.spec.ts
+++ b/tests/e2e/qa-full-workflow.spec.ts
@@ -1016,8 +1016,8 @@ test.describe('QA Test Suite: Full Workflow', () => {
     test('7g. Double-create project does not corrupt state', async ({ page }) => {
       await createProjectViaUI(page, 'First Project');
 
-      // Try to create another project via Cmd+N
-      await page.keyboard.press('Meta+n');
+      // Try to create another project via the browser-safe shortcut
+      await page.keyboard.press('Shift+KeyN');
       await page.waitForTimeout(500);
 
       const dialogVisible = await page.locator('text=New Project').first().isVisible().catch(() => false);

--- a/tests/e2e/real-user-scenarios.spec.ts
+++ b/tests/e2e/real-user-scenarios.spec.ts
@@ -363,8 +363,8 @@ test.describe('Real User Scenarios (Issue #110)', () => {
       ).toBeVisible({ timeout: 3000 });
     });
 
-    test('4g. Cmd+N opens new project dialog', async ({ page }) => {
-      await page.keyboard.press('Meta+n');
+    test('4g. Shift+N opens new project dialog', async ({ page }) => {
+      await page.keyboard.press('Shift+KeyN');
       await page.waitForTimeout(500);
 
       await expect(

--- a/tests/e2e/user-workflow.spec.ts
+++ b/tests/e2e/user-workflow.spec.ts
@@ -10,7 +10,9 @@ test.describe('Core User Workflow: Create → Add → Edit → Play → Export',
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
     await page.waitForFunction(
-      () => typeof (window as any).__store !== 'undefined',
+      () =>
+        typeof (window as any).__store !== 'undefined' &&
+        typeof (window as any).__shortcutsStore !== 'undefined',
       null,
       { timeout: 10000 },
     );
@@ -121,6 +123,27 @@ test.describe('Core User Workflow: Create → Add → Edit → Play → Export',
       (window as any).__store.getState().project?.tracks?.length ?? 0
     );
     expect(trackCount).toBe(1);
+  });
+
+  test('User can pick a migration preset during onboarding and use the remapped shortcut', async ({ page }) => {
+    const presetSelect = page.getByLabel('Shortcut migration preset').first();
+    if (await presetSelect.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await presetSelect.selectOption('logic-pro');
+      await page.locator('button:has-text("Create")').first().click();
+    } else {
+      await page.evaluate(() => {
+        (window as any).__shortcutsStore.getState().applyPreset('logic-pro');
+        (window as any).__store.getState().createProject({ name: 'Logic Migration Test' });
+      });
+    }
+
+    await page.keyboard.press('KeyC');
+    await page.waitForTimeout(200);
+
+    const loopEnabled = await page.evaluate(() =>
+      (window as any).__transportStore.getState().loopEnabled
+    );
+    expect(loopEnabled).toBe(true);
   });
 
   test('App does not crash on basic interactions', async ({ page }) => {

--- a/tests/unit/shortcutsStore.test.ts
+++ b/tests/unit/shortcutsStore.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { useShortcutsStore, comboEquals } from '../../src/store/shortcutsStore';
 import { SHORTCUT_ACTIONS, SHORTCUT_ACTION_MAP } from '../../src/constants/shortcutDefaults';
 import { SHORTCUT_PRESETS, SHORTCUT_PRESET_MAP } from '../../src/constants/shortcutPresets';
+import { findBrowserShortcutConflict } from '../../src/constants/shortcutConflicts';
 import type { KeyCombo } from '../../src/types/shortcuts';
 
 beforeEach(() => {
@@ -131,6 +132,71 @@ describe('findConflict', () => {
   });
 });
 
+// ── findBrowserConflict ─────────────────────────────────────────
+
+describe('findBrowserConflict', () => {
+  it('blocks hard browser-reserved shortcuts', () => {
+    const conflict = useShortcutsStore.getState().findBrowserConflict({ code: 'KeyN', mod: true });
+    expect(conflict?.severity).toBe('error');
+    expect(conflict?.suggestion).toEqual({ code: 'KeyN', shift: true });
+  });
+
+  it('marks browser preference shortcuts as warnings', () => {
+    const conflict = useShortcutsStore.getState().findBrowserConflict({ code: 'Comma', mod: true });
+    expect(conflict?.severity).toBe('warning');
+  });
+});
+
+// ── export/import ───────────────────────────────────────────────
+
+describe('exportBindings / importBindings', () => {
+  it('exports current overrides and effective bindings', () => {
+    useShortcutsStore.getState().setBinding('transport.record', { code: 'F5' });
+
+    const payload = useShortcutsStore.getState().exportBindings();
+    expect(payload.version).toBe(1);
+    expect(payload.overrides['transport.record']).toEqual({ code: 'F5' });
+    expect(payload.bindings['transport.record']).toEqual({ code: 'F5' });
+    expect(payload.bindings['transport.playPause']).toEqual(
+      SHORTCUT_ACTION_MAP['transport.playPause'].defaultCombo,
+    );
+  });
+
+  it('imports valid overrides and blocks browser-reserved combos', () => {
+    const result = useShortcutsStore.getState().importBindings({
+      version: 1,
+      presetId: 'custom',
+      exportedAt: new Date().toISOString(),
+      overrides: {
+        'transport.record': { code: 'F5' },
+        'project.new': { code: 'KeyN', mod: true },
+      },
+      bindings: {},
+    });
+
+    expect(result.importedCount).toBe(1);
+    expect(result.blockedActionIds).toContain('project.new');
+    expect(useShortcutsStore.getState().overrides['transport.record']).toEqual({ code: 'F5' });
+    expect(useShortcutsStore.getState().overrides['project.new']).toBeUndefined();
+  });
+
+  it('skips unknown actions during import', () => {
+    const result = useShortcutsStore.getState().importBindings({
+      version: 1,
+      presetId: 'custom',
+      exportedAt: new Date().toISOString(),
+      overrides: {
+        'transport.record': { code: 'F5' },
+        'unknown.action': { code: 'F7' },
+      },
+      bindings: {},
+    });
+
+    expect(result.skippedActionIds).toContain('unknown.action');
+    expect(result.importedCount).toBe(1);
+  });
+});
+
 // ── SHORTCUT_ACTIONS ─────────────────────────────────────────────
 
 describe('SHORTCUT_ACTIONS', () => {
@@ -148,6 +214,12 @@ describe('SHORTCUT_ACTIONS', () => {
       expect(action.label.length).toBeGreaterThan(0);
       expect(action.defaultCombo.code.length).toBeGreaterThan(0);
     }
+  });
+
+  it('ships browser-safe defaults for project navigation shortcuts', () => {
+    expect(SHORTCUT_ACTION_MAP['project.new'].defaultCombo).toEqual({ code: 'KeyN', shift: true });
+    expect(SHORTCUT_ACTION_MAP['project.open'].defaultCombo).toEqual({ code: 'KeyO', shift: true });
+    expect(SHORTCUT_ACTION_MAP['project.settings'].defaultCombo).toEqual({ code: 'Comma', alt: true });
   });
 });
 
@@ -179,6 +251,14 @@ describe('SHORTCUT_PRESETS', () => {
     for (const preset of SHORTCUT_PRESETS) {
       for (const [, combo] of Object.entries(preset.map)) {
         expect(combo.code.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('preset entries avoid browser-blocked shortcuts', () => {
+    for (const preset of SHORTCUT_PRESETS) {
+      for (const [, combo] of Object.entries(preset.map)) {
+        expect(findBrowserShortcutConflict(combo)?.severity).not.toBe('error');
       }
     }
   });

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -26,7 +26,7 @@ This starts the Vite development server. Open [http://localhost:5173](http://loc
 
 ## Your First Project
 
-1. **Create a new project** — Press `Cmd/Ctrl + N` or use the project menu.
+1. **Create a new project** — Press `Shift + N` or use the project menu.
 2. **Add a track** — Press `Cmd/Ctrl + Shift + I` to open the instrument picker. Choose from 12 named instruments (Drums, Bass, Guitar, Vocals, etc.) or create a custom track.
 3. **Choose a track type** — Each track can be a Stems, Sample, Sequencer, or Piano Roll track.
 4. **Add content** — Depending on your track type:
@@ -50,7 +50,7 @@ Your projects are saved automatically to IndexedDB in your browser. Each project
 - Undo/redo history (up to 50 states)
 
 ::: tip
-Projects persist across browser sessions. Use `Cmd/Ctrl + O` to browse and switch between saved projects.
+Projects persist across browser sessions. Use `Shift + O` to browse and switch between saved projects.
 :::
 
 ## Next Steps

--- a/website/guide/recording.md
+++ b/website/guide/recording.md
@@ -5,7 +5,7 @@ ACE-Step DAW supports microphone recording directly into sample tracks with real
 ## Setup
 
 1. **Allow microphone access** — Your browser will prompt for permission when you first use recording
-2. **Select input device** — Open Settings (`Cmd/Ctrl + ,`) to choose from available microphone inputs
+2. **Select input device** — Open Settings (`Alt/Option + ,`) to choose from available microphone inputs
 3. **Arm a track** — Select the track you want to record into
 
 ![Recording](/demos/feature-complete-tour.gif)

--- a/website/guide/shortcuts.md
+++ b/website/guide/shortcuts.md
@@ -44,9 +44,9 @@ A complete reference of all keyboard shortcuts in ACE-Step DAW.
 
 | Shortcut | Action |
 |---|---|
-| `Cmd/Ctrl + N` | New project |
-| `Cmd/Ctrl + O` | Open project list |
-| `Cmd/Ctrl + ,` | Settings |
+| `Shift + N` | New project |
+| `Shift + O` | Open project list |
+| `Alt/Option + ,` | Settings |
 | `Cmd/Ctrl + Shift + E` | Export to WAV |
 
 ## Tracks


### PR DESCRIPTION
## Summary
- add a full shortcut editor flow with searchable remapping, JSON import/export, inline conflict surfacing, and browser-reserved shortcut validation
- add DAW migration preset entry points to onboarding and settings, plus browser-safe default/project shortcuts and safer preset mappings
- make the shortcuts help overlay reflect live bindings, add competitive research notes, and cover the new behavior with unit and focused Playwright tests

## User Stories
- As a migrating DAW user, I want shortcut presets that match my muscle memory, so that I can become productive immediately.
- As a power user, I want to customize and search shortcuts, so that the app fits my workflow instead of fighting it.
- As a browser DAW user, I want reserved shortcuts flagged before they interrupt my session, so that I do not lose focus or unsaved work.

## Files Touched
- `src/components/dialogs/ShortcutEditorDialog.tsx`
- `src/components/dialogs/KeyboardShortcutsDialog.tsx`
- `src/components/dialogs/NewProjectDialog.tsx`
- `src/components/dialogs/SettingsDialog.tsx`
- `src/store/shortcutsStore.ts`
- `src/constants/shortcutConflicts.ts`
- `src/constants/shortcutDefaults.ts`
- `src/constants/shortcutPresets.ts`
- `src/types/shortcuts.ts`
- `tests/unit/shortcutsStore.test.ts`
- `tests/e2e/user-workflow.spec.ts`
- `tests/e2e/real-user-scenarios.spec.ts`
- `tests/e2e/qa-full-workflow.spec.ts`
- `website/guide/shortcuts.md`
- `website/guide/getting-started.md`
- `website/guide/recording.md`
- `docs/research-notes/shortcut-editor-daw-migration-competitive-research-20260319.md`

## Verification
- `npx tsc --noEmit`
- `npm run build`
- `npm test`
- `npx playwright test tests/e2e/user-workflow.spec.ts tests/e2e/real-user-scenarios.spec.ts --grep "migration preset|4g\. Shift\+N|Keyboard shortcuts work|User can create a new project via dialog"`

## Issue
- Closes #338
