### PR TITLE
fix: workflow CI guards — E2E failure tracking + merge safety

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,9 +24,14 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium
+
       - name: Run E2E tests
-        run: npx playwright test
+        id: e2e
+        run: |
+          npx playwright test 2>&1 | tee /tmp/e2e-output.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
         continue-on-error: true
+
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4
@@ -34,3 +39,23 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+      - name: Report E2E failures
+        if: steps.e2e.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SUMMARY=$(tail -30 /tmp/e2e-output.txt)
+          gh issue create \
+            --title "E2E regression: $(date '+%Y-%m-%d') on ${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" \
+            --body "$(cat <<BODY
+          ## E2E Test Failure
+          **Branch**: ${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
+          **Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          \`\`\`
+          $SUMMARY
+          \`\`\`
+          BODY
+          )" \
+            --label "bug,e2e-regression"

--- a/.github/workflows/ops-on-merge.yml
+++ b/.github/workflows/ops-on-merge.yml
@@ -13,22 +13,57 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Auto-merge ready PRs + trigger PM
+
+      - name: Auto-merge ready PRs (all checks must pass)
         run: |
           cd /Users/junmingong/.openclaw/workspace/acestep-daw
-          
-          # Auto-merge any PR that's ready + CI green
+
+          # Auto-merge any PR that's ready + ALL checks green
           READY=$(gh pr list --repo ${{ github.repository }} --state open --json number,isDraft,mergeable --jq '.[] | select(.isDraft==false and .mergeable=="MERGEABLE") | .number')
           for PR in $READY; do
-            ALL_GREEN=$(gh pr checks $PR --repo ${{ github.repository }} 2>&1 | grep -c "fail" || true)
-            if [ "$ALL_GREEN" = "0" ]; then
-              echo "Auto-merging PR #$PR"
-              gh pr merge $PR --repo ${{ github.repository }} --squash --admin || true
+            # Require ALL checks to pass (not just absence of "fail")
+            CHECK_STATUS=$(gh pr checks $PR --repo ${{ github.repository }} --json bucket --jq '[.[] | select(.bucket != "pass")] | length')
+            if [ "$CHECK_STATUS" = "0" ]; then
+              PENDING=$(gh pr checks $PR --repo ${{ github.repository }} --json bucket --jq '[.[] | select(.bucket == "pending")] | length')
+              if [ "$PENDING" = "0" ]; then
+                echo "Auto-merging PR #$PR — all checks passed"
+                gh pr merge $PR --repo ${{ github.repository }} --squash --admin || true
+              else
+                echo "Skipping PR #$PR — $PENDING check(s) still pending"
+              fi
+            else
+              echo "Skipping PR #$PR — $CHECK_STATUS check(s) not passing"
             fi
           done
-          
-          # Run Project Manager brain
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify test workflow passed before running PM
+        id: verify-tests
+        run: |
+          MERGE_SHA=$(git rev-parse HEAD)
+          echo "Checking test workflow status for commit $MERGE_SHA"
+
+          # Query the test workflow conclusion for the current commit
+          TEST_STATUS=$(gh api \
+            repos/${{ github.repository }}/actions/workflows/test.yml/runs \
+            --jq ".workflow_runs[] | select(.head_sha==\"$MERGE_SHA\") | .conclusion" \
+            | head -1)
+
+          if [ "$TEST_STATUS" = "success" ]; then
+            echo "Test workflow passed for $MERGE_SHA"
+            echo "tests_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Test workflow status: ${TEST_STATUS:-not found}. Skipping PM."
+            echo "tests_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Project Manager brain
+        if: steps.verify-tests.outputs.tests_passed == 'true'
+        run: |
+          cd /Users/junmingong/.openclaw/workspace/acestep-daw
           bash scripts/agents/project-manager.sh &
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- **ops-on-merge**: Auto-merge now verifies ALL checks pass (not just "mergeable"); PM only runs after test workflow confirms green for the merge commit
- **e2e**: Captures test exit code and auto-creates a GitHub Issue labeled `bug` + `e2e-regression` on failure, so it enters the backlog for PM to assign
- E2E remains non-blocking for PR merge but failures are no longer silently swallowed

## Test plan
- [ ] Verify ops-on-merge skips PM when test workflow has not succeeded
- [ ] Verify auto-merge only proceeds when all checks (including pending) are resolved as pass
- [ ] Verify E2E failure creates an issue with correct labels and run link
- [ ] Verify E2E success does not create an issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)