### PR TITLE
fix: remove hardcoded paths, add ROLE sanitization

### DIFF
--- a/scripts/agents/devops.sh
+++ b/scripts/agents/devops.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # DevOps Agent — Monitor CI health, optimize pipeline, fix infrastructure
 set -e
-cd /Users/junmingong/.openclaw/workspace/acestep-daw
+cd "$(dirname "$0")/../.."
 REPO="ace-step/ACE-Step-DAW"
 
 ~/.local/bin/claude --print --permission-mode bypassPermissions \

--- a/scripts/agents/ensure-worktree.sh
+++ b/scripts/agents/ensure-worktree.sh
@@ -7,8 +7,22 @@
 # other agents' uncommitted work.
 
 ROLE=${1:?"Usage: source ensure-worktree.sh <role-name>"}
-DAW="/Users/junmingong/.openclaw/workspace/acestep-daw"
+
+# Sanitize ROLE: only allow alphanumeric, hyphen, underscore
+if [[ ! "$ROLE" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  echo "ERROR: invalid role name '$ROLE' (only [A-Za-z0-9_-] allowed)" >&2
+  exit 1
+fi
+
+# Derive DAW root from this script's location (scripts/agents/ensure-worktree.sh → repo root)
+DAW="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WT="/tmp/daw-worktrees/${ROLE}"
+
+# Safety guard before rm -rf
+if [[ "$WT" != /tmp/daw-worktrees/* ]]; then
+  echo "ERROR: refusing to delete '$WT' — not under /tmp/daw-worktrees/" >&2
+  exit 1
+fi
 
 # Clean stale worktree
 [ -d "$WT" ] && rm -rf "$WT"

--- a/scripts/agents/launch-dev.sh
+++ b/scripts/agents/launch-dev.sh
@@ -3,7 +3,7 @@
 ISSUE_NUM=$1
 TOOL=${2:-"codex"}
 REPO="ace-step/ACE-Step-DAW"
-DAW="/Users/junmingong/.openclaw/workspace/acestep-daw"
+DAW="$(cd "$(dirname "$0")/../.." && pwd)"
 WT="/tmp/daw-worktrees/agent-$ISSUE_NUM"
 LOCKDIR="/tmp/daw-claude-launch.lock"
 MAX_CLAUDE=3

--- a/scripts/agents/product-manager-review.sh
+++ b/scripts/agents/product-manager-review.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Product Manager — Review and accept completed work
 set -e
-cd /Users/junmingong/.openclaw/workspace/acestep-daw
+cd "$(dirname "$0")/../.."
 ~/.local/bin/claude --print --permission-mode bypassPermissions \
   "You are the Product Manager for ACE-Step DAW.
   1. Check recently merged PRs: gh pr list --repo ace-step/ACE-Step-DAW --state merged --limit 10

--- a/scripts/agents/project-manager.sh
+++ b/scripts/agents/project-manager.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Project Manager — Wake, see everything, decide, dispatch, EXIT
 set -e
-cd /Users/junmingong/.openclaw/workspace/acestep-daw
+cd "$(dirname "$0")/../.."
 REPO="ace-step/ACE-Step-DAW"
 
 # ── Gather FULL team status ──

--- a/scripts/agents/qa-tester.sh
+++ b/scripts/agents/qa-tester.sh
@@ -35,4 +35,4 @@ For any bugs: gh issue create --repo $REPO --title 'bug: ...' --label 'priority:
 
 # Cleanup worktree after agent exits
 cd /tmp && rm -rf "$WT"
-git -C /Users/junmingong/.openclaw/workspace/acestep-daw worktree prune 2>/dev/null
+git -C "$DAW" worktree prune 2>/dev/null

--- a/scripts/agents/refactorer.sh
+++ b/scripts/agents/refactorer.sh
@@ -32,4 +32,4 @@ Create PR via gh pr create --repo $REPO. Request copilot review."
 
 # Cleanup
 cd /tmp && rm -rf "$WT"
-git -C /Users/junmingong/.openclaw/workspace/acestep-daw worktree prune 2>/dev/null
+git -C "$DAW" worktree prune 2>/dev/null

--- a/scripts/agents/release-manager.sh
+++ b/scripts/agents/release-manager.sh
@@ -40,4 +40,4 @@ If NOT ready: print what's missing and what needs to happen first."
 
 # Cleanup
 cd /tmp && rm -rf "$WT"
-git -C /Users/junmingong/.openclaw/workspace/acestep-daw worktree prune 2>/dev/null
+git -C "$DAW" worktree prune 2>/dev/null

--- a/scripts/agents/researcher.sh
+++ b/scripts/agents/researcher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Researcher — Competitive gap analysis
 set -e
-cd /Users/junmingong/.openclaw/workspace/acestep-daw
+cd "$(dirname "$0")/../.."
 ~/.local/bin/claude --print --permission-mode bypassPermissions \
   "You are a DAW researcher. Compare ACE-Step DAW with Ableton/Logic/FL Studio.
   1. Read our features: cat README.md


### PR DESCRIPTION
## Summary
- Replace all hardcoded `/Users/junmingong/...` paths with `$(dirname "$0")/../..` in 8 agent scripts
- `ensure-worktree.sh`: derive DAW from `BASH_SOURCE`, validate ROLE with `[A-Za-z0-9_-]+` regex, add `[[ "$WT" == /tmp/daw-worktrees/* ]]` safety guard before `rm -rf`

Addresses review feedback from PR #420.

## Test plan
- [ ] Run `bash scripts/agents/qa-tester.sh` from repo root — verify DAW path resolves correctly
- [ ] Run with invalid ROLE containing `../` — verify rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)