### PR TITLE
feat: #219 — snap to zero crossing — prevent audio clicks on edits

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -370,7 +370,7 @@ export function useKeyboardShortcuts() {
         const selected = [...ui.selectedClipIds];
         if (selected.length === 1) {
           event.preventDefault();
-          project.splitClip(selected[0], transport.currentTime);
+          project.splitClipAtZeroCrossing(selected[0], transport.currentTime);
         }
         return;
       }

--- a/src/services/commandPalette.ts
+++ b/src/services/commandPalette.ts
@@ -75,6 +75,7 @@ export interface CommandPaletteContext {
     updateTrackEffect: (trackId: string, effectId: string, updates: Partial<TrackEffect>) => void;
     duplicateClip: (clipId: string) => void;
     splitClip: (clipId: string, splitTime: number) => void;
+    splitClipAtZeroCrossing: (clipId: string, splitTime: number) => Promise<void>;
     removeClip: (clipId: string) => void;
     setEditingClip: (clipId: string | null) => void;
     deselectAll: () => void;
@@ -657,7 +658,7 @@ export function buildCommandPaletteCommands(context: CommandPaletteContext): Com
         'action',
         ['clip', 'split', 'selected', 'playhead'],
         ['cut selected clip', 'split current clip'],
-        () => context.actions.splitClip(selectedClipId, context.currentTime),
+        () => context.actions.splitClipAtZeroCrossing(selectedClipId, context.currentTime),
         ['S'],
         'Selected clip action',
       ),

