### PR TITLE
fix: harden agent pipeline — locking, cleanup, safety

### DIFF
--- a/scripts/agents/launch-dev.sh
+++ b/scripts/agents/launch-dev.sh
@@ -8,6 +8,24 @@ WT="/tmp/daw-worktrees/agent-$ISSUE_NUM"
 LOCKDIR="/tmp/daw-claude-launch.lock"
 MAX_CLAUDE=3
 
+# Cleanup stale worktrees older than 24h
+cleanup_stale_worktrees() {
+  for wt in /tmp/daw-worktrees/agent-*; do
+    [ -d "$wt" ] || continue
+    local age=$(( $(date +%s) - $(stat -f %m "$wt" 2>/dev/null || echo 0) ))
+    if [ "$age" -gt 86400 ]; then
+      local issue_num=$(basename "$wt" | sed 's/agent-//')
+      # Only clean if no active process
+      if ! pgrep -f "run-agent.sh.*$wt" > /dev/null 2>&1; then
+        echo "[$(date)] Cleaning stale worktree: $wt (${age}s old)" >> /tmp/pm-activity.log
+        rm -rf "$wt"
+        cd "$DAW" && git worktree prune 2>/dev/null
+      fi
+    fi
+  done
+}
+cleanup_stale_worktrees
+
 # Skip if already running — check for active run-agent.sh process for this exact issue
 if pgrep -f "run-agent.sh.*/tmp/daw-worktrees/agent-$ISSUE_NUM " > /dev/null 2>&1; then
   echo "SKIP: #$ISSUE_NUM already running"
@@ -118,9 +136,9 @@ run_claude() {
         "$prompt" 2>&1)
     fi
 
-    if echo "$output" | grep -qi "403.*forbidden\|Request not allowed\|authentication_failed"; then
+    if echo "$output" | grep -qiE "403.*forbidden|Request not allowed|authentication_failed|500|502|503|overloaded|rate.limit|timeout|ETIMEDOUT|ECONNRESET"; then
       retries=$((retries + 1))
-      log "Claude 403, retry $retries/3"
+      log "Claude transient error, retry $retries/3"
       sleep $((retries * 15))
     else
       echo "$output"
@@ -229,6 +247,15 @@ $reviews
   echo "$feedback"
 }
 
+# Detect stale session — if file is older than 2 hours, session is likely dead
+if [ -f "$SESSION_FILE" ]; then
+  SESSION_AGE=$(( $(date +%s) - $(stat -f %m "$SESSION_FILE" 2>/dev/null || echo 0) ))
+  if [ "$SESSION_AGE" -gt 7200 ]; then
+    log "Session file is ${SESSION_AGE}s old (>2hr), starting fresh"
+    rm -f "$SESSION_FILE"
+  fi
+fi
+
 # ═══════════════════════════════════════════
 # Phase 1: Initial implementation
 # ═══════════════════════════════════════════
@@ -236,13 +263,17 @@ PROMPT=$(cat "$WT/agent-prompt.txt")
 log "Phase 1: initial implementation for #$ISSUE"
 run_agent "$PROMPT"
 
-# Post-agent: verify + rebase + push + PR
+# Post-agent: verify + push + rebase + push + PR
 cd "$WT" || exit 0
 AHEAD=$(git rev-list origin/main..HEAD --count 2>/dev/null)
 [ "$AHEAD" = "0" ] && { log "No commits produced, exiting"; exit 0; }
+# Push raw commits first (safety net — work is on remote even if rebase fails)
+git push origin "$BRANCH" --force-with-lease 2>/dev/null
+# Then rebase for clean history
 git fetch origin main 2>/dev/null
-git rebase origin/main 2>/dev/null || { git rebase --abort 2>/dev/null; exit 0; }
-git push origin "$BRANCH" --force-with-lease 2>/dev/null || exit 0
+git rebase origin/main 2>/dev/null || { git rebase --abort 2>/dev/null; log "Rebase conflict, raw commits preserved on remote"; }
+# Push rebased version
+git push origin "$BRANCH" --force-with-lease 2>/dev/null || { log "Push failed after rebase"; }
 
 # Create PR (or get existing PR number)
 gh pr create --repo "$REPO" --title "feat: #$ISSUE — $TITLE" \
@@ -304,9 +335,13 @@ Do NOT push."
 
   # Push the fix
   cd "$WT" || exit 0
+  # Push raw commits first (safety net — work is on remote even if rebase fails)
+  git push origin "$BRANCH" --force-with-lease 2>/dev/null
+  # Then rebase for clean history
   git fetch origin main 2>/dev/null
