### PR TITLE
feat: #339 — upgrade sampler into one-step Quick Sampler workflow

### DIFF
--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { samplerEngine } from '../../engine/SamplerEngine';
 import { useAudioImport } from '../../hooks/useAudioImport';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
-import type { PianoRollGrid, SamplerConfig, SamplerPlaybackMode } from '../../types/project';
+import type { PianoRollGrid, SamplerConfig } from '../../types/project';
+import { QuickSamplerEditor } from './QuickSamplerEditor';
 import { GeneratePatternDialog } from './GeneratePatternDialog';
 import { PianoRollCanvas } from './PianoRollCanvas';
 import { PianoRollEmptyState } from './PianoRollEmptyState';
 import { QuantizeDialog } from './QuantizeDialog';
 import { TransformMenu } from './TransformMenu';
-import { getPianoRollToolShortcut, midiNoteToName, type PianoRollTool } from './PianoRollConstants';
+import { getPianoRollToolShortcut, type PianoRollTool } from './PianoRollConstants';
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
@@ -298,149 +298,18 @@ export function PianoRoll() {
       {track.synthPreset === 'sampler' && (
         <div
           aria-label="Quick Sampler target"
-          className={`grid grid-cols-[minmax(220px,1.2fr)_minmax(180px,1fr)] gap-3 px-3 py-3 border-b border-[#1f2536] bg-[#0b1220] shrink-0 ${samplerDropActive ? 'ring-1 ring-cyan-400/70' : ''}`}
+          className={samplerDropActive ? 'ring-1 ring-cyan-400/70 shrink-0' : 'shrink-0'}
           onDragOver={handleSamplerDragOver}
           onDragLeave={() => setSamplerDropActive(false)}
           onDrop={handleSamplerDrop}
         >
-          <div className={`rounded-xl border px-3 py-3 ${track.sampler?.audioKey ? 'border-amber-400/25 bg-amber-300/[0.08]' : 'border-cyan-400/25 bg-cyan-300/[0.06]'}`}>
-            <div className="flex items-center justify-between gap-2">
-              <div>
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Quick Sampler</div>
-                <div className="text-sm text-zinc-100">{track.sampler?.sampleName ?? 'Drop audio here to build an instrument'}</div>
-              </div>
-              <button
-                aria-label={`Load sampler source for ${track.displayName}`}
-                className="px-2 py-1 rounded text-[10px] bg-amber-500/15 text-amber-200 hover:bg-amber-500/25 transition-colors"
-                onClick={() => openSamplerFilePicker(track.id)}
-              >
-                {track.sampler?.audioKey ? 'Swap Sample' : 'Load Sample'}
-              </button>
-            </div>
-            <div className="mt-2 text-[11px] text-zinc-400">
-              {track.sampler?.audioKey
-                ? `Drag an imported asset here to remap it instantly. Current range: ${sampleDuration.toFixed(2)}s`
-                : 'Drop an audio file or imported asset here to create a playable instrument in one step.'}
-            </div>
-            {track.sampler?.audioKey && samplerConfig && (
-              <div className="mt-3 grid grid-cols-2 gap-2">
-                <label className="text-[10px] text-zinc-400 flex items-center gap-1">
-                  Root
-                  <input
-                    aria-label="Sampler root note"
-                    type="number"
-                    min="0"
-                    max="127"
-                    value={track.sampler?.rootNote ?? 60}
-                    onChange={(e) => {
-                      const rootNote = Number(e.target.value);
-                      setTrackSampler(track.id, { rootNote });
-                      applySamplerConfig({ rootNote });
-                    }}
-                    className="w-14 bg-[#111] border border-[#333] rounded px-1.5 py-1 text-[11px] text-zinc-200"
-                  />
-                  <span className="text-zinc-500">{midiNoteToName(track.sampler?.rootNote ?? 60)}</span>
-                </label>
-                <label className="text-[10px] text-zinc-400 flex items-center gap-1">
-                  Mode
-                  <select
-                    aria-label="Quick Sampler playback mode"
-                    value={samplerConfig.playbackMode}
-                    onChange={(e) => applySamplerConfig({ playbackMode: e.target.value as SamplerPlaybackMode })}
-                    className="bg-[#111] border border-[#333] rounded px-2 py-1 text-[11px] text-zinc-200"
-                  >
-                    <option value="classic">Classic</option>
-                    <option value="oneShot">One Shot</option>
-                    <option value="loop">Loop</option>
-                  </select>
-                </label>
-                <button
-                  aria-label="Preview quick sampler root note"
-                  className="px-2 py-1 rounded text-[10px] bg-cyan-500/15 text-cyan-200 hover:bg-cyan-500/25 transition-colors"
-                  onClick={() => void samplerEngine.previewTrackNote(track, track.sampler?.rootNote ?? 60, 110, 0.6)}
-                >
-                  Preview
-                </button>
-                <button
-                  aria-label={`Clear sampler source for ${track.displayName}`}
-                  className="px-2 py-1 rounded text-[10px] bg-white/5 text-zinc-400 hover:bg-white/10"
-                  onClick={() => clearTrackSampler(track.id)}
-                >
-                  Clear
-                </button>
-              </div>
-            )}
-          </div>
-
-          <div className="rounded-xl border border-white/8 bg-white/[0.03] px-3 py-3">
-            {samplerConfig ? (
-              <div className="space-y-2">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Sample Editor</div>
-                <label className="block text-[10px] text-zinc-400">
-                  Trim Start
-                  <input
-                    aria-label="Quick Sampler trim start"
-                    type="range"
-                    min="0"
-                    max={sampleDuration}
-                    step="0.01"
-                    value={samplerConfig.trimStart}
-                    onChange={(e) => applySamplerConfig({ trimStart: Number(e.target.value) })}
-                    className="w-full"
-                  />
-                  <span className="text-zinc-500">{samplerConfig.trimStart.toFixed(2)}s</span>
-                </label>
-                <label className="block text-[10px] text-zinc-400">
-                  Trim End
-                  <input
-                    aria-label="Quick Sampler trim end"
-                    type="range"
-                    min="0.01"
-                    max={sampleDuration}
-                    step="0.01"
-                    value={samplerConfig.trimEnd}
-                    onChange={(e) => applySamplerConfig({ trimEnd: Number(e.target.value) })}
-                    className="w-full"
-                  />
-                  <span className="text-zinc-500">{samplerConfig.trimEnd.toFixed(2)}s</span>
-                </label>
-                {samplerConfig.playbackMode === 'loop' && (
-                  <>
-                    <label className="block text-[10px] text-zinc-400">
-                      Loop Start
-                      <input
-                        aria-label="Quick Sampler loop start"
-                        type="range"
-                        min={samplerConfig.trimStart}
-                        max={samplerConfig.trimEnd - 0.01}
-                        step="0.01"
-                        value={samplerConfig.loopStart}
-                        onChange={(e) => applySamplerConfig({ loopStart: Number(e.target.value) })}
-                        className="w-full"
-                      />
-                      <span className="text-zinc-500">{samplerConfig.loopStart.toFixed(2)}s</span>
-                    </label>
-                    <label className="block text-[10px] text-zinc-400">
-                      Loop End
-                      <input
-                        aria-label="Quick Sampler loop end"
-                        type="range"
-                        min={samplerConfig.loopStart + 0.01}
-                        max={samplerConfig.trimEnd}
-                        step="0.01"
-                        value={samplerConfig.loopEnd}
-                        onChange={(e) => applySamplerConfig({ loopEnd: Number(e.target.value) })}
-                        className="w-full"
-                      />
-                      <span className="text-zinc-500">{samplerConfig.loopEnd.toFixed(2)}s</span>
-                    </label>
-                  </>
-                )}
-              </div>
-            ) : (
-              <div className="text-[11px] text-zinc-500">Load a sample to reveal trim and loop controls.</div>
-            )}
-          </div>
+          <QuickSamplerEditor
+            track={track}
+            onSamplerConfigChange={applySamplerConfig}
+            onSamplerSettingsChange={(updates) => setTrackSampler(track.id, updates)}
+            onClear={() => clearTrackSampler(track.id)}
+            onLoadSample={() => openSamplerFilePicker(track.id)}
+          />
         </div>
       )}
 

--- a/src/components/pianoroll/QuickSamplerEditor.tsx
+++ b/src/components/pianoroll/QuickSamplerEditor.tsx
@@ -1,0 +1,291 @@
+import { useCallback } from 'react';
+import { samplerEngine } from '../../engine/SamplerEngine';
+import type { SamplerConfig, SamplerPlaybackMode, SamplerSettings, Track } from '../../types/project';
+import { midiNoteToName } from './PianoRollConstants';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/** The 12 notes of one octave, centred on the root note. Used for the audition keyboard. */
+const AUDITION_OFFSETS = [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7];
+const BLACK_OFFSETS = new Set([-4, -2, 1, 3, 6]);
+
+interface QuickSamplerEditorProps {
+  track: Track;
+  onSamplerConfigChange: (updates: Partial<SamplerConfig>) => void;
+  onSamplerSettingsChange: (updates: Partial<SamplerSettings>) => void;
+  onClear: () => void;
+  onLoadSample: () => void;
+}
+
+export function QuickSamplerEditor({
+  track,
+  onSamplerConfigChange,
+  onSamplerSettingsChange,
+  onClear,
+  onLoadSample,
+}: QuickSamplerEditorProps) {
+  const samplerConfig = track.samplerConfig ?? null;
+  const sampleDuration = Math.max(0.01, track.sampler?.sampleDuration ?? samplerConfig?.trimEnd ?? 1);
+  const hasAudio = !!track.sampler?.audioKey;
+  const rootNote = track.sampler?.rootNote ?? 60;
+
+  const handleAdsrChange = useCallback(
+    (param: 'attack' | 'decay' | 'sustain' | 'release', value: number) => {
+      onSamplerConfigChange({ [param]: value });
+    },
+    [onSamplerConfigChange],
+  );
+
+  const handleAuditionNote = useCallback(
+    (pitch: number) => {
+      void samplerEngine.previewTrackNote(track, pitch, 110, 0.5);
+    },
+    [track],
+  );
+
+  return (
+    <div className="grid grid-cols-[minmax(220px,1.2fr)_minmax(180px,1fr)] gap-3 px-3 py-3 border-b border-[#1f2536] bg-[#0b1220] shrink-0">
+      {/* Left column: sample info + controls */}
+      <div className={`rounded-xl border px-3 py-3 ${hasAudio ? 'border-amber-400/25 bg-amber-300/[0.08]' : 'border-cyan-400/25 bg-cyan-300/[0.06]'}`}>
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Quick Sampler</div>
+            <div className="text-sm text-zinc-100">{track.sampler?.sampleName ?? 'Drop audio here to build an instrument'}</div>
+          </div>
+          <button
+            aria-label={`Load sampler source for ${track.displayName}`}
+            className="px-2 py-1 rounded text-[10px] bg-amber-500/15 text-amber-200 hover:bg-amber-500/25 transition-colors"
+            onClick={onLoadSample}
+          >
+            {hasAudio ? 'Swap Sample' : 'Load Sample'}
+          </button>
+        </div>
+
+        {!hasAudio && (
+          <div className="mt-2 text-[11px] text-zinc-400">
+            Drop an audio file or imported asset here to create a playable instrument in one step.
+          </div>
+        )}
+
+        {hasAudio && samplerConfig && (
+          <>
+            <div className="mt-2 text-[11px] text-zinc-400">
+              Drag an imported asset here to remap it instantly. Current range: {sampleDuration.toFixed(2)}s
+            </div>
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <label className="text-[10px] text-zinc-400 flex items-center gap-1">
+                Root
+                <input
+                  aria-label="Sampler root note"
+                  type="number"
+                  min="0"
+                  max="127"
+                  value={rootNote}
+                  onChange={(e) => {
+                    const rn = Number(e.target.value);
+                    onSamplerSettingsChange({ rootNote: rn });
+                    onSamplerConfigChange({ rootNote: rn });
+                  }}
+                  className="w-14 bg-[#111] border border-[#333] rounded px-1.5 py-1 text-[11px] text-zinc-200"
+                />
+                <span className="text-zinc-500">{midiNoteToName(rootNote)}</span>
+              </label>
+              <label className="text-[10px] text-zinc-400 flex items-center gap-1">
+                Mode
+                <select
+                  aria-label="Quick Sampler playback mode"
+                  value={samplerConfig.playbackMode}
+                  onChange={(e) => onSamplerConfigChange({ playbackMode: e.target.value as SamplerPlaybackMode })}
+                  className="bg-[#111] border border-[#333] rounded px-2 py-1 text-[11px] text-zinc-200"
+                >
+                  <option value="classic">Classic</option>
+                  <option value="oneShot">One Shot</option>
+                  <option value="loop">Loop</option>
+                </select>
+              </label>
+              <button
+                aria-label="Preview quick sampler root note"
+                className="px-2 py-1 rounded text-[10px] bg-cyan-500/15 text-cyan-200 hover:bg-cyan-500/25 transition-colors"
+                onClick={() => handleAuditionNote(rootNote)}
+              >
+                Preview
+              </button>
+              <button
+                aria-label={`Clear sampler source for ${track.displayName}`}
+                className="px-2 py-1 rounded text-[10px] bg-white/5 text-zinc-400 hover:bg-white/10"
+                onClick={onClear}
+              >
+                Clear
+              </button>
+            </div>
+
+            {/* ADSR controls */}
+            <div className="mt-3 grid grid-cols-4 gap-2">
+              <AdsrSlider
+                label="Attack"
+                value={samplerConfig.attack}
+                min={0}
+                max={2}
+                step={0.005}
+                onChange={(v) => handleAdsrChange('attack', v)}
+              />
+              <AdsrSlider
+                label="Decay"
+                value={samplerConfig.decay}
+                min={0}
+                max={2}
+                step={0.01}
+                onChange={(v) => handleAdsrChange('decay', v)}
+              />
+              <AdsrSlider
+                label="Sustain"
+                value={samplerConfig.sustain}
+                min={0}
+                max={1}
+                step={0.01}
+                onChange={(v) => handleAdsrChange('sustain', v)}
+              />
+              <AdsrSlider
+                label="Release"
+                value={samplerConfig.release}
+                min={0}
+                max={5}
+                step={0.01}
+                onChange={(v) => handleAdsrChange('release', v)}
+              />
+            </div>
+
+            {/* Audition keyboard */}
+            <div data-testid="audition-keyboard" className="mt-3 flex gap-px h-7 select-none">
+              {AUDITION_OFFSETS.map((offset) => {
+                const pitch = clamp(rootNote + offset, 0, 127);
+                const isBlack = BLACK_OFFSETS.has(offset);
+                const isRoot = offset === 0;
+                return (
+                  <button
+                    key={offset}
+                    aria-label={`Audition ${midiNoteToName(pitch)}`}
+                    className={`flex-1 rounded-b text-[8px] leading-none flex items-end justify-center pb-0.5 transition-colors
+                      ${isBlack ? 'bg-zinc-800 text-zinc-500 hover:bg-zinc-600' : 'bg-zinc-200 text-zinc-700 hover:bg-white'}
+                      ${isRoot ? 'ring-1 ring-amber-400' : ''}
+                    `}
+                    onMouseDown={() => handleAuditionNote(pitch)}
+                  >
+                    {isRoot ? midiNoteToName(pitch) : ''}
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Right column: trim, loop, sample editor */}
+      <div className="rounded-xl border border-white/8 bg-white/[0.03] px-3 py-3">
+        {samplerConfig ? (
+          <div className="space-y-2">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Sample Editor</div>
+            <label className="block text-[10px] text-zinc-400">
+              Trim Start
+              <input
+                aria-label="Quick Sampler trim start"
+                type="range"
+                min="0"
+                max={sampleDuration}
+                step="0.01"
+                value={samplerConfig.trimStart}
+                onChange={(e) => onSamplerConfigChange({ trimStart: Number(e.target.value) })}
+                className="w-full"
+              />
+              <span className="text-zinc-500">{samplerConfig.trimStart.toFixed(2)}s</span>
+            </label>
+            <label className="block text-[10px] text-zinc-400">
+              Trim End
+              <input
+                aria-label="Quick Sampler trim end"
+                type="range"
+                min="0.01"
+                max={sampleDuration}
+                step="0.01"
+                value={samplerConfig.trimEnd}
+                onChange={(e) => onSamplerConfigChange({ trimEnd: Number(e.target.value) })}
+                className="w-full"
+              />
+              <span className="text-zinc-500">{samplerConfig.trimEnd.toFixed(2)}s</span>
+            </label>
+            {samplerConfig.playbackMode === 'loop' && (
+              <>
+                <label className="block text-[10px] text-zinc-400">
+                  Loop Start
+                  <input
+                    aria-label="Quick Sampler loop start"
+                    type="range"
+                    min={samplerConfig.trimStart}
+                    max={samplerConfig.trimEnd - 0.01}
+                    step="0.01"
+                    value={samplerConfig.loopStart}
+                    onChange={(e) => onSamplerConfigChange({ loopStart: Number(e.target.value) })}
+                    className="w-full"
+                  />
+                  <span className="text-zinc-500">{samplerConfig.loopStart.toFixed(2)}s</span>
+                </label>
+                <label className="block text-[10px] text-zinc-400">
+                  Loop End
+                  <input
+                    aria-label="Quick Sampler loop end"
+                    type="range"
+                    min={samplerConfig.loopStart + 0.01}
+                    max={samplerConfig.trimEnd}
+                    step="0.01"
+                    value={samplerConfig.loopEnd}
+                    onChange={(e) => onSamplerConfigChange({ loopEnd: Number(e.target.value) })}
+                    className="w-full"
+                  />
+                  <span className="text-zinc-500">{samplerConfig.loopEnd.toFixed(2)}s</span>
+                </label>
+              </>
+            )}
+          </div>
+        ) : (
+          <div className="text-[11px] text-zinc-500">Load a sample to reveal trim and loop controls.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Compact ADSR slider with label. */
+function AdsrSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="flex flex-col items-center gap-0.5 text-[9px] text-zinc-500">
+      <span>{label[0]}</span>
+      <input
+        aria-label={label}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full h-1 accent-amber-400"
+      />
+      <span>{value.toFixed(label === 'Sustain' ? 1 : 2)}</span>
+    </label>
+  );
+}

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -24,10 +24,11 @@ interface LaneContextMenuProps {
   onAddLayer: () => void;
   onOpenSequencer?: () => void;
   onOpenPianoRoll?: () => void;
+  onCreateQuickSampler?: () => void;
   onClose: () => void;
 }
 
-function LaneContextMenu({ x, y, onAddLayer, onOpenSequencer, onOpenPianoRoll, onClose }: LaneContextMenuProps) {
+function LaneContextMenu({ x, y, onAddLayer, onOpenSequencer, onOpenPianoRoll, onCreateQuickSampler, onClose }: LaneContextMenuProps) {
   const clampedX = Math.min(x, window.innerWidth - 180);
   const clampedY = Math.min(y, window.innerHeight - 80);
   return (
@@ -55,6 +56,14 @@ function LaneContextMenu({ x, y, onAddLayer, onOpenSequencer, onOpenPianoRoll, o
             className="w-full text-left px-3 py-1.5 text-[11px] text-violet-300 hover:bg-daw-accent hover:text-white transition-colors"
           >
             Open Piano Roll...
+          </button>
+        )}
+        {onCreateQuickSampler && (
+          <button
+            onClick={() => { onClose(); onCreateQuickSampler(); }}
+            className="w-full text-left px-3 py-1.5 text-[11px] text-amber-300 hover:bg-daw-accent hover:text-white transition-colors"
+          >
+            Create Quick Sampler...
           </button>
         )}
         <button
@@ -92,10 +101,12 @@ export function TrackLane({ track }: TrackLaneProps) {
   const {
     importAssetAsQuickSampler,
     importAudioFileAsSampler,
+    importAudioFileAsNewQuickSampler,
     importAudioToTrack,
     importMidiFile,
     importLoopToTrack,
     importAssetToTrack,
+    openQuickSamplerFilePicker,
   } = useAudioImport();
   const [fileDragOver, setFileDragOver] = useState(false);
 
@@ -237,12 +248,16 @@ export function TrackLane({ track }: TrackLaneProps) {
     }
 
     // Handle file drop
+    // Alt+Drop on any track → create as Quick Sampler (new track)
+    const wantsQuickSampler = e.altKey;
     const files = e.dataTransfer.files;
     if (!files.length) return;
     for (const file of Array.from(files)) {
       if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
         if (track.trackType === 'pianoRoll') {
           await importAudioFileAsSampler(file, track.id);
+        } else if (wantsQuickSampler) {
+          await importAudioFileAsNewQuickSampler(file);
         } else {
           await importAudioToTrack(file, track.id, startTime);
         }
@@ -250,7 +265,7 @@ export function TrackLane({ track }: TrackLaneProps) {
         await importMidiFile(file, startTime);
       }
     }
-  }, [project, pixelsPerSecond, track.id, track.trackType, importAssetAsQuickSampler, importAssetToTrack, importAudioFileAsSampler, importAudioToTrack, importMidiFile, importLoopToTrack]);
+  }, [project, pixelsPerSecond, track.id, track.trackType, importAssetAsQuickSampler, importAssetToTrack, importAudioFileAsSampler, importAudioFileAsNewQuickSampler, importAudioToTrack, importMidiFile, importLoopToTrack]);
 
   const hasClips = track.clips.length > 0;
   const automationLanes = (project?.automationLanes ?? []).filter((l) => l.trackId === track.id);
@@ -270,7 +285,7 @@ export function TrackLane({ track }: TrackLaneProps) {
       >
         {fileDragOver && (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-30 border border-dashed border-blue-400/60 rounded-sm">
-            <span className="text-[10px] text-blue-300 bg-blue-950/80 px-2 py-0.5 rounded">Drop audio or MIDI here</span>
+            <span className="text-[10px] text-blue-300 bg-blue-950/80 px-2 py-0.5 rounded">Drop audio or MIDI here {track.trackType !== 'pianoRoll' ? '(Alt = Quick Sampler)' : ''}</span>
           </div>
         )}
 
@@ -317,6 +332,7 @@ export function TrackLane({ track }: TrackLaneProps) {
               const clip = ensureMidiClip(track.id, ctxMenu.startTime, ctxMenu.duration);
               setOpenPianoRoll(track.id, clip.id);
             } : undefined}
+            onCreateQuickSampler={() => openQuickSamplerFilePicker()}
             onClose={() => setCtxMenu(null)}
           />
         )}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -297,6 +297,8 @@ interface ProjectState {
     trackId?: string;
   }) => Track | undefined;
   createQuickSamplerFromClip: (trackId: string, clipId: string) => Track | undefined;
+  /** Create a Quick Sampler track directly from a project asset by ID. */
+  createQuickSamplerFromAsset: (assetId: string, options?: { trackId?: string; rootNote?: number }) => Track | undefined;
   saveTrackPreset: (trackId: string, presetName: string) => TrackPreset;
   applyTrackPreset: (presetId: string) => Track | undefined;
   deleteTrackPreset: (presetId: string) => void;
@@ -783,12 +785,12 @@ function createTrackFromTemplate(
   const info = TRACK_CATALOG[trackName] ?? TRACK_CATALOG.custom;
   const existingOrders = existingTracks.map((track) => track.order);
   const maxOrder = existingOrders.length > 0 ? Math.max(...existingOrders) : 0;
-  const displayName = buildTrackDisplayName(existingTracks, trackName);
+  const autoDisplayName = buildTrackDisplayName(existingTracks, trackName);
   const {
     id: _ignoredId,
     trackType: _ignoredTrackType,
     trackName: _ignoredTrackName,
-    displayName: _ignoredDisplayName,
+    displayName: overrideDisplayName,
     order: _ignoredOrder,
     muted: _ignoredMuted,
     soloed: _ignoredSoloed,
@@ -809,7 +811,7 @@ function createTrackFromTemplate(
     id: uuidv4(),
     trackType,
     trackName,
-    displayName,
+    displayName: overrideDisplayName || autoDisplayName,
     order: maxOrder + 1,
     muted: false,
     soloed: false,
@@ -1675,6 +1677,23 @@ export const useProjectStore = create<ProjectState>()(
       audioKey,
       sampleName,
       sampleDuration,
+    });
+  },
+
+  createQuickSamplerFromAsset: (assetId, options) => {
+    const state = get();
+    if (!state.project) return undefined;
+    const asset = (state.project.assets ?? []).find((a) => a.id === assetId);
+    if (!asset) return undefined;
+    const audioKey = asset.isolatedAudioKey ?? asset.cumulativeMixKey;
+    if (!audioKey) return undefined;
+    const sampleName = asset.prompt?.trim() || asset.trackDisplayName || 'Quick Sampler';
+    return get().createQuickSamplerTrack({
+      audioKey,
+      sampleName,
+      sampleDuration: asset.duration,
+      rootNote: options?.rootNote,
+      trackId: options?.trackId,
     });
   },
 

--- a/tests/unit/QuickSamplerEditor.test.tsx
+++ b/tests/unit/QuickSamplerEditor.test.tsx
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QuickSamplerEditor } from '../../src/components/pianoroll/QuickSamplerEditor';
+import type { SamplerConfig, Track } from '../../src/types/project';
+
+vi.mock('../../src/engine/SamplerEngine', () => ({
+  samplerEngine: {
+    previewTrackNote: vi.fn(),
+  },
+}));
+
+function makeTrack(overrides?: Partial<Track>): Track {
+  return {
+    id: 'track-1',
+    trackType: 'pianoRoll',
+    trackName: 'custom',
+    displayName: 'Test Sampler',
+    color: '#ff9800',
+    order: 0,
+    volume: 0.8,
+    muted: false,
+    soloed: false,
+    clips: [],
+    synthPreset: 'sampler',
+    sampler: {
+      audioKey: 'audio:test-key',
+      sampleName: 'Test Sound',
+      rootNote: 60,
+      sampleDuration: 2.0,
+    },
+    samplerConfig: {
+      audioKey: 'audio:test-key',
+      rootNote: 60,
+      trimStart: 0,
+      trimEnd: 2.0,
+      playbackMode: 'classic',
+      loopStart: 0,
+      loopEnd: 2.0,
+      attack: 0.005,
+      decay: 0.1,
+      sustain: 1,
+      release: 0.3,
+    },
+    ...overrides,
+  };
+}
+
+describe('QuickSamplerEditor', () => {
+  const onSamplerConfigChange = vi.fn();
+  const onSamplerSettingsChange = vi.fn();
+  const onClear = vi.fn();
+  const onLoadSample = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderEditor(track?: Track) {
+    return render(
+      <QuickSamplerEditor
+        track={track ?? makeTrack()}
+        onSamplerConfigChange={onSamplerConfigChange}
+        onSamplerSettingsChange={onSamplerSettingsChange}
+        onClear={onClear}
+        onLoadSample={onLoadSample}
+      />,
+    );
+  }
+
+  it('renders the Quick Sampler heading', () => {
+    renderEditor();
+    expect(screen.getByText('Quick Sampler')).toBeDefined();
+  });
+
+  it('shows sample name when loaded', () => {
+    renderEditor();
+    expect(screen.getByText('Test Sound')).toBeDefined();
+  });
+
+  it('shows root note input', () => {
+    renderEditor();
+    const rootInput = screen.getByLabelText('Sampler root note');
+    expect(rootInput).toBeDefined();
+    expect((rootInput as HTMLInputElement).value).toBe('60');
+  });
+
+  it('shows playback mode selector', () => {
+    renderEditor();
+    const modeSelect = screen.getByLabelText('Quick Sampler playback mode');
+    expect(modeSelect).toBeDefined();
+    expect((modeSelect as HTMLSelectElement).value).toBe('classic');
+  });
+
+  it('calls onSamplerConfigChange when root note changes', () => {
+    renderEditor();
+    const rootInput = screen.getByLabelText('Sampler root note');
+    fireEvent.change(rootInput, { target: { value: '48' } });
+    expect(onSamplerConfigChange).toHaveBeenCalledWith(expect.objectContaining({ rootNote: 48 }));
+  });
+
+  it('calls onSamplerConfigChange when playback mode changes', () => {
+    renderEditor();
+    const modeSelect = screen.getByLabelText('Quick Sampler playback mode');
+    fireEvent.change(modeSelect, { target: { value: 'oneShot' } });
+    expect(onSamplerConfigChange).toHaveBeenCalledWith(expect.objectContaining({ playbackMode: 'oneShot' }));
+  });
+
+  it('shows ADSR controls', () => {
+    renderEditor();
+    expect(screen.getByLabelText('Attack')).toBeDefined();
+    expect(screen.getByLabelText('Decay')).toBeDefined();
+    expect(screen.getByLabelText('Sustain')).toBeDefined();
+    expect(screen.getByLabelText('Release')).toBeDefined();
+  });
+
+  it('shows preview button', () => {
+    renderEditor();
+    expect(screen.getByLabelText('Preview quick sampler root note')).toBeDefined();
+  });
+
+  it('shows audition keyboard keys', () => {
+    renderEditor();
+    expect(screen.getByTestId('audition-keyboard')).toBeDefined();
+  });
+
+  it('shows trim controls', () => {
+    renderEditor();
+    expect(screen.getByLabelText('Quick Sampler trim start')).toBeDefined();
+    expect(screen.getByLabelText('Quick Sampler trim end')).toBeDefined();
+  });
+
+  it('shows loop controls when mode is loop', () => {
+    const track = makeTrack();
+    track.samplerConfig!.playbackMode = 'loop';
+    renderEditor(track);
+    expect(screen.getByLabelText('Quick Sampler loop start')).toBeDefined();
+    expect(screen.getByLabelText('Quick Sampler loop end')).toBeDefined();
+  });
+
+  it('hides loop controls when mode is classic', () => {
+    renderEditor();
+    expect(screen.queryByLabelText('Quick Sampler loop start')).toBeNull();
+    expect(screen.queryByLabelText('Quick Sampler loop end')).toBeNull();
+  });
+
+  it('shows empty state when no sample is loaded', () => {
+    const track = makeTrack({
+      sampler: { rootNote: 60 },
+      samplerConfig: undefined,
+    });
+    renderEditor(track);
+    expect(screen.getByText(/Drop audio here/i)).toBeDefined();
+  });
+
+  it('shows Load Sample button', () => {
+    renderEditor();
+    fireEvent.click(screen.getByText('Swap Sample'));
+    expect(onLoadSample).toHaveBeenCalled();
+  });
+
+  it('calls onClear when Clear button clicked', () => {
+    renderEditor();
+    fireEvent.click(screen.getByLabelText(/Clear sampler source/));
+    expect(onClear).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/quickSampler.test.ts
+++ b/tests/unit/quickSampler.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../../src/store/projectStore';
+import { createSamplerConfig } from '../../src/engine/SamplerEngine';
+import type { AssetClip } from '../../src/types/project';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+// ── createQuickSamplerFromAsset ─────────────────────────────────────────────
+
+describe('projectStore.createQuickSamplerFromAsset', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useProjectStore.getState().createProject();
+  });
+
+  function seedAsset(overrides?: Partial<AssetClip>): AssetClip {
+    const asset: AssetClip = {
+      id: 'asset-1',
+      clipId: 'clip-1',
+      trackDisplayName: 'Vocal Chop',
+      prompt: 'vocal chop',
+      source: 'uploaded',
+      isolatedAudioKey: 'audio:proj:clip-1:iso',
+      cumulativeMixKey: null,
+      waveformPeaks: null,
+      starred: false,
+      createdAt: Date.now(),
+      duration: 2.5,
+      ...overrides,
+    };
+    const state = useProjectStore.getState();
+    useProjectStore.setState({
+      project: {
+        ...state.project!,
+        assets: [...(state.project!.assets ?? []), asset],
+      },
+    });
+    return asset;
+  }
+
+  it('creates a sampler track from an asset by ID', () => {
+    seedAsset();
+    const track = useProjectStore.getState().createQuickSamplerFromAsset('asset-1');
+    expect(track).toBeDefined();
+    expect(track!.trackType).toBe('pianoRoll');
+    expect(track!.synthPreset).toBe('sampler');
+    expect(track!.samplerConfig?.audioKey).toBe('audio:proj:clip-1:iso');
+    expect(track!.sampler?.sampleName).toBe('vocal chop');
+  });
+
+  it('returns undefined for non-existent asset', () => {
+    const track = useProjectStore.getState().createQuickSamplerFromAsset('nonexistent');
+    expect(track).toBeUndefined();
+  });
+
+  it('returns undefined when asset has no audio key', () => {
+    seedAsset({ isolatedAudioKey: null, cumulativeMixKey: null });
+    const track = useProjectStore.getState().createQuickSamplerFromAsset('asset-1');
+    expect(track).toBeUndefined();
+  });
+
+  it('uses cumulativeMixKey when isolatedAudioKey is null', () => {
+    seedAsset({ isolatedAudioKey: null, cumulativeMixKey: 'audio:proj:clip-1:cum' });
+    const track = useProjectStore.getState().createQuickSamplerFromAsset('asset-1');
+    expect(track).toBeDefined();
+    expect(track!.samplerConfig?.audioKey).toBe('audio:proj:clip-1:cum');
+  });
+
+  it('sets the asset duration on the sampler config', () => {
+    seedAsset({ duration: 3.7 });
+    const track = useProjectStore.getState().createQuickSamplerFromAsset('asset-1');
+    expect(track!.samplerConfig?.trimEnd).toBeCloseTo(3.7, 1);
+    expect(track!.sampler?.sampleDuration).toBeCloseTo(3.7, 1);
+  });
+
+  it('accepts optional rootNote override', () => {
+    seedAsset();
+    const track = useProjectStore.getState().createQuickSamplerFromAsset('asset-1', { rootNote: 48 });
+    expect(track!.samplerConfig?.rootNote).toBe(48);
+  });
+
+  it('accepts optional trackId to update an existing track', () => {
+    seedAsset();
+    const existing = useProjectStore.getState().addTrack('custom', 'pianoRoll');
+    const track = useProjectStore.getState().createQuickSamplerFromAsset('asset-1', { trackId: existing.id });
+    expect(track!.id).toBe(existing.id);
+    expect(track!.synthPreset).toBe('sampler');
+  });
+
+  it('pushes to undo history', () => {
+    seedAsset();
+    const tracksBefore = useProjectStore.getState().project!.tracks.length;
+    useProjectStore.getState().createQuickSamplerFromAsset('asset-1');
+    expect(useProjectStore.getState().project!.tracks.length).toBe(tracksBefore + 1);
+
+    useProjectStore.getState().undo();
+    expect(useProjectStore.getState().project!.tracks.length).toBe(tracksBefore);
+  });
+
+  it('falls back to trackDisplayName when prompt is empty', () => {
+    seedAsset({ prompt: '', trackDisplayName: 'My Vocal' });
+    const track = useProjectStore.getState().createQuickSamplerFromAsset('asset-1');
+    expect(track!.sampler?.sampleName).toBe('My Vocal');
+  });
+});
+
+// ── createQuickSamplerTrack extended coverage ───────────────────────────────
+
+describe('projectStore.createQuickSamplerTrack (extended)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useProjectStore.getState().createProject();
+  });
+
+  it('creates a new track when no trackId is provided', () => {
+    const tracksBefore = useProjectStore.getState().project!.tracks.length;
+    const track = useProjectStore.getState().createQuickSamplerTrack({
+      audioKey: 'audio:test',
+      sampleName: 'Test Sample',
+      sampleDuration: 1.5,
+    });
+    expect(track).toBeDefined();
+    expect(useProjectStore.getState().project!.tracks.length).toBe(tracksBefore + 1);
+    expect(track!.displayName).toBe('Test Sample');
+    expect(track!.synthPreset).toBe('sampler');
+    expect(track!.samplerConfig?.playbackMode).toBe('classic');
+  });
+
+  it('sets correct ADSR defaults', () => {
+    const track = useProjectStore.getState().createQuickSamplerTrack({
+      audioKey: 'audio:test',
+      sampleDuration: 2.0,
+    });
+    expect(track!.samplerConfig?.attack).toBe(0.005);
+    expect(track!.samplerConfig?.decay).toBe(0.1);
+    expect(track!.samplerConfig?.sustain).toBe(1);
+    expect(track!.samplerConfig?.release).toBe(0.3);
+  });
+
+  it('defaults display name to Quick Sampler when sampleName is omitted', () => {
+    const track = useProjectStore.getState().createQuickSamplerTrack({
+      audioKey: 'audio:test',
+    });
+    expect(track!.displayName).toBe('Quick Sampler');
+  });
+});


### PR DESCRIPTION
Closes #339

## Summary
- **`createQuickSamplerFromAsset` store action** — one-step agent API to create a sampler track from any project asset by ID
- **`QuickSamplerEditor` component** — extracted and enhanced sampler editor with ADSR envelope controls and audition keyboard for instant chromatic playback
- **Fix `createTrackFromTemplate`** — now respects `displayName` overrides (was silently ignoring them)
- **Alt+Drop Quick Sampler** — hold Alt while dropping audio on any track lane to create a new Quick Sampler track instead of importing as audio
- **Context menu** — "Create Quick Sampler..." option added to track lane right-click menu
- **27 new unit tests** — 12 store action tests + 15 component tests

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run tests/unit/` — 652 tests pass
- [x] `npm run build` — clean build
- [ ] Manual: drag audio file onto timeline → Alt+drop creates Quick Sampler track
- [ ] Manual: right-click track lane → "Create Quick Sampler..." opens file picker
- [ ] Manual: piano roll sampler editor shows ADSR controls and audition keyboard
- [ ] Manual: `window.__store.getState().createQuickSamplerFromAsset('asset-id')` creates sampler track

🤖 Generated with [Claude Code](https://claude.com/claude-code)