--- a/src/store/__tests__/splitClipAtZeroCrossing.test.ts
+++ b/src/store/__tests__/splitClipAtZeroCrossing.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../services/audioFileManager', () => ({
+  loadAudioBlobByKey: vi.fn(),
+  saveAudioBlob: vi.fn(),
+}));
+
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(),
+}));
+
+import { loadAudioBlobByKey } from '../../services/audioFileManager';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+
+function fakeAudioBuffer(samples: Float32Array, sampleRate: number) {
+  return {
+    numberOfChannels: 1,
+    sampleRate,
+    length: samples.length,
+    duration: samples.length / sampleRate,
+    getChannelData: (ch: number) => {
+      if (ch !== 0) throw new Error('only channel 0');
+      return samples;
+    },
+  } as unknown as AudioBuffer;
+}
+
+describe('splitClipAtZeroCrossing', () => {
+  let clipId: string;
+  let trackId: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('stems');
+    trackId = track.id;
+    const clip = useProjectStore.getState().addClip(trackId, {
+      startTime: 0, duration: 4, prompt: 'test', lyrics: '',
+    });
+    clipId = clip.id;
+    useProjectStore.getState().updateClip(clipId, {
+      audioDuration: 4,
+      audioOffset: 0,
+      generationStatus: 'ready',
+      isolatedAudioKey: 'test-audio-key',
+    });
+  });
+
+  it('snaps split time to nearest zero crossing', async () => {
+    // 4000 samples at 1000 Hz → 4 seconds
+    // Zero crossing at sample 1199→1200
+    const samples = new Float32Array(4000);
+    for (let i = 0; i < 4000; i++) {
+      samples[i] = i < 1200 ? 0.5 : -0.5;
+    }
+    samples[1199] = 0.02;
+    samples[1200] = -0.03;
+    const buffer = fakeAudioBuffer(samples, 1000);
+
+    vi.mocked(loadAudioBlobByKey).mockResolvedValue(new Blob(['fake']));
+    vi.mocked(getAudioEngine).mockReturnValue({
+      decodeAudioData: vi.fn().mockResolvedValue(buffer),
+    } as any);
+
+    // Split at 1.203s — snaps to sample 1199 (time 1.199s)
+    await useProjectStore.getState().splitClipAtZeroCrossing(clipId, 1.203);
+
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(2);
+    expect(clips[0].duration).toBeCloseTo(1.199, 3);
+    expect(clips[1].startTime).toBeCloseTo(1.199, 3);
+  });
+
+  it('falls back to original split time when audio buffer is unavailable', async () => {
+    vi.mocked(loadAudioBlobByKey).mockResolvedValue(null);
+
+    await useProjectStore.getState().splitClipAtZeroCrossing(clipId, 2.0);
+
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(2);
+    expect(clips[0].duration).toBeCloseTo(2.0, 2);
+    expect(clips[1].startTime).toBeCloseTo(2.0, 2);
+  });
+
+  it('falls back when clip has no isolatedAudioKey', async () => {
+    useProjectStore.getState().updateClip(clipId, { isolatedAudioKey: null });
+
+    await useProjectStore.getState().splitClipAtZeroCrossing(clipId, 2.0);
+
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(2);
+    expect(clips[0].duration).toBeCloseTo(2.0, 2);
+  });
+
+  it('does nothing for invalid split time', async () => {
+    await useProjectStore.getState().splitClipAtZeroCrossing(clipId, 10);
+
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(1);
+  });
+
+  it('accounts for audioOffset when snapping', async () => {
+    useProjectStore.getState().updateClip(clipId, {
+      audioOffset: 1,
+      audioDuration: 5,
+    });
+
+    // 5000 samples at 1000 Hz → 5 seconds
+    // Zero crossing at sample 1999→2000 (buffer time 2.0s)
+    const samples = new Float32Array(5000);
+    for (let i = 0; i < 5000; i++) {
+      samples[i] = i < 2000 ? 0.5 : -0.5;
+    }
+    samples[1999] = 0.02;
+    samples[2000] = -0.03;
+    const buffer = fakeAudioBuffer(samples, 1000);
+
+    vi.mocked(loadAudioBlobByKey).mockResolvedValue(new Blob(['fake']));
+    vi.mocked(getAudioEngine).mockReturnValue({
+      decodeAudioData: vi.fn().mockResolvedValue(buffer),
+    } as any);
+
+    // Split at absolute time 1.003s
+    // Buffer time = audioOffset + (1.003 - 0) = 2.003s → sample 2003
+    // Search 5ms = 5 samples → finds crossing at 1999→2000, picks 1999
+    // Snapped buffer time = 1.999s → absolute = 0 + (1.999 - 1) = 0.999s
+    await useProjectStore.getState().splitClipAtZeroCrossing(clipId, 1.003);
+
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(2);
+    expect(clips[0].duration).toBeCloseTo(0.999, 3);
+    expect(clips[1].startTime).toBeCloseTo(0.999, 3);
+  });
+
+  it('falls back gracefully when decoding fails', async () => {
+    vi.mocked(loadAudioBlobByKey).mockResolvedValue(new Blob(['fake']));
+    vi.mocked(getAudioEngine).mockReturnValue({
+      decodeAudioData: vi.fn().mockRejectedValue(new Error('decode failed')),
+    } as any);
+
+    await useProjectStore.getState().splitClipAtZeroCrossing(clipId, 2.0);
+
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(2);
+    expect(clips[0].duration).toBeCloseTo(2.0, 2);
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -88,6 +88,7 @@ import { buildConsolidatedMidiClipData, renderConsolidatedAudioClip, validateCli
 import { audioBufferToWavBlob } from '../utils/wav';
 import { DEFAULT_BOUNCE_IN_PLACE_OPTIONS, renderTrackForBounceInPlace } from '../services/bounceInPlace';
 import type { MidiCaptureService } from '../services/midiCaptureService';
+import { snapTimeToZeroCrossing } from '../utils/zeroCrossing';
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
   return (60 / bpm) * timeSig;
@@ -334,6 +335,7 @@ interface ProjectState {
   /** Slip-edit: shift audioOffset by deltaSeconds without changing startTime/duration. */
   slipClip: (clipId: string, deltaSeconds: number) => void;
   splitClip: (clipId: string, splitTime: number) => void;
+  splitClipAtZeroCrossing: (clipId: string, splitTime: number) => Promise<void>;
   consolidateClips: (trackId: string, clipIds: string[]) => Promise<Clip | undefined>;
   toggleClipStar: (clipId: string) => void;
   moveClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => void;
@@ -2254,6 +2256,53 @@ export const useProjectStore = create<ProjectState>()(
         tracks: newTracks,
       },
     });
+  },
+
+  splitClipAtZeroCrossing: async (clipId, splitTime) => {
+    const state = get();
+    if (!state.project) return;
+
+    let sourceClip: Clip | undefined;
+    for (const t of state.project.tracks) {
+      const c = t.clips.find((c) => c.id === clipId);
+      if (c) {
+        sourceClip = c;
+        break;
+      }
+    }
+    if (!sourceClip) return;
+
+    const audioKey = sourceClip.isolatedAudioKey ?? sourceClip.cumulativeMixKey;
+    if (!audioKey) {
+      get().splitClip(clipId, splitTime);
+      return;
+    }
+
+    try {
+      const blob = await loadAudioBlobByKey(audioKey);
+      if (!blob) {
+        get().splitClip(clipId, splitTime);
+        return;
+      }
+
+      const engine = getAudioEngine();
+      const buffer = await engine.decodeAudioData(blob);
+      const samples = buffer.getChannelData(0);
+
+      const audioOffset = sourceClip.audioOffset ?? 0;
+      const bufferTime = audioOffset + (splitTime - sourceClip.startTime);
+      const snappedBufferTime = snapTimeToZeroCrossing(
+        samples,
+        buffer.sampleRate,
+        bufferTime,
+      );
+      const snappedSplitTime =
+        sourceClip.startTime + (snappedBufferTime - audioOffset);
+
+      get().splitClip(clipId, snappedSplitTime);
+    } catch {
+      get().splitClip(clipId, splitTime);
+    }
   },
 
   consolidateClips: async (trackId, clipIds) => {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -657,6 +657,7 @@ function buildCommandPaletteContext(state: UIState) {
         projectStore.duplicateClip(clipId);
       },
       splitClip: projectStore.splitClip,
+      splitClipAtZeroCrossing: projectStore.splitClipAtZeroCrossing,
       removeClip: projectStore.removeClip,
       setEditingClip: state.setEditingClip,
       deselectAll: state.deselectAll,


### PR DESCRIPTION
## Summary
- Add `splitClipAtZeroCrossing` async store action that loads the audio buffer and snaps the split point to the nearest zero crossing within 5ms, preventing audible clicks
- Update command palette (`clip:split-selected`) and keyboard shortcut (`S`) to use zero-crossing-aware split by default
- Graceful fallback to exact split time when audio buffer is unavailable or decoding fails

Closes #219

## Test plan
- [x] Unit tests for `splitClipAtZeroCrossing` (6 tests covering snapping, fallbacks, audioOffset, decode failure)
- [x] Existing `zeroCrossing.test.ts` tests still pass (10 tests)
- [x] All 994 unit tests pass
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Production build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)