### PR TITLE
feat: track meter peak hold + clip indicator (#216)

### DIFF
--- a/src/components/mixer/LevelMeter.tsx
+++ b/src/components/mixer/LevelMeter.tsx
@@ -105,7 +105,11 @@ export function LevelMeter({ trackId, masterStage }: LevelMeterProps) {
         />
         <div
           data-testid="meter-peak-hold"
-          className="absolute inset-x-0 h-[2px] bg-white/90 shadow-[0_0_4px_rgba(255,255,255,0.45)]"
+          className={`absolute inset-x-0 h-[2px] ${
+            clipped
+              ? 'bg-red-500 shadow-[0_0_4px_rgba(239,68,68,0.6)]'
+              : 'bg-white/90 shadow-[0_0_4px_rgba(255,255,255,0.45)]'
+          }`}
           style={{ bottom: `calc(${Math.max(0, Math.min(1, peakLevel)) * 100}% - 1px)` }}
         />
       </div>

--- a/src/components/tracks/TrackHeaderMeter.tsx
+++ b/src/components/tracks/TrackHeaderMeter.tsx
@@ -3,7 +3,6 @@ import { getAudioEngine } from '../../hooks/useAudioEngine';
 
 const FALL_RATE_PER_FRAME = 0.012;
 const PEAK_HOLD_FRAMES = 18;
-const CLIP_THRESHOLD = 0.95;
 
 function levelToDb(level: number): number {
   if (level <= 0) return -Infinity;
@@ -28,14 +27,17 @@ export function TrackHeaderMeter({ trackId }: TrackHeaderMeterProps) {
   const [level, setLevel] = useState(0);
   const [peakLevel, setPeakLevel] = useState(0);
   const [clipping, setClipping] = useState(false);
-  const clippingRef = useRef(false);
 
   useEffect(() => {
     const engine = getAudioEngine();
 
     const tick = () => {
-      const nextLevel = engine.getTrackLevel(trackId);
+      const meter = engine.getTrackMeter(trackId);
+      const nextLevel = meter.level;
       setLevel(nextLevel);
+
+      // Clip detection — uses engine's clipped flag (> 0dB), latches until reset
+      setClipping((wasClipping) => wasClipping || meter.clipped);
 
       // Peak hold logic
       if (nextLevel >= peakLevelRef.current) {
@@ -51,12 +53,6 @@ export function TrackHeaderMeter({ trackId }: TrackHeaderMeterProps) {
       }
       setPeakLevel(peakLevelRef.current);
 
-      // Clip detection — latches on until manually reset
-      if (nextLevel >= CLIP_THRESHOLD && !clippingRef.current) {
-        clippingRef.current = true;
-        setClipping(true);
-      }
-
       rafRef.current = requestAnimationFrame(tick);
     };
 
@@ -65,7 +61,8 @@ export function TrackHeaderMeter({ trackId }: TrackHeaderMeterProps) {
   }, [trackId]);
 
   const resetClip = () => {
-    clippingRef.current = false;
+    const engine = getAudioEngine();
+    engine.resetTrackClip(trackId);
     setClipping(false);
   };
 
@@ -87,10 +84,12 @@ export function TrackHeaderMeter({ trackId }: TrackHeaderMeterProps) {
             background: getMeterColor(level),
           }}
         />
-        {/* Peak hold indicator */}
+        {/* Peak hold indicator — turns red when clipping */}
         <div
           data-testid="meter-peak"
-          className="absolute top-0 bottom-0 w-[2px] bg-white/80"
+          className={`absolute top-0 bottom-0 w-[2px] ${
+            clipping ? 'bg-red-500' : 'bg-white/80'
+          }`}
           style={{ left: `${clampedPeak * 100}%` }}
         />
       </div>

--- a/src/components/tracks/__tests__/TrackHeaderMeter.test.tsx
+++ b/src/components/tracks/__tests__/TrackHeaderMeter.test.tsx
@@ -3,11 +3,13 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import { TrackHeaderMeter } from '../TrackHeaderMeter';
 
 // Mock the audio engine
-let mockLevel = 0;
+const engine = {
+  getTrackMeter: vi.fn().mockReturnValue({ level: 0, clipped: false }),
+  resetTrackClip: vi.fn(),
+};
+
 vi.mock('../../../hooks/useAudioEngine', () => ({
-  getAudioEngine: () => ({
-    getTrackLevel: () => mockLevel,
-  }),
+  getAudioEngine: () => engine,
 }));
 
 describe('TrackHeaderMeter', () => {
@@ -15,7 +17,8 @@ describe('TrackHeaderMeter', () => {
   let rafId: number;
 
   beforeEach(() => {
-    mockLevel = 0;
+    engine.getTrackMeter.mockReset().mockReturnValue({ level: 0, clipped: false });
+    engine.resetTrackClip.mockReset();
     rafCallbacks = [];
     rafId = 1;
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
@@ -29,8 +32,8 @@ describe('TrackHeaderMeter', () => {
     vi.restoreAllMocks();
   });
 
-  function tickFrame(level?: number) {
-    if (level !== undefined) mockLevel = level;
+  function tickFrame(level: number, clipped = false) {
+    engine.getTrackMeter.mockReturnValue({ level, clipped });
     const cbs = [...rafCallbacks];
     rafCallbacks = [];
     cbs.forEach((cb) => cb(performance.now()));
@@ -50,7 +53,6 @@ describe('TrackHeaderMeter', () => {
     const meter = screen.getByLabelText('Track header level meter for track-1');
     const levelBar = meter.querySelector('[data-testid="meter-level"]') as HTMLElement;
     expect(levelBar).toBeTruthy();
-    // Width should reflect the level (50%)
     expect(levelBar.style.width).toBe('50%');
   });
 
@@ -61,50 +63,46 @@ describe('TrackHeaderMeter', () => {
     const meter = screen.getByLabelText('Track header level meter for track-1');
     const peakHold = meter.querySelector('[data-testid="meter-peak"]') as HTMLElement;
     expect(peakHold).toBeTruthy();
-    // Peak should be at 80%
     expect(peakHold.style.left).toBe('80%');
   });
 
   it('holds the peak after level drops', () => {
     render(<TrackHeaderMeter trackId="track-1" />);
-    // Spike to 0.9
     act(() => tickFrame(0.9));
-    // Drop to 0.2
     act(() => tickFrame(0.2));
 
     const meter = screen.getByLabelText('Track header level meter for track-1');
     const peakHold = meter.querySelector('[data-testid="meter-peak"]') as HTMLElement;
-    // Peak should still be at 90% (held)
     expect(peakHold.style.left).toBe('90%');
   });
 
-  it('shows clip indicator when level exceeds threshold', () => {
+  it('shows clip indicator when engine reports clipping', () => {
     render(<TrackHeaderMeter trackId="track-1" />);
-    act(() => tickFrame(0.97));
+    act(() => tickFrame(1.0, true));
 
     const clipIndicator = screen.getByTestId('clip-indicator');
-    expect(clipIndicator).toBeInTheDocument();
-    // Should have red color when clipping
     expect(clipIndicator.className).toMatch(/bg-red/);
   });
 
   it('clip indicator stays lit after level drops below threshold', () => {
     render(<TrackHeaderMeter trackId="track-1" />);
-    act(() => tickFrame(0.97));
+    act(() => tickFrame(1.0, true));
     act(() => tickFrame(0.3));
 
     const clipIndicator = screen.getByTestId('clip-indicator');
     expect(clipIndicator.className).toMatch(/bg-red/);
   });
 
-  it('clip indicator resets on click', () => {
+  it('clip indicator resets on click and calls engine.resetTrackClip', () => {
     render(<TrackHeaderMeter trackId="track-1" />);
-    act(() => tickFrame(0.97));
+    act(() => tickFrame(1.0, true));
 
     const clipIndicator = screen.getByTestId('clip-indicator');
     expect(clipIndicator.className).toMatch(/bg-red/);
 
     fireEvent.click(clipIndicator);
+
+    expect(engine.resetTrackClip).toHaveBeenCalledWith('track-1');
 
     // After click + level below threshold, clip indicator should be inactive
     act(() => tickFrame(0.3));
@@ -112,13 +110,21 @@ describe('TrackHeaderMeter', () => {
     expect(resetIndicator.className).not.toMatch(/bg-red/);
   });
 
+  it('peak hold line turns red when clipping', () => {
+    render(<TrackHeaderMeter trackId="track-1" />);
+    act(() => tickFrame(1.0, true));
+
+    const meter = screen.getByLabelText('Track header level meter for track-1');
+    const peakHold = meter.querySelector('[data-testid="meter-peak"]') as HTMLElement;
+    expect(peakHold.className).toMatch(/bg-red/);
+  });
+
   it('uses green color for normal levels', () => {
     render(<TrackHeaderMeter trackId="track-1" />);
-    act(() => tickFrame(0.15)); // ~-16 dB, below -12 dB threshold
+    act(() => tickFrame(0.15));
 
     const meter = screen.getByLabelText('Track header level meter for track-1');
     const levelBar = meter.querySelector('[data-testid="meter-level"]') as HTMLElement;
-    // jsdom converts hex to rgb
     expect(levelBar.style.background).toContain('rgb(34, 197, 94)');
   });
 

--- a/tests/unit/levelMeter.test.tsx
+++ b/tests/unit/levelMeter.test.tsx
@@ -77,4 +77,28 @@ describe('LevelMeter', () => {
     expect(engine.resetTrackClip).toHaveBeenCalledWith('track-1');
     expect(screen.queryByRole('button', { name: 'Reset clip indicator for track-1' })).not.toBeInTheDocument();
   });
+
+  it('peak hold line turns red when clipping', () => {
+    engine.getTrackMeter
+      .mockReturnValueOnce({ level: 1, clipped: true })
+      .mockReturnValue({ level: 0.5, clipped: false });
+
+    render(<LevelMeter trackId="track-1" />);
+
+    runFrame();
+
+    const peakHold = screen.getByTestId('meter-peak-hold');
+    expect(peakHold.className).toMatch(/bg-red/);
+  });
+
+  it('peak hold line is white when not clipping', () => {
+    engine.getTrackMeter.mockReturnValue({ level: 0.5, clipped: false });
+
+    render(<LevelMeter trackId="track-1" />);
+
+    runFrame();
+
+    const peakHold = screen.getByTestId('meter-peak-hold');
+    expect(peakHold.className).toMatch(/bg-white/);
+  });
 });


### PR DESCRIPTION
## Summary

- **TrackHeaderMeter** now uses `engine.getTrackMeter()` for accurate clip detection (>0dB threshold from engine) instead of a premature local `0.95` threshold
- **TrackHeaderMeter** calls `engine.resetTrackClip()` on clip indicator reset, consistent with mixer `LevelMeter`
- **Peak hold line turns red** when clipping in both `LevelMeter` and `TrackHeaderMeter` for immediate visual feedback

## Test plan

- [x] All 16 meter tests pass (TrackHeaderMeter: 12, LevelMeter: 4)
- [x] Full unit test suite: 776 tests pass
- [x] TypeScript: 0 type errors
- [x] Production build succeeds

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)