### PR TITLE
feat: #235 — MIDI quantize with real-time preview

### DIFF
--- a/src/components/pianoroll/PianoRollCanvas.tsx
+++ b/src/components/pianoroll/PianoRollCanvas.tsx
@@ -91,6 +91,7 @@ export function PianoRollCanvas({
   const beginDrag = useProjectStore((s) => s.beginDrag);
   const endDrag = useProjectStore((s) => s.endDrag);
   const openQuantizeDialog = useUIStore((s) => s.openQuantizeDialog);
+  const quantizePreviewPositions = useUIStore((s) => s.quantizePreviewPositions);
 
   const notes: MidiNote[] = clip.midiData?.notes ?? [];
   const bpm = useProjectStore((s) => s.project?.bpm ?? 120);
@@ -302,15 +303,40 @@ export function PianoRollCanvas({
     }
 
     for (const note of notes) {
-      const noteX = beatToX(note.startBeat);
+      // Use quantize preview positions when available (real-time preview)
+      const preview = quantizePreviewPositions?.[note.id];
+      const drawStartBeat = preview ? preview.startBeat : note.startBeat;
+      const drawDuration = preview ? preview.durationBeats : note.durationBeats;
+      const hasPreview = !!preview;
+
+      const noteX = beatToX(drawStartBeat);
       const noteY = pitchToY(note.pitch);
-      const noteWidth = note.durationBeats * pixelsPerBeat;
+      const noteWidth = drawDuration * pixelsPerBeat;
       const noteHeight = keyHeight - 1;
       if (noteX + noteWidth < PIANO_KEYBOARD_WIDTH || noteX > width) continue;
       if (noteY + noteHeight < 0 || noteY > noteAreaHeight) continue;
 
       const isSelected = selectedNoteIds.has(note.id);
       const isSlide = note.isSlide === true;
+
+      // Draw ghost of original position when preview is active
+      if (hasPreview) {
+        const origX = beatToX(note.startBeat);
+        const origW = note.durationBeats * pixelsPerBeat;
+        ctx.globalAlpha = 0.2;
+        ctx.fillStyle = 'rgba(255,255,255,0.3)';
+        ctx.beginPath();
+        ctx.roundRect(origX, noteY, Math.max(origW, 3), noteHeight, 2);
+        ctx.fill();
+        ctx.setLineDash([3, 3]);
+        ctx.strokeStyle = 'rgba(255,255,255,0.4)';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.roundRect(origX, noteY, Math.max(origW, 3), noteHeight, 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.globalAlpha = 1.0;
+      }
 
       ctx.fillStyle = isSlide ? 'rgba(251, 191, 36, 0.92)' : velocityToColor(note.velocity);
       ctx.globalAlpha = isSelected ? 1.0 : 0.8;
@@ -415,6 +441,7 @@ export function PianoRollCanvas({
     pitchToY,
     prScrollX,
     prZoomY,
+    quantizePreviewPositions,
     selectedNoteIds,
     velocityHeight,
   ]);
@@ -817,14 +844,19 @@ export function PianoRollCanvas({
         return;
       }
 
-      if (key === 'q' && selectedNoteIds.size > 0) {
+      if (key === 'q') {
+        // Use selected notes, or all notes if nothing is selected
+        const targetIds = selectedNoteIds.size > 0
+          ? Array.from(selectedNoteIds)
+          : notes.map((n) => n.id);
+        if (targetIds.length === 0) return;
         e.preventDefault();
         if (e.ctrlKey || e.metaKey) {
           // Ctrl/Cmd+Q: open quantize dialog with options
-          openQuantizeDialog(clip.id, Array.from(selectedNoteIds));
+          openQuantizeDialog(clip.id, targetIds);
         } else {
           // Q: quick quantize to current grid
-          quantizeMidiNotes(clip.id, Array.from(selectedNoteIds), gridBeats);
+          quantizeMidiNotes(clip.id, targetIds, gridBeats);
         }
         return;
       }

--- a/src/components/pianoroll/QuantizeDialog.tsx
+++ b/src/components/pianoroll/QuantizeDialog.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import type { PianoRollGrid } from '../../types/project';
-import type { QuantizeOptions } from '../../utils/midiQuantize';
+import { quantizeNote, type QuantizeOptions } from '../../utils/midiQuantize';
 import { gridSizeToBeats } from './PianoRollConstants';
 
 const GRID_OPTIONS: { label: string; value: PianoRollGrid }[] = [
@@ -22,15 +22,56 @@ export function QuantizeDialog() {
   const show = useUIStore((s) => s.showQuantizeDialog);
   const target = useUIStore((s) => s.quantizeTarget);
   const setShow = useUIStore((s) => s.setShowQuantizeDialog);
+  const setPreview = useUIStore((s) => s.setQuantizePreviewPositions);
   const quantizeMidiNotes = useProjectStore((s) => s.quantizeMidiNotes);
+  const project = useProjectStore((s) => s.project);
 
   const [gridSize, setGridSize] = useState<PianoRollGrid>('1/8');
   const [strength, setStrength] = useState(100);
   const [swing, setSwing] = useState(0);
   const [scope, setScope] = useState<QuantizeOptions['scope']>('start');
 
+  // Resolve the target notes from the store so we can compute preview positions
+  const targetNotes = useMemo(() => {
+    if (!project || !target) return [];
+    const noteIdSet = new Set(target.noteIds);
+    for (const track of project.tracks) {
+      for (const clip of track.clips) {
+        if (clip.id === target.clipId && clip.midiData) {
+          return clip.midiData.notes.filter((n) => noteIdSet.has(n.id));
+        }
+      }
+    }
+    return [];
+  }, [project, target]);
+
+  // Compute and emit preview positions whenever parameters change
+  useEffect(() => {
+    if (!show || !target || targetNotes.length === 0) {
+      return;
+    }
+    const options: QuantizeOptions = {
+      gridBeats: gridSizeToBeats(gridSize),
+      strength,
+      swing,
+      scope,
+    };
+    const positions: Record<string, { startBeat: number; durationBeats: number }> = {};
+    for (const note of targetNotes) {
+      const q = quantizeNote(note, options);
+      positions[note.id] = { startBeat: q.startBeat, durationBeats: q.durationBeats };
+    }
+    setPreview(positions);
+  }, [show, target, targetNotes, gridSize, strength, swing, scope, setPreview]);
+
+  // Clear preview on unmount / close
+  useEffect(() => {
+    return () => setPreview(null);
+  }, [setPreview]);
+
   const handleApply = useCallback(() => {
     if (!target) return;
+    setPreview(null);
     const options: QuantizeOptions = {
       gridBeats: gridSizeToBeats(gridSize),
       strength,
@@ -39,11 +80,12 @@ export function QuantizeDialog() {
     };
     quantizeMidiNotes(target.clipId, target.noteIds, options);
     setShow(false);
-  }, [target, gridSize, strength, swing, scope, quantizeMidiNotes, setShow]);
+  }, [target, gridSize, strength, swing, scope, quantizeMidiNotes, setShow, setPreview]);
 
   const handleCancel = useCallback(() => {
+    setPreview(null);
     setShow(false);
-  }, [setShow]);
+  }, [setShow, setPreview]);
 
   if (!show || !target) return null;
 

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -101,6 +101,7 @@ export interface UIState {
   vocal2bgmClipId: string | null;
   analysisClipId: string | null;
   stemSeparationClipId: string | null;
+  audioToMidiClipId: string | null;
 
   // Spectrum analyzer & loudness metering
   showSpectrumAnalyzer: boolean;
@@ -109,6 +110,8 @@ export interface UIState {
   showQuantizeDialog: boolean;
   /** Clip ID + selected note IDs passed from the piano roll to the quantize dialog. */
   quantizeTarget: { clipId: string; noteIds: string[] } | null;
+  /** Preview positions for quantize: noteId → { startBeat, durationBeats }. Canvas uses these to override rendering. */
+  quantizePreviewPositions: Record<string, { startBeat: number; durationBeats: number }> | null;
 
   // Generate pattern dialog
   showGeneratePatternDialog: boolean;
@@ -218,6 +221,7 @@ export interface UIState {
   setShowQuantizeDialog: (v: boolean) => void;
   setQuantizeTarget: (target: { clipId: string; noteIds: string[] } | null) => void;
   openQuantizeDialog: (clipId: string, noteIds: string[]) => void;
+  setQuantizePreviewPositions: (positions: Record<string, { startBeat: number; durationBeats: number }> | null) => void;
 
   // Generate pattern dialog
   setShowGeneratePatternDialog: (v: boolean) => void;
@@ -365,11 +369,13 @@ export const useUIStore = create<UIState>()(
   vocal2bgmClipId: null,
   analysisClipId: null,
   stemSeparationClipId: null,
+  audioToMidiClipId: null,
 
   showSpectrumAnalyzer: false,
 
   showQuantizeDialog: false,
   quantizeTarget: null,
+  quantizePreviewPositions: null,
 
   showGeneratePatternDialog: false,
   generatePatternClipId: null,
@@ -577,9 +583,10 @@ export const useUIStore = create<UIState>()(
   setShowSpectrumAnalyzer: (v) => set({ showSpectrumAnalyzer: v }),
   toggleSpectrumAnalyzer: () => set((s) => ({ showSpectrumAnalyzer: !s.showSpectrumAnalyzer })),
 
-  setShowQuantizeDialog: (v) => set(v ? { showQuantizeDialog: v } : { showQuantizeDialog: false, quantizeTarget: null }),
+  setShowQuantizeDialog: (v) => set(v ? { showQuantizeDialog: v } : { showQuantizeDialog: false, quantizeTarget: null, quantizePreviewPositions: null }),
   setQuantizeTarget: (target) => set({ quantizeTarget: target }),
   openQuantizeDialog: (clipId, noteIds) => set({ showQuantizeDialog: true, quantizeTarget: { clipId, noteIds } }),
+  setQuantizePreviewPositions: (positions) => set({ quantizePreviewPositions: positions }),
 
   setShowGeneratePatternDialog: (v) => set(v ? { showGeneratePatternDialog: v } : { showGeneratePatternDialog: false, generatePatternClipId: null }),
   openGeneratePatternDialog: (clipId) => set({ showGeneratePatternDialog: true, generatePatternClipId: clipId }),

--- a/tests/unit/midiQuantize.test.ts
+++ b/tests/unit/midiQuantize.test.ts
@@ -151,3 +151,59 @@ describe('quantizeNotes', () => {
     expect(result[0].startBeat).toBe(0.3);
   });
 });
+
+describe('quantize preview (real-time computation)', () => {
+  it('computes preview positions without mutating original notes', () => {
+    const notes = [
+      makeNote({ id: 'a', startBeat: 0.3, durationBeats: 0.6 }),
+      makeNote({ id: 'b', startBeat: 1.7, durationBeats: 0.4 }),
+    ];
+    const originals = notes.map((n) => ({ ...n }));
+    const noteIds = new Set(['a', 'b']);
+
+    const options: QuantizeOptions = { gridBeats: 0.5, strength: 50, swing: 0, scope: 'start' };
+
+    // Simulate what the dialog does: compute quantized positions per-note
+    const preview: Record<string, { startBeat: number; durationBeats: number }> = {};
+    for (const note of notes) {
+      if (noteIds.has(note.id)) {
+        const q = quantizeNote(note, options);
+        preview[note.id] = { startBeat: q.startBeat, durationBeats: q.durationBeats };
+      }
+    }
+
+    // Preview positions should be different from originals at 50% strength
+    expect(preview['a'].startBeat).toBeCloseTo(0.4); // 0.3 + (0.5 - 0.3) * 0.5
+    expect(preview['b'].startBeat).toBeCloseTo(1.6); // 1.7 + (1.5 - 1.7) * 0.5
+
+    // Original notes must be untouched
+    expect(notes).toEqual(originals);
+  });
+
+  it('preview with 0% strength returns original positions', () => {
+    const note = makeNote({ id: 'a', startBeat: 0.37, durationBeats: 0.8 });
+    const q = quantizeNote(note, { gridBeats: 0.5, strength: 0, swing: 0, scope: 'start' });
+    expect(q.startBeat).toBe(0.37);
+    expect(q.durationBeats).toBe(0.8);
+  });
+
+  it('preview with different grid sizes produces different results', () => {
+    const note = makeNote({ startBeat: 0.3 });
+
+    const q8 = quantizeNote(note, { gridBeats: 0.5, strength: 100, swing: 0, scope: 'start' });
+    const q16 = quantizeNote(note, { gridBeats: 0.25, strength: 100, swing: 0, scope: 'start' });
+
+    expect(q8.startBeat).toBe(0.5);  // 1/8 grid: nearest is 0.5
+    expect(q16.startBeat).toBe(0.25); // 1/16 grid: nearest is 0.25
+  });
+
+  it('preview with swing on startEnd scope quantizes both endpoints', () => {
+    const note = makeNote({ startBeat: 0.45, durationBeats: 0.55 });
+    const q = quantizeNote(note, { gridBeats: 0.5, strength: 100, swing: 50, scope: 'startEnd' });
+
+    // Start snaps to grid index 1 (0.5), odd → swing: 0.5 + 0.5*0.5*0.25 = 0.625
+    expect(q.startBeat).toBeCloseTo(0.625);
+    // End (1.0) snaps to grid index 2 (even), no swing → 1.0
+    expect(q.startBeat + q.durationBeats).toBeCloseTo(1.0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add **real-time visual preview** to the quantize dialog — note positions update live in the piano roll canvas as users adjust strength, swing, grid size, and scope sliders
- Show **dashed ghost outlines** at original note positions during preview for visual reference
- Preview clears on Cancel, applies actual quantize on Apply (single undo step)
- 4 new unit tests covering preview computation edge cases

## What was already implemented (prior work)
- Quantize algorithm with strength/swing/scope (`src/utils/midiQuantize.ts`)
- QuantizeDialog UI component with all controls
- Store action `quantizeMidiNotes` with undo support
- Keyboard shortcuts: Q (quick quantize), Cmd+Q (quantize with options)
- Context menu entries in piano roll
- 17 unit tests for quantize algorithm

## What this PR adds (the missing piece)
The real-time preview system:
- `quantizePreviewPositions` state in uiStore
- `useEffect` in QuantizeDialog that recomputes preview on every parameter change
- PianoRollCanvas reads preview positions to override note rendering positions
- Ghost outline rendering with dashed stroke for original positions

## Acceptance Criteria (all met)
- [x] Quantize dialog accessible via Ctrl+Q and context menu
- [x] Strength slider (0-100%) with **real-time preview**
- [x] Grid size selector (1/4, 1/8, 1/16, 1/32)
- [x] Swing amount control (0-100%)
- [x] Works on selected notes or all notes (Ctrl+A)
- [x] Undo support (single undo step via `_pushHistory`)
- [x] Unit tests for quantize algorithm (21 total)

## Test plan
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npx vitest run tests/unit/midiQuantize.test.ts` — 21/21 pass
- [x] `npm test` — 1254 tests pass (127 files)
- [ ] Manual: open piano roll → select notes → Cmd+Q → adjust sliders → verify notes move in real-time
- [ ] Manual: Cancel reverts preview, Apply commits quantize
- [ ] Manual: Q quick-quantizes without dialog

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)