### PR TITLE
feat: build Cmd+K command palette with natural-language search

### DIFF
--- a/docs/plans/feat-command-palette.md
+++ b/docs/plans/feat-command-palette.md
@@ -1,0 +1,101 @@
+# Feature Plan: Command Palette with Natural-Language Action Search
+
+Issue: #322
+
+## 1. Problem
+
+ACE-Step’s design documentation treats `Cmd+K` as a core navigation and execution surface, but the application has no command palette implementation.
+
+- Users cannot discover DAW actions from a single keyboard-first entry point.
+- Natural-language intents such as `add reverb to vocals` or `tempo 140` have no searchable execution path.
+- Repeat workflows are slower because the app does not remember recent commands.
+- Agents can call Zustand actions directly, but there is no shared searchable command surface that matches how human users would trigger the same operations.
+
+## 2. Root Cause
+
+- `src/hooks/useKeyboardShortcuts.ts` defines many shortcuts, but there is no `Cmd/Ctrl+K` handler or command registry.
+- `src/store/uiStore.ts` owns modal and panel state, but it has no state or actions for a command palette, recent command history, or searchable command execution.
+- The UI exposes several isolated entry points in `Toolbar.tsx` and dialog components, but those actions are not indexed into a common search model.
+- No unit or E2E coverage currently verifies a searchable action layer or command execution parity.
+
+## 3. Solution
+
+### 3a. Add a typed command registry
+
+- Create `src/services/commandPalette.ts`.
+- Build command definitions from current DAW state so results can include:
+  - transport actions
+  - project/settings actions
+  - panel toggles
+  - selected-clip actions
+  - dynamic per-track effect actions
+  - parsed BPM / tempo commands
+- Add fuzzy-ish ranking using normalized aliases, keywords, and token matching.
+
+### 3b. Add UI-store command palette state
+
+- Extend `src/store/uiStore.ts` with:
+  - `showCommandPalette`
+  - `commandPaletteQuery`
+  - `recentCommandIds`
+  - `openCommandPalette`
+  - `closeCommandPalette`
+  - `setCommandPaletteQuery`
+  - `searchCommandPalette`
+  - `executeCommandPaletteCommand`
+- Persist only recent command ids, not transient dialog/query state.
+
+### 3c. Build the palette dialog
+
+- Add `src/components/dialogs/CommandPalette.tsx`.
+- Requirements:
+  - autofocus search input
+  - arrow-key result navigation
+  - Enter to execute
+  - Escape / backdrop close
+  - ARIA labels for dialog, input, and results
+- Mount it from `AppShell.tsx` and add a discoverable toolbar button.
+
+### 3d. Wire keyboard entry
+
+- Update `src/hooks/useKeyboardShortcuts.ts` so `Cmd/Ctrl+K` toggles the palette even when focus is inside a text field.
+- Make Escape close the palette before other dialogs.
+- Add the shortcut to `KeyboardShortcutsDialog.tsx`.
+
+### 3e. Verify with tests
+
+- Unit test fuzzy intent matching and BPM parsing in `tests/unit/commandPalette.test.ts`.
+- Extend `tests/unit/uiStore.test.ts` for recent command persistence behavior.
+- Add Playwright coverage in `tests/e2e/command-palette.spec.ts`:
+  - open via keyboard
+  - search `add reverb to vocals`
+  - execute the command
+  - verify the track effect was added through store state
+
+## 4. Verification
+
+- `npx tsc --noEmit`
+- `npm run build`
+- `npm test`
+- `npx playwright test tests/e2e/command-palette.spec.ts`
+
+User-story verification:
+
+- As a user, I want to press `Cmd/Ctrl+K` and open a global command palette from anywhere in the DAW, so that I can reach actions without panel hunting.
+- As a user, I want to type `add reverb to vocals` or `tempo 140` and execute the intended command, so that I can work in plain language.
+- As an agent, I want to call `window.__uiStore.getState().searchCommandPalette(query)` and `executeCommandPaletteCommand(id)`, so that I can use the same command surface programmatically.
+
+## 5. Files To Touch
+
+- `docs/research-notes/command-palette-competitive-research-20260319.md`
+- `docs/plans/feat-command-palette.md`
+- `src/components/dialogs/CommandPalette.tsx`
+- `src/components/dialogs/KeyboardShortcutsDialog.tsx`
+- `src/components/layout/AppShell.tsx`
+- `src/components/layout/Toolbar.tsx`
+- `src/hooks/useKeyboardShortcuts.ts`
+- `src/services/commandPalette.ts`
+- `src/store/uiStore.ts`
+- `tests/e2e/command-palette.spec.ts`
+- `tests/unit/commandPalette.test.ts`
+- `tests/unit/uiStore.test.ts`

