### PR TITLE
feat: #212 — recent projects list with clip thumbnails & quick access

### DIFF
--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -13,6 +13,7 @@ import {
 import {
   listProjects,
   loadProject,
+  deleteProject,
   listTemplates,
   loadTemplate,
   deleteTemplate,
@@ -20,20 +21,46 @@ import {
   type TemplateSummary,
 } from '../../services/projectStorage';
 import { toastSuccess } from '../../hooks/useToast';
+import { formatRelativeTime } from '../../utils/formatRelativeTime';
+import type { ClipLayoutItem } from '../../utils/clipLayout';
 
-function formatDate(ts: number) {
-  const d = new Date(ts);
-  return d.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
+function ProjectThumbnail({
+  trackCount,
+  clipLayout,
+}: {
+  trackCount: number;
+  clipLayout?: ClipLayoutItem[];
+}) {
+  const fallbackColors = ['#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7'];
 
-function ProjectThumbnail({ trackCount }: { trackCount: number }) {
+  if (clipLayout && clipLayout.length > 0) {
+    const maxTrackIdx = Math.max(...clipLayout.map((c) => c.trackIndex));
+    const laneCount = Math.min(maxTrackIdx + 1, 6);
+    const laneHeight = Math.max(2, Math.floor(48 / laneCount));
+
+    return (
+      <div
+        data-testid="project-thumbnail"
+        className="w-full h-16 bg-daw-bg rounded border border-daw-border/50 overflow-hidden relative"
+      >
+        {clipLayout.map((clip, i) => (
+          <div
+            key={i}
+            className="absolute rounded-sm opacity-70"
+            style={{
+              backgroundColor: clip.color,
+              top: `${(clip.trackIndex / laneCount) * 100}%`,
+              left: `${clip.startNorm * 100}%`,
+              width: `${Math.max(clip.widthNorm * 100, 2)}%`,
+              height: `${laneHeight}px`,
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
   const lanes = Math.min(trackCount, 6);
-  const colors = ['#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7'];
   return (
     <div
       data-testid="project-thumbnail"
@@ -44,7 +71,7 @@ function ProjectThumbnail({ trackCount }: { trackCount: number }) {
           key={i}
           className="rounded-sm opacity-60"
           style={{
-            backgroundColor: colors[i % colors.length],
+            backgroundColor: fallbackColors[i % fallbackColors.length],
             height: `${Math.max(2, 12 / lanes)}px`,
             width: `${40 + ((i * 17) % 50)}%`,
           }}
@@ -102,6 +129,12 @@ export function NewProjectDialog() {
     }
   };
 
+  const handleDeleteRecent = async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    await deleteProject(id);
+    setRecentProjects((prev) => prev.filter((p) => p.id !== id));
+  };
+
   const handleUseTemplate = async (templateId: string) => {
     const template = await loadTemplate(templateId);
     if (template) {
@@ -136,20 +169,34 @@ export function NewProjectDialog() {
               <h3 className="text-xs font-medium text-zinc-400 mb-3">Recent Projects</h3>
               <div className="grid grid-cols-3 gap-2">
                 {recentProjects.slice(0, 6).map((p) => (
-                  <button
+                  <div
                     key={p.id}
                     data-project-id={p.id}
+                    className="relative text-left rounded-lg border border-daw-border/50 hover:border-daw-accent/50 hover:bg-daw-surface-2 transition-colors p-2 group cursor-pointer"
                     onClick={() => handleOpenRecent(p.id)}
-                    className="text-left rounded-lg border border-daw-border/50 hover:border-daw-accent/50 hover:bg-daw-surface-2 transition-colors p-2 group"
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => e.key === 'Enter' && handleOpenRecent(p.id)}
                   >
-                    <ProjectThumbnail trackCount={p.trackCount} />
+                    <ProjectThumbnail trackCount={p.trackCount} clipLayout={p.clipLayout} />
                     <p className="text-xs text-zinc-200 truncate mt-1.5 group-hover:text-white">
                       {p.name}
                     </p>
                     <p className="text-[10px] text-zinc-500">
-                      {p.trackCount} track{p.trackCount !== 1 ? 's' : ''} &middot; {formatDate(p.updatedAt)}
+                      {p.trackCount} track{p.trackCount !== 1 ? 's' : ''}
+                      {' · '}{p.bpm} BPM · {p.keyScale}
                     </p>
-                  </button>
+                    <p className="text-[10px] text-zinc-600">
+                      {formatRelativeTime(p.updatedAt)}
+                    </p>
+                    <button
+                      onClick={(e) => handleDeleteRecent(e, p.id)}
+                      className="absolute top-1 right-1 text-zinc-600 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100 transition-opacity p-0.5"
+                      title="Remove from recent"
+                    >
+                      ×
+                    </button>
+                  </div>
                 ))}
               </div>
             </div>

--- a/src/services/projectStorage.ts
+++ b/src/services/projectStorage.ts
@@ -1,5 +1,6 @@
 import { get, set, del, keys } from 'idb-keyval';
 import type { Project, ProjectTemplate } from '../types/project';
+import { buildClipLayout, type ClipLayoutItem } from '../utils/clipLayout';
 
 const PROJECT_PREFIX = 'project:';
 const TEMPLATE_PREFIX = 'template:';
@@ -12,6 +13,9 @@ export interface ProjectSummary {
   createdAt: number;
   updatedAt: number;
   trackCount: number;
+  bpm: number;
+  keyScale: string;
+  clipLayout: ClipLayoutItem[];
 }
 
 export interface TemplateSummary {
@@ -55,6 +59,9 @@ export async function listProjects(): Promise<ProjectSummary[]> {
         createdAt: project.createdAt,
         updatedAt: project.updatedAt,
         trackCount: project.tracks.length,
+        bpm: project.bpm,
+        keyScale: project.keyScale,
+        clipLayout: buildClipLayout(project.tracks, project.totalDuration),
       });
     }
   }

--- a/src/utils/clipLayout.ts
+++ b/src/utils/clipLayout.ts
@@ -1,0 +1,34 @@
+import type { Track } from '../types/project';
+
+export interface ClipLayoutItem {
+  trackIndex: number;
+  startNorm: number;
+  widthNorm: number;
+  color: string;
+}
+
+/**
+ * Build a normalized clip layout from tracks for thumbnail rendering.
+ * Each clip is mapped to a 0-1 coordinate space based on totalDuration.
+ */
+export function buildClipLayout(tracks: Track[], totalDuration: number): ClipLayoutItem[] {
+  if (totalDuration <= 0 || tracks.length === 0) return [];
+
+  const items: ClipLayoutItem[] = [];
+
+  for (let i = 0; i < tracks.length; i++) {
+    const track = tracks[i];
+    for (const clip of track.clips) {
+      const startNorm = Math.max(0, clip.startTime / totalDuration);
+      const widthNorm = Math.min(1 - startNorm, clip.duration / totalDuration);
+      items.push({
+        trackIndex: i,
+        startNorm,
+        widthNorm,
+        color: track.color,
+      });
+    }
+  }
+
+  return items;
+}

--- a/src/utils/formatRelativeTime.ts
+++ b/src/utils/formatRelativeTime.ts
@@ -1,0 +1,19 @@
+/**
+ * Format a timestamp as a relative time string (e.g. "5m ago", "2d ago").
+ * @param timestamp - Unix ms timestamp to format
+ * @param now - Current time in ms (defaults to Date.now())
+ */
+export function formatRelativeTime(timestamp: number, now: number = Date.now()): string {
+  const diffMs = now - timestamp;
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+  const diffMonth = Math.floor(diffDay / 30);
+
+  if (diffMin < 1) return 'just now';
+  if (diffHour < 1) return `${diffMin}m ago`;
+  if (diffDay < 1) return `${diffHour}h ago`;
+  if (diffMonth < 1) return `${diffDay}d ago`;
+  return `${diffMonth}mo ago`;
+}

--- a/tests/unit/newProjectDialog.test.tsx
+++ b/tests/unit/newProjectDialog.test.tsx
@@ -9,11 +9,13 @@ import type { ProjectSummary } from '../../src/services/projectStorage';
 const mockListProjects = vi.fn<() => Promise<ProjectSummary[]>>();
 const mockLoadProject = vi.fn();
 const mockSaveProject = vi.fn();
+const mockDeleteProject = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../../src/services/projectStorage', () => ({
   listProjects: (...args: unknown[]) => mockListProjects(...(args as [])),
   loadProject: (...args: unknown[]) => mockLoadProject(...(args as [])),
   saveProject: (...args: unknown[]) => mockSaveProject(...(args as [])),
+  deleteProject: (...args: unknown[]) => mockDeleteProject(...(args as [])),
   listTemplates: vi.fn().mockResolvedValue([]),
   loadTemplate: vi.fn().mockResolvedValue(null),
   deleteTemplate: vi.fn().mockResolvedValue(undefined),
@@ -33,9 +35,9 @@ vi.mock('../../src/hooks/useToast', () => ({
 }));
 
 const recentProjects: ProjectSummary[] = [
-  { id: 'p1', name: 'My Song', createdAt: 1710000000000, updatedAt: 1710100000000, trackCount: 3 },
-  { id: 'p2', name: 'Demo Beat', createdAt: 1709000000000, updatedAt: 1709900000000, trackCount: 5 },
-  { id: 'p3', name: 'Chill Vibes', createdAt: 1708000000000, updatedAt: 1708800000000, trackCount: 2 },
+  { id: 'p1', name: 'My Song', createdAt: 1710000000000, updatedAt: 1710100000000, trackCount: 3, bpm: 120, keyScale: 'C major', clipLayout: [] },
+  { id: 'p2', name: 'Demo Beat', createdAt: 1709000000000, updatedAt: 1709900000000, trackCount: 5, bpm: 140, keyScale: 'G minor', clipLayout: [] },
+  { id: 'p3', name: 'Chill Vibes', createdAt: 1708000000000, updatedAt: 1708800000000, trackCount: 2, bpm: 90, keyScale: 'F major', clipLayout: [] },
 ];
 
 function openDialog() {
@@ -50,6 +52,7 @@ describe('NewProjectDialog — recent projects (#212)', () => {
     mockListProjects.mockReset();
     mockLoadProject.mockReset();
     mockSaveProject.mockReset();
+    mockDeleteProject.mockReset().mockResolvedValue(undefined);
   });
 
   it('shows "Recent Projects" heading when saved projects exist', async () => {
@@ -73,10 +76,21 @@ describe('NewProjectDialog — recent projects (#212)', () => {
       expect(screen.getByText('Chill Vibes')).toBeInTheDocument();
     });
 
-    // Track counts should appear somewhere
     expect(screen.getByText(/3 track/)).toBeInTheDocument();
     expect(screen.getByText(/5 track/)).toBeInTheDocument();
     expect(screen.getByText(/2 track/)).toBeInTheDocument();
+  });
+
+  it('shows BPM and key info for recent projects', async () => {
+    mockListProjects.mockResolvedValue(recentProjects);
+    openDialog();
+    render(<NewProjectDialog />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/120 BPM · C major/)).toBeInTheDocument();
+      expect(screen.getByText(/140 BPM · G minor/)).toBeInTheDocument();
+      expect(screen.getByText(/90 BPM · F major/)).toBeInTheDocument();
+    });
   });
 
   it('clicking a recent project loads it and closes the dialog', async () => {
@@ -109,7 +123,6 @@ describe('NewProjectDialog — recent projects (#212)', () => {
 
     await waitFor(() => {
       expect(mockLoadProject).toHaveBeenCalledWith('p1');
-      // Dialog should close
       expect(useUIStore.getState().showNewProjectDialog).toBe(false);
     });
   });
@@ -119,7 +132,6 @@ describe('NewProjectDialog — recent projects (#212)', () => {
     openDialog();
     render(<NewProjectDialog />);
 
-    // Wait for async load to finish
     await waitFor(() => {
       expect(mockListProjects).toHaveBeenCalled();
     });
@@ -132,7 +144,6 @@ describe('NewProjectDialog — recent projects (#212)', () => {
     openDialog();
     render(<NewProjectDialog />);
 
-    // The new project form elements should still be present
     expect(screen.getByText('New Project')).toBeInTheDocument();
     expect(screen.getByText('Create')).toBeInTheDocument();
   });
@@ -160,8 +171,26 @@ describe('NewProjectDialog — recent projects (#212)', () => {
       expect(screen.getByText('My Song')).toBeInTheDocument();
     });
 
-    // Each card should have a thumbnail area
     const thumbnails = container.querySelectorAll('[data-testid="project-thumbnail"]');
     expect(thumbnails.length).toBe(3);
+  });
+
+  it('delete button removes a recent project', async () => {
+    mockListProjects.mockResolvedValue(recentProjects);
+    openDialog();
+    const { container } = render(<NewProjectDialog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Song')).toBeInTheDocument();
+    });
+
+    const deleteButtons = container.querySelectorAll('[title="Remove from recent"]');
+    expect(deleteButtons.length).toBe(3);
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(mockDeleteProject).toHaveBeenCalledWith('p1');
+      expect(screen.queryByText('My Song')).not.toBeInTheDocument();
+    });
   });
 });

--- a/tests/unit/recentProjects.test.ts
+++ b/tests/unit/recentProjects.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from '../../src/utils/formatRelativeTime';
+import {
+  buildClipLayout,
+  type ClipLayoutItem,
+} from '../../src/utils/clipLayout';
+import type { Track, Clip } from '../../src/types/project';
+
+describe('formatRelativeTime', () => {
+  const now = Date.now();
+
+  it('returns "just now" for timestamps less than 60s ago', () => {
+    expect(formatRelativeTime(now - 30_000, now)).toBe('just now');
+  });
+
+  it('returns minutes for timestamps less than 60min ago', () => {
+    expect(formatRelativeTime(now - 5 * 60_000, now)).toBe('5m ago');
+  });
+
+  it('returns hours for timestamps less than 24h ago', () => {
+    expect(formatRelativeTime(now - 3 * 3600_000, now)).toBe('3h ago');
+  });
+
+  it('returns days for timestamps less than 30d ago', () => {
+    expect(formatRelativeTime(now - 2 * 86400_000, now)).toBe('2d ago');
+  });
+
+  it('returns months for timestamps more than 30d ago', () => {
+    expect(formatRelativeTime(now - 45 * 86400_000, now)).toBe('1mo ago');
+  });
+
+  it('returns "1m ago" for exactly 60 seconds', () => {
+    expect(formatRelativeTime(now - 60_000, now)).toBe('1m ago');
+  });
+
+  it('returns "1h ago" for exactly 60 minutes', () => {
+    expect(formatRelativeTime(now - 3600_000, now)).toBe('1h ago');
+  });
+
+  it('returns "1d ago" for exactly 24 hours', () => {
+    expect(formatRelativeTime(now - 86400_000, now)).toBe('1d ago');
+  });
+});
+
+function makeClip(overrides: Partial<Clip>): Clip {
+  return {
+    id: 'clip-1',
+    trackId: 'track-1',
+    startTime: 0,
+    duration: 4,
+    generationStatus: 'ready',
+    ...overrides,
+  } as Clip;
+}
+
+function makeTrack(overrides: Partial<Track>): Track {
+  return {
+    id: 'track-1',
+    trackType: 'stems',
+    trackName: 'drums',
+    displayName: 'Drums',
+    color: '#ef4444',
+    order: 0,
+    volume: 0.8,
+    muted: false,
+    soloed: false,
+    armed: false,
+    inputMonitoring: 'off',
+    clips: [],
+    ...overrides,
+  } as Track;
+}
+
+describe('buildClipLayout', () => {
+  it('returns empty array for empty tracks', () => {
+    expect(buildClipLayout([], 16)).toEqual([]);
+  });
+
+  it('returns empty array for tracks with no clips', () => {
+    const tracks = [makeTrack({ clips: [] })];
+    expect(buildClipLayout(tracks, 16)).toEqual([]);
+  });
+
+  it('builds normalized clip layout from tracks', () => {
+    const tracks = [
+      makeTrack({
+        id: 'track-1',
+        color: '#ef4444',
+        clips: [makeClip({ startTime: 0, duration: 8 })],
+      }),
+      makeTrack({
+        id: 'track-2',
+        color: '#3b82f6',
+        order: 1,
+        clips: [makeClip({ startTime: 4, duration: 4 })],
+      }),
+    ];
+
+    const layout = buildClipLayout(tracks, 16);
+
+    expect(layout).toHaveLength(2);
+    expect(layout[0]).toEqual<ClipLayoutItem>({
+      trackIndex: 0,
+      startNorm: 0,
+      widthNorm: 0.5,
+      color: '#ef4444',
+    });
+    expect(layout[1]).toEqual<ClipLayoutItem>({
+      trackIndex: 1,
+      startNorm: 0.25,
+      widthNorm: 0.25,
+      color: '#3b82f6',
+    });
+  });
+
+  it('clamps values to 0-1 range', () => {
+    const tracks = [
+      makeTrack({
+        clips: [makeClip({ startTime: 0, duration: 20 })],
+      }),
+    ];
+    const layout = buildClipLayout(tracks, 16);
+    expect(layout[0].widthNorm).toBeLessThanOrEqual(1);
+    expect(layout[0].startNorm).toBeGreaterThanOrEqual(0);
+  });
+
+  it('handles totalDuration of 0 gracefully', () => {
+    const tracks = [
+      makeTrack({ clips: [makeClip({ startTime: 0, duration: 4 })] }),
+    ];
+    expect(buildClipLayout(tracks, 0)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Enhanced recent projects section in startup dialog with richer metadata (BPM, key, clip layout thumbnails)
- Added relative time display ("5m ago", "2d ago") replacing absolute dates
- Added delete button on recent project cards for quick removal
- Added keyboard accessibility (Enter to open, role/tabIndex on cards)
- New utilities: `formatRelativeTime`, `buildClipLayout` with full test coverage

## Changes
- `src/utils/formatRelativeTime.ts` — new relative time formatting utility
- `src/utils/clipLayout.ts` — new clip layout builder for thumbnail rendering
- `src/services/projectStorage.ts` — extended `ProjectSummary` with bpm, keyScale, clipLayout
- `src/components/dialogs/NewProjectDialog.tsx` — enhanced thumbnail, metadata display, delete action
- `tests/unit/recentProjects.test.ts` — 13 new tests for utilities
- `tests/unit/newProjectDialog.test.tsx` — 2 new tests (BPM/key display, delete button)

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run tests/unit/` — 717 tests pass
- [x] `npm run build` — succeeds
- [ ] Manual: open app with saved projects, verify thumbnails show clip layout
- [ ] Manual: verify relative time updates ("just now" → "5m ago")
- [ ] Manual: verify delete button removes project from list without reload

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)