### PR TITLE
feat: dev agent owns PR until merge — session resume feedback loop

### DIFF
--- a/scripts/agents/AGENT_CONTEXT.md
+++ b/scripts/agents/AGENT_CONTEXT.md
@@ -39,3 +39,12 @@ You are a developer for ACE-Step DAW, a browser-based AI-native DAW.
 - Body: "Closes #NUMBER"
 - Must include tests for new functionality
 - Branch: fix/issue-NUMBER
+
+### 6. You Own the PR Until It Merges
+- Your job is NOT done when you create a PR — you own it until it merges.
+- After your initial implementation, the system will wait for CI and code reviews.
+- If CI fails or reviewers leave comments, you will be **resumed in the same session**
+  with full context of your prior work. No need to re-read files you already know.
+- You MUST fix every CI failure and address every review comment — do not skip any.
+- This may happen multiple times. Each round, fix all issues and pass quality gates.
+- If you cannot resolve an issue, explain why clearly in your commit message.

--- a/scripts/agents/launch-dev.sh
+++ b/scripts/agents/launch-dev.sh
@@ -81,43 +81,239 @@ echo "You are on branch fix/issue-$ISSUE_NUM. Implement, then: npx tsc --noEmit 
 cat > "$WT/run-agent.sh" << 'WEOF'
 #!/bin/bash
 WT="$1"; TOOL="$2"; ISSUE="$3"; TITLE="$4"; REPO="ace-step/ACE-Step-DAW"
-cd "$WT" || exit 1
-PROMPT=$(cat "$WT/agent-prompt.txt")
+BRANCH="fix/issue-$ISSUE"
+MAX_ROUNDS=5          # Max fix iterations before giving up
+CI_POLL_INTERVAL=60   # Seconds between CI status checks
+CI_POLL_TIMEOUT=900   # Max seconds to wait for CI (15 min)
+LOG="/tmp/pm-activity.log"
+SESSION_FILE="$WT/.agent-session-id"  # Persist session ID across rounds
 
