### PR TITLE
feat: consolidate/glue clips — merge selection into single clip

### DIFF
--- a/docs/plans/feat-consolidate-clips.md
+++ b/docs/plans/feat-consolidate-clips.md
@@ -1,0 +1,53 @@
+# Feature Plan: Consolidate / Glue Clips
+
+## User stories
+
+- As a user, I want to select multiple clips on one track and press `Cmd+J`, so that I can turn fragmented edits into one clip.
+- As a user, I want to use a clip context menu action for consolidation, so that the workflow is discoverable without memorizing shortcuts.
+- As an agent, I want `window.__store.getState().consolidateClips(trackId, clipIds)`, so that I can automate clip-merging workflows end-to-end.
+
+## Problem
+
+Issue #330 reports that ACE-Step DAW supports splitting, dragging, and duplicating clips but has no inverse action to merge them back into a single clip. This leaves arrangement edits fragmented and makes later editing cumbersome.
+
+## Root Cause
+
+- [src/store/projectStore.ts](/tmp/daw-worktrees/agent-330/src/store/projectStore.ts) includes `splitClip`, `duplicateClip`, and batch move/duplicate actions, but no track-local consolidate action.
+- [src/hooks/useKeyboardShortcuts.ts](/tmp/daw-worktrees/agent-330/src/hooks/useKeyboardShortcuts.ts) has clip shortcuts for duplicate, split, edit, and generate, but no `Cmd+J` binding.
+- [src/components/timeline/ClipContextMenu.tsx](/tmp/daw-worktrees/agent-330/src/components/timeline/ClipContextMenu.tsx) exposes clip editing actions but no consolidate entry.
+- The codebase has no helper that merges MIDI note timing across clips or renders selected audio clips plus silence into one new source buffer.
+
+## Solution
+
+- Add `consolidateClips(trackId, clipIds)` to the project store.
+- Add a clip consolidation service/helper that:
+  - validates same-track, same-media-type selections;
+  - merges MIDI notes into one clip spanning the selected time range;
+  - renders audio clips into a new WAV blob with silence in gaps, honoring clip offsets, fades, and gain envelopes;
+  - returns a replacement clip plus updated persisted audio metadata.
+- Wire `Cmd+J` / `Ctrl+J` in keyboard shortcuts.
+- Add `Consolidate` to the clip context menu and keep the new clip selected after the action from UI surfaces.
+- Add unit tests for MIDI merge, audio merge, and undo restoration.
+- Add an E2E workflow that creates clips through the store API, consolidates through the shortcut or menu, and verifies the visible timeline result plus store state.
+
+## Verification
+
+- `npm run test -- tests/unit/projectStore.test.ts tests/unit/undoRedo.test.ts`
+- `npm run test:e2e -- tests/e2e/consolidate-clips.spec.ts`
+- `npx tsc --noEmit`
+- `npm run build`
+
+## Files to touch
+
+- `docs/research-notes/consolidate-clips-competitive-research-20260319.md`
+- `docs/plans/feat-consolidate-clips.md`
+- `src/store/projectStore.ts`
+- `src/components/timeline/ClipContextMenu.tsx`
+- `src/components/timeline/ClipBlock.tsx`
+- `src/hooks/useKeyboardShortcuts.ts`
+- `src/components/dialogs/KeyboardShortcutsDialog.tsx`
+- `src/types/project.ts`
+- `src/services/clipConsolidation.ts`
+- `tests/unit/projectStore.test.ts`
+- `tests/unit/undoRedo.test.ts`
+- `tests/e2e/consolidate-clips.spec.ts`

