### PR TITLE
feat: #215 — MIDI export — export MIDI clips as .mid files

### DIFF
--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -190,8 +190,11 @@ export function Toolbar() {
         <button onClick={() => setShowNewProjectDialog(true)} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors" title="New Project">
           New
         </button>
-        <button onClick={() => setShowExportDialog(true)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Export">
+        <button onClick={() => setShowExportDialog(true)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Export Audio">
           Export
+        </button>
+        <button onClick={() => useProjectStore.getState().exportProjectMidi()} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Export all MIDI tracks as .mid file">
+          Export MIDI
         </button>
         <button onClick={openFilePicker} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Import Audio or MIDI">
           Import

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -36,6 +36,7 @@ export function TrackHeader({
   const setTrackHeightPreset = useProjectStore((s) => s.setTrackHeightPreset);
   const setAllTracksHeightPreset = useProjectStore((s) => s.setAllTracksHeightPreset);
   const setInputMonitoring = useProjectStore((s) => s.setInputMonitoring);
+  const exportTrackMidi = useProjectStore((s) => s.exportTrackMidi);
   const unfreezeTrack = useProjectStore((s) => s.unfreezeTrack);
   const project = useProjectStore((s) => s.project);
 
@@ -516,6 +517,14 @@ export function TrackHeader({
           >
             Bounce in Place...
           </button>
+          {track.clips.some((c) => c.midiData?.notes.length) && (
+            <button
+              onClick={() => { setCtxMenu(null); exportTrackMidi(track.id); }}
+              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
+            >
+              Export MIDI
+            </button>
+          )}
           <div className="my-1 border-t border-[#555]" />
           <button
             onClick={() => { setCtxMenu(null); void handleFreeze(); }}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -80,6 +80,7 @@ import type { StemCount } from '../types/api';
 import { separateClipAudioToStems } from '../services/stemSeparation';
 import { beatToTime, getBeatAtBar } from '../utils/tempoMap';
 import { encodeMidiFile } from '../utils/midi';
+import { encodeMidiFile as encodeMultiTrackMidiFile, type MidiExportTrack } from '../utils/midiEncoder';
 import { clampClipFadeDurations } from '../utils/clipFade';
 import { extractGroove, applyGroove, type ExtractGrooveOptions, type ApplyGrooveOptions } from '../utils/groovePool';
 import type { GrooveTemplate } from '../types/project';
@@ -463,6 +464,10 @@ interface ProjectState {
   /** Create a new project from a template. */
   createProjectFromTemplate: (template: ProjectTemplate, projectName?: string) => void;
   exportMidiClip: (clipId: string) => void;
+  /** Export all MIDI clips from a track merged into a single .mid file. */
+  exportTrackMidi: (trackId: string) => void;
+  /** Export all MIDI tracks as a multi-track .mid file for sharing with other DAWs. */
+  exportProjectMidi: () => void;
 
   // Groove pool
   extractGrooveFromClip: (clipId: string, name: string, options: ExtractGrooveOptions) => GrooveTemplate | undefined;
@@ -4744,6 +4749,119 @@ export const useProjectStore = create<ProjectState>()(
       `${fileName}.mid`,
     );
     toastSuccess(`Exported MIDI clip from ${track.displayName}`);
+  },
+
+  exportTrackMidi: (trackId: string) => {
+    const project = get().project;
+    if (!project) {
+      toastError('Create or open a project before exporting MIDI');
+      return;
+    }
+
+    const track = project.tracks.find((t) => t.id === trackId);
+    if (!track) {
+      toastError('Track not found');
+      return;
+    }
+
+    const bpm = project.bpm;
+    const secPerBeat = 60 / bpm;
+    const allNotes: MidiNote[] = [];
+
+    for (const clip of track.clips) {
+      if (!clip.midiData?.notes.length) continue;
+      const clipStartBeat = clip.startTime / secPerBeat;
+      for (const note of clip.midiData.notes) {
+        allNotes.push({
+          ...note,
+          id: note.id,
+          startBeat: clipStartBeat + note.startBeat,
+        });
+      }
+    }
+
+    if (allNotes.length === 0) {
+      toastError('Track has no MIDI notes to export');
+      return;
+    }
+
+    const numerator = project.timeSignatureMap?.[0]?.numerator ?? project.timeSignature;
+    const denominator = project.timeSignatureMap?.[0]?.denominator ?? 4;
+
+    const bytes = encodeMidiFile(allNotes, {
+      bpm,
+      timeSignature: { numerator, denominator },
+      trackName: track.displayName,
+    });
+
+    const fileName = [
+      sanitizeFileNameSegment(project.name),
+      sanitizeFileNameSegment(track.displayName),
+    ].join('_');
+
+    downloadBlob(
+      new Blob([Uint8Array.from(bytes)], { type: 'audio/midi' }),
+      `${fileName}.mid`,
+    );
+    toastSuccess(`Exported MIDI from ${track.displayName}`);
+  },
+
+  exportProjectMidi: () => {
+    const project = get().project;
+    if (!project) {
+      toastError('Create or open a project before exporting MIDI');
+      return;
+    }
+
+    const bpm = project.bpm;
+    const secPerBeat = 60 / bpm;
+    const numerator = project.timeSignatureMap?.[0]?.numerator ?? project.timeSignature;
+    const denominator = project.timeSignatureMap?.[0]?.denominator ?? 4;
+
+    const exportTracks: MidiExportTrack[] = [];
+    let channelIndex = 0;
+
+    for (const track of project.tracks) {
+      const allNotes: MidiNote[] = [];
+      for (const clip of track.clips) {
+        if (!clip.midiData?.notes.length) continue;
+        const clipStartBeat = clip.startTime / secPerBeat;
+        for (const note of clip.midiData.notes) {
+          allNotes.push({
+            ...note,
+            id: note.id,
+            startBeat: clipStartBeat + note.startBeat,
+          });
+        }
+      }
+
+      if (allNotes.length > 0) {
+        exportTracks.push({
+          name: track.displayName,
+          channel: channelIndex % 16,
+          notes: allNotes,
+        });
+        channelIndex++;
+      }
+    }
+
+    if (exportTracks.length === 0) {
+      toastError('No MIDI tracks with notes to export');
+      return;
+    }
+
+    const encoded = encodeMultiTrackMidiFile(exportTracks, {
+      bpm,
+      timeSignature: { bar: 1, numerator, denominator },
+    });
+
+    const fileName = sanitizeFileNameSegment(project.name);
+
+    downloadBlob(
+      new Blob([new Uint8Array(encoded)], { type: 'audio/midi' }),
+      `${fileName}.mid`,
+    );
+    toastSuccess(`Exported ${exportTracks.length} MIDI track${exportTracks.length > 1 ? 's' : ''} from ${project.name}`);
   },
 
   // ── Groove Pool ─────────────────────────────────────────────────────────

--- a/tests/unit/projectStore.test.ts
+++ b/tests/unit/projectStore.test.ts
@@ -357,6 +357,100 @@ describe('projectStore', () => {
     });
   });
 
+  describe('exportTrackMidi', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject({ name: 'Track MIDI Export' });
+    });
+
+    it('exports all MIDI clips from a track merged into a single .mid file', () => {
+      const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mid');
+      const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+      const click = vi.fn();
+      const anchor = { click, href: '', download: '' } as unknown as HTMLAnchorElement;
+      const originalCreateElement = document.createElement.bind(document);
+      const createElement = vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+        if (tagName === 'a') return anchor;
+        return originalCreateElement(tagName);
+      }) as typeof document.createElement);
+
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      useProjectStore.getState().updateTrack(track.id, { displayName: 'Lead Synth' });
+
+      const clip1 = useProjectStore.getState().ensureMidiClip(track.id);
+      useProjectStore.getState().addMidiNote(clip1.id, {
+        pitch: 60, startBeat: 0, durationBeats: 1, velocity: 0.8,
+      });
+      useProjectStore.getState().addClip(track.id, {
+        startTime: 2, duration: 2, prompt: 'phrase-b', globalCaption: '', lyrics: '',
+        midiData: { grid: '1/16', notes: [{ id: 'n2', pitch: 64, startBeat: 0, durationBeats: 1, velocity: 0.9 }] },
+        source: 'uploaded',
+      });
+
+      useProjectStore.getState().exportTrackMidi(track.id);
+
+      expect(createObjectURL).toHaveBeenCalledOnce();
+      expect(anchor.download).toBe('Track MIDI Export_Lead Synth.mid');
+      expect(click).toHaveBeenCalledOnce();
+
+      createElement.mockRestore();
+      revokeObjectURL.mockRestore();
+      createObjectURL.mockRestore();
+    });
+
+    it('shows error when track has no MIDI notes', () => {
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      useProjectStore.getState().exportTrackMidi(track.id);
+      expect(mockToastError).toHaveBeenCalledWith('Track has no MIDI notes to export');
+    });
+  });
+
+  describe('exportProjectMidi', () => {
+    beforeEach(() => {
+      useProjectStore.getState().createProject({ name: 'Project MIDI Export' });
+    });
+
+    it('exports all MIDI tracks as a multi-track .mid file', () => {
+      const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mid');
+      const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+      const click = vi.fn();
+      const anchor = { click, href: '', download: '' } as unknown as HTMLAnchorElement;
+      const originalCreateElement = document.createElement.bind(document);
+      const createElement = vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+        if (tagName === 'a') return anchor;
+        return originalCreateElement(tagName);
+      }) as typeof document.createElement);
+
+      const track1 = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      useProjectStore.getState().updateTrack(track1.id, { displayName: 'Piano' });
+      const clip1 = useProjectStore.getState().ensureMidiClip(track1.id);
+      useProjectStore.getState().addMidiNote(clip1.id, {
+        pitch: 60, startBeat: 0, durationBeats: 1, velocity: 0.8,
+      });
+
+      const track2 = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      useProjectStore.getState().updateTrack(track2.id, { displayName: 'Bass' });
+      const clip2 = useProjectStore.getState().ensureMidiClip(track2.id);
+      useProjectStore.getState().addMidiNote(clip2.id, {
+        pitch: 36, startBeat: 0, durationBeats: 2, velocity: 1.0,
+      });
+
+      useProjectStore.getState().exportProjectMidi();
+
+      expect(createObjectURL).toHaveBeenCalledOnce();
+      expect(anchor.download).toBe('Project MIDI Export.mid');
+      expect(click).toHaveBeenCalledOnce();
+
+      createElement.mockRestore();
+      revokeObjectURL.mockRestore();
+      createObjectURL.mockRestore();
+    });
+
+    it('shows error when no MIDI tracks have notes', () => {
+      useProjectStore.getState().exportProjectMidi();
+      expect(mockToastError).toHaveBeenCalledWith('No MIDI tracks with notes to export');
+    });
+  });
+
   describe('consolidateClips', () => {
     beforeEach(() => {
       useProjectStore.getState().createProject();


### PR DESCRIPTION
## Summary
- Add `exportTrackMidi(trackId)` — merges all MIDI clips from a track into a single .mid file with correct timeline positions
- Add `exportProjectMidi()` — exports all MIDI tracks as a multi-track Standard MIDI File (Format 1) with separate channels per track
- Track header context menu shows "Export MIDI" for tracks containing MIDI notes
- Toolbar "Export MIDI" button for one-click project-wide MIDI export
- 4 new unit tests covering happy path and error handling

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run tests/unit/projectStore.test.ts` — 27 tests pass (4 new)
- [x] `npm run build` — succeeds
- [ ] Manual: create project with 2+ piano roll tracks, right-click track → Export MIDI → verify .mid opens in external DAW
- [ ] Manual: click toolbar "Export MIDI" → verify multi-track .mid contains all tracks

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)