### PR TITLE
feat: add bounce/render in place workflow

### DIFF
--- a/docs/plans/feat-bounce-render-in-place.md
+++ b/docs/plans/feat-bounce-render-in-place.md
@@ -1,0 +1,55 @@
+# Plan: Bounce / Render In Place
+
+## User Stories
+
+- As a human user, I want to right-click a track and bounce it in place, so that I can turn MIDI or processed audio into an editable audio clip without leaving the arrangement.
+- As an AI agent, I want to call `window.__store.getState().bounceInPlace(trackId, options)`, so that I can render tracks programmatically without coordinate-based UI interaction.
+
+## Problem
+
+- The repo already supports freeze and flatten, but issue `#332` requires a creative bounce workflow with options, a keyboard shortcut, and a store API.
+- Current track-header UI exposes `Freeze Track` and `Flatten Track`, but there is no `Bounce in Place` action or options dialog.
+- `useKeyboardShortcuts` does not implement the design-doc shortcut for bounce.
+
+## Root Cause
+
+- Offline rendering exists in `src/engine/offlineRender.ts` and `src/engine/exportMix.ts`, but there is no store action that converts one track into a bounced audio result.
+- Track-header actions in `src/components/tracks/TrackHeader.tsx` only call freeze/flatten services.
+- Modal state in `src/store/uiStore.ts` has no bounce-dialog target, so the workflow cannot be opened from context menu or keyboard.
+
+## Solution
+
+- Add a dedicated bounce renderer in `src/services/bounceInPlace.ts` that:
+  - computes the renderable range for one track,
+  - renders MIDI, sampler, sequencer, and ready audio clips offline,
+  - optionally bakes track effects,
+  - optionally normalizes the result.
+- Add `bounceInPlace(trackId, options)` to `src/store/projectStore.ts` so the store owns undo/redo-safe state mutation.
+- Add dialog state to `src/store/uiStore.ts` and a new modal component at `src/components/dialogs/BounceInPlaceDialog.tsx`.
+- Add context-menu and keyboard entry points in `src/components/tracks/TrackHeader.tsx` and `src/hooks/useKeyboardShortcuts.ts`.
+- Add unit coverage for the render pipeline and store mutation plus an E2E workflow for shortcut + context-menu bounce.
+
+## Verification
+
+- `npx tsc --noEmit`
+- `npm run build`
+- `npm run test -- bounceInPlace`
+- `npm run test -- TrackHeader`
+- `npx playwright test tests/e2e/bounce-in-place.spec.ts`
+
+## Files To Touch
+
+- `src/types/project.ts`
+- `src/services/bounceInPlace.ts`
+- `src/store/projectStore.ts`
+- `src/store/uiStore.ts`
+- `src/hooks/useKeyboardShortcuts.ts`
+- `src/components/dialogs/BounceInPlaceDialog.tsx`
+- `src/components/dialogs/KeyboardShortcutsDialog.tsx`
+- `src/components/layout/AppShell.tsx`
+- `src/components/tracks/TrackHeader.tsx`
+- `src/services/__tests__/bounceInPlace.test.ts`
+- `src/store/__tests__/bounceInPlace.test.ts`
+- `tests/e2e/bounce-in-place.spec.ts`
+- `docs/research-notes/bounce-in-place-competitive-research-20260319.md`
+- `docs/plans/feat-bounce-render-in-place.md`

--- a/docs/research-notes/bounce-in-place-competitive-research-20260319.md
+++ b/docs/research-notes/bounce-in-place-competitive-research-20260319.md
@@ -1,0 +1,33 @@
+# Bounce In Place Competitive Research — 2026-03-19
+
+## User Story
+
+As a producer, I want to commit a track to editable audio without leaving the arrangement, so that I can slice, reverse, resample, and reduce instrument complexity quickly.
+
+## Competitor Notes
+
+### Ableton Live 12
+
+- Freeze/Flatten is track-scoped and explicitly destructive only at the flatten step.
+- Bounce-related actions are available close to the track context, not buried in export flows.
+- The core mental model is "commit this lane to audio, then continue arranging."
+
+### Logic Pro
+
+- Bounce in Place is region-oriented and designed as a creative workflow, not only a CPU optimization tool.
+- The flow exposes options before rendering so users decide whether the result replaces the source or creates a sibling audio result.
+- The default expectation is immediate editability after render.
+
+### FL Studio
+
+- "Render as audio clip" keeps the operation close to the playlist workflow.
+- The result is an audio clip the user can manipulate immediately inside the arrangement.
+- Keeping the original material available is treated as a practical option for experimentation.
+
+## Product Decisions For ACE-Step
+
+- Keep bounce in the track-header context menu to match DAW expectations.
+- Add a preflight dialog instead of a one-click destructive action.
+- Support both destructive replace and non-destructive sibling-track creation.
+- Expose the action through `window.__store.getState().bounceInPlace(trackId, options)` so agents can drive the same workflow without canvas clicks.
+- Reuse the offline render pipeline already used by export/freeze instead of inventing a second rendering stack.