-  git rebase origin/main 2>/dev/null || { git rebase --abort 2>/dev/null; log "Rebase conflict round $ROUND"; exit 0; }
-  git push origin "$BRANCH" --force-with-lease 2>/dev/null || { log "Push failed round $ROUND"; exit 0; }
+  git rebase origin/main 2>/dev/null || { git rebase --abort 2>/dev/null; log "Rebase conflict, raw commits preserved on remote"; }
+  # Push rebased version
+  git push origin "$BRANCH" --force-with-lease 2>/dev/null || { log "Push failed after rebase"; }
   log "Fix pushed (round $ROUND), looping back to wait for CI"
 done
 

--- a/scripts/agents/project-manager.sh
+++ b/scripts/agents/project-manager.sh
@@ -9,25 +9,38 @@ LOG="/tmp/pm-activity.log"
 
 log() { echo "[$(date)] [PM] $*" >> "$LOG"; }
 
+# ── Mutex: skip if previous tick still running ──
+LOCKFILE="/tmp/pm-tick.lock"
+exec 200>"$LOCKFILE"
+flock -n 200 || { echo "[$(date)] PM tick skipped — previous tick still running" >> "$LOG"; exit 0; }
+
 # ── Gather FULL team status ──
+
+GH_ERRORS=0
 
 ISSUES=$(gh issue list --repo $REPO --state open --limit 30 \
   --json number,title,labels,assignees \
-  --jq '[.[] | {num:.number, title:.title[:50], labels:[.labels[].name], assignees:[.assignees[].login]}]' 2>/dev/null)
+  --jq '[.[] | {num:.number, title:.title[:50], labels:[.labels[].name], assignees:[.assignees[].login]}]' 2>&1) || { log "WARN: gh issue list failed"; GH_ERRORS=$((GH_ERRORS+1)); ISSUES="[]"; }
 
 PRS=$(gh pr list --repo $REPO --state open --limit 20 \
   --json number,title,isDraft,mergeable,headRefName,statusCheckRollup,reviewDecision \
-  --jq '[.[] | {num:.number, title:.title[:40], draft:.isDraft, merge:.mergeable, branch:.headRefName, review:.reviewDecision, checks:[.statusCheckRollup[] | "\(.name):\(.conclusion // "pending")"]}]' 2>/dev/null)
+  --jq '[.[] | {num:.number, title:.title[:40], draft:.isDraft, merge:.mergeable, branch:.headRefName, review:.reviewDecision, checks:[.statusCheckRollup[] | "\(.name):\(.conclusion // "pending")"]}]' 2>&1) || { log "WARN: gh pr list (open) failed"; GH_ERRORS=$((GH_ERRORS+1)); PRS="[]"; }
 
 # PRs with failed CI — dev agents should be fixing these
 FAILED_PRS=$(gh pr list --repo $REPO --state open --limit 20 \
   --json number,headRefName,statusCheckRollup \
-  --jq '[.[] | select(.statusCheckRollup[]?.conclusion == "FAILURE") | {num:.number, branch:.headRefName}]' 2>/dev/null)
+  --jq '[.[] | select(.statusCheckRollup[]?.conclusion == "FAILURE") | {num:.number, branch:.headRefName}]' 2>&1) || { log "WARN: gh pr list (failed CI) failed"; GH_ERRORS=$((GH_ERRORS+1)); FAILED_PRS="[]"; }
 
 # PRs with unresolved review comments
 REVIEW_BLOCKED_PRS=$(gh pr list --repo $REPO --state open --limit 20 \
   --json number,reviewDecision \
-  --jq '[.[] | select(.reviewDecision == "CHANGES_REQUESTED") | .number]' 2>/dev/null)
+  --jq '[.[] | select(.reviewDecision == "CHANGES_REQUESTED") | .number]' 2>&1) || { log "WARN: gh pr list (review blocked) failed"; GH_ERRORS=$((GH_ERRORS+1)); REVIEW_BLOCKED_PRS="[]"; }
+
+# If all gh commands failed, GitHub is likely unreachable — skip tick
+if [ "$GH_ERRORS" -ge 3 ]; then
+  log "ERROR: GitHub unreachable ($GH_ERRORS failures), skipping tick"
+  exit 0
+fi
 
 # Running agents — WHO is doing WHAT
 CC_DETAIL=$(ps aux | grep -E 'claude.*(--print|bypassPermissions|dangerously)' | grep -v grep | awk '{for(i=11;i<=NF;i++) printf "%s ",$i; print ""}' | grep -oE 'issue.#[0-9]+|Issue #[0-9]+|#[0-9]+|issue-[0-9]+' | sort -u | tr '\n' ',' | sed 's/,$//')
