### PR TITLE
feat: add first-run onboarding with genr

### DIFF
--- a/docs/plans/feat-first-run-onboarding-genr.md
+++ b/docs/plans/feat-first-run-onboarding-genr.md
@@ -1,0 +1,84 @@
+# Feature Plan: First-Run Onboarding With genr
+
+Issue: #328
+
+## 1. Problem
+
+ACE-Step has onboarding guidance in the design docs, but the product still drops first-time users into an empty DAW plus the generic new-project dialog. That misses the issue scope for starter templates, complexity tiers, a skippable tutorial, contextual tips, and immediately explorable demo sessions.
+
+## 2. Root Cause
+
+- `src/components/layout/AppShell.tsx` only checks whether a project exists and then opens `NewProjectDialog`.
+- `src/store/uiStore.ts` persists general layout state, but it has no onboarding lifecycle, no complexity-tier defaults, and no persistent tip-dismissal model.
+- The toolbar has generation shortcuts, but no explicit `genr` entry point for first-run teaching.
+- The app has project-template support in `src/store/projectStore.ts`, but there is no built-in onboarding catalog that turns it into a guided first-run experience.
+
+## 3. Solution
+
+### 3a. Add onboarding state and density-tier defaults
+
+- Extend `src/store/uiStore.ts` with:
+  - first-run visibility state
+  - onboarding completion / skip persistence
+  - workspace complexity persistence
+  - tutorial progress
+  - dismissed contextual tips
+- Add an `applyWorkspaceComplexity(...)` action that changes visible defaults immediately.
+
+### 3b. Add starter catalog for templates and demo sessions
+
+- Add `src/data/onboardingCatalog.ts`.
+- Define:
+  - built-in genre templates
+  - built-in demo projects
+  - tutorial steps
+  - contextual tips
+
+### 3c. Add first-run UI and tutorial overlays
+
+- Add `src/components/onboarding/FirstRunOnboarding.tsx`.
+- Add `src/components/onboarding/GuidedTutorialOverlay.tsx`.
+- Add `src/components/onboarding/ContextualTips.tsx`.
+- Mount them from `src/components/layout/AppShell.tsx`.
+
+### 3d. Make genr part of the visible first-run path
+
+- Add a dedicated `genr` toolbar button in `src/components/layout/Toolbar.tsx`.
+- Expose stable onboarding targets on toolbar and timeline elements so the tutorial and agent tests can point at real UI.
+
+### 3e. Verify with tests
+
+- Add unit coverage for onboarding state transitions and complexity-tier defaults.
+- Add Playwright coverage for:
+  - first launch showing onboarding
+  - starting from a demo/template without manual setup
+  - persistent tip dismissal across reload
+
+## 4. Verification
+
+- `npx tsc --noEmit`
+- `npm test`
+- `npm run build`
+- `npx playwright test tests/e2e/onboarding.spec.ts`
+
+User-story verification:
+
+- As a new user, I want to start from a genre template or demo project, so that I am not dropped into an empty DAW.
+- As a user, I want to choose a simple, standard, or advanced workspace, so that the visible defaults match my experience level.
+- As a user, I want a skippable 5-step tutorial and dismissible contextual tips, so that I can learn the DAW in context and never see the same tip again once dismissed.
+
+## 5. Files To Touch
+
+- `docs/research-notes/first-run-onboarding-competitive-research-20260319.md`
+- `docs/plans/feat-first-run-onboarding-genr.md`
+- `src/components/layout/AppShell.tsx`
+- `src/components/layout/Toolbar.tsx`
+- `src/components/timeline/Timeline.tsx`
+- `src/components/onboarding/FirstRunOnboarding.tsx`
+- `src/components/onboarding/GuidedTutorialOverlay.tsx`
+- `src/components/onboarding/ContextualTips.tsx`
+- `src/data/onboardingCatalog.ts`
+- `src/hooks/useKeyboardShortcuts.ts`
+- `src/store/uiStore.ts`
+- `tests/e2e/onboarding.spec.ts`
+- `tests/unit/onboardingStore.test.ts`

--- a/docs/research-notes/first-run-onboarding-competitive-research-20260319.md
+++ b/docs/research-notes/first-run-onboarding-competitive-research-20260319.md
@@ -1,0 +1,46 @@
+# First-Run Onboarding Research
+
+Date: 2026-03-19
+Issue: #328
+
+## Problem
+
+ACE-Step already documents onboarding expectations in the design guide, but the shipped app still starts with an empty workspace plus the generic new-project dialog. That misses the intended genre-template, density-tier, tutorial, and contextual-tip flow.
+
+## Competitive Notes
+
+### GarageBand
+
+- Template-based onboarding is explicit and low-friction.
+- The product does not ask the user to understand the entire DAW before making sound.
+- The first-run flow narrows the surface area and gets the user into a meaningful starter session quickly.
+
+### FL Studio
+
+- Demo projects are part of the learning loop, not a separate documentation exercise.
+- Rich tooltip behavior helps users learn controls in context without leaving the app.
+- First-run exploration is supported by immediate examples instead of a blank canvas.
+
+### ACE-Step Design References
+
+- `docs/design/UX_IMPROVEMENT_CHECKLIST.md`
+  - Genre template selection
+  - Complexity tier
+  - 5-step interactive tutorial
+  - Contextual tips
+  - Demo projects
+- `docs/design/INTERACTION_DESIGN_GUIDE.md`
+  - Template-based onboarding per genre
+  - Demo projects showing different genres
+  - 5-step overlay tutorial
+  - Contextual tips persisted in local storage
+
+## Implementation Takeaways
+
+- First launch should open into a full-screen onboarding layer before the default new-project dialog.
+- The flow should offer both:
+  - a fresh template path
+  - a demo-project path
+- Complexity tier must produce visible UI differences immediately, not just store metadata.
+- The tutorial should point at real in-app controls, especially timeline, transport, genr, mixer, and help.
+- Contextual tips should be attached to discoverable UI targets and persist after dismissal.

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -32,6 +32,9 @@ import { EffectChain } from '../mixer/EffectChain';
 import { SessionView } from '../session/SessionView';
 import { ToastContainer } from '../ui/Toast';
 import { UndoHistoryPanel } from './UndoHistoryPanel';
+import { FirstRunOnboarding } from '../onboarding/FirstRunOnboarding';
+import { GuidedTutorialOverlay } from '../onboarding/GuidedTutorialOverlay';
+import { ContextualTips } from '../onboarding/ContextualTips';
 import { useAudioEngine } from '../../hooks/useAudioEngine';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
