### PR TITLE
fix: prevent Claude Code CLI 403 from concurrent session limits

### DIFF
--- a/scripts/agents/launch-dev.sh
+++ b/scripts/agents/launch-dev.sh
@@ -5,6 +5,8 @@ TOOL=${2:-"codex"}
 REPO="ace-step/ACE-Step-DAW"
 DAW="/Users/junmingong/.openclaw/workspace/acestep-daw"
 WT="/tmp/daw-worktrees/agent-$ISSUE_NUM"
+LOCKDIR="/tmp/daw-claude-launch.lock"
+MAX_CLAUDE=3
 
 # Skip if already running — check for active run-agent.sh process for this exact issue
 if pgrep -f "run-agent.sh.*/tmp/daw-worktrees/agent-$ISSUE_NUM " > /dev/null 2>&1; then
@@ -12,22 +14,44 @@ if pgrep -f "run-agent.sh.*/tmp/daw-worktrees/agent-$ISSUE_NUM " > /dev/null 2>&
   exit 0
 fi
 
-# Get issue info (with timeout)
-# Concurrent limit: max 4 Claude at once (MAX plan limit)
-if [ "$TOOL" = "claude" ]; then
-  CC_COUNT=$(ps aux | grep "claude.*print" | grep -v grep | wc -l | tr -d " ")
-  if [ "$CC_COUNT" -ge 4 ]; then
-    echo "WARN: Claude at capacity ($CC_COUNT), using Codex for #$ISSUE_NUM" >> /tmp/pm-activity.log
-    TOOL="codex"
-  fi
-fi
+# Count ALL running Claude Code CLI processes (match multiple invocation patterns)
+count_claude() {
+  ps aux | grep -E "claude.*(--print|bypassPermissions|dangerously)" | grep -v grep | wc -l | tr -d " "
+}
 
-# Auth check: if Claude requested but auth fails, fallback to Codex
+# Concurrent limit with mkdir-based lock (macOS compatible, atomic)
+acquire_lock() {
+  local attempts=0
+  while [ $attempts -lt 15 ]; do
+    if mkdir "$LOCKDIR" 2>/dev/null; then
+      trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+      return 0
+    fi
+    sleep 2
+    attempts=$((attempts + 1))
+  done
+  return 1
+}
+
 if [ "$TOOL" = "claude" ]; then
-  AUTH_TEST=$(~/.local/bin/claude --print -p "ok" 2>&1 | head -1)
-  if echo "$AUTH_TEST" | grep -qi "403\|forbidden\|authenticate"; then
-    echo "WARN: Claude auth failed, falling back to Codex for #$ISSUE_NUM" >> /tmp/pm-activity.log
+  if ! acquire_lock; then
+    echo "WARN: Could not acquire Claude launch lock for #$ISSUE_NUM, using Codex" >> /tmp/pm-activity.log
     TOOL="codex"
+  else
+    CC_COUNT=$(count_claude)
+    if [ "$CC_COUNT" -ge "$MAX_CLAUDE" ]; then
+      echo "WARN: Claude at capacity ($CC_COUNT/$MAX_CLAUDE), using Codex for #$ISSUE_NUM" >> /tmp/pm-activity.log
+      TOOL="codex"
+    else
+      # Stagger launches: wait 3s between Claude starts to let Anthropic register sessions
+      sleep 3
+      # Re-check after sleep (another launch-dev.sh may have started one)
+      CC_COUNT=$(count_claude)
+      if [ "$CC_COUNT" -ge "$MAX_CLAUDE" ]; then
+        echo "WARN: Claude filled during wait ($CC_COUNT/$MAX_CLAUDE), using Codex for #$ISSUE_NUM" >> /tmp/pm-activity.log
+        TOOL="codex"
+      fi
+    fi
   fi
 fi
 
@@ -63,7 +87,26 @@ PROMPT=$(cat "$WT/agent-prompt.txt")
 if [ "$TOOL" = "codex" ]; then
   codex exec -C "$WT" -s danger-full-access "$PROMPT"
 else