@@ -40,7 +53,7 @@ ACTIVE_WORKTREES=$(ls -d /tmp/daw-worktrees/agent-* 2>/dev/null | sed 's|.*/agen
 
 # Recent merges
 RECENT=$(gh pr list --repo $REPO --state merged --limit 5 \
-  --json number,title,mergedAt --jq '[.[] | "\(.number): \(.title[:40])"]' 2>/dev/null)
+  --json number,title,mergedAt --jq '[.[] | "\(.number): \(.title[:40])"]' 2>&1) || { log "WARN: gh pr list (merged) failed"; GH_ERRORS=$((GH_ERRORS+1)); RECENT="[]"; }
 
 # Own recent decisions (external memory — survives session loss)
 PREV_DECISIONS=""
@@ -96,6 +109,15 @@ $PREV_DECISIONS
 5. After all decisions, write a concise summary of EACH action you took.
    This will be saved as memory for your next tick."
 
+# Detect stale session — if file is older than 30 min, session is likely dead
+if [ -f "$SESSION_FILE" ]; then
+  SESSION_AGE=$(( $(date +%s) - $(stat -f %m "$SESSION_FILE" 2>/dev/null || echo 0) ))
+  if [ "$SESSION_AGE" -gt 1800 ]; then
+    log "Session file is ${SESSION_AGE}s old (>30min), starting fresh"
+    rm -f "$SESSION_FILE"
+  fi
+fi
+
 # ── Resume or start PM session ──
 if [ -f "$SESSION_FILE" ]; then
   SESSION_ID=$(cat "$SESSION_FILE")
@@ -124,3 +146,8 @@ if [ -f /tmp/pm-last-output.txt ]; then
 fi
 
 log "PM tick complete"
+
+# Trim activity log to prevent disk fillup
+if [ -f "$LOG" ]; then
+  tail -500 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+fi

--- a/scripts/agents/qa-tester.sh
+++ b/scripts/agents/qa-tester.sh
@@ -33,6 +33,16 @@ Your working directory is $WT (an isolated worktree on origin/main). Do NOT cd e
 
 For any bugs: gh issue create --repo $REPO --title 'bug: ...' --label 'priority:P0,role:developer'"
 
+# Safe worktree removal
+safe_rm_worktree() {
+  local dir="$1"
+  if [[ -n "$dir" && "$dir" =~ ^/tmp/daw-worktrees/ ]]; then
+    rm -rf "$dir"
+  else
+    echo "WARN: refusing to rm unsafe path: $dir" >> /tmp/pm-activity.log
+  fi
+}
+
 # Cleanup worktree after agent exits
-cd /tmp && rm -rf "$WT"
+cd /tmp && safe_rm_worktree "$WT"
 git -C "$DAW" worktree prune 2>/dev/null

--- a/scripts/agents/release-manager.sh
+++ b/scripts/agents/release-manager.sh
@@ -38,6 +38,16 @@ If ready to release:
 
 If NOT ready: print what's missing and what needs to happen first."
 
+# Safe worktree removal
+safe_rm_worktree() {
+  local dir="$1"
+  if [[ -n "$dir" && "$dir" =~ ^/tmp/daw-worktrees/ ]]; then
+    rm -rf "$dir"
+  else
+    echo "WARN: refusing to rm unsafe path: $dir" >> /tmp/pm-activity.log
+  fi
+}
+
 # Cleanup
-cd /tmp && rm -rf "$WT"
+cd /tmp && safe_rm_worktree "$WT"
 git -C "$DAW" worktree prune 2>/dev/null


### PR DESCRIPTION
## Summary
- Add `flock`-based mutex to prevent concurrent PM ticks from overlapping
- Detect and cleanup stale sessions (30min threshold for PM, 2hr for dev agents)
- Auto-cleanup worktrees older than 24 hours with process-safety checks
- Replace bare `rm -rf "$WT"` with `safe_rm_worktree()` that validates paths in qa-tester.sh and release-manager.sh
- Push commits before rebase in run-agent.sh so work is preserved on remote even if rebase fails
- Replace `2>/dev/null` on gh commands with error capture; skip tick if GitHub is unreachable (3+ failures)
- Expand Claude CLI retry pattern to catch 500/502/503, overloaded, rate limits, timeouts, ETIMEDOUT, ECONNRESET
- Add activity log trimming (`tail -500`) at end of PM tick to prevent disk fillup

## Test plan
- [ ] Verify PM script exits immediately when lock is held by another process
- [ ] Confirm stale session files (>30min for PM, >2hr for dev) are deleted on next run
- [ ] Validate worktree cleanup skips directories with active processes
- [ ] Test safe_rm_worktree rejects paths outside /tmp/daw-worktrees/
- [ ] Confirm push-before-rebase preserves commits on remote when rebase conflicts
- [ ] Simulate GitHub API failures and verify tick is skipped after 3 errors
- [ ] Verify expanded retry regex matches all listed transient error strings
- [ ] Check log file is trimmed to 500 lines after PM tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)