--- a/docs/research-notes/consolidate-clips-competitive-research-20260319.md
+++ b/docs/research-notes/consolidate-clips-competitive-research-20260319.md
@@ -1,0 +1,34 @@
+# Consolidate / Glue Clips Competitive Research (2026-03-19)
+
+## User stories
+
+- As a producer, I want to merge split arrangement clips back into one clip, so that further edits are simpler and less error-prone.
+- As an AI agent, I want to call `window.__store.getState().consolidateClips(trackId, clipIds)`, so that I can complete clip-editing workflows without canvas-only interactions.
+
+## Ableton Live 12
+
+Source: https://www.ableton.com/en/live-manual/12/arrangement-view/
+
+- `Consolidate` is available from the Edit menu, the Arrangement clip context menu, and the keyboard shortcut `Cmd+J` / `Ctrl+J`.
+- It combines selected material from adjacent clips into one new clip.
+- It works per track and can also consolidate selections across multiple tracks, producing one new sample per track.
+- The resulting clip behaves like a normal clip after creation and is commonly used to create a reusable loop from several edited regions.
+- For audio, the rendered result includes in-clip attenuation, time-warping, pitch shifting, and clip envelopes.
+- For audio, the rendered result does not include downstream track effects or mixer processing. That is a separate export workflow.
+
+## Product decision for ACE-Step DAW #330
+
+- Match the single-track consolidate workflow first.
+- Support both audio clips and MIDI clips on the same track.
+- Keep the render scope aligned with Ableton's clip-level behavior:
+  - Include silence between selected clips.
+  - Include clip offsets, clip gain envelopes, and fades in the rendered audio.
+  - Do not bake track FX or mixer state into the consolidated clip.
+- Reject mixed audio+MIDI selections and cross-track selections with a clear error, because the issue scope and current data model are track-local.
+
+## UX implications
+
+- `Cmd+J` / `Ctrl+J` should operate on the current timeline selection.
+- Right-clicking a selected clip should expose `Consolidate` without forcing users into a separate toolbar flow.
+- After consolidation, the new clip should remain selected so the next action is immediate.
+- Undo must restore the original clip set in one step.

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -29,6 +29,7 @@ const SECTIONS: Section[] = [
     rows: [
       { keys: ['Delete', 'Backspace'],  description: 'Delete selected clips' },
       { keys: [`${mod}`, 'D'],          description: 'Duplicate selected clip' },
+      { keys: [`${mod}`, 'J'],          description: 'Consolidate selected clips' },
       { keys: ['S'],                    description: 'Split clip at playhead' },
       { keys: [`${mod}`, 'A'],          description: 'Select all clips' },
       { keys: ['E'],                    description: 'Edit selected clip' },

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -60,6 +60,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const setClipFade = useProjectStore((s) => s.setClipFade);
   const removeClip = useProjectStore((s) => s.removeClip);
   const duplicateClip = useProjectStore((s) => s.duplicateClip);
+  const consolidateClips = useProjectStore((s) => s.consolidateClips);
   const convertAudioToMidi = useProjectStore((s) => s.convertAudioToMidi);
   const exportMidiClip = useProjectStore((s) => s.exportMidiClip);
   const batchDuplicateClips = useProjectStore((s) => s.batchDuplicateClips);
@@ -389,6 +390,21 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const peaks = clip.waveformPeaks;
   const audioDuration = clip.audioDuration ?? clip.duration;
   const audioOffset = clip.audioOffset ?? 0;
+  const selectedActionClipIds = selectedClipIds.has(clip.id) ? [...selectedClipIds] : [clip.id];
+  const selectedActionClips = selectedActionClipIds
+    .map((clipId) => project?.tracks.flatMap((candidate) => candidate.clips).find((candidate) => candidate.id === clipId))
+    .filter((candidate): candidate is Clip => Boolean(candidate));
+  const canConsolidate = selectedActionClips.length === selectedActionClipIds.length
+    && selectedActionClips.every((candidate) => candidate.trackId === track.id)
+    && new Set(selectedActionClips.map((candidate) => Boolean(candidate.midiData))).size <= 1;
+
+  const handleConsolidate = async () => {
+    const consolidatedClip = await consolidateClips(track.id, selectedActionClipIds);
+    closeCtxMenu();
+    if (consolidatedClip) {
+      selectClip(consolidatedClip.id, false);
+    }
+  };
 
   return (
     <>
@@ -567,6 +583,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           onOpenMidi={() => { closeCtxMenu(); setOpenPianoRoll(track.id, clip.id); }}
           onExportMidi={() => { closeCtxMenu(); exportMidiClip(clip.id); }}
           onDuplicate={() => { closeCtxMenu(); duplicateClip(clip.id); }}
+          onConsolidate={() => { void handleConsolidate(); }}
           onDelete={() => { closeCtxMenu(); removeClip(clip.id); }}
           onAddLayer={() => { closeCtxMenu(); setAddLayerOpen(true); }}
           onCreateCover={() => {
@@ -606,6 +623,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           isMidiClip={isMidiClip}
           isVocalTrack={track.trackName === 'vocals' || track.trackName === 'backing_vocals'}
           hasAudio={!!(clip.isolatedAudioKey || clip.cumulativeMixKey)}
+          canConsolidate={canConsolidate}
         />
       )}
 

--- a/src/components/timeline/ClipContextMenu.tsx
+++ b/src/components/timeline/ClipContextMenu.tsx
@@ -7,6 +7,7 @@ interface ClipContextMenuProps {
   onOpenMidi: () => void;
   onExportMidi: () => void;
   onDuplicate: () => void;
+  onConsolidate: () => void;
   onDelete: () => void;
   onAddLayer: () => void;
   onCreateCover: () => void;
@@ -21,6 +22,7 @@ interface ClipContextMenuProps {
   isMidiClip: boolean;
   isVocalTrack: boolean;
   hasAudio: boolean;
+  canConsolidate: boolean;
 }
 
 export function ClipContextMenu({
@@ -32,6 +34,7 @@ export function ClipContextMenu({
   onOpenMidi,
   onExportMidi,
   onDuplicate,
+  onConsolidate,
   onDelete,
   onAddLayer,
   onCreateCover,
@@ -46,6 +49,7 @@ export function ClipContextMenu({
   isMidiClip,
   isVocalTrack,
   hasAudio,
+  canConsolidate,
 }: ClipContextMenuProps) {
   const clampedX = Math.min(x, window.innerWidth - 210);
   const clampedY = Math.min(y, window.innerHeight - 300);
@@ -116,6 +120,13 @@ export function ClipContextMenu({
         <div className="my-1 border-t border-[#555]" />
         <button onClick={onDuplicate} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors">
           Duplicate
+        </button>
+        <button
+          onClick={onConsolidate}
+          disabled={!canConsolidate}
+          className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors disabled:text-zinc-600 disabled:cursor-not-allowed"
+        >
+          Consolidate
         </button>
         {!isMidiClip && (
           <button onClick={onAddLayer} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors">

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -173,6 +173,25 @@ export function useKeyboardShortcuts() {
         }
         return;
       }
+      if (mod && e.code === 'KeyJ' && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        if (!anyModalOpen && ui.selectedClipIds.size > 0 && project.project) {
+          const selectedIds = [...ui.selectedClipIds];
+          const selectedClips = project.project.tracks
+            .flatMap((track) => track.clips)
+            .filter((clip) => selectedIds.includes(clip.id));
+          const trackIds = [...new Set(selectedClips.map((clip) => clip.trackId))];
+          if (trackIds.length === 1) {
+            void (async () => {
+              const consolidatedClip = await project.consolidateClips(trackIds[0], selectedIds);
+              if (consolidatedClip) {
+                ui.selectClip(consolidatedClip.id, false);
+              }
+            })();
+          }
+        }
+        return;
+      }
       if (matches('clips.generate')) {
         e.preventDefault();
         if (!anyModalOpen && !gen.isGenerating) {

--- a/src/services/clipConsolidation.ts
+++ b/src/services/clipConsolidation.ts
@@ -1,0 +1,233 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { Clip, MidiNote, Project } from '../types/project';
+import { interpolateGainEnvelope } from '../utils/gainEnvelope';
+import { timeToBeat } from '../utils/tempoMap';
+import { audioBufferToWavBlob } from '../utils/wav';
+import { computeWaveformPeaks } from '../utils/waveformPeaks';
+import { loadAudioBlobByKey, saveAudioBlob } from './audioFileManager';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+
+type AudioBufferLike = Pick<AudioBuffer, 'numberOfChannels' | 'length' | 'sampleRate' | 'duration' | 'getChannelData'>;
+
+export type ConsolidationMediaType = 'audio' | 'midi';
+
+export interface ConsolidationValidation {
+  clips: Clip[];
+  mediaType: ConsolidationMediaType;
+}
+
+interface AudioClipRenderInput {
+  clip: Clip;
+  buffer: AudioBufferLike;
+  sourceRegionStart: number;
+}
+
+interface MergedAudioData {
+  channels: Float32Array[];
+  sampleRate: number;
+  numberOfChannels: number;
+  duration: number;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function validateClipConsolidation(trackId: string, clips: Clip[]): ConsolidationValidation {
+  if (clips.length === 0) {
+    throw new Error('Select at least one clip to consolidate');
+  }
+
+  if (clips.some((clip) => clip.trackId !== trackId)) {
+    throw new Error('Consolidate only works on clips from the same track');
+  }
+
+  const sorted = [...clips].sort((a, b) => a.startTime - b.startTime || a.duration - b.duration || a.id.localeCompare(b.id));
+  const midiCount = sorted.filter((clip) => clip.midiData).length;
+
+  if (midiCount > 0 && midiCount < sorted.length) {
+    throw new Error('Select only audio clips or only MIDI clips when consolidating');
+  }
+
+  return {
+    clips: sorted,
+    mediaType: midiCount === sorted.length ? 'midi' : 'audio',
+  };
+}
+
+function buildConsolidatedPrompt(clips: Clip[], fallback: string) {
+  const prompts = [...new Set(clips.map((clip) => clip.prompt.trim()).filter(Boolean))];
+  return prompts.length === 1 ? prompts[0] : fallback;
+}
+
+export function buildConsolidatedMidiClipData(project: Project, clips: Clip[]) {
+  const { clips: validatedClips } = validateClipConsolidation(clips[0]?.trackId ?? '', clips);
+  const startTime = validatedClips[0].startTime;
+  const endTime = Math.max(...validatedClips.map((clip) => clip.startTime + clip.duration));
+  const mergedNotes: MidiNote[] = [];
+
+  for (const clip of validatedClips) {
+    const midiData = clip.midiData;
+    if (!midiData) continue;
+
+    const clipStartBeat = timeToBeat(clip.startTime, project.tempoMap, project.bpm);
+    const consolidatedStartBeat = timeToBeat(startTime, project.tempoMap, project.bpm);
+
+    for (const note of midiData.notes) {
+      const noteAbsoluteStartBeat = clipStartBeat + note.startBeat;
+      mergedNotes.push({
+        ...note,
+        id: uuidv4(),
+        startBeat: noteAbsoluteStartBeat - consolidatedStartBeat,
+      });
+    }
+  }
+
+  mergedNotes.sort((a, b) => a.startBeat - b.startBeat || a.pitch - b.pitch || a.id.localeCompare(b.id));
+
+  return {
+    startTime,
+    duration: endTime - startTime,
+    midiData: {
+      notes: mergedNotes,
+      grid: validatedClips.find((clip) => clip.midiData?.grid)?.midiData?.grid ?? '1/16',
+    },
+  };
+}
+
+function sampleBufferAtTime(buffer: AudioBufferLike, channel: number, time: number) {
+  const channelIndex = Math.min(channel, buffer.numberOfChannels - 1);
+  const samples = buffer.getChannelData(channelIndex);
+  const position = time * buffer.sampleRate;
+  if (position < 0 || position >= samples.length) return 0;
+
+  const leftIndex = Math.floor(position);
+  const rightIndex = Math.min(leftIndex + 1, samples.length - 1);
+  const frac = position - leftIndex;
+  const left = samples[leftIndex] ?? 0;
+  const right = samples[rightIndex] ?? 0;
+  return left + (right - left) * frac;
+}
+
+function getFadeGain(curve: Clip['fadeInCurve'] | Clip['fadeOutCurve'] | undefined, ratio: number) {
+  const x = clamp(ratio, 0, 1);
+  switch (curve) {
+    case 'equal-power':
+      return Math.sin((x * Math.PI) / 2);
+    case 'exponential':
+      return x <= 0 ? 0 : x * x;
+    case 'linear':
+    default:
+      return x;
+  }
+}
+
+function getClipGainAtTime(clip: Clip, localTime: number) {
+  let gain = clip.gainEnvelope?.length ? interpolateGainEnvelope(clip.gainEnvelope, localTime) : 1;
+
+  const fadeInDuration = clip.fadeInDuration ?? 0;
+  if (fadeInDuration > 0 && localTime < fadeInDuration) {
+    gain *= getFadeGain(clip.fadeInCurve, localTime / fadeInDuration);
+  }
+
+  const fadeOutDuration = clip.fadeOutDuration ?? 0;
+  const fadeOutStart = clip.duration - fadeOutDuration;
+  if (fadeOutDuration > 0 && localTime > fadeOutStart) {
+    const fadeProgress = (clip.duration - localTime) / fadeOutDuration;
+    gain *= getFadeGain(clip.fadeOutCurve, fadeProgress);
+  }
+
+  return gain;
+}
+
+export function mergeAudioClipBuffers(inputs: AudioClipRenderInput[]): MergedAudioData {
+  if (inputs.length === 0) {
+    throw new Error('No audio clips available to consolidate');
+  }
+
+  const sortedInputs = [...inputs].sort((a, b) => a.clip.startTime - b.clip.startTime || a.clip.id.localeCompare(b.clip.id));
+  const startTime = sortedInputs[0].clip.startTime;
+  const endTime = Math.max(...sortedInputs.map(({ clip }) => clip.startTime + clip.duration));
+  const sampleRate = Math.max(...sortedInputs.map(({ buffer }) => buffer.sampleRate));
+  const numberOfChannels = Math.max(...sortedInputs.map(({ buffer }) => buffer.numberOfChannels));
+  const totalLength = Math.max(1, Math.ceil((endTime - startTime) * sampleRate));
+  const channels = Array.from({ length: numberOfChannels }, () => new Float32Array(totalLength));
+
+  for (const { clip, buffer, sourceRegionStart } of sortedInputs) {
+    const clipStartSample = Math.round((clip.startTime - startTime) * sampleRate);
+    const clipLengthSamples = Math.max(1, Math.ceil(clip.duration * sampleRate));
+    const rate = clip.timeStretchRate ?? 1;
+    const audioOffset = clip.audioOffset ?? 0;
+
+    for (let sampleIndex = 0; sampleIndex < clipLengthSamples; sampleIndex++) {
+      const localTime = sampleIndex / sampleRate;
+      const sourceTime = sourceRegionStart + audioOffset + localTime * rate;
+      const gain = getClipGainAtTime(clip, localTime);
+      if (gain === 0) continue;
+
+      const outputIndex = clipStartSample + sampleIndex;
+      if (outputIndex >= totalLength) break;
+
+      for (let channel = 0; channel < numberOfChannels; channel++) {
+        channels[channel][outputIndex] += sampleBufferAtTime(buffer, channel, sourceTime) * gain;
+      }
+    }
+  }
+
+  return {
+    channels,
+    sampleRate,
+    numberOfChannels,
+    duration: endTime - startTime,
+  };
+}
+
+async function loadAudioInputs(project: Project, clips: Clip[]): Promise<AudioClipRenderInput[]> {
+  const engine = getAudioEngine();
+  const inputs: AudioClipRenderInput[] = [];
+
+  for (const clip of clips) {
+    const sourceKey = clip.isolatedAudioKey ?? clip.cumulativeMixKey;
+    if (!sourceKey) {
+      throw new Error('One or more selected clips do not have audio to consolidate');
+    }
+
+    const blob = await loadAudioBlobByKey(sourceKey);
+    if (!blob) {
+      throw new Error('One or more selected clips are missing audio data');
+    }
+
+    const buffer = await engine.decodeAudioData(blob);
+    inputs.push({
+      clip,
+      buffer,
+      sourceRegionStart: clip.isolatedAudioKey ? 0 : clip.startTime,
+    });
+  }
+
+  return inputs;
+}
+
+export async function renderConsolidatedAudioClip(project: Project, clips: Clip[]) {
+  const audioInputs = await loadAudioInputs(project, clips);
+  const merged = mergeAudioClipBuffers(audioInputs);
+  const engine = getAudioEngine();
+  const outputBuffer = engine.ctx.createBuffer(merged.numberOfChannels, merged.channels[0].length, merged.sampleRate);
+
+  for (let channel = 0; channel < merged.numberOfChannels; channel++) {
+    outputBuffer.getChannelData(channel).set(merged.channels[channel]);
+  }
+
+  const wavBlob = audioBufferToWavBlob(outputBuffer);
+  const clipId = uuidv4();
+  const isolatedAudioKey = await saveAudioBlob(project.id, clipId, 'isolated', wavBlob);
+
+  return {
+    id: clipId,
+    isolatedAudioKey,
+    waveformPeaks: computeWaveformPeaks(outputBuffer, 256),
+    duration: merged.duration,
+    audioDuration: merged.duration,
+  };
+}
+

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -81,6 +81,7 @@ import { beatToTime, getBeatAtBar } from '../utils/tempoMap';
 import { encodeMidiFile } from '../utils/midi';
 import { clampClipFadeDurations } from '../utils/clipFade';
 import { toastError, toastSuccess } from '../hooks/useToast';
+import { buildConsolidatedMidiClipData, renderConsolidatedAudioClip, validateClipConsolidation } from '../services/clipConsolidation';
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
   return (60 / bpm) * timeSig;
@@ -89,6 +90,11 @@ function getBarDurationSec(bpm: number, timeSig: number): number {
 function sanitizeFileNameSegment(value: string) {
   const trimmed = value.trim().replace(/[\\/:*?"<>|]/g, ' ');
   return trimmed.replace(/\s+/g, ' ').trim() || 'untitled';
+}
+
+function buildConsolidatedPrompt(clips: Clip[], fallback: string) {
+  const prompts = [...new Set(clips.map((clip) => clip.prompt.trim()).filter(Boolean))];
+  return prompts.length === 1 ? prompts[0] : fallback;
 }
 
 function downloadBlob(blob: Blob, fileName: string) {
@@ -215,6 +221,7 @@ interface ProjectState {
   /** Slip-edit: shift audioOffset by deltaSeconds without changing startTime/duration. */
   slipClip: (clipId: string, deltaSeconds: number) => void;
   splitClip: (clipId: string, splitTime: number) => void;
+  consolidateClips: (trackId: string, clipIds: string[]) => Promise<Clip | undefined>;
   toggleClipStar: (clipId: string) => void;
   moveClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => void;
   duplicateClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => Clip | undefined;
@@ -1837,6 +1844,119 @@ export const useProjectStore = create<ProjectState>()(
         tracks: newTracks,
       },
     });
+  },
+
+  consolidateClips: async (trackId, clipIds) => {
+    const state = get();
+    if (!state.project) {
+      toastError('Create or open a project before consolidating clips');
+      return undefined;
+    }
+
+    if (clipIds.length === 0) {
+      toastError('Select at least one clip to consolidate');
+      return undefined;
+    }
+
+    const track = state.project.tracks.find((candidate) => candidate.id === trackId);
+    if (!track) {
+      toastError('Track not found for consolidate');
+      return undefined;
+    }
+
+    const selectedClips = clipIds
+      .map((clipId) => track.clips.find((clip) => clip.id === clipId))
+      .filter((clip): clip is Clip => Boolean(clip));
+
+    if (selectedClips.length !== clipIds.length) {
+      toastError('Select clips from a single track before consolidating');
+      return undefined;
+    }
+
+    let validatedSelection;
+    try {
+      validatedSelection = validateClipConsolidation(trackId, selectedClips);
+    } catch (error) {
+      toastError(error instanceof Error ? error.message : 'Unable to consolidate the selected clips');
+      return undefined;
+    }
+
+    const { clips, mediaType } = validatedSelection;
+    const startTime = clips[0].startTime;
+    const endTime = Math.max(...clips.map((clip) => clip.startTime + clip.duration));
+    const prompt = buildConsolidatedPrompt(clips, mediaType === 'midi' ? 'Consolidated MIDI Clip' : 'Consolidated Audio Clip');
+    const lyrics = clips.map((clip) => clip.lyrics.trim()).filter(Boolean).join('\n');
+    const source = clips.every((clip) => clip.source === 'generated') ? 'generated' : 'uploaded';
+
+    _pushHistory(state.project);
+
+    let consolidatedClip: Clip;
+    if (mediaType === 'midi') {
+      const merged = buildConsolidatedMidiClipData(state.project, clips);
+      consolidatedClip = {
+        id: uuidv4(),
+        trackId,
+        startTime: merged.startTime,
+        duration: merged.duration,
+        prompt,
+        globalCaption: clips.map((clip) => clip.globalCaption?.trim()).filter(Boolean).join('\n'),
+        lyrics,
+        generationStatus: 'ready',
+        generationJobId: null,
+        cumulativeMixKey: null,
+        isolatedAudioKey: null,
+        waveformPeaks: null,
+        source,
+        midiData: merged.midiData,
+      };
+    } else {
+      try {
+        const rendered = await renderConsolidatedAudioClip(state.project, clips);
+        consolidatedClip = {
+          id: rendered.id,
+          trackId,
+          startTime,
+          duration: rendered.duration,
+          prompt,
+          globalCaption: clips.map((clip) => clip.globalCaption?.trim()).filter(Boolean).join('\n'),
+          lyrics,
+          generationStatus: 'ready',
+          generationJobId: null,
+          cumulativeMixKey: null,
+          isolatedAudioKey: rendered.isolatedAudioKey,
+          waveformPeaks: rendered.waveformPeaks,
+          source,
+          audioDuration: rendered.audioDuration,
+          audioOffset: 0,
+        };
+      } catch (error) {
+        _history.pop();
+        toastError(error instanceof Error ? error.message : 'Unable to consolidate the selected audio clips');
+        return undefined;
+      }
+    }
+
+    const clipIdSet = new Set(clips.map((clip) => clip.id));
+    const nextTracks = state.project.tracks.map((candidate) => {
+      if (candidate.id !== trackId) return candidate;
+      const remainingClips = candidate.clips.filter((clip) => !clipIdSet.has(clip.id));
+      return {
+        ...candidate,
+        clips: [...remainingClips, consolidatedClip].sort((a, b) => a.startTime - b.startTime || a.id.localeCompare(b.id)),
+      };
+    });
+
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(nextTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.tempoMap, state.project.timeSignatureMap),
+        tracks: nextTracks,
+      },
+    });
+
+    toastSuccess(mediaType === 'midi' ? 'Consolidated MIDI clips' : 'Consolidated audio clips');
+    return consolidatedClip;
   },
 
   updateClipStatus: (clipId, status, extra) => {

--- a/tests/e2e/consolidate-clips.spec.ts
+++ b/tests/e2e/consolidate-clips.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from '@playwright/test';
+
+const modKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+type ConsolidateTestWindow = Window & typeof globalThis & {
+  __store: {
+    getState(): {
+      createProject: (input: { name: string }) => void;
+      addTrack: (name: string, type: 'pianoRoll') => { id: string };
+      addClip: (
+        trackId: string,
+        clip: {
+          startTime: number;
+          duration: number;
+          prompt: string;
+          globalCaption: string;
+          lyrics: string;
+          midiData: {
+            grid: '1/16';
+            notes: Array<{ id: string; pitch: number; startBeat: number; durationBeats: number; velocity: number }>;
+          };
+          source: 'uploaded';
+        },
+      ) => { id: string };
+      project?: {
+        tracks?: Array<{
+          clips?: Array<{
+            midiData?: {
+              notes?: Array<unknown>;
+            };
+          }>;
+        }>;
+      };
+    };
+  };
+  __uiStore: {
+    getState(): {
+      setShowNewProjectDialog: (value: boolean) => void;
+      selectClips: (clipIds: string[]) => void;
+    };
+  };
+};
+
+test.describe('Consolidate Clips Workflow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(
+      () => typeof (window as unknown as Partial<ConsolidateTestWindow>).__store !== 'undefined',
+      null,
+      { timeout: 10000 },
+    );
+    await page.evaluate(() => {
+      const testWindow = window as unknown as ConsolidateTestWindow;
+      testWindow.__store.getState().createProject({ name: 'Consolidate E2E' });
+      testWindow.__uiStore.getState().setShowNewProjectDialog(false);
+    });
+    await page.getByText('Click anywhere to enable audio').click();
+  });
+
+  test('consolidates selected clips with the keyboard shortcut', async ({ page }) => {
+    const clipIds = await page.evaluate(() => {
+      const store = (window as unknown as ConsolidateTestWindow).__store;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      const clipA = store.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 1,
+        prompt: 'phrase-a',
+        globalCaption: '',
+        lyrics: '',
+        midiData: {
+          grid: '1/16',
+          notes: [{ id: 'note-a', pitch: 60, startBeat: 0, durationBeats: 1, velocity: 0.8 }],
+        },
+        source: 'uploaded',
+      });
+      const clipB = store.getState().addClip(track.id, {
+        startTime: 1,
+        duration: 1,
+        prompt: 'phrase-b',
+        globalCaption: '',
+        lyrics: '',
+        midiData: {
+          grid: '1/16',
+          notes: [{ id: 'note-b', pitch: 64, startBeat: 0.5, durationBeats: 0.5, velocity: 0.7 }],
+        },
+        source: 'uploaded',
+      });
+      return [clipA.id, clipB.id];
+    });
+
+    await page.evaluate((ids) => {
+      (window as unknown as ConsolidateTestWindow).__uiStore.getState().selectClips(ids);
+    }, clipIds);
+
+    await page.evaluate((mod) => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        code: 'KeyJ',
+        key: 'j',
+        bubbles: true,
+        ctrlKey: mod === 'Control',
+        metaKey: mod === 'Meta',
+      }));
+    }, modKey);
+
+    await page.waitForFunction(() => {
+      const testWindow = window as unknown as ConsolidateTestWindow;
+      return testWindow.__store.getState().project?.tracks?.[0]?.clips?.length === 1;
+    });
+    await expect(page.getByTestId(`clip-${clipIds[0]}`)).toHaveCount(0);
+    await expect(page.getByTestId(`clip-${clipIds[1]}`)).toHaveCount(0);
+
+    const consolidated = await page.evaluate(() => {
+      const clips = (window as unknown as ConsolidateTestWindow).__store.getState().project?.tracks?.[0]?.clips ?? [];
+      return {
+        count: clips.length,
+        noteCount: clips[0]?.midiData?.notes?.length ?? 0,
+      };
+    });
+
+    expect(consolidated).toEqual({ count: 1, noteCount: 2 });
+  });
+
+  test('shows consolidate in the clip context menu and merges the current selection', async ({ page }) => {
+    const clipIds = await page.evaluate(() => {
+      const store = (window as unknown as ConsolidateTestWindow).__store;
+      const track = store.getState().addTrack('keyboard', 'pianoRoll');
+      const clipA = store.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 1,
+        prompt: 'riff-a',
+        globalCaption: '',
+        lyrics: '',
+        midiData: {
+          grid: '1/16',
+          notes: [{ id: 'note-a', pitch: 67, startBeat: 0, durationBeats: 1, velocity: 0.9 }],
+        },
+        source: 'uploaded',
+      });
+      const clipB = store.getState().addClip(track.id, {
+        startTime: 1,
+        duration: 1,
+        prompt: 'riff-b',
+        globalCaption: '',
+        lyrics: '',
+        midiData: {
+          grid: '1/16',
+          notes: [{ id: 'note-b', pitch: 69, startBeat: 0, durationBeats: 1, velocity: 0.75 }],
+        },
+        source: 'uploaded',
+      });
+      return [clipA.id, clipB.id];
+    });
+
+    await page.evaluate((ids) => {
+      (window as unknown as ConsolidateTestWindow).__uiStore.getState().selectClips(ids);
+    }, clipIds);
+
+    await page.evaluate((clipId) => {
+      const node = document.querySelector(`[data-testid="clip-${clipId}"]`);
+      if (!node) return;
+      node.dispatchEvent(new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 240,
+        clientY: 180,
+        button: 2,
+      }));
+    }, clipIds[1]);
+    await expect(page.getByRole('button', { name: 'Consolidate' })).toBeVisible();
+    await page.getByRole('button', { name: 'Consolidate' }).click();
+
+    await page.waitForFunction(() => {
+      const testWindow = window as unknown as ConsolidateTestWindow;
+      return testWindow.__store.getState().project?.tracks?.[0]?.clips?.length === 1;
+    });
+    const count = await page.evaluate(() => (
+      (window as unknown as ConsolidateTestWindow).__store.getState().project?.tracks?.[0]?.clips?.length ?? 0
+    ));
+    expect(count).toBe(1);
+  });
+});

--- a/tests/unit/clipConsolidation.test.ts
+++ b/tests/unit/clipConsolidation.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { Clip, Project } from '../../src/types/project';
+import { buildConsolidatedMidiClipData, mergeAudioClipBuffers } from '../../src/services/clipConsolidation';
+
+function makeProject(): Project {
+  return {
+    id: 'project-1',
+    name: 'Consolidation Test',
+    createdAt: 1,
+    updatedAt: 1,
+    bpm: 120,
+    keyScale: 'C major',
+    timeSignature: 4,
+    totalDuration: 32,
+    measures: 16,
+    tracks: [],
+    trackPresets: [],
+    generationDefaults: {
+      inferenceSteps: 20,
+      guidanceScale: 7.5,
+      shift: 0,
+      thinking: false,
+      model: 'test-model',
+    },
+    globalCaption: '',
+    automationLanes: [],
+    assets: [],
+  };
+}
+
+function makeClip(overrides: Partial<Clip>): Clip {
+  return {
+    id: overrides.id ?? 'clip',
+    trackId: overrides.trackId ?? 'track-1',
+    startTime: overrides.startTime ?? 0,
+    duration: overrides.duration ?? 1,
+    prompt: overrides.prompt ?? '',
+    lyrics: overrides.lyrics ?? '',
+    generationStatus: overrides.generationStatus ?? 'ready',
+    generationJobId: overrides.generationJobId ?? null,
+    cumulativeMixKey: overrides.cumulativeMixKey ?? null,
+    isolatedAudioKey: overrides.isolatedAudioKey ?? null,
+    waveformPeaks: overrides.waveformPeaks ?? null,
+    ...overrides,
+  };
+}
+
+function makeMockAudioBuffer(channelData: number[][], sampleRate: number) {
+  const channels = channelData.map((values) => Float32Array.from(values));
+  const length = channels[0]?.length ?? 0;
+  return {
+    numberOfChannels: channels.length,
+    length,
+    sampleRate,
+    duration: length / sampleRate,
+    getChannelData: (channel: number) => channels[channel],
+  } as AudioBuffer;
+}
+
+describe('clipConsolidation', () => {
+  it('merges MIDI notes into one clip-relative note list', () => {
+    const project = makeProject();
+    const clipA = makeClip({
+      id: 'clip-a',
+      startTime: 0,
+      duration: 1,
+      midiData: {
+        grid: '1/16',
+        notes: [{ id: 'n1', pitch: 60, startBeat: 0, durationBeats: 1, velocity: 0.8 }],
+      },
+    });
+    const clipB = makeClip({
+      id: 'clip-b',
+      startTime: 1,
+      duration: 1,
+      midiData: {
+        grid: '1/16',
+        notes: [{ id: 'n2', pitch: 64, startBeat: 0.5, durationBeats: 0.5, velocity: 0.7 }],
+      },
+    });
+
+    const merged = buildConsolidatedMidiClipData(project, [clipB, clipA]);
+
+    expect(merged.startTime).toBe(0);
+    expect(merged.duration).toBe(2);
+    expect(merged.midiData.notes).toHaveLength(2);
+    expect(merged.midiData.notes.map((note) => note.pitch)).toEqual([60, 64]);
+    expect(merged.midiData.notes.map((note) => note.startBeat)).toEqual([0, 2.5]);
+  });
+
+  it('merges audio clips with silence gaps and clip gain', () => {
+    const clipA = makeClip({
+      id: 'clip-a',
+      startTime: 0,
+      duration: 0.5,
+      gainEnvelope: [{ time: 0, gain: 0.5 }],
+    });
+    const clipB = makeClip({
+      id: 'clip-b',
+      startTime: 1,
+      duration: 0.5,
+    });
+
+    const merged = mergeAudioClipBuffers([
+      {
+        clip: clipA,
+        buffer: makeMockAudioBuffer([[1, 1]], 4),
+        sourceRegionStart: 0,
+      },
+      {
+        clip: clipB,
+        buffer: makeMockAudioBuffer([[1, 1]], 4),
+        sourceRegionStart: 0,
+      },
+    ]);
+
+    expect(merged.duration).toBe(1.5);
+    expect(Array.from(merged.channels[0])).toEqual([0.5, 0.5, 0, 0, 1, 1]);
+  });
+});

--- a/tests/unit/projectStore.test.ts
+++ b/tests/unit/projectStore.test.ts
@@ -7,6 +7,59 @@ vi.mock('../../src/services/projectStorage', () => ({
   saveProject: vi.fn(),
 }));
 
+const mockLoadAudioBlobByKey = vi.fn();
+const mockSaveAudioBlob = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock('../../src/services/audioFileManager', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/audioFileManager')>('../../src/services/audioFileManager');
+  return {
+    ...actual,
+    loadAudioBlobByKey: (...args: unknown[]) => mockLoadAudioBlobByKey(...args),
+    saveAudioBlob: (...args: unknown[]) => mockSaveAudioBlob(...args),
+  };
+});
+
+vi.mock('../../src/hooks/useToast', () => ({
+  toastSuccess: (...args: unknown[]) => mockToastSuccess(...args),
+  toastError: (...args: unknown[]) => mockToastError(...args),
+}));
+
+function createMockAudioBuffer(channelData: number[][], sampleRate = 4): AudioBuffer {
+  const channels = channelData.map((values) => Float32Array.from(values));
+  const length = channels[0]?.length ?? 0;
+  return {
+    numberOfChannels: channels.length,
+    length,
+    sampleRate,
+    duration: length / sampleRate,
+    getChannelData: (channel: number) => channels[channel],
+  } as AudioBuffer;
+}
+
+const mockAudioContext = {
+  createBuffer: vi.fn((numberOfChannels: number, length: number, sampleRate: number) => {
+    const channels = Array.from({ length: numberOfChannels }, () => new Float32Array(length));
+    return {
+      numberOfChannels,
+      length,
+      sampleRate,
+      duration: length / sampleRate,
+      getChannelData: (channel: number) => channels[channel],
+    } as AudioBuffer;
+  }),
+};
+
+const mockDecodeAudioData = vi.fn();
+
+vi.mock('../../src/hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    ctx: mockAudioContext,
+    decodeAudioData: (...args: unknown[]) => mockDecodeAudioData(...args),
+  }),
+}));
+
 function makeProject(): Project {
   return {
     id: 'project-1',
@@ -37,6 +90,12 @@ describe('projectStore', () => {
   beforeEach(() => {
     localStorage.clear();
     useProjectStore.setState(useProjectStore.getInitialState(), true);
+    mockLoadAudioBlobByKey.mockReset();
+    mockSaveAudioBlob.mockReset();
+    mockToastSuccess.mockReset();
+    mockToastError.mockReset();
+    mockDecodeAudioData.mockReset();
+    mockAudioContext.createBuffer.mockClear();
   });
 
   describe('setProject / project getter', () => {
@@ -49,8 +108,9 @@ describe('projectStore', () => {
         ...project,
         mastering: createDefaultMasteringState(),
       });
-    });
   });
+});
+});
 
   describe('addTrack / removeTrack', () => {
     beforeEach(() => {
@@ -296,7 +356,92 @@ describe('projectStore', () => {
       createObjectURL.mockRestore();
     });
   });
-});
+
+  describe('consolidateClips', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject();
+    });
+
+    it('merges selected MIDI clips on one track into a single clip', async () => {
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      const clipA = useProjectStore.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 1,
+        prompt: 'phrase-a',
+        globalCaption: '',
+        lyrics: '',
+        midiData: {
+          grid: '1/16',
+          notes: [{ id: 'n1', pitch: 60, startBeat: 0, durationBeats: 1, velocity: 0.8 }],
+        },
+        source: 'uploaded',
+      });
+      const clipB = useProjectStore.getState().addClip(track.id, {
+        startTime: 1,
+        duration: 1,
+        prompt: 'phrase-b',
+        globalCaption: '',
+        lyrics: '',
+        midiData: {
+          grid: '1/16',
+          notes: [{ id: 'n2', pitch: 64, startBeat: 0.5, durationBeats: 0.5, velocity: 0.7 }],
+        },
+        source: 'uploaded',
+      });
+
+      const consolidated = await useProjectStore.getState().consolidateClips(track.id, [clipA.id, clipB.id]);
+
+      expect(consolidated).toBeDefined();
+      expect(useProjectStore.getState().project?.tracks[0].clips).toHaveLength(1);
+      expect(consolidated?.midiData?.notes).toHaveLength(2);
+      expect(consolidated?.midiData?.notes.map((note) => note.startBeat)).toEqual([0, 2.5]);
+    });
+
+    it('renders selected audio clips into one replacement clip', async () => {
+      const track = useProjectStore.getState().addTrack('drums', 'sample');
+      const clipA = useProjectStore.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 0.5,
+        prompt: 'kick-a',
+        globalCaption: '',
+        lyrics: '',
+        source: 'uploaded',
+      });
+      const clipB = useProjectStore.getState().addClip(track.id, {
+        startTime: 1,
+        duration: 0.5,
+        prompt: 'kick-b',
+        globalCaption: '',
+        lyrics: '',
+        source: 'uploaded',
+      });
+
+      useProjectStore.getState().updateClip(clipA.id, {
+        generationStatus: 'ready',
+        isolatedAudioKey: 'audio-a',
+        gainEnvelope: [{ time: 0, gain: 0.5 }],
+      });
+      useProjectStore.getState().updateClip(clipB.id, {
+        generationStatus: 'ready',
+        isolatedAudioKey: 'audio-b',
+      });
+
+      mockLoadAudioBlobByKey.mockResolvedValue(new Blob(['wav'], { type: 'audio/wav' }));
+      mockSaveAudioBlob.mockResolvedValue('merged-audio-key');
+      mockDecodeAudioData
+        .mockResolvedValueOnce(createMockAudioBuffer([[1, 1]], 4))
+        .mockResolvedValueOnce(createMockAudioBuffer([[1, 1]], 4));
+
+      const consolidated = await useProjectStore.getState().consolidateClips(track.id, [clipA.id, clipB.id]);
+
+      expect(consolidated).toBeDefined();
+      expect(consolidated?.isolatedAudioKey).toBe('merged-audio-key');
+      expect(consolidated?.generationStatus).toBe('ready');
+      expect(consolidated?.duration).toBe(1.5);
+      expect(useProjectStore.getState().project?.tracks[0].clips).toHaveLength(1);
+      expect(mockSaveAudioBlob).toHaveBeenCalledTimes(1);
+    });
+  });
 
   describe('duplicateTrack', () => {
     beforeEach(() => {

--- a/tests/unit/undoRedo.test.ts
+++ b/tests/unit/undoRedo.test.ts
@@ -120,4 +120,38 @@ describe('Undo / Redo', () => {
     useProjectStore.getState().undo();
     expect(useProjectStore.getState().project!.tracks[0].clips[0].midiData!.notes[0].startBeat).toBe(0.3);
   });
+
+  it('undoes clip consolidation', async () => {
+    const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+    const clipA = useProjectStore.getState().addClip(track.id, {
+      startTime: 0,
+      duration: 1,
+      prompt: 'part-a',
+      globalCaption: '',
+      lyrics: '',
+      midiData: {
+        grid: '1/16',
+        notes: [{ id: 'n1', pitch: 60, startBeat: 0, durationBeats: 1, velocity: 0.8 }],
+      },
+      source: 'uploaded',
+    });
+    const clipB = useProjectStore.getState().addClip(track.id, {
+      startTime: 1,
+      duration: 1,
+      prompt: 'part-b',
+      globalCaption: '',
+      lyrics: '',
+      midiData: {
+        grid: '1/16',
+        notes: [{ id: 'n2', pitch: 64, startBeat: 0, durationBeats: 1, velocity: 0.7 }],
+      },
+      source: 'uploaded',
+    });
+
+    await useProjectStore.getState().consolidateClips(track.id, [clipA.id, clipB.id]);
+    expect(useProjectStore.getState().project!.tracks[0].clips).toHaveLength(1);
+
+    useProjectStore.getState().undo();
+    expect(useProjectStore.getState().project!.tracks[0].clips).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Summary
- add track-local `consolidateClips(trackId, clipIds)` to the project store for both MIDI and audio selections
- add a dedicated consolidation service that merges MIDI note timing and renders audio clips with silence gaps, clip gain envelopes, and fades
- wire the workflow into `Cmd/Ctrl+J`, the clip context menu, research/plan docs, and unit/E2E coverage

## Problem
ACE-Step DAW supported splitting and duplicating clips but not merging fragmented edits back into one clip. Issue #330 asked for a same-track consolidate/glue workflow with store API, undo support, keyboard shortcut, context menu access, and tests.

## What changed
- `src/store/projectStore.ts`
  - added async `consolidateClips(trackId, clipIds)`
  - validates same-track/same-media selections
  - replaces selected clips with one consolidated clip
  - preserves undo as a single history step
- `src/services/clipConsolidation.ts`
  - added MIDI merge helper using clip-relative note rebasing
  - added audio merge renderer with silence gaps, gain envelopes, fades, and WAV persistence
- `src/hooks/useKeyboardShortcuts.ts`
  - added `Cmd/Ctrl+J` binding for current clip selection
- `src/components/timeline/ClipContextMenu.tsx`
  - added `Consolidate` action
- `src/components/timeline/ClipBlock.tsx`
  - routes the current selection into consolidate and reselects the new clip
- `src/components/dialogs/KeyboardShortcutsDialog.tsx`
  - documented the new shortcut
- `tests/unit/clipConsolidation.test.ts`
  - added pure merge tests for MIDI and audio consolidation logic
- `tests/unit/projectStore.test.ts`
  - added store API tests for MIDI and audio consolidate workflows
- `tests/unit/undoRedo.test.ts`
  - added undo coverage for consolidation
- `tests/e2e/consolidate-clips.spec.ts`
  - added browser coverage for shortcut and context-menu workflows via exposed stores/events
- `docs/research-notes/consolidate-clips-competitive-research-20260319.md`
  - documented Ableton-based behavior reference
- `docs/plans/feat-consolidate-clips.md`
  - added executable feature plan per AGENTS.md

## Verification
- `npm test -- tests/unit/clipConsolidation.test.ts tests/unit/projectStore.test.ts tests/unit/undoRedo.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `npx playwright test tests/e2e/consolidate-clips.spec.ts --workers=1`

Closes #330.
