### PR TITLE
feat: #218 — loop recording overdub mode for multiple takes

### DIFF
--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -14,6 +14,9 @@ function LCDDisplay() {
   const countInActive = useTransportStore((s) => s.countInActive);
   const countInBeat = useTransportStore((s) => s.countInBeat);
   const sessionArrangementRecording = useTransportStore((s) => s.sessionArrangementRecording);
+  const isRecording = useTransportStore((s) => s.isRecording);
+  const loopRecordingEnabled = useTransportStore((s) => s.loopRecordingEnabled);
+  const loopCycleCount = useTransportStore((s) => s.loopCycleCount);
   const project = useProjectStore((s) => s.project);
   const barsBeats = project
     ? formatBarsBeats(currentTime, project.bpm, project.timeSignature)
@@ -22,6 +25,8 @@ function LCDDisplay() {
   // During count-in: show negative beat count in cyan (Ableton convention)
   const displayBarsBeats = countInActive ? `${countInBeat}` : barsBeats;
   const barsBeatsColor = countInActive ? 'text-cyan-400 animate-pulse' : 'text-green-400';
+
+  const showLoopCycleBadge = isRecording && loopRecordingEnabled && loopCycleCount > 0;
 
   return (
     <div className="gb-lcd flex items-center gap-3 px-3 py-1 min-w-[200px] justify-center">
@@ -38,6 +43,15 @@ function LCDDisplay() {
       )}
       {!countInActive && sessionArrangementRecording && (
         <span className="text-[11px] font-mono text-red-400 animate-pulse">SESSION REC</span>
+      )}
+      {showLoopCycleBadge && (
+        <span
+          className="text-[10px] font-mono font-semibold text-orange-400 bg-orange-900/30 rounded px-1.5 py-0.5"
+          title={`Loop recording pass ${loopCycleCount}`}
+          data-testid="loop-cycle-badge"
+        >
+          Pass {loopCycleCount}
+        </span>
       )}
     </div>
   );
@@ -105,6 +119,8 @@ export function Toolbar() {
   const loopEnabled = useTransportStore((s) => s.loopEnabled);
   const isRecording = useTransportStore((s) => s.isRecording);
   const toggleLoop = useTransportStore((s) => s.toggleLoop);
+  const loopRecordingEnabled = useTransportStore((s) => s.loopRecordingEnabled);
+  const toggleLoopRecording = useTransportStore((s) => s.toggleLoopRecording);
   const metronomeEnabled = useTransportStore((s) => s.metronomeEnabled);
   const toggleMetronome = useTransportStore((s) => s.toggleMetronome);
   const zoomIn = useUIStore((s) => s.zoomIn);
@@ -282,6 +298,15 @@ export function Toolbar() {
             <path d="M4 13l-2-2 2-2" />
             <path d="M12 3H5a3 3 0 0 0 0 6" />
             <path d="M2 11h7a3 3 0 0 0 0-6" />
+          </svg>
+        </ControlBarButton>
+        <ControlBarButton active={loopRecordingEnabled} onClick={toggleLoopRecording} title="Overdub / Loop Recording (Shift+L)">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M10 1l2 2-2 2" />
+            <path d="M4 13l-2-2 2-2" />
+            <path d="M12 3H5a3 3 0 0 0 0 6" />
+            <path d="M2 11h7a3 3 0 0 0 0-6" />
+            <circle cx="7" cy="7" r="2" fill="currentColor" stroke="none" />
           </svg>
         </ControlBarButton>
         <ControlBarButton active={metronomeEnabled} onClick={toggleMetronome} title="Metronome (K)">

--- a/src/hooks/useRecording.ts
+++ b/src/hooks/useRecording.ts
@@ -159,6 +159,17 @@ export function useRecording() {
       }
     }
 
+    // Auto-show take lanes on armed tracks after loop recording
+    if (isLoopRec) {
+      const armedIds = useTransportStore.getState().armedTrackIds;
+      for (const trackId of armedIds) {
+        const track = useProjectStore.getState().project?.tracks.find((t) => t.id === trackId);
+        if (track && !track.showTakeLanes) {
+          useProjectStore.getState().toggleTakeLanes(trackId);
+        }
+      }
+    }
+
     loopRecordingClipIds.clear();
     useTransportStore.getState().setLoopCycleCount(0);
 

--- a/src/store/transportStore.ts
+++ b/src/store/transportStore.ts
@@ -119,7 +119,13 @@ export const useTransportStore = create<TransportState>((set) => ({
   setPunchIn: (time) => set({ punchInTime: time }),
   setPunchOut: (time) => set({ punchOutTime: time }),
   togglePunch: () => set((s) => ({ punchEnabled: !s.punchEnabled })),
-  toggleLoopRecording: () => set((s) => ({ loopRecordingEnabled: !s.loopRecordingEnabled })),
+  toggleLoopRecording: () =>
+    set((s) => {
+      const next = !s.loopRecordingEnabled;
+      return next
+        ? { loopRecordingEnabled: true, loopEnabled: true }
+        : { loopRecordingEnabled: false };
+    }),
   setLoopCycleCount: (count) => set({ loopCycleCount: count }),
   incrementLoopCycle: () => set((s) => ({ loopCycleCount: s.loopCycleCount + 1 })),
   launchSessionClip: (trackId, clipId, sceneIndex, launchedAt) => set((s) => {

--- a/tests/unit/loopRecording.test.ts
+++ b/tests/unit/loopRecording.test.ts
@@ -43,10 +43,10 @@ describe('Loop Recording — Overdub Mode', () => {
       expect(useTransportStore.getState().loopCycleCount).toBe(0);
     });
 
-    it('loopRecordingEnabled can be set independently of loopEnabled', () => {
+    it('enabling loopRecordingEnabled also enables loopEnabled', () => {
       useTransportStore.getState().toggleLoopRecording();
       expect(useTransportStore.getState().loopRecordingEnabled).toBe(true);
-      expect(useTransportStore.getState().loopEnabled).toBe(false);
+      expect(useTransportStore.getState().loopEnabled).toBe(true);
     });
   });
 

--- a/tests/unit/loopRecordingOverdub.test.ts
+++ b/tests/unit/loopRecordingOverdub.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTransportStore } from '../../src/store/transportStore';
+import { useProjectStore } from '../../src/store/projectStore';
+
+describe('Loop Recording — Overdub Workflow', () => {
+  beforeEach(() => {
+    useTransportStore.setState({
+      loopRecordingEnabled: false,
+      loopCycleCount: 0,
+      loopEnabled: false,
+      loopStart: 0,
+      loopEnd: 8,
+      isRecording: false,
+      isPlaying: false,
+      armedTrackIds: [],
+    });
+  });
+
+  describe('toggleLoopRecording auto-enables loop', () => {
+    it('enabling loopRecordingEnabled also enables loopEnabled', () => {
+      const s = useTransportStore.getState();
+      expect(s.loopEnabled).toBe(false);
+      expect(s.loopRecordingEnabled).toBe(false);
+
+      useTransportStore.getState().toggleLoopRecording();
+
+      const after = useTransportStore.getState();
+      expect(after.loopRecordingEnabled).toBe(true);
+      expect(after.loopEnabled).toBe(true);
+    });
+
+    it('disabling loopRecordingEnabled does NOT disable loopEnabled', () => {
+      useTransportStore.getState().toggleLoopRecording(); // on
+      useTransportStore.getState().toggleLoopRecording(); // off
+
+      const after = useTransportStore.getState();
+      expect(after.loopRecordingEnabled).toBe(false);
+      expect(after.loopEnabled).toBe(true); // stays on
+    });
+  });
+
+  describe('multiple take accumulation across loop cycles', () => {
+    beforeEach(() => {
+      const store = useProjectStore.getState();
+      store.createProject({ name: 'Overdub Test' });
+      store.addTrack('vocals', 'stems');
+    });
+
+    it('each addTake increases the take count', () => {
+      const store = useProjectStore.getState();
+      const track = store.project!.tracks[0];
+      const clip = store.addClip(track.id, {
+        startTime: 0,
+        duration: 8,
+        prompt: 'Recording',
+        lyrics: '',
+        source: 'uploaded',
+      });
+
+      // Simulate 4 loop passes
+      store.addTake(clip.id, 'take-pass-1');
+      store.addTake(clip.id, 'take-pass-2');
+      store.addTake(clip.id, 'take-pass-3');
+      store.addTake(clip.id, 'take-pass-4');
+
+      const updated = useProjectStore.getState().getClipById(clip.id)!;
+      expect(updated.takes).toHaveLength(4);
+    });
+
+    it('the last added take is not auto-selected', () => {
+      const store = useProjectStore.getState();
+      const track = store.project!.tracks[0];
+      const clip = store.addClip(track.id, {
+        startTime: 0,
+        duration: 8,
+        prompt: 'Recording',
+        lyrics: '',
+        source: 'uploaded',
+      });
+
+      store.addTake(clip.id, 'take-1');
+      store.addTake(clip.id, 'take-2');
+
+      const updated = useProjectStore.getState().getClipById(clip.id)!;
+      expect(updated.takes!.every((t) => !t.selected)).toBe(true);
+    });
+
+    it('selectTake deselects all other takes', () => {
+      const store = useProjectStore.getState();
+      const track = store.project!.tracks[0];
+      const clip = store.addClip(track.id, {
+        startTime: 0,
+        duration: 8,
+        prompt: 'Recording',
+        lyrics: '',
+        source: 'uploaded',
+      });
+
+      store.addTake(clip.id, 'take-1');
+      store.addTake(clip.id, 'take-2');
+      store.addTake(clip.id, 'take-3');
+
+      const takes = useProjectStore.getState().getClipById(clip.id)!.takes!;
+      store.selectTake(clip.id, takes[1].id);
+
+      const after = useProjectStore.getState().getClipById(clip.id)!.takes!;
+      expect(after[0].selected).toBe(false);
+      expect(after[1].selected).toBe(true);
+      expect(after[2].selected).toBe(false);
+
+      // Now select a different take
+      store.selectTake(clip.id, takes[2].id);
+      const final = useProjectStore.getState().getClipById(clip.id)!.takes!;
+      expect(final[0].selected).toBe(false);
+      expect(final[1].selected).toBe(false);
+      expect(final[2].selected).toBe(true);
+    });
+  });
+
+  describe('cycle counter during overdub', () => {
+    it('incrementLoopCycle tracks the pass number', () => {
+      useTransportStore.getState().toggleLoopRecording();
+      useTransportStore.setState({ isRecording: true });
+
+      useTransportStore.getState().incrementLoopCycle();
+      expect(useTransportStore.getState().loopCycleCount).toBe(1);
+
+      useTransportStore.getState().incrementLoopCycle();
+      expect(useTransportStore.getState().loopCycleCount).toBe(2);
+
+      useTransportStore.getState().incrementLoopCycle();
+      expect(useTransportStore.getState().loopCycleCount).toBe(3);
+    });
+
+    it('stop resets cycle count', () => {
+      useTransportStore.getState().setLoopCycleCount(5);
+      useTransportStore.getState().stop();
+      expect(useTransportStore.getState().loopCycleCount).toBe(0);
+    });
+
+    it('setLoopCycleCount(0) resets after recording ends', () => {
+      useTransportStore.getState().setLoopCycleCount(7);
+      useTransportStore.getState().setLoopCycleCount(0);
+      expect(useTransportStore.getState().loopCycleCount).toBe(0);
+    });
+  });
+
+  describe('take lanes visibility', () => {
+    beforeEach(() => {
+      const store = useProjectStore.getState();
+      store.createProject({ name: 'Take Lanes Test' });
+      store.addTrack('guitar', 'stems');
+    });
+
+    it('toggleTakeLanes shows/hides take lanes per track', () => {
+      const store = useProjectStore.getState();
+      const track = store.project!.tracks[0];
+
+      expect(track.showTakeLanes).toBeFalsy();
+
+      store.toggleTakeLanes(track.id);
+      expect(useProjectStore.getState().project!.tracks[0].showTakeLanes).toBe(true);
+
+      store.toggleTakeLanes(track.id);
+      expect(useProjectStore.getState().project!.tracks[0].showTakeLanes).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Overdub toggle button** in toolbar (cycle icon + record dot) to enable/disable loop recording mode
- **Auto-enable loop** when activating overdub mode — ensures loop playback is on
- **LCD cycle count badge** shows "Pass N" during active loop recording
- **Auto-show take lanes** on armed tracks after loop recording stops
- Each loop pass creates a new take on the clip; users can comp between takes via take lane UI

## Changed Files
- `src/store/transportStore.ts` — `toggleLoopRecording` now auto-enables `loopEnabled`
- `src/components/layout/Toolbar.tsx` — Overdub button + LCD cycle badge
- `src/hooks/useRecording.ts` — Auto-show take lanes post loop recording
- `tests/unit/loopRecording.test.ts` — Updated test for new coupling behavior
- `tests/unit/loopRecordingOverdub.test.ts` — **New**: 9 comprehensive overdub workflow tests

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run tests/unit/` — 764/764 tests pass
- [x] `npm run build` — succeeds
- [ ] Manual: enable overdub, arm track, record in loop region, verify multiple takes created
- [ ] Manual: verify take lanes auto-show after stopping loop recording
- [ ] Manual: verify LCD "Pass N" badge appears during loop recording

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)