@@ -53,6 +56,10 @@ export function AppShell() {
   const setShowNewProjectDialog = useUIStore((s) => s.setShowNewProjectDialog);
   const setHistoryFocusScope = useUIStore((s) => s.setHistoryFocusScope);
   const { seek } = useTransport();
+  const showOnboarding = useUIStore((s) => s.showOnboarding);
+  const onboardingCompleted = useUIStore((s) => s.onboardingCompleted);
+  const onboardingSkipped = useUIStore((s) => s.onboardingSkipped);
+  const setShowOnboarding = useUIStore((s) => s.setShowOnboarding);
   const [audioResumed, setAudioResumed] = useState(false);
   const sessionPlaybackSignature = useMemo(() => JSON.stringify({
     view: mainView,
@@ -67,9 +74,15 @@ export function AppShell() {
 
   useEffect(() => {
     if (!project) {
-      setShowNewProjectDialog(true);
+      if (!onboardingCompleted && !onboardingSkipped) {
+        setShowOnboarding(true);
+        setShowNewProjectDialog(false);
+      } else {
+        setShowOnboarding(false);
+        setShowNewProjectDialog(true);
+      }
     }
-  }, []);
+  }, [onboardingCompleted, onboardingSkipped, project, setShowNewProjectDialog, setShowOnboarding]);
 
   // Warn before closing tab with unsaved project
   useEffect(() => {
@@ -147,6 +160,9 @@ export function AppShell() {
       <StatusBar />
       <ToastContainer />
       <UndoHistoryPanel />
+      {project && !showOnboarding && <ContextualTips />}
+      <GuidedTutorialOverlay />
+      <FirstRunOnboarding />
 
       {/* Modals */}
       <NewProjectDialog />

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -62,12 +62,14 @@ function ControlBarButton({
   onClick,
   title,
   disabled,
+  dataTarget,
   children,
 }: {
   active?: boolean;
   onClick: () => void | Promise<void>;
   title: string;
   disabled?: boolean;
+  dataTarget?: string;
   children: React.ReactNode;
 }) {
   return (
@@ -75,6 +77,8 @@ function ControlBarButton({
       onClick={onClick}
       disabled={disabled}
       title={title}
+      aria-label={title.replace(/\s*\(.+?\)$/, '')}
+      data-onboarding-target={dataTarget}
       className={`w-8 h-7 flex items-center justify-center rounded transition-colors ${
         active
           ? 'bg-daw-accent text-white shadow-sm'
@@ -98,6 +102,7 @@ export function Toolbar() {
   const setShowUndoHistoryPanel = useUIStore((s) => s.setShowUndoHistoryPanel);
   const mainView = useUIStore((s) => s.mainView);
   const setMainView = useUIStore((s) => s.setMainView);
+  const setBatchGenerateMode = useUIStore((s) => s.setBatchGenerateMode);
   const showMixer = useUIStore((s) => s.showMixer);
   const setShowMixer = useUIStore((s) => s.setShowMixer);
   const loopBrowserOpen = useUIStore((s) => s.loopBrowserOpen);
@@ -202,6 +207,16 @@ export function Toolbar() {
         <button onClick={toggleArrangementView} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Toggle Arrangement / Session (Tab)">
           {arrangementView === 'arrangement' ? 'Session' : 'Arrange'}
         </button>
+        <button
+          onClick={() => setBatchGenerateMode('silence')}
+          disabled={!project}
+          data-onboarding-target="genr-button"
+          aria-label="Open genr"
+          className="rounded-md border border-cyan-400/30 bg-cyan-400/10 px-2.5 py-1 text-[11px] font-semibold tracking-[0.18em] text-cyan-200 uppercase transition-colors hover:bg-cyan-400/20 disabled:opacity-30"
+          title="genr (Cmd+G)"
+        >
+          genr
+        </button>
         <button onClick={() => setShowProjectListDialog(true)} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors" title="Projects">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" className="inline -mt-px mr-1">
             <path d="M1.5 4.5L7 1.5l5.5 3M1.5 7l5.5 3 5.5-3M1.5 9.5l5.5 3 5.5-3" />
@@ -231,7 +246,7 @@ export function Toolbar() {
       <div className="flex-1" />
 
       {/* Center: Transport controls */}
-      <div className="flex items-center gap-0.5" data-testid="transport-bar">
+      <div className="flex items-center gap-0.5" data-testid="transport-bar" data-onboarding-target="transport">
         {/* Rewind */}
         <ControlBarButton onClick={() => void stop()} title="Go to Beginning (Enter)">
           <svg width="14" height="12" viewBox="0 0 14 12" fill="currentColor">
@@ -327,6 +342,7 @@ export function Toolbar() {
           onClick={() => setShowMixer(!showMixer)}
           title="Mixer (X)"
           disabled={!project}
+          dataTarget="mixer-button"
         >
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4">
             <line x1="3" y1="2" x2="3" y2="12" />
@@ -342,6 +358,7 @@ export function Toolbar() {
           onClick={toggleLoopBrowser}
           title="Loop Browser (O)"
           disabled={!project}
+          dataTarget="loop-browser-button"
         >
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4">
             <circle cx="6" cy="6" r="4" />
@@ -352,6 +369,7 @@ export function Toolbar() {
           active={showAIAssistant}
           onClick={toggleAIAssistant}
           title="AI Assistant (Cmd+/)"
+          dataTarget="assistant-button"
         >
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3">
             <circle cx="7" cy="7" r="5.5" />

--- a/src/components/onboarding/ContextualTips.tsx
+++ b/src/components/onboarding/ContextualTips.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ONBOARDING_TIPS } from '../../data/onboardingCatalog';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+
+type Rect = { top: number; left: number; width: number; height: number };
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function ContextualTips() {
+  const project = useProjectStore((s) => s.project);
+  const onboardingCompleted = useUIStore((s) => s.onboardingCompleted);
+  const activeTutorialStep = useUIStore((s) => s.activeTutorialStep);
+  const dismissedOnboardingTipIds = useUIStore((s) => s.dismissedOnboardingTipIds);
+  const dismissOnboardingTip = useUIStore((s) => s.dismissOnboardingTip);
+  const [targetRect, setTargetRect] = useState<Rect | null>(null);
+
+  const tip = useMemo(() => {
+    if (!project || !onboardingCompleted || activeTutorialStep !== null) return null;
+    return ONBOARDING_TIPS.find((candidate) => !dismissedOnboardingTipIds.includes(candidate.id)) ?? null;
+  }, [activeTutorialStep, dismissedOnboardingTipIds, onboardingCompleted, project]);
+
+  useEffect(() => {
+    if (!tip) return;
+
+    const update = () => {
+      const element = document.querySelector(tip.selector) as HTMLElement | null;
+      if (!element) {
+        setTargetRect(null);
+        return;
+      }
+
+      const rect = element.getBoundingClientRect();
+      setTargetRect({
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      });
+    };
+
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [tip]);
+
+  if (!tip || !targetRect) return null;
+
+  const width = 280;
+  const top = clamp(targetRect.top + targetRect.height + 14, 18, window.innerHeight - 180);
+  const left = clamp(targetRect.left, 18, window.innerWidth - width - 18);
+
+  return (
+    <div
+      className="fixed z-[210] rounded-2xl border border-cyan-400/30 bg-[#111723]/95 p-4 text-zinc-100 shadow-xl shadow-black/50"
+      style={{ top, left, width }}
+      aria-label={`Tip: ${tip.title}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-cyan-300">Tip</p>
+          <h3 className="mt-1 text-sm font-semibold text-white">{tip.title}</h3>
+        </div>
+        <button
+          type="button"
+          aria-label={`Dismiss tip ${tip.title}`}
+          onClick={() => dismissOnboardingTip(tip.id)}
+          className="text-sm text-zinc-500 transition-colors hover:text-white"
+        >
+          ×
+        </button>
+      </div>
+      <p className="mt-2 text-sm leading-6 text-zinc-300">{tip.body}</p>
+    </div>
+  );
+}

--- a/src/components/onboarding/FirstRunOnboarding.tsx
+++ b/src/components/onboarding/FirstRunOnboarding.tsx
@@ -1,0 +1,197 @@
+import { useMemo, useState } from 'react';
+import { ONBOARDING_STARTERS, getStarterTemplate, instantiateDemoProject } from '../../data/onboardingCatalog';
+import { useProjectStore } from '../../store/projectStore';
+import { useUIStore } from '../../store/uiStore';
+
+const COMPLEXITY_TIERS = [
+  {
+    id: 'simple' as const,
+    title: 'Simple',
+    description: 'Prioritize the core writing surface with fewer open panels and Smart Controls on by default.',
+    details: 'Best for first-time users who want to create quickly and keep the workspace light.',
+  },
+  {
+    id: 'standard' as const,
+    title: 'Standard',
+    description: 'Balanced defaults for arranging, generating, and editing without exposing every panel at once.',
+    details: 'Good default for regular music-making sessions.',
+  },
+  {
+    id: 'advanced' as const,
+    title: 'Advanced',
+    description: 'Open more of the DAW immediately, including library, loop browser, mixer, and tempo lane.',
+    details: 'Best for experienced users who want denser control from the first minute.',
+  },
+];
+
+export function FirstRunOnboarding() {
+  const showOnboarding = useUIStore((s) => s.showOnboarding);
+  const workspaceComplexity = useUIStore((s) => s.workspaceComplexity);
+  const applyWorkspaceComplexity = useUIStore((s) => s.applyWorkspaceComplexity);
+  const completeOnboarding = useUIStore((s) => s.completeOnboarding);
+  const skipOnboarding = useUIStore((s) => s.skipOnboarding);
+  const startTutorial = useUIStore((s) => s.startTutorial);
+  const setShowNewProjectDialog = useUIStore((s) => s.setShowNewProjectDialog);
+  const createProjectFromTemplate = useProjectStore((s) => s.createProjectFromTemplate);
+  const setProject = useProjectStore((s) => s.setProject);
+
+  const [starterId, setStarterId] = useState(ONBOARDING_STARTERS[0].id);
+  const selectedStarter = useMemo(
+    () => ONBOARDING_STARTERS.find((starter) => starter.id === starterId) ?? ONBOARDING_STARTERS[0],
+    [starterId],
+  );
+
+  if (!showOnboarding) return null;
+
+  const handleStart = () => {
+    applyWorkspaceComplexity(workspaceComplexity);
+
+    if (selectedStarter.kind === 'template') {
+      const template = getStarterTemplate(selectedStarter.id);
+      if (template) createProjectFromTemplate(template);
+    } else {
+      setProject(instantiateDemoProject(selectedStarter.id));
+    }
+
+    completeOnboarding();
+    setShowNewProjectDialog(false);
+    startTutorial();
+  };
+
+  const handleSkip = () => {
+    skipOnboarding();
+    setShowNewProjectDialog(true);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[240] bg-[#090b10]/92 backdrop-blur-sm text-zinc-100" aria-label="First-run onboarding">
+      <div className="h-full overflow-y-auto">
+        <div className="mx-auto flex min-h-full w-full max-w-7xl flex-col px-5 py-8">
+          <div className="mb-8 flex items-start justify-between gap-4">
+            <div className="max-w-3xl">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.28em] text-cyan-300">First Run</p>
+              <h1 className="text-3xl font-semibold text-white">Start in a session that already knows where you are going.</h1>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-300">
+                Choose a genre starter or open a demo project, then set the workspace density that matches your experience.
+                The guided tutorial is optional and you can dismiss tips permanently.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleSkip}
+              className="rounded-full border border-zinc-700 px-4 py-2 text-xs font-medium text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white"
+            >
+              Skip For Now
+            </button>
+          </div>
+
+          <div className="grid gap-6 xl:grid-cols-[1.45fr_0.95fr]">
+            <section className="rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(28,36,49,0.92),rgba(13,16,23,0.96))] p-5 shadow-2xl shadow-black/30">
+              <div className="mb-5 flex items-end justify-between gap-4">
+                <div>
+                  <h2 className="text-lg font-semibold text-white">1. Pick a starter</h2>
+                  <p className="mt-1 text-sm text-zinc-400">Templates create a fresh scaffold. Demo projects open with content ready for editing.</p>
+                </div>
+                <p className="text-[11px] uppercase tracking-[0.22em] text-zinc-500">Template + Demo</p>
+              </div>
+
+              <div className="grid gap-3 lg:grid-cols-2">
+                {ONBOARDING_STARTERS.map((starter) => {
+                  const active = starter.id === starterId;
+                  return (
+                    <button
+                      key={starter.id}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => setStarterId(starter.id)}
+                      className={`rounded-3xl border p-4 text-left transition-all ${
+                        active
+                          ? 'border-cyan-400/60 bg-cyan-400/10 shadow-lg shadow-cyan-950/50'
+                          : 'border-white/10 bg-white/4 hover:border-white/20 hover:bg-white/7'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-cyan-300">{starter.genre}</p>
+                          <h3 className="mt-1 text-lg font-semibold text-white">{starter.title}</h3>
+                        </div>
+                        <div className="rounded-full border border-white/10 px-2.5 py-1 text-[10px] uppercase tracking-[0.18em] text-zinc-400">
+                          {starter.bpm} BPM
+                        </div>
+                      </div>
+
+                      <p className="mt-3 text-sm leading-6 text-zinc-300">{starter.description}</p>
+                      <p className="mt-3 text-xs leading-5 text-zinc-400">{starter.summary}</p>
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {starter.tracks.map((track) => (
+                          <span key={track} className="rounded-full border border-white/10 bg-black/20 px-2.5 py-1 text-[11px] text-zinc-300">
+                            {track}
+                          </span>
+                        ))}
+                      </div>
+                      <p className="mt-4 text-[11px] uppercase tracking-[0.18em] text-zinc-500">
+                        {starter.keyScale}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(24,27,35,0.94),rgba(10,12,16,0.98))] p-5 shadow-2xl shadow-black/30">
+              <div className="mb-5">
+                <h2 className="text-lg font-semibold text-white">2. Choose workspace density</h2>
+                <p className="mt-1 text-sm text-zinc-400">This changes the visible defaults before you land in the main workspace.</p>
+              </div>
+
+              <div className="space-y-3">
+                {COMPLEXITY_TIERS.map((tier) => {
+                  const active = tier.id === workspaceComplexity;
+                  return (
+                    <button
+                      key={tier.id}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => applyWorkspaceComplexity(tier.id)}
+                      className={`w-full rounded-2xl border p-4 text-left transition-all ${
+                        active
+                          ? 'border-emerald-400/60 bg-emerald-400/10'
+                          : 'border-white/10 bg-white/4 hover:border-white/20'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <h3 className="text-sm font-semibold text-white">{tier.title}</h3>
+                        <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+                          {active ? 'Selected' : 'Available'}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-zinc-300">{tier.description}</p>
+                      <p className="mt-2 text-xs leading-5 text-zinc-500">{tier.details}</p>
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="mt-6 rounded-2xl border border-white/10 bg-black/20 p-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">What happens next</p>
+                <ul className="mt-3 space-y-2 text-sm leading-6 text-zinc-300">
+                  <li>First launch opens into the selected starter, not an empty DAW.</li>
+                  <li>A skippable 5-step tutorial points out timeline, transport, genr, mixer, and help.</li>
+                  <li>Contextual tips stay dismissible and do not return once removed.</li>
+                </ul>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleStart}
+                className="mt-6 w-full rounded-2xl bg-cyan-500 px-4 py-3 text-sm font-semibold text-slate-950 transition-colors hover:bg-cyan-400"
+              >
+                Open {selectedStarter.title}
+              </button>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/GuidedTutorialOverlay.tsx
+++ b/src/components/onboarding/GuidedTutorialOverlay.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ONBOARDING_TUTORIAL_STEPS } from '../../data/onboardingCatalog';
+import { useUIStore } from '../../store/uiStore';
+
+type Rect = { top: number; left: number; width: number; height: number };
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function GuidedTutorialOverlay() {
+  const activeTutorialStep = useUIStore((s) => s.activeTutorialStep);
+  const nextTutorialStep = useUIStore((s) => s.nextTutorialStep);
+  const finishTutorial = useUIStore((s) => s.finishTutorial);
+  const skipTutorial = useUIStore((s) => s.skipTutorial);
+  const [targetRect, setTargetRect] = useState<Rect | null>(null);
+
+  const step = useMemo(
+    () => (activeTutorialStep === null ? null : ONBOARDING_TUTORIAL_STEPS[activeTutorialStep] ?? null),
+    [activeTutorialStep],
+  );
+
+  useEffect(() => {
+    if (!step) return;
+
+    const update = () => {
+      const element = document.querySelector(step.selector) as HTMLElement | null;
+      if (!element) {
+        setTargetRect(null);
+        return;
+      }
+
+      const rect = element.getBoundingClientRect();
+      setTargetRect({
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      });
+    };
+
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [step]);
+
+  if (!step || activeTutorialStep === null) return null;
+
+  const cardWidth = 340;
+  const top = targetRect
+    ? clamp(targetRect.top + targetRect.height + 18, 24, window.innerHeight - 240)
+    : window.innerHeight / 2 - 120;
+  const left = targetRect
+    ? clamp(targetRect.left, 24, window.innerWidth - cardWidth - 24)
+    : window.innerWidth / 2 - cardWidth / 2;
+
+  const isLastStep = activeTutorialStep === ONBOARDING_TUTORIAL_STEPS.length - 1;
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-[250]">
+      <div className="absolute inset-0 bg-black/45" />
+      {targetRect && (
+        <div
+          className="absolute rounded-2xl border-2 border-cyan-300 shadow-[0_0_0_9999px_rgba(0,0,0,0.35)] transition-all"
+          style={{
+            top: targetRect.top - 8,
+            left: targetRect.left - 8,
+            width: targetRect.width + 16,
+            height: targetRect.height + 16,
+          }}
+        />
+      )}
+
+      <div
+        className="pointer-events-auto absolute rounded-3xl border border-white/10 bg-[#0f141d] p-5 text-zinc-100 shadow-2xl shadow-black/60"
+        style={{ top, left, width: cardWidth }}
+      >
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-cyan-300">
+          Tutorial {activeTutorialStep + 1}/{ONBOARDING_TUTORIAL_STEPS.length}
+        </p>
+        <h2 className="mt-2 text-lg font-semibold text-white">{step.title}</h2>
+        <p className="mt-2 text-sm leading-6 text-zinc-300">{step.body}</p>
+        <div className="mt-4 flex items-center justify-between gap-3">
+          <button
+            type="button"
+            aria-label="Skip onboarding tutorial"
+            onClick={skipTutorial}
+            className="rounded-full border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white"
+          >
+            Skip
+          </button>
+          <button
+            type="button"
+            onClick={isLastStep ? finishTutorial : nextTutorialStep}
+            className="rounded-full bg-cyan-400 px-4 py-1.5 text-xs font-semibold text-slate-950 transition-colors hover:bg-cyan-300"
+          >
+            {isLastStep ? 'Finish' : 'Next'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -343,6 +343,7 @@ export function Timeline() {
         data-keyboard-context="timeline"
         role="grid"
         tabIndex={0}
+        data-onboarding-target="timeline"
         className="flex-1 overflow-auto bg-[#242424] relative"
         onWheel={handleWheel}
         onMouseDownCapture={handleMouseDownCapture}

--- a/src/data/onboardingCatalog.ts
+++ b/src/data/onboardingCatalog.ts
@@ -1,0 +1,541 @@
+import { DEFAULT_GENERATION } from '../constants/defaults';
+import { createDefaultMasteringState } from '../utils/mastering';
+import type { Clip, MidiNote, Project, ProjectTemplate, SequencerPattern, Track, TrackName, TrackType } from '../types/project';
+
+export type OnboardingStarterKind = 'template' | 'demo';
+
+export interface OnboardingStarter {
+  id: string;
+  kind: OnboardingStarterKind;
+  title: string;
+  genre: string;
+  description: string;
+  bpm: number;
+  keyScale: string;
+  summary: string;
+  tracks: string[];
+}
+
+export interface OnboardingTutorialStep {
+  id: string;
+  selector: string;
+  title: string;
+  body: string;
+}
+
+export interface OnboardingTip {
+  id: string;
+  selector: string;
+  title: string;
+  body: string;
+}
+
+type TrackInput = {
+  trackName: TrackName;
+  trackType: TrackType;
+  displayName?: string;
+  color: string;
+  synthPreset?: Track['synthPreset'];
+  localCaption?: string;
+  sequencerPattern?: SequencerPattern;
+  clips?: Clip[];
+};
+
+const DEMO_LENGTH_BARS = 16;
+
+function createSteps(activeIndexes: number[], length = 16) {
+  return Array.from({ length }, (_, index) => ({
+    active: activeIndexes.includes(index),
+    velocity: activeIndexes.includes(index) ? 0.85 : 0,
+  }));
+}
+
+function createSequencerPattern(name: string, rows: { id: string; name: string; color: string; active: number[] }[]): SequencerPattern {
+  return {
+    id: crypto.randomUUID(),
+    name,
+    bars: 1,
+    stepsPerBar: 16,
+    swing: 0.08,
+    rows: rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      sampleKey: row.id,
+      steps: createSteps(row.active),
+      volume: 0.8,
+      pan: 0,
+      muted: false,
+      color: row.color,
+    })),
+  };
+}
+
+function createMidiClip(trackId: string, startTime: number, duration: number, prompt: string, notes: Omit<MidiNote, 'id'>[]): Clip {
+  return {
+    id: crypto.randomUUID(),
+    trackId,
+    startTime,
+    duration,
+    prompt,
+    lyrics: '',
+    generationStatus: 'empty',
+    generationJobId: null,
+    cumulativeMixKey: null,
+    isolatedAudioKey: null,
+    waveformPeaks: null,
+    midiData: {
+      notes: notes.map((note) => ({ ...note, id: crypto.randomUUID() })),
+      grid: '1/16',
+    },
+  };
+}
+
+function createTrack(order: number, input: TrackInput): Track {
+  return {
+    id: crypto.randomUUID(),
+    trackName: input.trackName,
+    trackType: input.trackType,
+    displayName: input.displayName ?? input.trackName,
+    color: input.color,
+    order,
+    volume: 0.8,
+    muted: false,
+    soloed: false,
+    pan: 0,
+    clips: input.clips ?? [],
+    synthPreset: input.synthPreset,
+    localCaption: input.localCaption,
+    sequencerPattern: input.sequencerPattern,
+  };
+}
+
+function createTemplate(id: string, name: string, description: string, bpm: number, keyScale: string, tracks: TrackInput[]): ProjectTemplate {
+  return {
+    id,
+    name,
+    description,
+    createdAt: Date.now(),
+    bpm,
+    keyScale,
+    timeSignature: 4,
+    measures: 64,
+    generationDefaults: structuredClone(DEFAULT_GENERATION),
+    tracks: tracks.map((track) => ({
+      trackName: track.trackName,
+      trackType: track.trackType,
+      displayName: track.displayName ?? track.trackName,
+      color: track.color,
+      volume: 0.8,
+      pan: 0,
+      synthPreset: track.synthPreset,
+      localCaption: track.localCaption,
+      sequencerPattern: track.sequencerPattern,
+    })),
+  };
+}
+
+export const ONBOARDING_STARTERS: OnboardingStarter[] = [
+  {
+    id: 'electronic-template',
+    kind: 'template',
+    title: 'Electronic Pulse',
+    genre: 'Template',
+    description: 'Fast lane for club, synthwave, and polished pop sketches with genr-ready starter tracks.',
+    bpm: 124,
+    keyScale: 'A minor',
+    summary: 'Drum machine, bass synth, lead synth, and FX return ready for the first genr pass.',
+    tracks: ['Drum Machine', 'Bass Synth', 'Lead Synth', 'FX'],
+  },
+  {
+    id: 'hip-hop-template',
+    kind: 'template',
+    title: 'Late Night Hip Hop',
+    genre: 'Template',
+    description: 'Laid-back drums, warm keys, and a vocal lane prepped for lyric-first production.',
+    bpm: 92,
+    keyScale: 'D minor',
+    summary: 'Boom-bap drum rack, bass, keys, and vocal stem lane with relaxed defaults.',
+    tracks: ['Drums', 'Bass', 'Keys', 'Vocals'],
+  },
+  {
+    id: 'songwriter-template',
+    kind: 'template',
+    title: 'Songwriter Session',
+    genre: 'Template',
+    description: 'A clean arrangement scaffold for guitar, keys, and vocal ideas without visual overload.',
+    bpm: 108,
+    keyScale: 'G major',
+    summary: 'Verse/chorus-friendly starter layout with drums, guitar, keys, and lead vocals.',
+    tracks: ['Drums', 'Guitar', 'Keys', 'Lead Vocal'],
+  },
+  {
+    id: 'synthwave-demo',
+    kind: 'demo',
+    title: 'Neon Run Demo',
+    genre: 'Demo Project',
+    description: 'Open a fully seeded session with drums, bass, hooks, markers, and MIDI clips already in place.',
+    bpm: 118,
+    keyScale: 'E minor',
+    summary: 'Shows a complete intro-to-drop arrangement with sequencer drums and MIDI hooks.',
+    tracks: ['Drums', 'Bassline', 'Hook', 'Atmos'],
+  },
+  {
+    id: 'lofi-demo',
+    kind: 'demo',
+    title: 'Lofi Sketch Demo',
+    genre: 'Demo Project',
+    description: 'A softer demo session with chords and melody clips so first-time users can explore editing immediately.',
+    bpm: 78,
+    keyScale: 'C major',
+    summary: 'Ready-made beat, keys, and melody clips for timeline, piano roll, and mixer exploration.',
+    tracks: ['Beat', 'Keys', 'Melody', 'Vocal Chop'],
+  },
+];
+
+const TEMPLATE_MAP: Record<string, ProjectTemplate> = {
+  'electronic-template': createTemplate(
+    'electronic-template',
+    'Electronic Pulse',
+    'Club-ready starter with drum machine and synth lanes.',
+    124,
+    'A minor',
+    [
+      {
+        trackName: 'drums',
+        trackType: 'drumMachine',
+        displayName: 'Drum Machine',
+        color: '#ef4444',
+        localCaption: 'punchy electronic drums, tight kick, crisp hats',
+      },
+      {
+        trackName: 'bass',
+        trackType: 'pianoRoll',
+        displayName: 'Bass Synth',
+        color: '#f97316',
+        synthPreset: 'bass',
+        localCaption: 'driving analog bass, sidechained, warm low end',
+      },
+      {
+        trackName: 'synth',
+        trackType: 'pianoRoll',
+        displayName: 'Lead Synth',
+        color: '#3b82f6',
+        synthPreset: 'lead',
+        localCaption: 'glossy synth lead with bright attack and motion',
+      },
+      {
+        trackName: 'fx',
+        trackType: 'stems',
+        displayName: 'FX',
+        color: '#8b5cf6',
+        localCaption: 'riser, impacts, and transitional ear candy',
+      },
+    ],
+  ),
+  'hip-hop-template': createTemplate(
+    'hip-hop-template',
+    'Late Night Hip Hop',
+    'Boom-bap oriented starter session with drums, keys, and vocal lane.',
+    92,
+    'D minor',
+    [
+      {
+        trackName: 'drums',
+        trackType: 'sequencer',
+        displayName: 'Drums',
+        color: '#ef4444',
+        localCaption: 'dusty hip hop drums with pocket and swing',
+        sequencerPattern: createSequencerPattern('Boom Bap', [
+          { id: 'kick', name: 'Kick', color: '#ef4444', active: [0, 7, 8, 12] },
+          { id: 'snare', name: 'Snare', color: '#f97316', active: [4, 12] },
+          { id: 'closed_hh', name: 'Closed HH', color: '#eab308', active: [0, 2, 4, 6, 8, 10, 12, 14] },
+        ]),
+      },
+      {
+        trackName: 'bass',
+        trackType: 'stems',
+        displayName: 'Bass',
+        color: '#f97316',
+        localCaption: 'round sub bass, muted attack, deep groove',
+      },
+      {
+        trackName: 'keyboard',
+        trackType: 'pianoRoll',
+        displayName: 'Keys',
+        color: '#22c55e',
+        synthPreset: 'piano',
+        localCaption: 'jazzy electric piano chords with tape warmth',
+      },
+      {
+        trackName: 'vocals',
+        trackType: 'stems',
+        displayName: 'Vocals',
+        color: '#f43f5e',
+        localCaption: 'intimate lead vocal, close mic, low-key delivery',
+      },
+    ],
+  ),
+  'songwriter-template': createTemplate(
+    'songwriter-template',
+    'Songwriter Session',
+    'Clean arrangement-first template for writing around vocal and harmony.',
+    108,
+    'G major',
+    [
+      {
+        trackName: 'drums',
+        trackType: 'stems',
+        displayName: 'Drums',
+        color: '#ef4444',
+        localCaption: 'natural indie-pop drums, light room, steady groove',
+      },
+      {
+        trackName: 'guitar',
+        trackType: 'stems',
+        displayName: 'Guitar',
+        color: '#eab308',
+        localCaption: 'strummed acoustic guitar, open and warm',
+      },
+      {
+        trackName: 'keyboard',
+        trackType: 'pianoRoll',
+        displayName: 'Keys',
+        color: '#22c55e',
+        synthPreset: 'piano',
+        localCaption: 'supportive piano chords with dynamic phrasing',
+      },
+      {
+        trackName: 'vocals',
+        trackType: 'stems',
+        displayName: 'Lead Vocal',
+        color: '#f43f5e',
+        localCaption: 'clear lead vocal, emotional delivery, close upfront tone',
+      },
+    ],
+  ),
+};
+
+function createDemoProject(id: string): Project {
+  const now = Date.now();
+  if (id === 'synthwave-demo') {
+    const drums = createTrack(0, {
+      trackName: 'drums',
+      trackType: 'sequencer',
+      displayName: 'Drums',
+      color: '#ef4444',
+      localCaption: 'retro electronic kit with pulsing hats and snare fill',
+      sequencerPattern: createSequencerPattern('Neon Beat', [
+        { id: 'kick', name: 'Kick', color: '#ef4444', active: [0, 4, 8, 12] },
+        { id: 'snare', name: 'Snare', color: '#f97316', active: [4, 12] },
+        { id: 'closed_hh', name: 'Closed HH', color: '#eab308', active: [0, 2, 4, 6, 8, 10, 12, 14] },
+        { id: 'clap', name: 'Clap', color: '#22c55e', active: [12] },
+      ]),
+    });
+    const bass = createTrack(1, {
+      trackName: 'bass',
+      trackType: 'pianoRoll',
+      displayName: 'Bassline',
+      color: '#f97316',
+      synthPreset: 'bass',
+      localCaption: 'retro arpeggiated bass with sidechain space',
+    });
+    bass.clips = [
+      createMidiClip(bass.id, 0, 8, 'syncopated bassline', [
+        { pitch: 40, startBeat: 0, durationBeats: 1, velocity: 0.9 },
+        { pitch: 43, startBeat: 2, durationBeats: 1, velocity: 0.82 },
+        { pitch: 47, startBeat: 4, durationBeats: 1, velocity: 0.88 },
+        { pitch: 43, startBeat: 6, durationBeats: 1, velocity: 0.8 },
+      ]),
+    ];
+    const hook = createTrack(2, {
+      trackName: 'synth',
+      trackType: 'pianoRoll',
+      displayName: 'Hook',
+      color: '#3b82f6',
+      synthPreset: 'lead',
+      localCaption: 'glassy synth hook with 80s phrasing',
+    });
+    hook.clips = [
+      createMidiClip(hook.id, 4, 8, 'anthem lead hook', [
+        { pitch: 76, startBeat: 0, durationBeats: 1, velocity: 0.82 },
+        { pitch: 79, startBeat: 1, durationBeats: 1, velocity: 0.84 },
+        { pitch: 83, startBeat: 2, durationBeats: 2, velocity: 0.88 },
+        { pitch: 79, startBeat: 4, durationBeats: 1, velocity: 0.8 },
+      ]),
+    ];
+    const atmos = createTrack(3, {
+      trackName: 'strings',
+      trackType: 'pianoRoll',
+      displayName: 'Atmos',
+      color: '#06b6d4',
+      synthPreset: 'pad',
+      localCaption: 'wide pad with long swells and cinematic space',
+    });
+    atmos.clips = [
+      createMidiClip(atmos.id, 0, 16, 'evolving pad bed', [
+        { pitch: 64, startBeat: 0, durationBeats: 4, velocity: 0.62 },
+        { pitch: 67, startBeat: 0, durationBeats: 4, velocity: 0.6 },
+        { pitch: 71, startBeat: 0, durationBeats: 4, velocity: 0.58 },
+      ]),
+    ];
+
+    return {
+      id: crypto.randomUUID(),
+      name: 'Neon Run Demo',
+      createdAt: now,
+      updatedAt: now,
+      bpm: 118,
+      keyScale: 'E minor',
+      timeSignature: 4,
+      totalDuration: DEMO_LENGTH_BARS * 2,
+      measures: DEMO_LENGTH_BARS,
+      tracks: [drums, bass, hook, atmos],
+      generationDefaults: structuredClone(DEFAULT_GENERATION),
+      globalCaption: 'synthwave night drive, glossy drums, cinematic retro hook',
+      mastering: createDefaultMasteringState(),
+      markers: [
+        { id: crypto.randomUUID(), time: 0, name: 'Intro', color: '#6366f1' },
+        { id: crypto.randomUUID(), time: 8, name: 'Build', color: '#22c55e' },
+        { id: crypto.randomUUID(), time: 16, name: 'Drop', color: '#f97316' },
+      ],
+      trackPresets: [],
+    };
+  }
+
+  const beat = createTrack(0, {
+    trackName: 'drums',
+    trackType: 'sequencer',
+    displayName: 'Beat',
+    color: '#ef4444',
+    localCaption: 'dusty lo-fi drums with soft swing and vinyl texture',
+    sequencerPattern: createSequencerPattern('Lofi Beat', [
+      { id: 'kick', name: 'Kick', color: '#ef4444', active: [0, 6, 8, 13] },
+      { id: 'snare', name: 'Snare', color: '#f97316', active: [4, 12] },
+      { id: 'closed_hh', name: 'Closed HH', color: '#eab308', active: [0, 2, 4, 7, 8, 10, 12, 15] },
+    ]),
+  });
+  const keys = createTrack(1, {
+    trackName: 'keyboard',
+    trackType: 'pianoRoll',
+    displayName: 'Keys',
+    color: '#22c55e',
+    synthPreset: 'piano',
+    localCaption: 'warm jazz chords with soft attack and room tone',
+  });
+  keys.clips = [
+    createMidiClip(keys.id, 0, 16, 'jazzy lofi chords', [
+      { pitch: 60, startBeat: 0, durationBeats: 4, velocity: 0.6 },
+      { pitch: 64, startBeat: 0, durationBeats: 4, velocity: 0.58 },
+      { pitch: 67, startBeat: 0, durationBeats: 4, velocity: 0.56 },
+      { pitch: 62, startBeat: 4, durationBeats: 4, velocity: 0.6 },
+      { pitch: 65, startBeat: 4, durationBeats: 4, velocity: 0.58 },
+      { pitch: 69, startBeat: 4, durationBeats: 4, velocity: 0.56 },
+    ]),
+  ];
+  const melody = createTrack(2, {
+    trackName: 'synth',
+    trackType: 'pianoRoll',
+    displayName: 'Melody',
+    color: '#3b82f6',
+    synthPreset: 'lead',
+    localCaption: 'tape-worn topline with sparse phrasing',
+  });
+  melody.clips = [
+    createMidiClip(melody.id, 8, 8, 'gentle topline', [
+      { pitch: 72, startBeat: 0, durationBeats: 1, velocity: 0.7 },
+      { pitch: 74, startBeat: 1.5, durationBeats: 0.5, velocity: 0.65 },
+      { pitch: 79, startBeat: 3, durationBeats: 1, velocity: 0.68 },
+    ]),
+  ];
+  const vocal = createTrack(3, {
+    trackName: 'vocals',
+    trackType: 'stems',
+    displayName: 'Vocal Chop',
+    color: '#f43f5e',
+    localCaption: 'airy vocal chop with distant reverb and pitch texture',
+  });
+
+  return {
+    id: crypto.randomUUID(),
+    name: 'Lofi Sketch Demo',
+    createdAt: now,
+    updatedAt: now,
+    bpm: 78,
+    keyScale: 'C major',
+    timeSignature: 4,
+    totalDuration: DEMO_LENGTH_BARS * 3,
+    measures: DEMO_LENGTH_BARS,
+    tracks: [beat, keys, melody, vocal],
+    generationDefaults: structuredClone(DEFAULT_GENERATION),
+    globalCaption: 'lofi study beat, dusty drums, mellow piano, intimate textures',
+    mastering: createDefaultMasteringState(),
+    markers: [
+      { id: crypto.randomUUID(), time: 0, name: 'Intro', color: '#6366f1' },
+      { id: crypto.randomUUID(), time: 12, name: 'Theme', color: '#22c55e' },
+      { id: crypto.randomUUID(), time: 24, name: 'B Section', color: '#f97316' },
+    ],
+    trackPresets: [],
+  };
+}
+
+export function getStarterTemplate(id: string) {
+  return TEMPLATE_MAP[id];
+}
+
+export function instantiateDemoProject(id: string) {
+  return createDemoProject(id);
+}
+
+export const ONBOARDING_TUTORIAL_STEPS: OnboardingTutorialStep[] = [
+  {
+    id: 'timeline',
+    selector: '[data-onboarding-target="timeline"]',
+    title: 'Timeline',
+    body: 'Arrange clips here. Drag regions, make selections, and build the song structure from left to right.',
+  },
+  {
+    id: 'transport',
+    selector: '[data-onboarding-target="transport"]',
+    title: 'Transport',
+    body: 'Use Space to play and stop. Record, loop, and navigate from the transport bar while you sketch.',
+  },
+  {
+    id: 'genr',
+    selector: '[data-onboarding-target="genr-button"]',
+    title: 'genr',
+    body: 'Open genr with Cmd+G to generate a first pass for the current arrangement or starter template.',
+  },
+  {
+    id: 'mixer',
+    selector: '[data-onboarding-target="mixer-button"]',
+    title: 'Mixer',
+    body: 'Toggle the mixer with X to balance level, pan, and effects once the first ideas are in place.',
+  },
+  {
+    id: 'assistant',
+    selector: '[data-onboarding-target="assistant-button"]',
+    title: 'Help In Context',
+    body: 'Open the in-DAW assistant with Cmd+/ when you need workflow, arrangement, or mixing guidance.',
+  },
+];
+
+export const ONBOARDING_TIPS: OnboardingTip[] = [
+  {
+    id: 'genr-first-pass',
+    selector: '[data-onboarding-target="genr-button"]',
+    title: 'Start with genr',
+    body: 'Use Cmd+G to open genr and generate the first pass against your starter tracks instead of building from silence.',
+  },
+  {
+    id: 'loop-browser',
+    selector: '[data-onboarding-target="loop-browser-button"]',
+    title: 'Quick Layering',
+    body: 'Press O to open the loop browser and drag a texture or groove directly into the timeline.',
+  },
+  {
+    id: 'timeline-selection',
+    selector: '[data-onboarding-target="timeline"]',
+    title: 'Fast Selection',
+    body: 'Hold Cmd or Ctrl while dragging on the timeline to define a generate window for a focused genr pass.',
+  },
+];

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -165,6 +165,9 @@ export function useKeyboardShortcuts() {
         } else if (ui.showUndoHistoryPanel) {
           event.preventDefault();
           ui.setShowUndoHistoryPanel(false);
+        } else if (ui.activeTutorialStep !== null) {
+          event.preventDefault();
+          ui.skipTutorial();
         } else if (ui.showAIAssistant) {
           event.preventDefault();
           ui.setShowAIAssistant(false);
@@ -195,6 +198,8 @@ export function useKeyboardShortcuts() {
         } else if (ui.showProjectListDialog) {
           event.preventDefault();
           ui.setShowProjectListDialog(false);
+        } else if (ui.showOnboarding) {
+          event.preventDefault();
         } else if (ui.selectWindow !== null) {
           event.preventDefault();
           ui.setSelectWindow(null);
@@ -218,7 +223,9 @@ export function useKeyboardShortcuts() {
         ui.showSettingsDialog ||
         ui.showExportDialog ||
         ui.showProjectListDialog ||
-        ui.showNewProjectDialog;
+        ui.showNewProjectDialog ||
+        ui.showOnboarding ||
+        ui.activeTutorialStep !== null;
 
       if (matches('view.zoomIn')) { event.preventDefault(); ui.zoomIn(); return; }
       if (matches('view.zoomOut')) { event.preventDefault(); ui.zoomOut(); return; }

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -120,6 +120,14 @@ interface UIState {
   aiAssistantStreaming: boolean;
   aiAssistantSuggestions: string[];
   aiAssistantError: string | null;
+  showOnboarding: boolean;
+  onboardingCompleted: boolean;
+  onboardingSkipped: boolean;
+  workspaceComplexity: 'simple' | 'standard' | 'advanced';
+  activeTutorialStep: number | null;
+  tutorialCompleted: boolean;
+  tutorialSkipped: boolean;
+  dismissedOnboardingTipIds: string[];
 
   // Inline AI regeneration & suggestions
   regionRegenerateTarget: { startTime: number; endTime: number; trackIds: string[] } | null;
@@ -236,9 +244,58 @@ interface UIState {
   dismissInlineSuggestion: (id: string) => void;
   clearInlineSuggestions: () => void;
   setSuggestionFrequency: (v: 'off' | 'subtle' | 'active') => void;
+  setShowOnboarding: (v: boolean) => void;
+  applyWorkspaceComplexity: (tier: 'simple' | 'standard' | 'advanced') => void;
+  completeOnboarding: () => void;
+  skipOnboarding: () => void;
+  startTutorial: () => void;
+  nextTutorialStep: () => void;
+  finishTutorial: () => void;
+  skipTutorial: () => void;
+  dismissOnboardingTip: (id: string) => void;
 }
 
 const ZOOM_LEVELS = [10, 25, 50, 100, 200, 500];
+const TUTORIAL_STEP_COUNT = 5;
+
+function getComplexityDefaults(tier: 'simple' | 'standard' | 'advanced') {
+  switch (tier) {
+    case 'simple':
+      return {
+        workspaceComplexity: tier,
+        showMixer: false,
+        showLibrary: false,
+        loopBrowserOpen: false,
+        showSmartControls: true,
+        showTempoLane: false,
+        trackListWidth: 200,
+        pixelsPerSecond: 50,
+      };
+    case 'advanced':
+      return {
+        workspaceComplexity: tier,
+        showMixer: true,
+        showLibrary: true,
+        loopBrowserOpen: true,
+        showSmartControls: false,
+        showTempoLane: true,
+        trackListWidth: 250,
+        pixelsPerSecond: 100,
+      };
+    case 'standard':
+    default:
+      return {
+        workspaceComplexity: tier,
+        showMixer: false,
+        showLibrary: false,
+        loopBrowserOpen: false,
+        showSmartControls: false,
+        showTempoLane: false,
+        trackListWidth: 220,
+        pixelsPerSecond: 50,
+      };
+  }
+}
 
 export const useUIStore = create<UIState>()(
   persist(
@@ -319,6 +376,14 @@ export const useUIStore = create<UIState>()(
   aiAssistantStreaming: false,
   aiAssistantSuggestions: [],
   aiAssistantError: null,
+  showOnboarding: false,
+  onboardingCompleted: false,
+  onboardingSkipped: false,
+  workspaceComplexity: 'standard',
+  activeTutorialStep: null,
+  tutorialCompleted: false,
+  tutorialSkipped: false,
+  dismissedOnboardingTipIds: [],
 
   regionRegenerateTarget: null,
   inlineSuggestions: [],
@@ -564,7 +629,6 @@ export const useUIStore = create<UIState>()(
       }));
     }
   },
-
   setRegionRegenerateTarget: (v) => set({ regionRegenerateTarget: v }),
   setInlineSuggestions: (v) => set({ inlineSuggestions: v }),
   dismissInlineSuggestion: (id) => set((s) => ({
@@ -572,6 +636,49 @@ export const useUIStore = create<UIState>()(
   })),
   clearInlineSuggestions: () => set({ inlineSuggestions: [] }),
   setSuggestionFrequency: (v) => set({ suggestionFrequency: v }),
+  setShowOnboarding: (v) => set({ showOnboarding: v }),
+  applyWorkspaceComplexity: (tier) => set(getComplexityDefaults(tier)),
+  completeOnboarding: () => set({
+    onboardingCompleted: true,
+    onboardingSkipped: false,
+    showOnboarding: false,
+  }),
+  skipOnboarding: () => set({
+    onboardingSkipped: true,
+    showOnboarding: false,
+    activeTutorialStep: null,
+    tutorialSkipped: true,
+  }),
+  startTutorial: () => set((state) => (
+    state.tutorialCompleted || state.tutorialSkipped
+      ? {}
+      : { activeTutorialStep: 0 }
+  )),
+  nextTutorialStep: () => set((state) => {
+    if (state.activeTutorialStep === null) return {};
+    if (state.activeTutorialStep >= TUTORIAL_STEP_COUNT - 1) {
+      return {
+        activeTutorialStep: null,
+        tutorialCompleted: true,
+        tutorialSkipped: false,
+      };
+    }
+    return { activeTutorialStep: state.activeTutorialStep + 1 };
+  }),
+  finishTutorial: () => set({
+    activeTutorialStep: null,
+    tutorialCompleted: true,
+    tutorialSkipped: false,
+  }),
+  skipTutorial: () => set({
+    activeTutorialStep: null,
+    tutorialSkipped: true,
+  }),
+  dismissOnboardingTip: (id) => set((state) => (
+    state.dismissedOnboardingTipIds.includes(id)
+      ? {}
+      : { dismissedOnboardingTipIds: [...state.dismissedOnboardingTipIds, id] }
+  )),
 }),
     {
       name: 'ace-step-daw-ui',
@@ -605,6 +712,13 @@ export const useUIStore = create<UIState>()(
         showGenerationPanel: state.showGenerationPanel,
         // AI Assistant
         showAIAssistant: state.showAIAssistant,
+        // Onboarding
+        onboardingCompleted: state.onboardingCompleted,
+        onboardingSkipped: state.onboardingSkipped,
+        workspaceComplexity: state.workspaceComplexity,
+        tutorialCompleted: state.tutorialCompleted,
+        tutorialSkipped: state.tutorialSkipped,
+        dismissedOnboardingTipIds: state.dismissedOnboardingTipIds,
         // Inline suggestions
         suggestionFrequency: state.suggestionFrequency,
         // Command palette

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('first-run onboarding', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    await page.goto('/');
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
+  });
+
+  test('first launch shows onboarding before the main workspace setup dialogs', async ({ page }) => {
+    await page.waitForFunction(() => (window as any).__uiStore.getState().showOnboarding === true, null, { timeout: 10000 });
+    await expect(page.getByLabel('First-run onboarding')).toBeVisible();
+    await expect(page.getByText('Start in a session that already knows where you are going.')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'New Project' })).not.toBeVisible();
+  });
+
+  test('starting from a demo project applies advanced defaults and opens tutorial', async ({ page }) => {
+    await page.getByRole('button', { name: 'Neon Run Demo' }).click();
+    await page.getByRole('button', { name: 'Advanced' }).click();
+    await page.getByRole('button', { name: 'Open Neon Run Demo' }).click();
+
+    await expect(page.getByText('Tutorial 1/5')).toBeVisible();
+
+    const state = await page.evaluate(() => {
+      const ui = (window as any).__uiStore.getState();
+      const project = (window as any).__store.getState().project;
+      return {
+        projectName: project?.name,
+        trackCount: project?.tracks?.length ?? 0,
+        showMixer: ui.showMixer,
+        showLibrary: ui.showLibrary,
+        loopBrowserOpen: ui.loopBrowserOpen,
+        workspaceComplexity: ui.workspaceComplexity,
+      };
+    });
+
+    expect(state.projectName).toBe('Neon Run Demo');
+    expect(state.trackCount).toBeGreaterThanOrEqual(4);
+    expect(state.showMixer).toBe(true);
+    expect(state.showLibrary).toBe(true);
+    expect(state.loopBrowserOpen).toBe(true);
+    expect(state.workspaceComplexity).toBe('advanced');
+  });
+
+  test('dismissing a contextual tip persists across reload', async ({ page }) => {
+    await page.getByRole('button', { name: 'Late Night Hip Hop' }).click();
+    await page.getByRole('button', { name: 'Open Late Night Hip Hop' }).click();
+
+    for (let i = 0; i < 5; i++) {
+      await page.getByRole('button', { name: i === 4 ? 'Finish' : 'Next' }).click();
+    }
+
+    await expect(page.getByLabel('Tip: Start with genr')).toBeVisible();
+    await page.getByLabel('Dismiss tip Start with genr').click();
+    await expect(page.getByLabel('Tip: Start with genr')).not.toBeVisible();
+
+    await page.reload();
+    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
+    await expect(page.getByLabel('Tip: Start with genr')).not.toBeVisible();
+  });
+});

--- a/tests/unit/onboardingStore.test.ts
+++ b/tests/unit/onboardingStore.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useUIStore } from '../../src/store/uiStore';
+
+describe('onboarding store', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useUIStore.setState(useUIStore.getInitialState(), true);
+  });
+
+  it('applies simple workspace defaults', () => {
+    useUIStore.getState().applyWorkspaceComplexity('simple');
+
+    const state = useUIStore.getState();
+    expect(state.workspaceComplexity).toBe('simple');
+    expect(state.showSmartControls).toBe(true);
+    expect(state.showMixer).toBe(false);
+    expect(state.showLibrary).toBe(false);
+    expect(state.trackListWidth).toBe(200);
+  });
+
+  it('applies advanced workspace defaults with higher panel density', () => {
+    useUIStore.getState().applyWorkspaceComplexity('advanced');
+
+    const state = useUIStore.getState();
+    expect(state.workspaceComplexity).toBe('advanced');
+    expect(state.showMixer).toBe(true);
+    expect(state.showLibrary).toBe(true);
+    expect(state.loopBrowserOpen).toBe(true);
+    expect(state.showTempoLane).toBe(true);
+    expect(state.pixelsPerSecond).toBe(100);
+  });
+
+  it('tracks tutorial completion after the fifth step', () => {
+    useUIStore.getState().startTutorial();
+
+    for (let i = 0; i < 5; i++) {
+      useUIStore.getState().nextTutorialStep();
+    }
+
+    const state = useUIStore.getState();
+    expect(state.activeTutorialStep).toBeNull();
+    expect(state.tutorialCompleted).toBe(true);
+    expect(state.tutorialSkipped).toBe(false);
+  });
+
+  it('persists dismissed onboarding tips without duplicates', () => {
+    useUIStore.getState().dismissOnboardingTip('genr-first-pass');
+    useUIStore.getState().dismissOnboardingTip('genr-first-pass');
+
+    expect(useUIStore.getState().dismissedOnboardingTipIds).toEqual(['genr-first-pass']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a first-run onboarding overlay with built-in genre starters, demo sessions, and visible workspace complexity tiers
- add a dedicated `genr` toolbar entry plus a 5-step guided tutorial and persistent dismissible contextual tips
- add issue-aligned planning/research docs and automated unit/E2E coverage for the new onboarding workflow

## Issue
- Closes #328

## Verification
- `npx tsc --noEmit`
- `npx vitest run`
- `npm run build`
- `npx playwright test tests/e2e/onboarding.spec.ts --workers=1`

## Notes
- The status bar still reports backend offline if the ACE-Step API is not running locally; onboarding and the tests above do not require the backend.