-if [ "$TOOL" = "codex" ]; then
-  codex exec -C "$WT" -s danger-full-access "$PROMPT"
-else
-  # Retry loop: if Claude returns 403, wait and retry up to 3 times
-  MAX_RETRIES=3
-  RETRY=0
-  while [ $RETRY -lt $MAX_RETRIES ]; do
-    OUTPUT=$(~/.local/bin/claude --print --permission-mode bypassPermissions --fallback-model sonnet "$PROMPT" 2>&1)
-    EXIT_CODE=$?
-    if echo "$OUTPUT" | grep -qi "403.*forbidden\|Request not allowed\|authentication_failed"; then
-      RETRY=$((RETRY + 1))
-      WAIT=$((RETRY * 15))
-      echo "[$(date)] Claude 403 for #$ISSUE, retry $RETRY/$MAX_RETRIES in ${WAIT}s" >> /tmp/pm-activity.log
-      sleep $WAIT
+log() { echo "[$(date)] [agent-$ISSUE] $*" >> "$LOG"; echo "$*"; }
+
+cd "$WT" || exit 1
+
+# ── Helper: run Claude with session persistence ──
+# First call: creates session. Subsequent calls: resume same session.
+run_claude() {
+  local prompt="$1"
+  local session_id
+  local retries=0
+
+  while [ $retries -lt 3 ]; do
+    local output
+    if [ -f "$SESSION_FILE" ]; then
+      # Resume existing session — agent has full context of prior work
+      session_id=$(cat "$SESSION_FILE")
+      log "Resuming Claude session $session_id"
+      output=$(~/.local/bin/claude --print --resume "$session_id" \
+        --permission-mode bypassPermissions --fallback-model sonnet \
+        "$prompt" 2>&1)
     else
-      echo "$OUTPUT"
-      break
+      # First run — create a named session with a stable UUID
+      session_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
+      echo "$session_id" > "$SESSION_FILE"
+      log "Starting Claude session $session_id"
+      output=$(~/.local/bin/claude --print --session-id "$session_id" \
+        --permission-mode bypassPermissions --fallback-model sonnet \
+        "$prompt" 2>&1)
+    fi
+
+    if echo "$output" | grep -qi "403.*forbidden\|Request not allowed\|authentication_failed"; then
+      retries=$((retries + 1))
+      log "Claude 403, retry $retries/3"
+      sleep $((retries * 15))
+    else
+      echo "$output"
+      return 0
     fi
   done
-  if [ $RETRY -ge $MAX_RETRIES ]; then
-    echo "[$(date)] Claude failed $MAX_RETRIES times for #$ISSUE, falling back to Codex" >> /tmp/pm-activity.log
-    codex exec -C "$WT" -s danger-full-access "$PROMPT"
+
+  log "Claude failed 3x, falling back to Codex"
+  # Fallback: start a codex session instead
+  rm -f "$SESSION_FILE"
+  TOOL="codex"
+  run_codex "$prompt"
+}
+
+# ── Helper: run Codex with session persistence ──
+# First call: creates session. Subsequent calls: resume same session.
+run_codex() {
+  local prompt="$1"
+
+  if [ -f "$SESSION_FILE" ]; then
+    local session_id
+    session_id=$(cat "$SESSION_FILE")
+    log "Resuming Codex session $session_id"
+    codex exec resume "$session_id" "$prompt"
+  else
+    # First run — capture session ID from codex output
+    # Use --json + -o to get structured output with session info
+    local output_file="$WT/.codex-output.tmp"
+    codex exec -C "$WT" -s danger-full-access \
+      -o "$output_file" "$prompt"
+    # Codex stores sessions by cwd; use --last for resume
+    # Save a marker so we know to use --last next time
+    echo "codex-last" > "$SESSION_FILE"
   fi
-fi
+}
+
+# ── Helper: dispatch to the right tool ──
+run_agent() {
+  local prompt="$1"
+  if [ "$TOOL" = "codex" ]; then
+    run_codex "$prompt"
+  else
+    run_claude "$prompt"
+  fi
+}
+
+# ── Helper: wait for CI to finish, return conclusion ──
+wait_for_ci() {
+  local pr_num="$1"
+  local elapsed=0
+  while [ $elapsed -lt $CI_POLL_TIMEOUT ]; do
+    sleep $CI_POLL_INTERVAL
+    elapsed=$((elapsed + CI_POLL_INTERVAL))
+    local status
+    status=$(gh pr checks "$pr_num" --repo "$REPO" 2>/dev/null)
+    if echo "$status" | grep -q "pending\|in_progress\|queued"; then
+      log "CI still running ($elapsed/${CI_POLL_TIMEOUT}s)..."
+      continue
+    fi
+    if echo "$status" | grep -qi "fail\|error"; then
+      echo "failure"
+      return 0
+    fi
+    echo "success"
+    return 0
+  done
+  echo "timeout"
+}
+
+# ── Helper: collect all feedback (CI failures + review comments) ──
+collect_feedback() {
+  local pr_num="$1"
+  local feedback=""
+
+  # 1. CI failure logs
+  local failed_run
+  failed_run=$(gh run list --branch "$BRANCH" --repo "$REPO" --status failure \
+    --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null)
+  if [ -n "$failed_run" ]; then
+    local ci_log
+    ci_log=$(gh run view "$failed_run" --repo "$REPO" --log-failed 2>/dev/null | tail -80)
+    [ -n "$ci_log" ] && feedback+="## CI Failure Log
+$ci_log
+
+"
+  fi
+
+  # 2. PR review comments (Copilot, humans, any reviewer)
+  local review_comments
+  review_comments=$(gh api "repos/$REPO/pulls/$pr_num/comments" \
+    --jq '.[] | "**\(.user.login)** on `\(.path):\(.line)`:\n\(.body)\n---"' 2>/dev/null)
+  [ -n "$review_comments" ] && feedback+="## Code Review Comments (address ALL of these)
+$review_comments
+
+"
+
+  # 3. PR reviews requesting changes
+  local reviews
+  reviews=$(gh api "repos/$REPO/pulls/$pr_num/reviews" \
+    --jq '.[] | select(.state != "APPROVED" and .state != "COMMENTED") | "**\(.user.login)** [\(.state)]:\n\(.body)\n---"' 2>/dev/null)
+  [ -n "$reviews" ] && feedback+="## Reviews Requesting Changes
+$reviews
+
+"
+
+  echo "$feedback"
+}
+
+# ═══════════════════════════════════════════
+# Phase 1: Initial implementation
+# ═══════════════════════════════════════════
+PROMPT=$(cat "$WT/agent-prompt.txt")
+log "Phase 1: initial implementation for #$ISSUE"
+run_agent "$PROMPT"
 
 # Post-agent: verify + rebase + push + PR
 cd "$WT" || exit 0
 AHEAD=$(git rev-list origin/main..HEAD --count 2>/dev/null)
-[ "$AHEAD" = "0" ] && echo "No commits" && exit 0
-npm run build 2>/dev/null || exit 0
+[ "$AHEAD" = "0" ] && { log "No commits produced, exiting"; exit 0; }
 git fetch origin main 2>/dev/null
 git rebase origin/main 2>/dev/null || { git rebase --abort 2>/dev/null; exit 0; }
