### PR TITLE
fix: split e2e into separate workflow to unblock auto-merge

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,36 @@
+name: E2E Tests (non-blocking)
+
+on:
+  push:
+    branches: ['*']
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress e2e runs for the same branch
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: npx playwright test
+        continue-on-error: true
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel in-progress runs for the same branch (saves CI minutes)
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   type-check:
     runs-on: ubuntu-latest
@@ -41,24 +46,3 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-  # E2E runs but does NOT block merging
-  e2e-test:
-    runs-on: ubuntu-latest
-    needs: build
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npx playwright install --with-deps chromium
-      - name: Run E2E tests
-        run: npx playwright test --timeout 60000
-        continue-on-error: true
-      - name: Report E2E results
-        if: always()
-        run: |
-          echo "E2E tests completed (non-blocking)"
-          echo "Check artifacts for details"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
+  globalTimeout: process.env.CI ? 4 * 60 * 1000 : undefined, // 4 min hard cap in CI
   use: {
     baseURL: `http://127.0.0.1:${e2ePort}`,
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary
- E2E tests were inside the main `Test` workflow with no timeout — when they hung, the entire `check_suite` never completed, blocking the auto-merge chain for all PRs
- Split e2e-test into independent workflow (`e2e.yml`) with `timeout-minutes: 5`
- Added `concurrency` groups to both `Test` and `E2E` workflows to auto-cancel stale runs on same branch
- Added Playwright `globalTimeout: 4min` in CI as defense-in-depth

## What was happening
15 workflow runs were stuck on e2e-test step (9+ minutes), preventing `check_suite: completed` from firing, which meant `ops-on-merge.yml` auto-merge chain never triggered.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 1080 tests pass
- [x] `npm run build` — clean
- [ ] Verify this PR's own CI completes in < 3 minutes (no e2e in Test workflow)
- [ ] Verify e2e.yml runs independently and respects timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)