--- a/src/components/dialogs/BounceInPlaceDialog.tsx
+++ b/src/components/dialogs/BounceInPlaceDialog.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+import { DEFAULT_BOUNCE_IN_PLACE_OPTIONS } from '../../services/bounceInPlace';
+import type { BounceInPlaceOptions } from '../../types/project';
+import { toastError } from '../../hooks/useToast';
+
+export function BounceInPlaceDialog() {
+  const trackId = useUIStore((state) => state.bounceInPlaceTrackId);
+  const close = useUIStore((state) => state.closeBounceInPlaceDialog);
+  const bounceInPlace = useProjectStore((state) => state.bounceInPlace);
+  const track = useProjectStore((state) =>
+    trackId ? state.project?.tracks.find((candidate) => candidate.id === trackId) ?? null : null,
+  );
+  const [options, setOptions] = useState<BounceInPlaceOptions>(DEFAULT_BOUNCE_IN_PLACE_OPTIONS);
+  const [isBouncing, setIsBouncing] = useState(false);
+
+  useEffect(() => {
+    if (trackId) {
+      setOptions(DEFAULT_BOUNCE_IN_PLACE_OPTIONS);
+    }
+  }, [trackId]);
+
+  if (!trackId || !track) return null;
+
+  const checkboxClass = 'h-4 w-4 rounded border border-daw-border bg-daw-surface-2 text-daw-accent focus:ring-1 focus:ring-daw-accent';
+
+  const handleBounce = async () => {
+    setIsBouncing(true);
+    try {
+      await bounceInPlace(trackId, options);
+      close();
+    } catch (error) {
+      console.error('Bounce in place failed', error);
+      toastError('Bounce in place failed');
+    } finally {
+      setIsBouncing(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onMouseDown={(event) => event.target === event.currentTarget && !isBouncing && close()}
+    >
+      <div
+        className="w-[420px] rounded-lg border border-daw-border bg-daw-surface shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-daw-border px-4 py-3">
+          <div>
+            <h2 className="text-sm font-semibold text-zinc-100">Bounce In Place</h2>
+            <p className="mt-1 text-xs text-zinc-400">{track.displayName}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => !isBouncing && close()}
+            className="text-lg leading-none text-zinc-500 transition-colors hover:text-zinc-200"
+            aria-label="Close bounce dialog"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="space-y-3 px-4 py-4">
+          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-daw-border bg-daw-surface-2/60 px-3 py-2">
+            <input
+              type="checkbox"
+              className={checkboxClass}
+              checked={options.includeEffects}
+              onChange={(event) => setOptions((current) => ({ ...current, includeEffects: event.target.checked }))}
+            />
+            <span>
+              <span className="block text-sm text-zinc-100">Include effects</span>
+              <span className="block text-xs text-zinc-400">Bake the track effect chain into the rendered audio.</span>
+            </span>
+          </label>
+
+          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-daw-border bg-daw-surface-2/60 px-3 py-2">
+            <input
+              type="checkbox"
+              className={checkboxClass}
+              checked={options.normalize}
+              onChange={(event) => setOptions((current) => ({ ...current, normalize: event.target.checked }))}
+            />
+            <span>
+              <span className="block text-sm text-zinc-100">Normalize render</span>
+              <span className="block text-xs text-zinc-400">Raise the bounced audio to a safe near-full-scale peak.</span>
+            </span>
+          </label>
+
+          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-daw-border bg-daw-surface-2/60 px-3 py-2">
+            <input
+              type="checkbox"
+              className={checkboxClass}
+              checked={options.replaceOriginal}
+              onChange={(event) => setOptions((current) => ({ ...current, replaceOriginal: event.target.checked }))}
+            />
+            <span>
+              <span className="block text-sm text-zinc-100">Replace original track</span>
+              <span className="block text-xs text-zinc-400">Turn this track into bounced audio instead of creating a sibling sample track.</span>
+            </span>
+          </label>
+        </div>
+
+        <div className="flex items-center justify-between border-t border-daw-border px-4 py-3">
+          <p className="text-[11px] text-zinc-500">Shortcut: {navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+B'}</p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => close()}
+              disabled={isBouncing}
+              className="rounded-md border border-daw-border px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleBounce()}
+              disabled={isBouncing}
+              className="rounded-md bg-daw-accent px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isBouncing ? 'Bouncing...' : 'Bounce Track'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -80,6 +80,7 @@ const SECTIONS: Section[] = [
       { keys: [`${mod}`, 'K'],         description: 'Open command palette' },
       { keys: [`${mod}`, 'N'],         description: 'New project' },
       { keys: [`${mod}`, 'O'],         description: 'Open project list' },
+      { keys: [`${mod}`, 'B'],         description: 'Bounce selected or focused track' },
       { keys: [`${mod}`, ','],         description: 'Settings' },
       { keys: [`${mod}`, '⇧', 'E'],    description: 'Export' },
       { keys: [`${mod}`, '⇧', 'I'],    description: 'Add Track' },

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -17,6 +17,7 @@ import { ProjectListDialog } from '../dialogs/ProjectListDialog';
 import { KeyboardShortcutsDialog } from '../dialogs/KeyboardShortcutsDialog';
 import { ShortcutEditorDialog } from '../dialogs/ShortcutEditorDialog';
 import { CommandPalette } from '../dialogs/CommandPalette';
+import { BounceInPlaceDialog } from '../dialogs/BounceInPlaceDialog';
 import { ShareDialog } from '../dialogs/ShareDialog';
 import { AIAssistantPanel } from '../dialogs/AIAssistantPanel';
 import { MixerPanel } from '../mixer/MixerPanel';
@@ -107,6 +108,7 @@ export function AppShell() {
       <KeyboardShortcutsDialog />
       <CommandPalette />
       <ShortcutEditorDialog />
+      <BounceInPlaceDialog />
       <CoverModal />
       <RepaintModal />
       <Vocal2BGMModal />

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -44,6 +44,7 @@ export function TrackHeader({
   const isImpliedMute = anySoloed && !track.soloed;
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
   const setOpenEffectChainTrackId = useUIStore((s) => s.setOpenEffectChainTrackId);
+  const openBounceInPlaceDialog = useUIStore((s) => s.openBounceInPlaceDialog);
   const { armedTrackIds, toggleArmTrack } = useRecording();
   const info = TRACK_CATALOG[track.trackName];
 
@@ -493,6 +494,13 @@ export function TrackHeader({
             className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
           >
             Duplicate Track
+          </button>
+          <div className="my-1 border-t border-[#555]" />
+          <button
+            onClick={() => { setCtxMenu(null); openBounceInPlaceDialog(track.id); }}
+            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
+          >
+            Bounce in Place...
           </button>
           <div className="my-1 border-t border-[#555]" />
           <button

--- a/src/constants/shortcutDefaults.ts
+++ b/src/constants/shortcutDefaults.ts
@@ -49,6 +49,7 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   // ── Project ────────────────────────────────────────────────────
   { id: 'project.new',           category: 'project',   label: 'New Project',               defaultCombo: { code: 'KeyN', mod: true } },
   { id: 'project.open',          category: 'project',   label: 'Open Project List',         defaultCombo: { code: 'KeyO', mod: true } },
+  { id: 'project.bounceInPlace', category: 'project',   label: 'Bounce Selected/Focused Track', defaultCombo: { code: 'KeyB', mod: true } },
   { id: 'project.settings',      category: 'project',   label: 'Settings',                  defaultCombo: { code: 'Comma', mod: true } },
   { id: 'project.export',        category: 'project',   label: 'Export',                    defaultCombo: { code: 'KeyE', mod: true, shift: true } },
   { id: 'project.addTrack',      category: 'project',   label: 'Add Track',                 defaultCombo: { code: 'KeyI', mod: true, shift: true } },

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -17,6 +17,27 @@ function isInputFocused(e: KeyboardEvent): boolean {
   );
 }
 
+function getBounceTargetTrackId(): string | null {
+  const ui = useUIStore.getState();
+  const projectState = useProjectStore.getState();
+  const project = projectState.project;
+  if (!project) return null;
+
+  const [selectedClipId] = [...ui.selectedClipIds];
+  if (selectedClipId) {
+    const track = projectState.getTrackForClip(selectedClipId);
+    if (track) return track.id;
+  }
+
+  return ui.openPianoRollTrackId
+    ?? ui.openSequencerTrackId
+    ?? ui.openDrumMachineTrackId
+    ?? ui.openEffectChainTrackId
+    ?? ui.expandedTrackId
+    ?? project.tracks[0]?.id
+    ?? null;
+}
+
 const NUDGE_SECONDS = 5;
 const DEFAULT_PIXELS_PER_SECOND = 50;
 
@@ -83,6 +104,9 @@ export function useKeyboardShortcuts() {
         } else if (ui.showAIAssistant) {
           e.preventDefault();
           ui.setShowAIAssistant(false);
+        } else if (ui.bounceInPlaceTrackId !== null) {
+          e.preventDefault();
+          ui.closeBounceInPlaceDialog();
         } else if (ui.editingClipId !== null) {
           e.preventDefault();
           ui.setEditingClip(null);
@@ -124,6 +148,7 @@ export function useKeyboardShortcuts() {
         ui.showCommandPalette ||
         ui.editingClipId !== null ||
         ui.batchGenerateMode !== null ||
+        ui.bounceInPlaceTrackId !== null ||
         ui.showKeyboardShortcutsDialog ||
         ui.showShortcutEditorDialog ||
         ui.showInstrumentPicker ||
@@ -148,6 +173,14 @@ export function useKeyboardShortcuts() {
       if (matches('project.export')) { e.preventDefault(); if (!anyModalOpen) ui.setShowExportDialog(true); return; }
       if (matches('project.addTrack')) { e.preventDefault(); if (!anyModalOpen) ui.setShowInstrumentPicker(true); return; }
       if (matches('project.help')) { e.preventDefault(); if (!anyModalOpen) ui.setShowKeyboardShortcutsDialog(true); return; }
+      if (matches('project.bounceInPlace')) {
+        e.preventDefault();
+        if (!anyModalOpen) {
+          const trackId = getBounceTargetTrackId();
+          if (trackId) ui.openBounceInPlaceDialog(trackId);
+        }
+        return;
+      }
 
       // Generation
       if (matches('generation.context')) {

--- a/src/services/__tests__/bounceInPlace.test.ts
+++ b/src/services/__tests__/bounceInPlace.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderTrackForBounceInPlace } from '../bounceInPlace';
+import type { BounceInPlaceOptions, Project, Track } from '../../types/project';
+
+vi.mock('../../services/audioFileManager', () => ({
+  loadAudioBlobByKey: vi.fn(),
+}));
+
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    decodeAudioData: vi.fn(async () => createMockAudioBuffer(2, 0.5)),
+  }),
+}));
+
+const mockRenderMixOffline = vi.fn();
+vi.mock('../../engine/exportMix', () => ({
+  renderMixOffline: (...args: unknown[]) => mockRenderMixOffline(...args),
+}));
+
+const mockRenderMidiTrackOffline = vi.fn();
+const mockRenderSamplerTrackOffline = vi.fn();
+const mockRenderSequencerTrackOffline = vi.fn();
+vi.mock('../../engine/offlineRender', () => ({
+  renderMidiTrackOffline: (...args: unknown[]) => mockRenderMidiTrackOffline(...args),
+  renderSamplerTrackOffline: (...args: unknown[]) => mockRenderSamplerTrackOffline(...args),
+  renderSequencerTrackOffline: (...args: unknown[]) => mockRenderSequencerTrackOffline(...args),
+}));
+
+vi.mock('../../utils/waveformPeaks', () => ({
+  computeWaveformPeaks: vi.fn(() => [0.1, 0.3, 0.8]),
+}));
+
+function createMockAudioBuffer(duration = 1, sample = 0.25): AudioBuffer {
+  const sampleRate = 48000;
+  const length = Math.ceil(duration * sampleRate);
+  const left = new Float32Array(length).fill(sample);
+  const right = new Float32Array(length).fill(sample);
+  return {
+    duration,
+    sampleRate,
+    length,
+    numberOfChannels: 2,
+    getChannelData: (channelIndex: number) => (channelIndex === 0 ? left : right),
+    copyFromChannel: vi.fn(),
+    copyToChannel: vi.fn(),
+  } as unknown as AudioBuffer;
+}
+
+function makeProject(track: Track): Project {
+  return {
+    id: 'project-1',
+    name: 'Bounce Test',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    bpm: 120,
+    keyScale: 'C major',
+    timeSignature: 4,
+    totalDuration: 8,
+    globalCaption: '',
+    generationDefaults: { inferenceSteps: 8, guidanceScale: 3, shift: 0, thinking: false, model: 'test' },
+    tracks: [track],
+    markers: [],
+    assets: [],
+    trackPresets: [],
+    automationLanes: [],
+    returnTracks: [],
+    tempoMap: [],
+    timeSignatureMap: [],
+    mastering: undefined,
+    measures: 8,
+    masterVolume: 0.8,
+  } as Project;
+}
+
+const baseOptions: BounceInPlaceOptions = {
+  includeEffects: true,
+  normalize: false,
+  replaceOriginal: true,
+};
+
+describe('renderTrackForBounceInPlace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRenderMixOffline.mockResolvedValue(createMockAudioBuffer(2, 0.5));
+    mockRenderMidiTrackOffline.mockResolvedValue(createMockAudioBuffer(2, 0.25));
+    mockRenderSamplerTrackOffline.mockResolvedValue(createMockAudioBuffer(2, 0.25));
+    mockRenderSequencerTrackOffline.mockResolvedValue(createMockAudioBuffer(8, 0.25));
+  });
+
+  it('renders piano-roll clips through the track effect chain', async () => {
+    const track: Track = {
+      id: 'track-1',
+      trackName: 'keyboard',
+      trackType: 'pianoRoll',
+      displayName: 'Keys',
+      color: '#22c55e',
+      order: 1,
+      volume: 0.8,
+      muted: false,
+      soloed: false,
+      synthPreset: 'pad',
+      effects: [{ id: 'fx-1', type: 'delay', enabled: true, params: { time: 0.25, feedback: 0.3, wet: 0.2 } }],
+      clips: [{
+        id: 'clip-1',
+        trackId: 'track-1',
+        startTime: 1,
+        duration: 2,
+        prompt: 'Hook',
+        lyrics: '',
+        generationStatus: 'empty',
+        generationJobId: null,
+        cumulativeMixKey: null,
+        isolatedAudioKey: null,
+        waveformPeaks: null,
+        midiData: { notes: [{ id: 'n1', pitch: 60, startBeat: 0, durationBeats: 1, velocity: 0.8 }], grid: '1/16' },
+      }],
+    } as Track;
+
+    const result = await renderTrackForBounceInPlace(makeProject(track), track, baseOptions);
+
+    expect(mockRenderMidiTrackOffline).toHaveBeenCalledOnce();
+    expect(mockRenderMixOffline).toHaveBeenCalledOnce();
+    expect(mockRenderMixOffline.mock.calls[0][0][0].effects).toEqual(track.effects);
+    expect(result).toMatchObject({
+      startTime: 1,
+      duration: 2,
+      waveformPeaks: [0.1, 0.3, 0.8],
+    });
+  });
+
+  it('skips track effects when includeEffects is false for audio tracks', async () => {
+    const { loadAudioBlobByKey } = await import('../../services/audioFileManager');
+    vi.mocked(loadAudioBlobByKey).mockResolvedValue(new Blob(['audio']));
+
+    const track: Track = {
+      id: 'track-2',
+      trackName: 'vocals',
+      trackType: 'stems',
+      displayName: 'Vocals',
+      color: '#f43f5e',
+      order: 1,
+      volume: 0.8,
+      muted: false,
+      soloed: false,
+      effects: [{ id: 'fx-1', type: 'compressor', enabled: true, params: { threshold: -18, ratio: 4, attack: 0.01, release: 0.2, knee: 12 } }],
+      clips: [{
+        id: 'clip-1',
+        trackId: 'track-2',
+        startTime: 2,
+        duration: 1.5,
+        prompt: 'Take',
+        lyrics: '',
+        generationStatus: 'ready',
+        generationJobId: null,
+        cumulativeMixKey: null,
+        isolatedAudioKey: 'audio-key-1',
+        waveformPeaks: null,
+      }],
+    } as Track;
+
+    await renderTrackForBounceInPlace(makeProject(track), track, {
+      ...baseOptions,
+      includeEffects: false,
+    });
+
+    expect(mockRenderMixOffline).toHaveBeenCalledOnce();
+    expect(mockRenderMixOffline.mock.calls[0][0][0].effects).toBeUndefined();
+  });
+
+  it('normalizes the rendered audio when requested', async () => {
+    const track: Track = {
+      id: 'track-3',
+      trackName: 'drums',
+      trackType: 'sequencer',
+      displayName: 'Drums',
+      color: '#ef4444',
+      order: 1,
+      volume: 0.8,
+      muted: false,
+      soloed: false,
+      effects: [],
+      sequencerPattern: {
+        id: 'pattern-1',
+        name: 'Pattern',
+        rows: [{ id: 'row-1', name: 'Kick', sampleKey: 'kick', steps: [{ active: true, velocity: 0.8 }], volume: 1, pan: 0, muted: false, color: '#ef4444' }],
+        stepsPerBar: 16,
+        bars: 1,
+        swing: 0,
+      },
+      clips: [],
+    } as Track;
+    const rendered = createMockAudioBuffer(8, 0.5);
+    mockRenderMixOffline.mockResolvedValue(rendered);
+
+    const result = await renderTrackForBounceInPlace(makeProject(track), track, {
+      ...baseOptions,
+      normalize: true,
+    });
+
+    expect(result?.buffer.getChannelData(0)[0]).toBeCloseTo(0.98, 2);
+  });
+});

--- a/src/services/bounceInPlace.ts
+++ b/src/services/bounceInPlace.ts
@@ -1,0 +1,203 @@
+import { renderMixOffline, type ExportClip } from '../engine/exportMix';
+import { renderMidiTrackOffline, renderSamplerTrackOffline, renderSequencerTrackOffline } from '../engine/offlineRender';
+import { createSamplerConfig } from '../engine/SamplerEngine';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+import type {
+  BounceInPlaceOptions,
+  DrumKitName,
+  Project,
+  SynthPreset,
+  Track,
+} from '../types/project';
+import { computeWaveformPeaks } from '../utils/waveformPeaks';
+import { loadAudioBlobByKey } from './audioFileManager';
+
+export const DEFAULT_BOUNCE_IN_PLACE_OPTIONS: BounceInPlaceOptions = {
+  includeEffects: true,
+  normalize: false,
+  replaceOriginal: true,
+};
+
+export interface BounceInPlaceRenderResult {
+  startTime: number;
+  duration: number;
+  buffer: AudioBuffer;
+  waveformPeaks: number[];
+}
+
+function getTrackBounceRange(track: Track, project: Project): { startTime: number; endTime: number } | null {
+  const readyAudioClips = track.clips.filter(
+    (clip) => clip.generationStatus === 'ready' && (clip.isolatedAudioKey ?? clip.cumulativeMixKey),
+  );
+
+  const midiClips = track.trackType === 'pianoRoll'
+    ? track.clips.filter((clip) => (clip.midiData?.notes.length ?? 0) > 0)
+    : [];
+
+  if (readyAudioClips.length === 0 && midiClips.length === 0) {
+    if (track.trackType === 'sequencer' && track.sequencerPattern) {
+      return { startTime: 0, endTime: project.totalDuration };
+    }
+    return null;
+  }
+
+  const contentClips = [...readyAudioClips, ...midiClips];
+  const startTime = Math.min(...contentClips.map((clip) => clip.startTime));
+  const endTime = Math.max(...contentClips.map((clip) => clip.startTime + clip.duration));
+  return { startTime, endTime };
+}
+
+async function renderAudioClipsForBounce(
+  track: Track,
+  rangeStartTime: number,
+): Promise<ExportClip[]> {
+  const engine = getAudioEngine();
+  const clips: ExportClip[] = [];
+
+  for (const clip of track.clips) {
+    if (clip.generationStatus !== 'ready') continue;
+
+    const audioKey = clip.isolatedAudioKey ?? clip.cumulativeMixKey;
+    if (!audioKey) continue;
+
+    const blob = await loadAudioBlobByKey(audioKey);
+    if (!blob) continue;
+
+    const buffer = await engine.decodeAudioData(blob);
+    clips.push({
+      startTime: Math.max(0, clip.startTime - rangeStartTime),
+      buffer,
+      volume: 1,
+    });
+  }
+
+  return clips;
+}
+
+async function renderPianoRollClipsForBounce(
+  project: Project,
+  track: Track,
+  rangeStartTime: number,
+): Promise<ExportClip[]> {
+  const clips: ExportClip[] = [];
+  const midiClips = track.clips.filter((clip) => (clip.midiData?.notes.length ?? 0) > 0);
+  if (midiClips.length === 0) return clips;
+
+  let sampleBuffer: AudioBuffer | null = null;
+  if (track.synthPreset === 'sampler' && track.sampler?.audioKey) {
+    const blob = await loadAudioBlobByKey(track.sampler.audioKey);
+    if (blob) {
+      sampleBuffer = await getAudioEngine().decodeAudioData(blob);
+    }
+  }
+
+  for (const clip of midiClips) {
+    const notes = clip.midiData?.notes ?? [];
+    if (notes.length === 0) continue;
+
+    let buffer: AudioBuffer | null = null;
+    if (track.synthPreset === 'sampler' && sampleBuffer && track.sampler?.audioKey) {
+      const samplerConfig = track.samplerConfig ?? createSamplerConfig(track.sampler.audioKey, {
+        rootNote: track.sampler.rootNote,
+        trimEnd: track.sampler.sampleDuration,
+        loopEnd: track.sampler.sampleDuration,
+      });
+      buffer = await renderSamplerTrackOffline(
+        notes,
+        0,
+        project.bpm,
+        sampleBuffer,
+        samplerConfig,
+        clip.duration,
+      );
+    } else {
+      buffer = await renderMidiTrackOffline(
+        notes,
+        0,
+        project.bpm,
+        (track.synthPreset ?? 'piano') as SynthPreset,
+        clip.duration,
+      );
+    }
+
+    clips.push({
+      startTime: Math.max(0, clip.startTime - rangeStartTime),
+      buffer,
+      volume: 1,
+    });
+  }
+
+  return clips;
+}
+
+function normalizeRenderedBuffer(buffer: AudioBuffer): void {
+  let peak = 0;
+
+  for (let channelIndex = 0; channelIndex < buffer.numberOfChannels; channelIndex += 1) {
+    const channel = buffer.getChannelData(channelIndex);
+    for (let sampleIndex = 0; sampleIndex < channel.length; sampleIndex += 1) {
+      peak = Math.max(peak, Math.abs(channel[sampleIndex]));
+    }
+  }
+
+  if (peak <= 0 || peak >= 0.999) return;
+
+  const gain = 0.98 / peak;
+  for (let channelIndex = 0; channelIndex < buffer.numberOfChannels; channelIndex += 1) {
+    const channel = buffer.getChannelData(channelIndex);
+    for (let sampleIndex = 0; sampleIndex < channel.length; sampleIndex += 1) {
+      channel[sampleIndex] *= gain;
+    }
+  }
+}
+
+export async function renderTrackForBounceInPlace(
+  project: Project,
+  track: Track,
+  options: BounceInPlaceOptions,
+): Promise<BounceInPlaceRenderResult | null> {
+  const range = getTrackBounceRange(track, project);
+  if (!range) return null;
+
+  const duration = Math.max(0.01, range.endTime - range.startTime);
+  const renderedClips: ExportClip[] = [
+    ...(await renderAudioClipsForBounce(track, range.startTime)),
+    ...(track.trackType === 'pianoRoll'
+      ? await renderPianoRollClipsForBounce(project, track, range.startTime)
+      : []),
+  ];
+
+  if (track.trackType === 'sequencer' && track.sequencerPattern && renderedClips.length === 0) {
+    renderedClips.push({
+      startTime: 0,
+      buffer: await renderSequencerTrackOffline(
+        track.sequencerPattern,
+        project.bpm,
+        duration,
+        (track.drumKit ?? '808') as DrumKitName,
+      ),
+      volume: 1,
+    });
+  }
+
+  if (renderedClips.length === 0) return null;
+
+  const rendered = await renderMixOffline(
+    renderedClips.map((clip) => ({
+      ...clip,
+      effects: options.includeEffects ? track.effects : undefined,
+    })),
+    duration,
+  );
+
+  if (options.normalize) {
+    normalizeRenderedBuffer(rendered);
+  }
+
+  return {
+    startTime: range.startTime,
+    duration,
+    buffer: rendered,
+    waveformPeaks: computeWaveformPeaks(rendered, 200),
+  };
+}

--- a/src/store/__tests__/bounceInPlace.test.ts
+++ b/src/store/__tests__/bounceInPlace.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../services/audioFileManager', () => ({
+  saveAudioBlob: vi.fn(async () => 'bounced-audio-key'),
+  loadAudioBlobByKey: vi.fn(),
+}));
+
+vi.mock('../../utils/wav', () => ({
+  audioBufferToWavBlob: vi.fn(() => new Blob(['wav'])),
+}));
+
+vi.mock('../../hooks/useToast', () => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+const mockRenderTrackForBounceInPlace = vi.fn();
+vi.mock('../../services/bounceInPlace', async () => {
+  const actual = await vi.importActual<typeof import('../../services/bounceInPlace')>('../../services/bounceInPlace');
+  return {
+    ...actual,
+    renderTrackForBounceInPlace: (...args: unknown[]) => mockRenderTrackForBounceInPlace(...args),
+  };
+});
+
+import { useProjectStore } from '../projectStore';
+
+function createMockAudioBuffer(duration = 2): AudioBuffer {
+  const sampleRate = 48000;
+  const length = Math.ceil(duration * sampleRate);
+  const channelData = new Float32Array(length).fill(0.25);
+  return {
+    duration,
+    sampleRate,
+    length,
+    numberOfChannels: 2,
+    getChannelData: () => channelData,
+    copyFromChannel: vi.fn(),
+    copyToChannel: vi.fn(),
+  } as unknown as AudioBuffer;
+}
+
+describe('projectStore bounceInPlace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject({ name: 'Bounce Project' });
+    mockRenderTrackForBounceInPlace.mockResolvedValue({
+      startTime: 1,
+      duration: 2,
+      buffer: createMockAudioBuffer(2),
+      waveformPeaks: [0.2, 0.6, 0.4],
+    });
+  });
+
+  it('replaces the source track with bounced audio and supports undo/redo', async () => {
+    const store = useProjectStore.getState();
+    const track = store.addTrack('keyboard', 'pianoRoll');
+    const clip = store.ensureMidiClip(track.id, 1, 2);
+    store.addMidiNote(clip.id, { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 0.8 });
+
+    await store.bounceInPlace(track.id, { replaceOriginal: true, includeEffects: true });
+
+    let updatedTrack = useProjectStore.getState().project!.tracks.find((candidate) => candidate.id === track.id)!;
+    expect(updatedTrack.trackType).toBe('sample');
+    expect(updatedTrack.clips).toHaveLength(1);
+    expect(updatedTrack.clips[0]).toMatchObject({
+      startTime: 1,
+      duration: 2,
+      isolatedAudioKey: 'bounced-audio-key',
+      generationStatus: 'ready',
+    });
+
+    useProjectStore.getState().undo();
+    updatedTrack = useProjectStore.getState().project!.tracks.find((candidate) => candidate.id === track.id)!;
+    expect(updatedTrack.trackType).toBe('pianoRoll');
+
+    useProjectStore.getState().redo();
+    updatedTrack = useProjectStore.getState().project!.tracks.find((candidate) => candidate.id === track.id)!;
+    expect(updatedTrack.trackType).toBe('sample');
+  });
+
+  it('creates a sibling bounced sample track when replaceOriginal is false', async () => {
+    const store = useProjectStore.getState();
+    const track = store.addTrack('vocals');
+    store.updateTrack(track.id, { color: '#abcdef' });
+
+    const bouncedClip = await store.bounceInPlace(track.id, { replaceOriginal: false, includeEffects: false });
+
+    const tracks = useProjectStore.getState().project!.tracks;
+    expect(tracks).toHaveLength(2);
+    const newTrack = tracks.find((candidate) => candidate.id !== track.id)!;
+    expect(newTrack.trackType).toBe('sample');
+    expect(newTrack.displayName).toContain('Bounce');
+    expect(newTrack.color).toBe('#abcdef');
+    expect(newTrack.clips[0].isolatedAudioKey).toBe('bounced-audio-key');
+    expect(bouncedClip?.trackId).toBe(newTrack.id);
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
 import { type TrackHeightPreset, getTrackHeightForPreset } from '../constants/trackHeight';
 import type {
+  BounceInPlaceOptions,
   Project,
   ProjectTemplate,
   ProjectTemplateTrack,
@@ -82,6 +83,8 @@ import { encodeMidiFile } from '../utils/midi';
 import { clampClipFadeDurations } from '../utils/clipFade';
 import { toastError, toastSuccess } from '../hooks/useToast';
 import { buildConsolidatedMidiClipData, renderConsolidatedAudioClip, validateClipConsolidation } from '../services/clipConsolidation';
+import { audioBufferToWavBlob } from '../utils/wav';
+import { DEFAULT_BOUNCE_IN_PLACE_OPTIONS, renderTrackForBounceInPlace } from '../services/bounceInPlace';
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
   return (60 / bpm) * timeSig;
@@ -171,6 +174,7 @@ interface ProjectState {
   freezeTrack: (trackId: string, frozenAudioKey?: string) => void;
   unfreezeTrack: (trackId: string) => void;
   flattenTrack: (trackId: string, audioKey: string, waveformPeaks?: number[], duration?: number) => void;
+  bounceInPlace: (trackId: string, options?: Partial<BounceInPlaceOptions>) => Promise<Clip | undefined>;
 
   addTrack: (trackName: TrackName, trackType?: TrackType) => Track;
   removeTrack: (trackId: string) => void;
@@ -642,6 +646,19 @@ function buildTrackDisplayName(existingTracks: Track[], trackName: TrackName): s
   const info = TRACK_CATALOG[trackName] ?? TRACK_CATALOG.custom;
   const sameNameCount = existingTracks.filter((track) => track.trackName === trackName).length;
   return sameNameCount === 0 ? info.displayName : `${info.displayName} ${sameNameCount + 1}`;
+}
+
+function buildUniqueTrackName(existingTracks: Track[], baseName: string): string {
+  const trimmedBaseName = baseName.trim() || 'Bounce';
+  let candidate = trimmedBaseName;
+  let suffix = 2;
+
+  while (existingTracks.some((track) => track.displayName === candidate)) {
+    candidate = `${trimmedBaseName} ${suffix}`;
+    suffix += 1;
+  }
+
+  return candidate;
 }
 
 function createTrackFromTemplate(
@@ -1153,6 +1170,182 @@ export const useProjectStore = create<ProjectState>()(
         ),
       },
     });
+  },
+
+  bounceInPlace: async (trackId, options) => {
+    const state = get();
+    const project = state.project;
+    if (!project) throw new Error('No project');
+
+    const track = project.tracks.find((candidate) => candidate.id === trackId);
+    if (!track) throw new Error(`Track '${trackId}' not found`);
+
+    const resolvedOptions: BounceInPlaceOptions = {
+      ...DEFAULT_BOUNCE_IN_PLACE_OPTIONS,
+      ...options,
+    };
+
+    const rendered = await renderTrackForBounceInPlace(project, track, resolvedOptions);
+    if (!rendered) return undefined;
+
+    const clipId = uuidv4();
+    const audioKey = await saveAudioBlob(
+      project.id,
+      clipId,
+      'isolated',
+      audioBufferToWavBlob(rendered.buffer),
+    );
+
+    const latest = get();
+    if (!latest.project) return undefined;
+    const latestTrack = latest.project.tracks.find((candidate) => candidate.id === trackId);
+    if (!latestTrack) return undefined;
+
+    _pushHistory(latest.project);
+
+    const baseClip: Clip = {
+      id: clipId,
+      trackId,
+      startTime: rendered.startTime,
+      duration: rendered.duration,
+      prompt: `${latestTrack.displayName} Bounce`,
+      lyrics: '',
+      generationStatus: 'ready',
+      generationJobId: null,
+      cumulativeMixKey: null,
+      isolatedAudioKey: audioKey,
+      waveformPeaks: rendered.waveformPeaks,
+      audioDuration: rendered.duration,
+      audioOffset: 0,
+      source: 'uploaded',
+    };
+
+    if (resolvedOptions.replaceOriginal) {
+      const updatedTracks = latest.project.tracks.map((candidate) =>
+        candidate.id === trackId
+          ? {
+              ...candidate,
+              trackType: 'sample' as TrackType,
+              clips: [{ ...baseClip, trackId }],
+              frozen: false,
+              frozenAudioKey: undefined,
+              sequencerPattern: undefined,
+              drumMachine: undefined,
+              synthPreset: undefined,
+              sampler: undefined,
+              samplerConfig: undefined,
+              midiEffects: [],
+              effects: resolvedOptions.includeEffects ? [] : candidate.effects,
+            }
+          : candidate,
+      );
+
+      set({
+        project: {
+          ...latest.project,
+          updatedAt: Date.now(),
+          totalDuration: computeTotalDuration(
+            updatedTracks,
+            latest.project.measures,
+            latest.project.bpm,
+            latest.project.timeSignature,
+            latest.project.tempoMap,
+            latest.project.timeSignatureMap,
+          ),
+          tracks: updatedTracks,
+          assets: [
+            ...(latest.project.assets ?? []),
+            {
+              id: uuidv4(),
+              clipId,
+              trackDisplayName: latestTrack.displayName,
+              prompt: baseClip.prompt,
+              source: 'uploaded',
+              isolatedAudioKey: audioKey,
+              cumulativeMixKey: null,
+              waveformPeaks: rendered.waveformPeaks,
+              starred: false,
+              createdAt: Date.now(),
+              duration: rendered.duration,
+            },
+          ],
+        },
+      });
+
+      toastSuccess(`Bounced ${latestTrack.displayName} in place`);
+      return baseClip;
+    }
+
+    const bouncedTrackId = uuidv4();
+    const insertAfterOrder = latestTrack.order;
+    const shiftedTracks = latest.project.tracks.map((candidate) =>
+      candidate.order > insertAfterOrder
+        ? { ...candidate, order: candidate.order + 1 }
+        : candidate,
+    );
+    const bouncedTrack: Track = {
+      ...createTrackFromTemplate(shiftedTracks, latestTrack.trackName, 'sample', {
+        color: latestTrack.color,
+        volume: latestTrack.volume,
+        laneHeight: latestTrack.laneHeight,
+        pan: latestTrack.pan,
+        eqLowGain: latestTrack.eqLowGain,
+        eqMidGain: latestTrack.eqMidGain,
+        eqHighGain: latestTrack.eqHighGain,
+        compressorEnabled: latestTrack.compressorEnabled,
+        compressorThreshold: latestTrack.compressorThreshold,
+        compressorRatio: latestTrack.compressorRatio,
+        reverbMix: latestTrack.reverbMix,
+        reverbRoomSize: latestTrack.reverbRoomSize,
+        effects: resolvedOptions.includeEffects ? [] : latestTrack.effects,
+      }),
+      id: bouncedTrackId,
+      displayName: buildUniqueTrackName(shiftedTracks, `${latestTrack.displayName} Bounce`),
+      order: insertAfterOrder + 1,
+      clips: [{ ...baseClip, trackId: bouncedTrackId }],
+      synthPreset: undefined,
+      sampler: undefined,
+      samplerConfig: undefined,
+      sequencerPattern: undefined,
+      drumMachine: undefined,
+      midiEffects: [],
+    };
+    const updatedTracks = [...shiftedTracks, bouncedTrack];
+
+    set({
+      project: {
+        ...latest.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(
+          updatedTracks,
+          latest.project.measures,
+          latest.project.bpm,
+          latest.project.timeSignature,
+          latest.project.tempoMap,
+          latest.project.timeSignatureMap,
+        ),
+        tracks: updatedTracks,
+        assets: [
+          ...(latest.project.assets ?? []),
+          {
+            id: uuidv4(),
+            clipId,
+            trackDisplayName: bouncedTrack.displayName,
+            prompt: baseClip.prompt,
+            source: 'uploaded',
+            isolatedAudioKey: audioKey,
+            cumulativeMixKey: null,
+            waveformPeaks: rendered.waveformPeaks,
+            starred: false,
+            createdAt: Date.now(),
+            duration: rendered.duration,
+          },
+        ],
+      },
+    });
+
+    toastSuccess(`Created bounced audio track for ${latestTrack.displayName}`);
+    return { ...baseClip, trackId: bouncedTrackId };
   },
 
   addTrack: (trackName, trackType) => {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -34,6 +34,7 @@ interface UIState {
   showExportDialog: boolean;
   showSettingsDialog: boolean;
   showProjectListDialog: boolean;
+  bounceInPlaceTrackId: string | null;
   /** Controls the BatchGenerateModal — lifted from GenerationPanel so keyboard shortcuts can open it. */
   batchGenerateMode: 'silence' | 'context' | null;
   /** Optional time range pre-filled into BatchGenerateModal when opened from a lane drag-select or context menu. */
@@ -128,6 +129,8 @@ interface UIState {
   setShowExportDialog: (v: boolean) => void;
   setShowSettingsDialog: (v: boolean) => void;
   setShowProjectListDialog: (v: boolean) => void;
+  openBounceInPlaceDialog: (trackId: string) => void;
+  closeBounceInPlaceDialog: () => void;
   setBatchGenerateMode: (mode: 'silence' | 'context' | null) => void;
   setBatchGenerateInitialRange: (v: { startTime: number; duration: number } | null) => void;
   setShowKeyboardShortcutsDialog: (v: boolean) => void;
@@ -223,6 +226,7 @@ export const useUIStore = create<UIState>()(
   showExportDialog: false,
   showSettingsDialog: false,
   showProjectListDialog: false,
+  bounceInPlaceTrackId: null,
   batchGenerateMode: null,
   batchGenerateInitialRange: null,
   showKeyboardShortcutsDialog: false,
@@ -326,6 +330,8 @@ export const useUIStore = create<UIState>()(
   setShowExportDialog: (v) => set({ showExportDialog: v }),
   setShowSettingsDialog: (v) => set({ showSettingsDialog: v }),
   setShowProjectListDialog: (v) => set({ showProjectListDialog: v }),
+  openBounceInPlaceDialog: (trackId) => set({ bounceInPlaceTrackId: trackId }),
+  closeBounceInPlaceDialog: () => set({ bounceInPlaceTrackId: null }),
   setBatchGenerateMode: (mode) => set(mode === null
     ? { batchGenerateMode: null, batchGenerateInitialRange: null }
     : { batchGenerateMode: mode }),

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -46,6 +46,12 @@ export interface SamplerSettings {
   sampleDuration?: number;
 }
 
+export interface BounceInPlaceOptions {
+  includeEffects: boolean;
+  normalize: boolean;
+  replaceOriginal: boolean;
+}
+
 export interface DrumPad {
   id: string;
   name: string;

--- a/tests/e2e/bounce-in-place.spec.ts
+++ b/tests/e2e/bounce-in-place.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test';
+
+const modKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+test.describe('Bounce In Place', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
+    await page.evaluate(() => {
+      const store = (window as any).__store;
+      const ui = (window as any).__uiStore;
+
+      store.getState().createProject({ name: 'Bounce E2E' });
+      ui.getState().setShowNewProjectDialog(false);
+
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      store.getState().updateTrack(track.id, { displayName: 'Agent Keys', synthPreset: 'pad' });
+      const clip = store.getState().ensureMidiClip(track.id, 1, 2);
+      store.getState().addMidiNote(clip.id, { pitch: 60, startBeat: 0, durationBeats: 1, velocity: 0.8 });
+      store.getState().addMidiNote(clip.id, { pitch: 64, startBeat: 1, durationBeats: 1, velocity: 0.75 });
+      store.getState().addMidiNote(clip.id, { pitch: 67, startBeat: 2, durationBeats: 0.5, velocity: 0.7 });
+    });
+  });
+
+  test('opens from shortcut and context menu, then bounces the track in place', async ({ page }) => {
+    await page.getByText('Click anywhere to enable audio').click();
+
+    const clip = page.getByTestId(/clip-/).first();
+    await expect(clip).toBeVisible();
+    await page.evaluate(() => {
+      const store = (window as any).__store;
+      const ui = (window as any).__uiStore;
+      const clipId = store.getState().project?.tracks?.[0]?.clips?.[0]?.id;
+      if (clipId) {
+        ui.getState().selectClip(clipId, false);
+      }
+    });
+
+    await page.keyboard.press(`${modKey}+B`);
+    await page.waitForFunction(() => (window as any).__uiStore.getState().bounceInPlaceTrackId !== null);
+    await expect(page.getByRole('heading', { name: 'Bounce In Place' })).toBeVisible();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    await page.getByText('Agent Keys').click({ button: 'right', force: true });
+    await expect(page.getByRole('button', { name: 'Bounce in Place...' })).toBeVisible();
+    await page.getByRole('button', { name: 'Bounce in Place...' }).click();
+
+    await expect(page.getByLabel('Include effects')).toBeVisible();
+    await Promise.all([
+      page.waitForFunction(() => {
+        const project = (window as any).__store.getState().project;
+        return project?.tracks?.[0]?.trackType === 'sample' && project?.tracks?.[0]?.clips?.[0]?.isolatedAudioKey;
+      }),
+      page.getByRole('button', { name: 'Bounce Track' }).click(),
+    ]);
+
+    const bounced = await page.evaluate(() => {
+      const track = (window as any).__store.getState().project?.tracks?.[0];
+      return {
+        trackType: track?.trackType,
+        clipCount: track?.clips?.length ?? 0,
+        audioKey: track?.clips?.[0]?.isolatedAudioKey ?? null,
+      };
+    });
+
+    expect(bounced).toEqual({
+      trackType: 'sample',
+      clipCount: 1,
+      audioKey: expect.any(String),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated bounce-in-place render pipeline with a store API for agent and UI use
- add a Bounce In Place dialog, track-header context action, and Cmd/Ctrl+B shortcut
- cover replace-in-place and sibling-track bounce flows with unit and E2E tests

## User Stories
- As a human user, I want to bounce a track in place from the track header, so that I can commit MIDI or processed audio into an editable sample clip.
- As an AI agent, I want to call `window.__store.getState().bounceInPlace(trackId, options)`, so that I can render a track programmatically without canvas-only interactions.

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `npm test -- src/services/__tests__/bounceInPlace.test.ts src/store/__tests__/bounceInPlace.test.ts src/components/tracks/__tests__/TrackHeader.test.tsx tests/unit/trackHeader.test.tsx`
- `E2E_PORT=5275 npx playwright test tests/e2e/bounce-in-place.spec.ts`

Closes #332