--- a/docs/research-notes/command-palette-competitive-research-20260319.md
+++ b/docs/research-notes/command-palette-competitive-research-20260319.md
@@ -1,0 +1,54 @@
+# Competitive Research: Command Palette for Keyboard-First DAW Workflows
+
+Date: 2026-03-19
+Issue: #322
+
+## Sources
+
+- ACE-Step interaction design guide
+  `docs/design/INTERACTION_DESIGN_GUIDE.md`
+- ACE-Step UX improvement checklist
+  `docs/design/UX_IMPROVEMENT_CHECKLIST.md`
+- Visual Studio Code keyboard shortcuts reference
+  https://code.visualstudio.com/docs/getstarted/keybindings
+
+## Interaction Findings
+
+### ACE-Step design requirements
+
+- The interaction guide treats `Cmd+K` as a critical surface for both human users and AI agents.
+- The guide requires command discovery to be action-oriented instead of panel-oriented. Users should be able to express an intention such as "add reverb to vocals" instead of hunting through mixer or inspector UI.
+- The UX checklist explicitly calls for fuzzy matching, natural-language matching, recent commands, and parameter search. Those are not optional polish items for this feature; they are the acceptance standard.
+
+### VS Code command palette
+
+- VS Code keeps the command palette globally reachable and keyboard-first. That establishes the baseline expectation that the surface can open from almost anywhere in the application.
+- Matching is tolerant of partial phrases and non-exact command names. This is useful for ACE-Step because DAW users often think in goals ("tempo 140", "open mixer", "reverb vocals") rather than exact menu labels.
+- Commands execute from a single action surface instead of bespoke UI-only handlers. That is the right model for ACE-Step because AGENTS.md requires parity between human and agent workflows.
+
+## Product Implications for ACE-Step
+
+- The palette must open with `Cmd/Ctrl+K` without depending on the current panel.
+- Results need more than title matching. They should index:
+  - action names
+  - settings and parameters such as BPM / tempo
+  - dynamic project entities such as track names
+  - natural-language aliases
+- Recent commands should be stored and boosted so repeat workflows become faster over time.
+- Command execution must call the same Zustand-backed actions used elsewhere in the app so browser automation and future agent tooling can execute identical operations.
+
+## Copy / Improve / Skip
+
+- Copy: globally reachable keyboard-first palette entry point.
+- Copy: tolerant matching against aliases and partial phrases.
+- Improve: index DAW-specific entities such as selected clips, track names, tempo, and effect intents.
+- Improve: expose palette search and execution through `window.__uiStore`.
+- Skip for now: full free-form NLP parsing and arbitrary parameter editing. Phase 1 should cover common action intents plus BPM parsing with deterministic behavior.
+
+## Implementation Standard for #322
+
+- Global palette dialog opened by `Cmd/Ctrl+K`.
+- Search results sourced from a typed command registry, not ad hoc component callbacks.
+- Dynamic commands for track/effect intents, including queries like `add reverb to vocals`.
+- Recent command ordering when the query is empty.
+- Programmatic execution path available via UI store actions for agents and browser tests.

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useUIStore } from '../../store/uiStore';
+
+function ShortcutHint({ keys }: { keys?: string[] }) {
+  if (!keys || keys.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1 flex-shrink-0">
+      {keys.map((key) => (
+        <kbd
+          key={key}
+          className="inline-flex min-w-[1.25rem] items-center justify-center rounded border border-white/10 bg-white/5 px-1.5 py-0.5 text-[10px] font-mono font-semibold text-zinc-400"
+        >
+          {key}
+        </kbd>
+      ))}
+    </div>
+  );
+}
+
+export function CommandPalette() {
+  const show = useUIStore((state) => state.showCommandPalette);
+  const query = useUIStore((state) => state.commandPaletteQuery);
+  const recentCommandIds = useUIStore((state) => state.recentCommandIds);
+  const setQuery = useUIStore((state) => state.setCommandPaletteQuery);
+  const close = useUIStore((state) => state.closeCommandPalette);
+  const search = useUIStore((state) => state.searchCommandPalette);
+  const execute = useUIStore((state) => state.executeCommandPaletteCommand);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const results = useMemo(() => search(query), [query, recentCommandIds, search]);
+
+  useEffect(() => {
+    if (!show) return;
+
+    setSelectedIndex(0);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+  }, [show]);
+
+  useEffect(() => {
+    if (selectedIndex >= results.length) {
+      setSelectedIndex(results.length > 0 ? results.length - 1 : 0);
+    }
+  }, [results, selectedIndex]);
+
+  if (!show) return null;
+
+  const activeResult = results[selectedIndex] ?? null;
+
+  const runSelected = async () => {
+    if (!activeResult) return;
+    await execute(activeResult.id);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[160] flex items-start justify-center bg-black/55 px-4 pt-[10vh] backdrop-blur-sm"
+      onMouseDown={(event) => event.target === event.currentTarget && close()}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        className="flex w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#171717]/96 shadow-[0_40px_120px_rgba(0,0,0,0.55)]"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="border-b border-white/8 px-4 py-3">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div>
+              <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-zinc-500">
+                Command Palette
+              </div>
+              <div className="text-xs text-zinc-400">
+                Search actions, track intents, parameters, and recent workflows
+              </div>
+            </div>
+            <ShortcutHint keys={['Esc']} />
+          </div>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setSelectedIndex((index) => Math.min(index + 1, results.length - 1));
+              } else if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                setSelectedIndex((index) => Math.max(index - 1, 0));
+              } else if (event.key === 'Enter') {
+                event.preventDefault();
+                void runSelected();
+              } else if (event.key === 'Escape') {
+                event.preventDefault();
+                close();
+              }
+            }}
+            placeholder="Try “add reverb to vocals” or “tempo 140”"
+            aria-label="Command palette search"
+            className="w-full rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-zinc-100 outline-none transition focus:border-cyan-400/60 focus:bg-black/30"
+          />
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto p-2">
+          {results.length > 0 ? (
+            <div className="space-y-1" role="listbox" aria-label="Command results">
+              {results.map((result, index) => {
+                const active = index === selectedIndex;
+                return (
+                  <button
+                    key={result.id}
+                    type="button"
+                    role="option"
+                    aria-selected={active}
+                    aria-label={result.title}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    onClick={() => {
+                      void execute(result.id);
+                    }}
+                    className={`flex w-full items-center justify-between gap-4 rounded-xl px-3 py-3 text-left transition ${
+                      active
+                        ? 'bg-cyan-500/14 ring-1 ring-cyan-400/35'
+                        : 'hover:bg-white/5'
+                    }`}
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate text-sm font-medium text-zinc-100">{result.title}</span>
+                        {result.isRecent && (
+                          <span className="rounded-full border border-cyan-400/30 bg-cyan-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-cyan-300">
+                            Recent
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+                        <span>{result.section}</span>
+                        {result.subtitle && (
+                          <>
+                            <span className="text-zinc-600">•</span>
+                            <span>{result.subtitle}</span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    <ShortcutHint keys={result.shortcut} />
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="px-4 py-8 text-center">
+              <div className="text-sm font-medium text-zinc-200">No matching commands</div>
+              <div className="mt-1 text-xs text-zinc-500">
+                Try a track intent, action name, or parameter such as “tempo 128”.
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -76,6 +76,7 @@ const SECTIONS: Section[] = [
   {
     title: 'Project',
     rows: [
+      { keys: [`${mod}`, 'K'],         description: 'Open command palette' },
       { keys: [`${mod}`, 'N'],         description: 'New project' },
       { keys: [`${mod}`, 'O'],         description: 'Open project list' },
       { keys: [`${mod}`, ','],         description: 'Settings' },
@@ -129,6 +130,7 @@ export function KeyboardShortcutsDialog() {
           <h2 className="text-sm font-semibold text-zinc-100">Keyboard Shortcuts</h2>
           <button
             onClick={() => setShow(false)}
+            aria-label="Close keyboard shortcuts"
             className="text-zinc-500 hover:text-zinc-200 transition-colors text-lg leading-none"
           >
             ×

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -16,6 +16,7 @@ import { SettingsDialog } from '../dialogs/SettingsDialog';
 import { ProjectListDialog } from '../dialogs/ProjectListDialog';
 import { KeyboardShortcutsDialog } from '../dialogs/KeyboardShortcutsDialog';
 import { ShortcutEditorDialog } from '../dialogs/ShortcutEditorDialog';
+import { CommandPalette } from '../dialogs/CommandPalette';
 import { ShareDialog } from '../dialogs/ShareDialog';
 import { AIAssistantPanel } from '../dialogs/AIAssistantPanel';
 import { MixerPanel } from '../mixer/MixerPanel';
@@ -104,6 +105,7 @@ export function AppShell() {
       <SettingsDialog />
       <ProjectListDialog />
       <KeyboardShortcutsDialog />
+      <CommandPalette />
       <ShortcutEditorDialog />
       <CoverModal />
       <RepaintModal />

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { useTransportStore } from '../../store/transportStore';
@@ -73,6 +74,7 @@ export function Toolbar() {
   const setShowExportDialog = useUIStore((s) => s.setShowExportDialog);
   const setShowProjectListDialog = useUIStore((s) => s.setShowProjectListDialog);
   const setShowKeyboardShortcutsDialog = useUIStore((s) => s.setShowKeyboardShortcutsDialog);
+  const openCommandPalette = useUIStore((s) => s.openCommandPalette);
   const showMixer = useUIStore((s) => s.showMixer);
   const setShowMixer = useUIStore((s) => s.setShowMixer);
   const loopBrowserOpen = useUIStore((s) => s.loopBrowserOpen);
@@ -96,6 +98,18 @@ export function Toolbar() {
   const toggleMetronome = useTransportStore((s) => s.toggleMetronome);
   const zoomIn = useUIStore((s) => s.zoomIn);
   const zoomOut = useUIStore((s) => s.zoomOut);
+
+  useEffect(() => {
+    (window as unknown as Record<string, unknown>).__commandPaletteRuntime = {
+      play,
+      pause,
+      stop,
+    };
+
+    return () => {
+      delete (window as unknown as Record<string, unknown>).__commandPaletteRuntime;
+    };
+  }, [pause, play, stop]);
 
   return (
     <div className="flex items-center h-11 px-2 gap-1 bg-gradient-to-b from-[#3a3a3a] to-[#2d2d2d] border-b border-[#1a1a1a] shrink-0 select-none">
@@ -261,6 +275,21 @@ export function Toolbar() {
 
       {/* Settings + Shortcuts */}
       <div className="flex items-center gap-0.5">
+        <button
+          onClick={() => openCommandPalette()}
+          className="flex items-center gap-2 rounded px-2 py-1 text-[11px] text-zinc-300 transition-colors hover:bg-daw-surface-2 hover:text-white"
+          title="Command Palette (Cmd/Ctrl+K)"
+          aria-label="Open command palette"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3">
+            <circle cx="6" cy="6" r="3.75" />
+            <path d="M8.8 8.8L12 12" strokeLinecap="round" />
+          </svg>
+          <span>Command</span>
+          <span className="rounded border border-white/10 bg-white/5 px-1.5 py-0.5 text-[9px] font-semibold text-zinc-400">
+            Cmd+K
+          </span>
+        </button>
         <button
           onClick={() => setShowSettingsDialog(true)}
           className="px-2 py-1 text-[11px] text-zinc-400 hover:text-white hover:bg-daw-surface-2 rounded transition-colors"

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -39,6 +39,17 @@ export function useKeyboardShortcuts() {
     const handler = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
       const getCombo = useShortcutsStore.getState().getCombo;
+      const ui = useUIStore.getState();
+
+      if (mod && e.code === 'KeyK') {
+        e.preventDefault();
+        if (ui.showCommandPalette) {
+          ui.closeCommandPalette();
+        } else {
+          ui.openCommandPalette();
+        }
+        return;
+      }
 
       // Undo/Redo are always available — even when an input field is focused
       if (mod && e.code === 'KeyZ' && !e.altKey) {
@@ -55,7 +66,6 @@ export function useKeyboardShortcuts() {
 
       if (isInputFocused(e)) return;
 
-      const ui = useUIStore.getState();
       const project = useProjectStore.getState();
       const transport = useTransportStore.getState();
       const gen = useGenerationStore.getState();
@@ -67,7 +77,10 @@ export function useKeyboardShortcuts() {
       // Escape — close topmost modal in priority order (not rebindable)
       // -----------------------------------------------------------------------
       if (e.code === 'Escape') {
-        if (ui.showAIAssistant) {
+        if (ui.showCommandPalette) {
+          e.preventDefault();
+          ui.closeCommandPalette();
+        } else if (ui.showAIAssistant) {
           e.preventDefault();
           ui.setShowAIAssistant(false);
         } else if (ui.editingClipId !== null) {
@@ -108,6 +121,7 @@ export function useKeyboardShortcuts() {
 
       // Don't fire any other shortcut when a modal is open (except Escape above)
       const anyModalOpen =
+        ui.showCommandPalette ||
         ui.editingClipId !== null ||
         ui.batchGenerateMode !== null ||
         ui.showKeyboardShortcutsDialog ||

--- a/src/services/commandPalette.ts
+++ b/src/services/commandPalette.ts
@@ -1,0 +1,601 @@
+import type { Project, Track, TrackEffectType, TrackName, TrackType } from '../types/project';
+
+export interface CommandPaletteCommand {
+  id: string;
+  title: string;
+  section: string;
+  subtitle?: string;
+  shortcut?: string[];
+  keywords: string[];
+  aliases: string[];
+  execute: () => void | Promise<void>;
+}
+
+export interface CommandPaletteSearchResult extends CommandPaletteCommand {
+  score: number;
+  isRecent: boolean;
+}
+
+export interface CommandPaletteContext {
+  project: Project | null;
+  selectedClipIds: string[];
+  currentTime: number;
+  isPlaying: boolean;
+  showMixer: boolean;
+  showLibrary: boolean;
+  showSmartControls: boolean;
+  showAIAssistant: boolean;
+  loopBrowserOpen: boolean;
+  showTempoLane: boolean;
+  loopEnabled: boolean;
+  metronomeEnabled: boolean;
+  expandedTrackId: string | null;
+  openPianoRollTrackId: string | null;
+  openSequencerTrackId: string | null;
+  openDrumMachineTrackId: string | null;
+  actions: {
+    play: () => void | Promise<void>;
+    pause: () => void | Promise<void>;
+    stop: () => void | Promise<void>;
+    toggleLoop: () => void;
+    toggleMetronome: () => void;
+    setShowNewProjectDialog: (v: boolean) => void;
+    setShowProjectListDialog: (v: boolean) => void;
+    setShowSettingsDialog: (v: boolean) => void;
+    setShowExportDialog: (v: boolean) => void;
+    setShowKeyboardShortcutsDialog: (v: boolean) => void;
+    setShowLibrary: (v: boolean) => void;
+    setShowMixer: (v: boolean) => void;
+    setShowSmartControls: (v: boolean) => void;
+    toggleLoopBrowser: () => void;
+    toggleTempoLane: () => void;
+    toggleAIAssistant: () => void;
+    setBatchGenerateMode: (mode: 'silence' | 'context' | null) => void;
+    addTrack: (trackName: TrackName, trackType?: TrackType) => Track;
+    addTrackEffect: (trackId: string, type: TrackEffectType) => string | undefined;
+    updateProject: (updates: Partial<Pick<Project, 'bpm'>>) => void;
+    duplicateClip: (clipId: string) => void;
+    splitClip: (clipId: string, splitTime: number) => void;
+    removeClip: (clipId: string) => void;
+    setEditingClip: (clipId: string | null) => void;
+    deselectAll: () => void;
+  };
+}
+
+const DEFAULT_RESULT_LIMIT = 12;
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenize(value: string): string[] {
+  return normalize(value).split(' ').filter(Boolean);
+}
+
+function buildSearchCorpus(command: CommandPaletteCommand): string {
+  return normalize([
+    command.title,
+    command.section,
+    command.subtitle ?? '',
+    ...command.keywords,
+    ...command.aliases,
+  ].join(' '));
+}
+
+function getTrackForSelection(context: CommandPaletteContext): Track | null {
+  const project = context.project;
+  if (!project) return null;
+
+  const candidateTrackId =
+    context.openPianoRollTrackId ??
+    context.openSequencerTrackId ??
+    context.openDrumMachineTrackId ??
+    context.expandedTrackId;
+
+  if (candidateTrackId) {
+    return project.tracks.find((track) => track.id === candidateTrackId) ?? null;
+  }
+
+  const selectedClipId = context.selectedClipIds[0];
+  if (!selectedClipId) return null;
+
+  return project.tracks.find((track) => track.clips.some((clip) => clip.id === selectedClipId)) ?? null;
+}
+
+function createTrackCommand(
+  id: string,
+  title: string,
+  section: string,
+  keywords: string[],
+  aliases: string[],
+  execute: () => void | Promise<void>,
+  shortcut?: string[],
+  subtitle?: string,
+): CommandPaletteCommand {
+  return {
+    id,
+    title,
+    section,
+    subtitle,
+    shortcut,
+    keywords,
+    aliases,
+    execute,
+  };
+}
+
+function buildTempoCommand(context: CommandPaletteContext, bpm: number): CommandPaletteCommand | null {
+  if (!context.project) return null;
+  if (!Number.isFinite(bpm) || bpm < 40 || bpm > 240) return null;
+
+  return createTrackCommand(
+    `project:set-tempo:${bpm}`,
+    `Set Tempo to ${bpm} BPM`,
+    'Project',
+    ['tempo', 'bpm', 'project setting', String(bpm)],
+    [`tempo ${bpm}`, `bpm ${bpm}`, `set tempo to ${bpm}`, `set bpm to ${bpm}`],
+    () => context.actions.updateProject({ bpm }),
+    undefined,
+    'Project setting',
+  );
+}
+
+function parseTempoCommand(query: string, context: CommandPaletteContext): CommandPaletteCommand[] {
+  const normalized = normalize(query);
+  const match = normalized.match(/\b(?:tempo|bpm)(?:\s+to)?\s+(\d{2,3})\b/);
+  if (!match) return [];
+
+  const bpm = Number(match[1]);
+  const command = buildTempoCommand(context, bpm);
+  return command ? [command] : [];
+}
+
+export function buildCommandPaletteCommands(context: CommandPaletteContext): CommandPaletteCommand[] {
+  const commands: CommandPaletteCommand[] = [];
+
+  commands.push(
+    createTrackCommand(
+      'transport:play-pause',
+      context.isPlaying ? 'Pause Playback' : 'Play Playback',
+      'Transport',
+      ['transport', 'play', 'pause', 'spacebar'],
+      ['start playback', 'pause transport', 'toggle transport'],
+      () => {
+        if (context.isPlaying) {
+          void context.actions.pause();
+        } else {
+          void context.actions.play();
+        }
+      },
+      ['Space'],
+      'Transport control',
+    ),
+    createTrackCommand(
+      'transport:stop',
+      'Stop Playback',
+      'Transport',
+      ['transport', 'stop', 'rewind'],
+      ['stop transport', 'go to start', 'rewind to start'],
+      () => {
+        void context.actions.stop();
+      },
+      ['Enter'],
+      'Transport control',
+    ),
+    createTrackCommand(
+      'transport:toggle-loop',
+      context.loopEnabled ? 'Disable Loop' : 'Enable Loop',
+      'Transport',
+      ['transport', 'loop', 'cycle'],
+      ['toggle loop', 'toggle cycle', 'cycle playback'],
+      context.actions.toggleLoop,
+      ['L'],
+      'Transport control',
+    ),
+    createTrackCommand(
+      'transport:toggle-metronome',
+      context.metronomeEnabled ? 'Disable Metronome' : 'Enable Metronome',
+      'Transport',
+      ['transport', 'metronome', 'click'],
+      ['toggle metronome', 'click track', 'count in click'],
+      context.actions.toggleMetronome,
+      ['K'],
+      'Transport control',
+    ),
+  );
+
+  commands.push(
+    createTrackCommand(
+      'project:new',
+      'New Project',
+      'Project',
+      ['project', 'new', 'create'],
+      ['create project', 'start new song'],
+      () => context.actions.setShowNewProjectDialog(true),
+      ['Cmd', 'N'],
+      'Project dialog',
+    ),
+    createTrackCommand(
+      'project:open',
+      'Open Project List',
+      'Project',
+      ['project', 'open', 'recent'],
+      ['show projects', 'project browser', 'open recent project'],
+      () => context.actions.setShowProjectListDialog(true),
+      ['Cmd', 'O'],
+      'Project dialog',
+    ),
+    createTrackCommand(
+      'project:settings',
+      'Open Settings',
+      'Project',
+      ['settings', 'preferences', 'project'],
+      ['preferences', 'project settings'],
+      () => context.actions.setShowSettingsDialog(true),
+      ['Cmd', ','],
+      'Project dialog',
+    ),
+    createTrackCommand(
+      'project:export',
+      'Open Export Dialog',
+      'Project',
+      ['export', 'bounce', 'render'],
+      ['export project', 'render mix', 'bounce song'],
+      () => context.actions.setShowExportDialog(true),
+      ['Cmd', 'Shift', 'E'],
+      'Project dialog',
+    ),
+    createTrackCommand(
+      'project:shortcuts',
+      'Show Keyboard Shortcuts',
+      'Project',
+      ['shortcuts', 'help', 'keyboard'],
+      ['shortcut help', 'show hotkeys', 'help overlay'],
+      () => context.actions.setShowKeyboardShortcutsDialog(true),
+      ['?'],
+      'Help dialog',
+    ),
+  );
+
+  commands.push(
+    createTrackCommand(
+      'panel:library',
+      context.showLibrary ? 'Hide Library' : 'Show Library',
+      'Panels',
+      ['panel', 'library', 'browser'],
+      ['toggle library', 'open library'],
+      () => context.actions.setShowLibrary(!context.showLibrary),
+      ['Y'],
+      'Panel toggle',
+    ),
+    createTrackCommand(
+      'panel:mixer',
+      context.showMixer ? 'Hide Mixer' : 'Show Mixer',
+      'Panels',
+      ['panel', 'mixer', 'volume'],
+      ['toggle mixer', 'open mixer', 'show levels'],
+      () => context.actions.setShowMixer(!context.showMixer),
+      ['X'],
+      'Panel toggle',
+    ),
+    createTrackCommand(
+      'panel:smart-controls',
+      context.showSmartControls ? 'Hide Smart Controls' : 'Show Smart Controls',
+      'Panels',
+      ['panel', 'smart controls', 'controls'],
+      ['toggle smart controls', 'open smart controls'],
+      () => context.actions.setShowSmartControls(!context.showSmartControls),
+      ['B'],
+      'Panel toggle',
+    ),
+    createTrackCommand(
+      'panel:loop-browser',
+      context.loopBrowserOpen ? 'Hide Loop Browser' : 'Show Loop Browser',
+      'Panels',
+      ['panel', 'loop browser', 'loops', 'samples'],
+      ['toggle loop browser', 'open loops', 'show sample browser'],
+      context.actions.toggleLoopBrowser,
+      ['O'],
+      'Panel toggle',
+    ),
+    createTrackCommand(
+      'panel:tempo-lane',
+      context.showTempoLane ? 'Hide Tempo Lane' : 'Show Tempo Lane',
+      'Panels',
+      ['panel', 'tempo lane', 'tempo', 'automation'],
+      ['toggle tempo lane', 'open tempo lane'],
+      context.actions.toggleTempoLane,
+      ['T'],
+      'Panel toggle',
+    ),
+    createTrackCommand(
+      'panel:ai-assistant',
+      context.showAIAssistant ? 'Hide AI Assistant' : 'Show AI Assistant',
+      'Panels',
+      ['panel', 'assistant', 'ai', 'help'],
+      ['toggle ai assistant', 'open ai assistant', 'assistant help'],
+      context.actions.toggleAIAssistant,
+      ['Cmd', '/'],
+      'Panel toggle',
+    ),
+  );
+
+  commands.push(
+    createTrackCommand(
+      'generation:silence',
+      'Generate from Silence',
+      'Generation',
+      ['generate', 'ai', 'silence', 'clip'],
+      ['generate clip', 'ai generate', 'create clip from silence'],
+      () => context.actions.setBatchGenerateMode('silence'),
+      ['Cmd', 'G'],
+      'AI generation',
+    ),
+    createTrackCommand(
+      'generation:context',
+      'Generate from Context',
+      'Generation',
+      ['generate', 'ai', 'context', 'clip'],
+      ['generate from context', 'continue idea', 'ai continue region'],
+      () => context.actions.setBatchGenerateMode('context'),
+      ['Cmd', 'Shift', 'G'],
+      'AI generation',
+    ),
+  );
+
+  commands.push(
+    createTrackCommand(
+      'track:add-drums',
+      'Add Drums Track',
+      'Tracks',
+      ['track', 'add', 'drums', 'beat'],
+      ['new drums track', 'add drum track', 'create drum track'],
+      () => {
+        context.actions.addTrack('drums');
+      },
+      undefined,
+      'Track action',
+    ),
+    createTrackCommand(
+      'track:add-bass',
+      'Add Bass Track',
+      'Tracks',
+      ['track', 'add', 'bass'],
+      ['new bass track', 'create bass track'],
+      () => {
+        context.actions.addTrack('bass');
+      },
+      undefined,
+      'Track action',
+    ),
+    createTrackCommand(
+      'track:add-piano',
+      'Add Piano Track',
+      'Tracks',
+      ['track', 'add', 'piano', 'keys', 'midi'],
+      ['new piano track', 'create piano track', 'add keyboard track'],
+      () => {
+        context.actions.addTrack('keyboard', 'pianoRoll');
+      },
+      undefined,
+      'Track action',
+    ),
+    createTrackCommand(
+      'track:add-sampler',
+      'Add Sampler Track',
+      'Tracks',
+      ['track', 'add', 'sampler', 'instrument'],
+      ['new sampler track', 'create sampler track'],
+      () => {
+        context.actions.addTrack('keyboard', 'pianoRoll');
+      },
+      undefined,
+      'Track action',
+    ),
+    createTrackCommand(
+      'track:add-drum-machine',
+      'Add Drum Machine Track',
+      'Tracks',
+      ['track', 'add', 'drum machine', 'sequencer'],
+      ['new drum machine', 'create drum machine track'],
+      () => {
+        context.actions.addTrack('drums', 'drumMachine');
+      },
+      undefined,
+      'Track action',
+    ),
+  );
+
+  const selectedClipId = context.selectedClipIds[0];
+  if (selectedClipId) {
+    commands.push(
+      createTrackCommand(
+        'clip:duplicate-selected',
+        'Duplicate Selected Clip',
+        'Clips',
+        ['clip', 'duplicate', 'selected'],
+        ['copy selected clip', 'duplicate current clip'],
+        () => context.actions.duplicateClip(selectedClipId),
+        ['Cmd', 'D'],
+        'Selected clip action',
+      ),
+      createTrackCommand(
+        'clip:split-selected',
+        'Split Selected Clip at Playhead',
+        'Clips',
+        ['clip', 'split', 'selected', 'playhead'],
+        ['cut selected clip', 'split current clip'],
+        () => context.actions.splitClip(selectedClipId, context.currentTime),
+        ['S'],
+        'Selected clip action',
+      ),
+      createTrackCommand(
+        'clip:edit-selected',
+        'Edit Selected Clip',
+        'Clips',
+        ['clip', 'edit', 'selected', 'piano roll'],
+        ['open clip editor', 'edit current clip'],
+        () => context.actions.setEditingClip(selectedClipId),
+        ['E'],
+        'Selected clip action',
+      ),
+    );
+  }
+
+  if (context.selectedClipIds.length > 0) {
+    commands.push(
+      createTrackCommand(
+        'clip:delete-selected',
+        'Delete Selected Clips',
+        'Clips',
+        ['clip', 'delete', 'remove', 'selected'],
+        ['remove selected clips', 'delete current clips'],
+        () => {
+          const ids = [...context.selectedClipIds];
+          context.actions.deselectAll();
+          ids.forEach((clipId) => context.actions.removeClip(clipId));
+        },
+        ['Delete'],
+        'Selected clip action',
+      ),
+    );
+  }
+
+  const selectedTrack = getTrackForSelection(context);
+  const tracks = context.project?.tracks ?? [];
+  for (const track of tracks) {
+    const trackName = track.displayName.toLowerCase();
+    const selectedKeywords = selectedTrack?.id === track.id ? ['selected track', 'focused track'] : [];
+    const effectDefs: { type: TrackEffectType; label: string; aliases: string[] }[] = [
+      {
+        type: 'reverb',
+        label: 'Reverb',
+        aliases: [`add reverb to ${trackName}`, `${trackName} reverb`, `put reverb on ${trackName}`],
+      },
+      {
+        type: 'delay',
+        label: 'Delay',
+        aliases: [`add delay to ${trackName}`, `${trackName} delay`, `echo ${trackName}`],
+      },
+      {
+        type: 'compressor',
+        label: 'Compressor',
+        aliases: [`add compressor to ${trackName}`, `compress ${trackName}`, `${trackName} compression`],
+      },
+      {
+        type: 'parametricEq',
+        label: 'Parametric EQ',
+        aliases: [`add eq to ${trackName}`, `${trackName} eq`, `equalize ${trackName}`],
+      },
+    ];
+
+    for (const effect of effectDefs) {
+      commands.push(
+        createTrackCommand(
+          `track:${track.id}:effect:${effect.type}`,
+          `Add ${effect.label} to ${track.displayName}`,
+          'Effects',
+          ['effect', effect.label.toLowerCase(), track.displayName, trackName, 'track', ...selectedKeywords],
+          effect.aliases,
+          () => {
+            context.actions.addTrackEffect(track.id, effect.type);
+          },
+          undefined,
+          `Track effect on ${track.displayName}`,
+        ),
+      );
+    }
+  }
+
+  return commands;
+}
+
+export function searchCommandPaletteCommands(
+  query: string,
+  commands: CommandPaletteCommand[],
+  recentCommandIds: string[],
+  extraCommands: CommandPaletteCommand[] = [],
+  limit = DEFAULT_RESULT_LIMIT,
+): CommandPaletteSearchResult[] {
+  const normalizedQuery = normalize(query);
+  const queryTokens = tokenize(query);
+  const recencyOrder = new Map(recentCommandIds.map((id, index) => [id, index]));
+  const seen = new Set<string>();
+  const allCommands = [...extraCommands, ...commands].filter((command) => {
+    if (seen.has(command.id)) return false;
+    seen.add(command.id);
+    return true;
+  });
+
+  const scored = allCommands
+    .map((command) => {
+      const corpus = buildSearchCorpus(command);
+      const aliasCorpus = normalize(command.aliases.join(' '));
+      const title = normalize(command.title);
+      const isRecent = recencyOrder.has(command.id);
+      let score = isRecent ? 40 - (recencyOrder.get(command.id) ?? 0) : 0;
+
+      if (!normalizedQuery) {
+        score += command.section === 'Transport' ? 4 : 0;
+      } else {
+        if (title === normalizedQuery || command.aliases.some((alias) => normalize(alias) === normalizedQuery)) {
+          score += 120;
+        } else if (title.startsWith(normalizedQuery)) {
+          score += 95;
+        } else if (title.includes(normalizedQuery)) {
+          score += 80;
+        }
+
+        if (aliasCorpus.includes(normalizedQuery)) {
+          score += 70;
+        }
+
+        let matchedTokens = 0;
+        for (const token of queryTokens) {
+          if (corpus.includes(token)) {
+            matchedTokens += 1;
+            score += 12;
+          }
+        }
+
+        if (queryTokens.length > 0 && matchedTokens === queryTokens.length) {
+          score += 40;
+        } else if (matchedTokens === 0) {
+          score = 0;
+        }
+      }
+
+      return { ...command, score, isRecent };
+    })
+    .filter((command) => command.score > 0 || !normalizedQuery)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+
+      const aRecency = recencyOrder.get(a.id);
+      const bRecency = recencyOrder.get(b.id);
+      if (aRecency !== undefined && bRecency !== undefined && aRecency !== bRecency) {
+        return aRecency - bRecency;
+      }
+      if (aRecency !== undefined) return -1;
+      if (bRecency !== undefined) return 1;
+
+      return a.title.localeCompare(b.title);
+    });
+
+  return scored.slice(0, limit);
+}
+
+export function searchCommandsForQuery(
+  query: string,
+  context: CommandPaletteContext,
+  recentCommandIds: string[],
+  limit = DEFAULT_RESULT_LIMIT,
+): CommandPaletteSearchResult[] {
+  const commands = buildCommandPaletteCommands(context);
+  const extraCommands = parseTempoCommand(query, context);
+  return searchCommandPaletteCommands(query, commands, recentCommandIds, extraCommands, limit);
+}

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -7,6 +7,11 @@ import { useTransportStore } from './transportStore';
 import type { AIChatContext } from '../utils/aiAssistantContext';
 import { buildAssistantContext } from '../utils/aiAssistantContext';
 import { getAssistantSuggestions, streamAssistantResponse } from '../services/aiAssistantService';
+import {
+  buildCommandPaletteCommands,
+  searchCommandsForQuery,
+  type CommandPaletteSearchResult,
+} from '../services/commandPalette';
 
 function createAssistantMessage(role: AIChatMessage['role'], content: string): AIChatMessage {
   return {
@@ -35,6 +40,9 @@ interface UIState {
   batchGenerateInitialRange: { startTime: number; duration: number } | null;
   showKeyboardShortcutsDialog: boolean;
   showShortcutEditorDialog: boolean;
+  showCommandPalette: boolean;
+  commandPaletteQuery: string;
+  recentCommandIds: string[];
   showMixer: boolean;
   mixerHeight: number;
   showAssetsPanel: boolean;
@@ -124,6 +132,11 @@ interface UIState {
   setBatchGenerateInitialRange: (v: { startTime: number; duration: number } | null) => void;
   setShowKeyboardShortcutsDialog: (v: boolean) => void;
   setShowShortcutEditorDialog: (v: boolean) => void;
+  openCommandPalette: (query?: string) => void;
+  closeCommandPalette: () => void;
+  setCommandPaletteQuery: (query: string) => void;
+  searchCommandPalette: (query?: string) => CommandPaletteSearchResult[];
+  executeCommandPaletteCommand: (commandId: string) => Promise<boolean>;
   setShowMixer: (v: boolean) => void;
   setMixerHeight: (v: number) => void;
   setShowAssetsPanel: (v: boolean) => void;
@@ -214,6 +227,9 @@ export const useUIStore = create<UIState>()(
   batchGenerateInitialRange: null,
   showKeyboardShortcutsDialog: false,
   showShortcutEditorDialog: false,
+  showCommandPalette: false,
+  commandPaletteQuery: '',
+  recentCommandIds: [],
   showMixer: false,
   mixerHeight: 420,
   showAssetsPanel: false,
@@ -316,6 +332,33 @@ export const useUIStore = create<UIState>()(
   setBatchGenerateInitialRange: (v) => set({ batchGenerateInitialRange: v }),
   setShowKeyboardShortcutsDialog: (v) => set({ showKeyboardShortcutsDialog: v }),
   setShowShortcutEditorDialog: (v) => set({ showShortcutEditorDialog: v }),
+  openCommandPalette: (query = '') => set({ showCommandPalette: true, commandPaletteQuery: query }),
+  closeCommandPalette: () => set({ showCommandPalette: false, commandPaletteQuery: '' }),
+  setCommandPaletteQuery: (query) => set({ commandPaletteQuery: query }),
+  searchCommandPalette: (query) => {
+    const state = get();
+    return searchCommandsForQuery(query ?? state.commandPaletteQuery, buildCommandPaletteContext(state), state.recentCommandIds);
+  },
+  executeCommandPaletteCommand: async (commandId) => {
+    const state = get();
+    const commands = buildCommandPaletteCommands(buildCommandPaletteContext(state));
+    const extraCommands = searchCommandsForQuery(state.commandPaletteQuery, buildCommandPaletteContext(state), state.recentCommandIds);
+    const command =
+      commands.find((item) => item.id === commandId)
+      ?? extraCommands.find((item) => item.id === commandId);
+
+    if (!command) return false;
+
+    await command.execute();
+
+    set((current) => ({
+      showCommandPalette: false,
+      commandPaletteQuery: '',
+      recentCommandIds: [commandId, ...current.recentCommandIds.filter((id) => id !== commandId)].slice(0, 8),
+    }));
+
+    return true;
+  },
   setShowMixer: (v) => set({ showMixer: v }),
   setMixerHeight: (v) => set({ mixerHeight: Math.min(500, Math.max(160, v)) }),
   setShowAssetsPanel: (v) => set({ showAssetsPanel: v }),
@@ -486,6 +529,8 @@ export const useUIStore = create<UIState>()(
         showAIAssistant: state.showAIAssistant,
         // Inline suggestions
         suggestionFrequency: state.suggestionFrequency,
+        // Command palette
+        recentCommandIds: state.recentCommandIds,
       }),
     },
   ),
@@ -493,4 +538,60 @@ export const useUIStore = create<UIState>()(
 
 function getAssistantContext(state: UIState): AIChatContext {
   return buildAssistantContext(useProjectStore.getState().project, state, useTransportStore.getState());
+}
+
+function buildCommandPaletteContext(state: UIState) {
+  const projectStore = useProjectStore.getState();
+  const transportStore = useTransportStore.getState();
+  const runtime = (window as unknown as Record<string, unknown>).__commandPaletteRuntime as
+    | { play?: () => void | Promise<void>; pause?: () => void | Promise<void>; stop?: () => void | Promise<void> }
+    | undefined;
+
+  return {
+    project: projectStore.project,
+    selectedClipIds: [...state.selectedClipIds],
+    currentTime: transportStore.currentTime,
+    isPlaying: transportStore.isPlaying,
+    showMixer: state.showMixer,
+    showLibrary: state.showLibrary,
+    showSmartControls: state.showSmartControls,
+    showAIAssistant: state.showAIAssistant,
+    loopBrowserOpen: state.loopBrowserOpen,
+    showTempoLane: state.showTempoLane,
+    loopEnabled: transportStore.loopEnabled,
+    metronomeEnabled: transportStore.metronomeEnabled,
+    expandedTrackId: state.expandedTrackId,
+    openPianoRollTrackId: state.openPianoRollTrackId,
+    openSequencerTrackId: state.openSequencerTrackId,
+    openDrumMachineTrackId: state.openDrumMachineTrackId,
+    actions: {
+      play: runtime?.play ?? transportStore.play,
+      pause: runtime?.pause ?? transportStore.pause,
+      stop: runtime?.stop ?? transportStore.stop,
+      toggleLoop: transportStore.toggleLoop,
+      toggleMetronome: transportStore.toggleMetronome,
+      setShowNewProjectDialog: state.setShowNewProjectDialog,
+      setShowProjectListDialog: state.setShowProjectListDialog,
+      setShowSettingsDialog: state.setShowSettingsDialog,
+      setShowExportDialog: state.setShowExportDialog,
+      setShowKeyboardShortcutsDialog: state.setShowKeyboardShortcutsDialog,
+      setShowLibrary: state.setShowLibrary,
+      setShowMixer: state.setShowMixer,
+      setShowSmartControls: state.setShowSmartControls,
+      toggleLoopBrowser: state.toggleLoopBrowser,
+      toggleTempoLane: state.toggleTempoLane,
+      toggleAIAssistant: state.toggleAIAssistant,
+      setBatchGenerateMode: state.setBatchGenerateMode,
+      addTrack: projectStore.addTrack,
+      addTrackEffect: projectStore.addTrackEffect,
+      updateProject: projectStore.updateProject,
+      duplicateClip: (clipId: string) => {
+        projectStore.duplicateClip(clipId);
+      },
+      splitClip: projectStore.splitClip,
+      removeClip: projectStore.removeClip,
+      setEditingClip: state.setEditingClip,
+      deselectAll: state.deselectAll,
+    },
+  };
 }

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Command Palette', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined');
+
+    await page.evaluate(() => {
+      const browserWindow = window as unknown as Record<string, unknown>;
+      const projectStore = browserWindow.__store as {
+        getState: () => {
+          createProject: (params: { name: string; bpm: number }) => void;
+          addTrack: (trackName: string) => { id: string };
+        };
+      };
+      const uiStore = browserWindow.__uiStore as {
+        getState: () => {
+          setShowNewProjectDialog: (value: boolean) => void;
+        };
+      };
+
+      projectStore.getState().createProject({ name: 'Command Palette Test', bpm: 120 });
+      const vocalsTrack = projectStore.getState().addTrack('vocals');
+      uiStore.getState().setShowNewProjectDialog(false);
+
+      browserWindow.__commandPaletteTrackId = vocalsTrack.id;
+    });
+
+    await page.mouse.click(20, 20);
+  });
+
+  test('opens with keyboard and executes a natural-language effect command', async ({ page }) => {
+    await page.evaluate(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'k',
+        code: 'KeyK',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+    await expect(page.getByRole('dialog', { name: 'Command palette' })).toBeVisible();
+
+    const searchInput = page.getByRole('textbox', { name: 'Command palette search' });
+    await searchInput.fill('add reverb to vocals');
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByRole('dialog', { name: 'Command palette' })).toBeHidden();
+
+    const result = await page.evaluate(() => {
+      const browserWindow = window as unknown as Record<string, unknown>;
+      const projectStore = browserWindow.__store as {
+        getState: () => {
+          project: {
+            tracks: Array<{ id: string; effects?: Array<{ type: string }> }>;
+          };
+        };
+      };
+      const trackId = browserWindow.__commandPaletteTrackId as string;
+      const track = projectStore.getState().project.tracks.find((item) => item.id === trackId);
+      return {
+        effectCount: track?.effects?.length ?? 0,
+        effectType: track?.effects?.[0]?.type ?? null,
+      };
+    });
+
+    expect(result.effectCount).toBe(1);
+    expect(result.effectType).toBe('reverb');
+  });
+});

--- a/tests/unit/commandPalette.test.ts
+++ b/tests/unit/commandPalette.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildCommandPaletteCommands,
+  searchCommandsForQuery,
+  type CommandPaletteContext,
+} from '../../src/services/commandPalette';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useTransportStore } from '../../src/store/transportStore';
+
+function createContext(): CommandPaletteContext {
+  const projectStore = useProjectStore.getState();
+  const transportStore = useTransportStore.getState();
+
+  return {
+    project: projectStore.project,
+    selectedClipIds: [],
+    currentTime: transportStore.currentTime,
+    isPlaying: transportStore.isPlaying,
+    showMixer: false,
+    showLibrary: false,
+    showSmartControls: false,
+    showAIAssistant: false,
+    loopBrowserOpen: false,
+    showTempoLane: false,
+    loopEnabled: transportStore.loopEnabled,
+    metronomeEnabled: transportStore.metronomeEnabled,
+    expandedTrackId: null,
+    openPianoRollTrackId: null,
+    openSequencerTrackId: null,
+    openDrumMachineTrackId: null,
+    actions: {
+      play: transportStore.play,
+      pause: transportStore.pause,
+      stop: transportStore.stop,
+      toggleLoop: transportStore.toggleLoop,
+      toggleMetronome: transportStore.toggleMetronome,
+      setShowNewProjectDialog: () => {},
+      setShowProjectListDialog: () => {},
+      setShowSettingsDialog: () => {},
+      setShowExportDialog: () => {},
+      setShowKeyboardShortcutsDialog: () => {},
+      setShowLibrary: () => {},
+      setShowMixer: () => {},
+      setShowSmartControls: () => {},
+      toggleLoopBrowser: () => {},
+      toggleTempoLane: () => {},
+      toggleAIAssistant: () => {},
+      setBatchGenerateMode: () => {},
+      addTrack: projectStore.addTrack,
+      addTrackEffect: projectStore.addTrackEffect,
+      updateProject: projectStore.updateProject,
+      duplicateClip: () => {},
+      splitClip: () => {},
+      removeClip: () => {},
+      setEditingClip: () => {},
+      deselectAll: () => {},
+    },
+  };
+}
+
+describe('commandPalette', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useTransportStore.setState(useTransportStore.getInitialState(), true);
+    useProjectStore.getState().createProject({ name: 'Palette Test', bpm: 120 });
+  });
+
+  it('matches natural-language effect intents against track names', () => {
+    useProjectStore.getState().addTrack('drums');
+    const vocalsTrack = useProjectStore.getState().addTrack('vocals');
+    const results = searchCommandsForQuery('add reverb to vocals', createContext(), []);
+
+    expect(results[0]?.id).toBe(`track:${vocalsTrack.id}:effect:reverb`);
+    expect(results[0]?.title).toBe(`Add Reverb to ${vocalsTrack.displayName}`);
+  });
+
+  it('adds parsed BPM commands for parameter search', async () => {
+    const context = createContext();
+    const results = searchCommandsForQuery('tempo 140', context, []);
+    const tempoCommand = results.find((result) => result.id === 'project:set-tempo:140');
+
+    expect(tempoCommand).toBeTruthy();
+    if (!tempoCommand) {
+      throw new Error('Expected tempo command to be available');
+    }
+
+    await tempoCommand.execute();
+
+    expect(useProjectStore.getState().project?.bpm).toBe(140);
+  });
+
+  it('builds dynamic effect commands for all project tracks', () => {
+    const drumsTrack = useProjectStore.getState().addTrack('drums');
+    const bassTrack = useProjectStore.getState().addTrack('bass');
+    const commandIds = buildCommandPaletteCommands(createContext()).map((command) => command.id);
+
+    expect(commandIds).toContain(`track:${drumsTrack.id}:effect:reverb`);
+    expect(commandIds).toContain(`track:${bassTrack.id}:effect:compressor`);
+  });
+});

--- a/tests/unit/uiStore.test.ts
+++ b/tests/unit/uiStore.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { useUIStore } from '../../src/store/uiStore';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useTransportStore } from '../../src/store/transportStore';
 
 describe('uiStore', () => {
   beforeEach(() => {
     localStorage.clear();
     useUIStore.setState(useUIStore.getInitialState(), true);
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useTransportStore.setState(useTransportStore.getInitialState(), true);
   });
 
   describe('pixelsPerSecond zoom', () => {
@@ -98,6 +102,35 @@ describe('uiStore', () => {
 
       useUIStore.getState().setPianoRollHeight(760);
       expect(useUIStore.getState().pianoRollHeight).toBe(700);
+    });
+  });
+
+  describe('command palette', () => {
+    it('opens, executes commands, and promotes recent commands', async () => {
+      useProjectStore.getState().createProject({ name: 'Palette Project' });
+      const vocalsTrack = useProjectStore.getState().addTrack('vocals');
+
+      const ui = useUIStore.getState();
+      ui.openCommandPalette('add reverb to vocals');
+
+      const results = useUIStore.getState().searchCommandPalette();
+      const commandId = results[0]?.id;
+
+      expect(commandId).toBe(`track:${vocalsTrack.id}:effect:reverb`);
+      if (!commandId) {
+        throw new Error('Expected a command palette result');
+      }
+
+      const executed = await useUIStore.getState().executeCommandPaletteCommand(commandId);
+
+      expect(executed).toBe(true);
+      expect(useUIStore.getState().showCommandPalette).toBe(false);
+      expect(useUIStore.getState().recentCommandIds[0]).toBe(commandId);
+      expect(useProjectStore.getState().project?.tracks[0].effects?.[0]?.type).toBe('reverb');
+
+      useUIStore.getState().openCommandPalette();
+      const defaultResults = useUIStore.getState().searchCommandPalette('');
+      expect(defaultResults[0]?.id).toBe(commandId);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a global `Cmd/Ctrl+K` command palette with fuzzy matching, recent commands, and deterministic natural-language aliases
- route palette search and execution through `uiStore` so browser automation and agents can use the same command surface
- cover the feature with unit tests plus a Playwright flow that opens the palette and executes `add reverb to vocals`

## What changed
- added competitive research and an executable plan doc for `#322`
- added `src/services/commandPalette.ts` to build searchable command definitions for project, panel, clip, transport, track, and effect actions
- extended `src/store/uiStore.ts` with command palette state, recent-command persistence, search, and execution helpers
- added `src/components/dialogs/CommandPalette.tsx`, mounted it in `AppShell`, exposed a toolbar entry point, and wired `Cmd/Ctrl+K` plus Escape handling
- updated keyboard shortcut help to include the new palette shortcut
- added unit coverage for natural-language matching, BPM parameter commands, and recent command ordering
- added Playwright coverage for the live keyboard-driven command palette workflow

## User stories
- As a user, I want to press `Cmd/Ctrl+K` and search DAW actions from anywhere, so that I can work without panel hunting.
- As a user, I want natural-language intents like `add reverb to vocals` and `tempo 140`, so that I can express goals instead of memorizing exact labels.
- As an agent, I want the same searchable command surface available through `window.__uiStore`, so that I can execute commands consistently.

## Verification
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `VITE_PORT=5274 npm run dev` + `npx playwright test tests/e2e/command-palette.spec.ts`

Closes #322.