-git push origin "fix/issue-$ISSUE" --force-with-lease 2>/dev/null || exit 0
-gh pr create --repo "$REPO" --title "feat: #$ISSUE — $TITLE" --body "Closes #$ISSUE" --base main --head "fix/issue-$ISSUE" 2>/dev/null
+git push origin "$BRANCH" --force-with-lease 2>/dev/null || exit 0
+
+# Create PR (or get existing PR number)
+gh pr create --repo "$REPO" --title "feat: #$ISSUE — $TITLE" \
+  --body "Closes #$ISSUE" --base main --head "$BRANCH" 2>/dev/null
+PR_NUM=$(gh pr list --repo "$REPO" --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null)
+[ -z "$PR_NUM" ] && { log "Could not find PR for $BRANCH, exiting"; exit 0; }
+log "PR #$PR_NUM created for #$ISSUE"
+
+# ═══════════════════════════════════════════
+# Phase 2: Feedback loop — same agent owns PR until merge
+# ═══════════════════════════════════════════
+ROUND=0
+while [ $ROUND -lt $MAX_ROUNDS ]; do
+  ROUND=$((ROUND + 1))
+  log "Round $ROUND/$MAX_ROUNDS: waiting for CI on PR #$PR_NUM"
+
+  CI_RESULT=$(wait_for_ci "$PR_NUM")
+  log "CI result: $CI_RESULT"
+
+  # Check if PR was already merged
+  PR_STATE=$(gh pr view "$PR_NUM" --repo "$REPO" --json state -q '.state' 2>/dev/null)
+  [ "$PR_STATE" = "MERGED" ] && { log "PR #$PR_NUM merged! Agent done."; exit 0; }
+
+  # If CI passed, wait for review comments to arrive
+  if [ "$CI_RESULT" = "success" ]; then
+    log "CI green. Waiting 120s for reviews..."
+    sleep 120
+  fi
+
+  FEEDBACK=$(collect_feedback "$PR_NUM")
+
+  # No feedback + CI green = done
+  if [ -z "$FEEDBACK" ] && [ "$CI_RESULT" = "success" ]; then
+    log "CI green + no review feedback. PR #$PR_NUM ready to merge."
+    exit 0
+  fi
+
+  # Build fix prompt — no feedback but CI failed
+  if [ -z "$FEEDBACK" ]; then
+    FEEDBACK="## CI Failed
+CI failed but no detailed logs captured. Run locally:
+npx tsc --noEmit && npm test && npm run build
+Fix any errors you find."
+  fi
+
+  # ── Resume the SAME agent to fix ──
+  FIX_PROMPT="Your PR #$PR_NUM has feedback that must be addressed (round $ROUND/$MAX_ROUNDS).
+
+$FEEDBACK
+
+Fix EVERY issue. Run quality gates before committing:
+npx tsc --noEmit && npm test && npm run build
+Then: git add -A && git commit -m 'fix: address feedback round $ROUND for #$ISSUE'
+Do NOT push."
+
+  log "Resuming agent for fix round $ROUND"
+  cd "$WT" || exit 0
+  run_agent "$FIX_PROMPT"
+
+  # Push the fix
+  cd "$WT" || exit 0
+  git fetch origin main 2>/dev/null
+  git rebase origin/main 2>/dev/null || { git rebase --abort 2>/dev/null; log "Rebase conflict round $ROUND"; exit 0; }
+  git push origin "$BRANCH" --force-with-lease 2>/dev/null || { log "Push failed round $ROUND"; exit 0; }
+  log "Fix pushed (round $ROUND), looping back to wait for CI"
+done
+
+log "WARN: PR #$PR_NUM not green after $MAX_ROUNDS rounds. Recording blocker."
+echo "- [ ] PR #$PR_NUM (#$ISSUE): failed $MAX_ROUNDS fix rounds — needs human review" >> "$WT/.llm/BLOCKERS.md" 2>/dev/null
+git add .llm/BLOCKERS.md 2>/dev/null && git commit -m "chore: record blocker for #$ISSUE" 2>/dev/null
+git push origin "$BRANCH" --force-with-lease 2>/dev/null
 WEOF
 chmod +x "$WT/run-agent.sh"
 


### PR DESCRIPTION
## Summary
- **Dev agent no longer exits after creating a PR** — it stays alive and owns the PR lifecycle until merge
- After initial implementation, enters a feedback loop: wait for CI → collect CI failure logs + GitHub Copilot/human review comments → **resume the same Claude/Codex session** (preserving full context) to fix → push → repeat
- Max 5 fix rounds; records blocker if still failing after that
- Leverages `claude --resume <session-id>` and `codex exec resume <session-id>` for context continuity across rounds

## Problem
Previously coding agents were fire-and-forget: code → create PR → exit. CI failures and code review comments were ignored, creating a bottleneck where PM had to manually triage and re-dispatch agents.

## Test plan
- [ ] Verify `launch-dev.sh` runs Phase 1 (initial implementation) correctly
- [ ] Verify CI polling detects failure and triggers fix round with resume
- [ ] Verify review comments from Copilot are collected and passed to agent
- [ ] Verify agent exits cleanly when CI green + no review feedback
- [ ] Verify blocker is recorded after 5 failed rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)