-  ~/.local/bin/claude --print --permission-mode bypassPermissions --fallback-model sonnet "$PROMPT"
+  # Retry loop: if Claude returns 403, wait and retry up to 3 times
+  MAX_RETRIES=3
+  RETRY=0
+  while [ $RETRY -lt $MAX_RETRIES ]; do
+    OUTPUT=$(~/.local/bin/claude --print --permission-mode bypassPermissions --fallback-model sonnet "$PROMPT" 2>&1)
+    EXIT_CODE=$?
+    if echo "$OUTPUT" | grep -qi "403.*forbidden\|Request not allowed\|authentication_failed"; then
+      RETRY=$((RETRY + 1))
+      WAIT=$((RETRY * 15))
+      echo "[$(date)] Claude 403 for #$ISSUE, retry $RETRY/$MAX_RETRIES in ${WAIT}s" >> /tmp/pm-activity.log
+      sleep $WAIT
+    else
+      echo "$OUTPUT"
+      break
+    fi
+  done
+  if [ $RETRY -ge $MAX_RETRIES ]; then
+    echo "[$(date)] Claude failed $MAX_RETRIES times for #$ISSUE, falling back to Codex" >> /tmp/pm-activity.log
+    codex exec -C "$WT" -s danger-full-access "$PROMPT"
+  fi
 fi
 
 # Post-agent: verify + rebase + push + PR

--- a/scripts/agents/project-manager.sh
+++ b/scripts/agents/project-manager.sh
@@ -13,9 +13,9 @@ ISSUES=$(gh issue list --repo $REPO --state open --limit 30 --json number,title,
 PRS=$(gh pr list --repo $REPO --state open --limit 20 --json number,title,isDraft,mergeable,headRefName,statusCheckRollup --jq '[.[] | {num:.number, title:.title[:40], draft:.isDraft, merge:.mergeable, checks:[.statusCheckRollup[] | "\(.name):\(.conclusion // "pending")"]}]' 2>/dev/null)
 
 # Running agents — WHO is doing WHAT
-CC_DETAIL=$(ps aux | grep 'claude.*print' | grep -v grep | awk '{for(i=11;i<=NF;i++) printf "%s ",$i; print ""}' | grep -oE 'issue.#[0-9]+|Issue #[0-9]+|#[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
+CC_DETAIL=$(ps aux | grep -E 'claude.*(--print|bypassPermissions|dangerously)' | grep -v grep | awk '{for(i=11;i<=NF;i++) printf "%s ",$i; print ""}' | grep -oE 'issue.#[0-9]+|Issue #[0-9]+|#[0-9]+|issue-[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
 CX_DETAIL=$(ps aux | grep 'codex exec' | grep -v grep | awk '{for(i=11;i<=NF;i++) printf "%s ",$i; print ""}' | grep -oE 'issue-[0-9]+|#[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
-CC_COUNT=$(ps aux | grep 'claude.*print' | grep -v grep | wc -l | tr -d ' ')
+CC_COUNT=$(ps aux | grep -E 'claude.*(--print|bypassPermissions|dangerously)' | grep -v grep | wc -l | tr -d ' ')
 CX_COUNT=$(ps aux | grep 'codex exec' | grep -v grep | wc -l | tr -d ' ')
 
 # Recent merges
@@ -35,7 +35,7 @@ $PRS
 RUNNING AGENTS:
 - Claude Code CLI: $CC_COUNT running → working on: $CC_DETAIL
 - Codex CLI: $CX_COUNT running → working on: $CX_DETAIL
-- Max capacity: Claude Code 5, Codex 10
+- Max capacity: Claude Code 3, Codex 10
 
 RECENTLY MERGED:
 $RECENT
@@ -52,6 +52,6 @@ $RECENT
    - Prefer Codex (cheaper): codex exec -s danger-full-access 'cd /tmp/daw-worktrees/agent-ISSUE && ...' &
    - Only use Claude Code if Codex is at 10
 
-4. BALANCE: If Claude Code > 5, don't add more. If Codex < 10 and there are unworked issues, add Codex.
+4. BALANCE: If Claude Code >= 3, don't add more. If Codex < 10 and there are unworked issues, add Codex.
 
 5. EXIT when done. Print summary of what you did."


### PR DESCRIPTION
## Summary
- **launch-dev.sh**: Add atomic mkdir lock, improved process detection, 403 retry with backoff, staggered launches, remove wasteful auth pre-test
- **project-manager.sh**: Reduce Claude Code max capacity 5→3, sync process detection grep pattern

## Root Cause
Multiple `launch-dev.sh` invocations raced simultaneously, spawning more Claude Code CLI sessions than the Anthropic OAuth concurrent session limit allows, causing `403 {"error":{"type":"forbidden","message":"Request not allowed"}}`.

## Test plan
- [ ] Run PM with 3+ issues queued, verify only 3 Claude CLI sessions launch
- [ ] Verify 403 retry logic in pm-activity.log
- [ ] Confirm Codex fallback when Claude at capacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)