### PR TITLE
feat: #238 — Phase 1 collaboration: cloud storage & viewer mode enforcement

### DIFF
--- a/src/services/cloudStorageService.ts
+++ b/src/services/cloudStorageService.ts
@@ -1,0 +1,83 @@
+import type { Project } from '../types/project';
+
+export interface CloudProject {
+  cloudId: string;
+  projectId: string;
+  owner: string;
+  version: number;
+  savedAt: number;
+  project: Project;
+}
+
+export interface CloudProjectSummary {
+  cloudId: string;
+  projectId: string;
+  name: string;
+  owner: string;
+  version: number;
+  savedAt: number;
+  trackCount: number;
+}
+
+export interface CloudVersionEntry {
+  version: number;
+  savedAt: number;
+  cloudId: string;
+}
+
+let _store = new Map<string, CloudProject>();
+let _versionHistory = new Map<string, CloudVersionEntry[]>();
+
+function generateCloudId(projectId: string, version: number): string {
+  return `cloud_${projectId}_v${version}_${Date.now().toString(36)}`;
+}
+
+export const cloudStorage = {
+  async save(project: Project, owner: string): Promise<CloudProject> {
+    const existing = _store.get(project.id);
+    const version = existing ? existing.version + 1 : 1;
+    const now = Date.now();
+    const cloudId = generateCloudId(project.id, version);
+    const record: CloudProject = {
+      cloudId, projectId: project.id, owner, version, savedAt: now,
+      project: structuredClone(project),
+    };
+    _store.set(project.id, record);
+    const history = _versionHistory.get(project.id) ?? [];
+    history.push({ version, savedAt: now, cloudId });
+    _versionHistory.set(project.id, history);
+    return record;
+  },
+  async load(projectId: string): Promise<CloudProject | null> {
+    return _store.get(projectId) ?? null;
+  },
+  async list(): Promise<CloudProjectSummary[]> {
+    const summaries: CloudProjectSummary[] = [];
+    for (const record of _store.values()) {
+      summaries.push({
+        cloudId: record.cloudId, projectId: record.projectId, name: record.project.name,
+        owner: record.owner, version: record.version, savedAt: record.savedAt,
+        trackCount: record.project.tracks.length,
+      });
+    }
+    return summaries.sort((a, b) => {
+      const aTime = _store.get(a.projectId)?.project.updatedAt ?? a.savedAt;
+      const bTime = _store.get(b.projectId)?.project.updatedAt ?? b.savedAt;
+      return bTime - aTime;
+    });
+  },
+  async delete(projectId: string): Promise<boolean> {
+    const existed = _store.has(projectId);
+    _store.delete(projectId);
+    _versionHistory.delete(projectId);
+    return existed;
+  },
+  async getVersionHistory(projectId: string): Promise<CloudVersionEntry[]> {
+    return _versionHistory.get(projectId) ?? [];
+  },
+};
+
+export function resetCloudStorage(): void {
+  _store = new Map();
+  _versionHistory = new Map();
+}

--- a/src/store/collaborationStore.ts
+++ b/src/store/collaborationStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { CloudProjectSummary } from '../services/cloudStorageService';
 
 export interface Collaborator {
   id: string;
@@ -21,6 +22,12 @@ export interface CollaborationState {
   collaborators: Collaborator[];
   /** Whether the project has unsaved cloud changes (Phase 2). */
   hasCloudChanges: boolean;
+  /** Whether the current project is saved to the cloud. */
+  isCloudProject: boolean;
+  /** List of cloud project summaries. */
+  cloudProjects: CloudProjectSummary[];
+  /** Whether a cloud operation is in progress. */
+  cloudBusy: boolean;
 
   // Actions
   setViewerMode: (v: boolean) => void;
@@ -30,6 +37,9 @@ export interface CollaborationState {
   addCollaborator: (collaborator: Collaborator) => void;
   removeCollaborator: (id: string) => void;
   setHasCloudChanges: (v: boolean) => void;
+  setIsCloudProject: (v: boolean) => void;
+  setCloudProjects: (projects: CloudProjectSummary[]) => void;
+  setCloudBusy: (v: boolean) => void;
   reset: () => void;
 }
 
@@ -40,7 +50,11 @@ const initialState = {
   activeShareUrl: null as string | null,
   collaborators: [] as Collaborator[],
   hasCloudChanges: false,
+  isCloudProject: false,
+  cloudProjects: [] as CloudProjectSummary[],
+  cloudBusy: false,
 };
+
 
 export const useCollaborationStore = create<CollaborationState>()((set) => ({
   ...initialState,
@@ -54,5 +68,8 @@ export const useCollaborationStore = create<CollaborationState>()((set) => ({
   removeCollaborator: (id) =>
     set((s) => ({ collaborators: s.collaborators.filter((c) => c.id !== id) })),
   setHasCloudChanges: (v) => set({ hasCloudChanges: v }),
+  setIsCloudProject: (v) => set({ isCloudProject: v }),
+  setCloudProjects: (projects) => set({ cloudProjects: projects }),
+  setCloudBusy: (v) => set({ cloudBusy: v }),
   reset: () => set(initialState),
 }));

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -96,7 +96,12 @@ import { buildConsolidatedMidiClipData, renderConsolidatedAudioClip, validateCli
 import type { MidiCaptureService } from '../services/midiCaptureService';
 import { snapTimeToZeroCrossing } from '../utils/zeroCrossing';
 import { useTransportStore } from './transportStore';
+import { useCollaborationStore } from './collaborationStore';
 import { bounceTrackToAudioAsset } from '../services/bounceInPlace';
+
+function _isViewerMode(): boolean {
+  return useCollaborationStore.getState().isViewerMode;
+}
 
 function getBarDurationSec(bpm: number, timeSig: number): number {
   return (60 / bpm) * timeSig;
@@ -1576,6 +1581,7 @@ export const useProjectStore = create<ProjectState>()(
 
   updateProject: (updates) => {
     const state = get();
+    if (_isViewerMode()) return;
     if (!state.project) return;
     _pushHistory(state.project, { scope: 'arrangement', label: 'Update project settings' });
     const merged = { ...state.project, ...updates, updatedAt: Date.now() };
@@ -1725,6 +1731,7 @@ export const useProjectStore = create<ProjectState>()(
 
   updateTrackMixer: (trackId, updates) => {
     const state = get();
+    if (_isViewerMode()) return;
     if (!state.project) return;
     _pushHistory(state.project, { scope: 'mixer', label: 'Adjust mixer', trackId });
     set({
@@ -1991,6 +1998,7 @@ export const useProjectStore = create<ProjectState>()(
 
   addTrack: (trackName, trackType) => {
     const state = get();
+    if (_isViewerMode()) return undefined as unknown as Track;
     if (!state.project) throw new Error('No project');
     _pushHistory(state.project, { scope: 'arrangement', label: 'Add track' });
 
@@ -2185,6 +2193,7 @@ export const useProjectStore = create<ProjectState>()(
 
   removeTrack: (trackId) => {
     const state = get();
+    if (_isViewerMode()) return;
     if (!state.project) return;
     _pushHistory(state.project, { scope: 'arrangement', label: 'Remove track', trackId });
     const newTracks = state.project.tracks.filter((t) => t.id !== trackId);
@@ -2200,6 +2209,7 @@ export const useProjectStore = create<ProjectState>()(
 
   duplicateTrack: (trackId) => {
     const state = get();
+    if (_isViewerMode()) return undefined;
     if (!state.project) return undefined;
     const source = state.project.tracks.find((t) => t.id === trackId);
     if (!source) return undefined;
@@ -2253,6 +2263,7 @@ export const useProjectStore = create<ProjectState>()(
 
   updateTrack: (trackId, updates) => {
     const state = get();
+    if (_isViewerMode()) return;
     if (!state.project) return;
     _pushHistory(state.project, getTrackUpdateHistoryOptions(trackId, updates));
     set({
@@ -2456,6 +2467,7 @@ export const useProjectStore = create<ProjectState>()(
 
   addClip: (trackId, clipData) => {
     const state = get();
+    if (_isViewerMode()) return undefined as unknown as Clip;
     if (!state.project) throw new Error('No project');
     _pushHistory(state.project);
 
@@ -2525,6 +2537,7 @@ export const useProjectStore = create<ProjectState>()(
 
   updateClip: (clipId, updates) => {
     const state = get();
+    if (_isViewerMode()) return;
     if (!state.project) return;
     _pushHistory(state.project);
     const newTracks = state.project.tracks.map((t) => ({
@@ -2545,6 +2558,7 @@ export const useProjectStore = create<ProjectState>()(
 
   removeClip: (clipId) => {
     const state = get();
+    if (_isViewerMode()) return;
     if (!state.project) return;
     _pushHistory(state.project);
     const newTracks = state.project.tracks.map((t) => ({
@@ -2576,6 +2590,7 @@ export const useProjectStore = create<ProjectState>()(
 
   duplicateClip: (clipId) => {
     const state = get();
+    if (_isViewerMode()) return undefined;
     if (!state.project) return undefined;
     _pushHistory(state.project);
 
@@ -3783,6 +3798,7 @@ export const useProjectStore = create<ProjectState>()(
 
   toggleSequencerStep: (trackId, rowId, stepIndex) => {
     const state = get();
+    if (_isViewerMode()) return;
     if (!state.project) return;
     _pushHistory(state.project, { scope: 'track', label: 'Toggle sequencer step', trackId });
     set({
@@ -4388,6 +4404,7 @@ export const useProjectStore = create<ProjectState>()(
 
   addMidiNote: (clipId, note) => {
     const state = get();
+    if (_isViewerMode()) return undefined;
     if (!state.project) return undefined;
     const noteId = note.id ?? uuidv4();
     _pushHistory(state.project, { scope: 'pianoRoll', label: 'Add MIDI note', clipId });
@@ -4416,6 +4433,7 @@ export const useProjectStore = create<ProjectState>()(
 
   updateMidiNote: (clipId, noteId, updates) => {
     const state = get();
+    if (_isViewerMode()) return;
     if (!state.project) return;
     _pushHistory(state.project, { scope: 'pianoRoll', label: 'Edit MIDI note', clipId });
     set({
@@ -4444,6 +4462,7 @@ export const useProjectStore = create<ProjectState>()(
 
   removeMidiNote: (clipId, noteId) => {
     const state = get();
+    if (_isViewerMode()) return;
     if (!state.project) return;
     _pushHistory(state.project, { scope: 'pianoRoll', label: 'Delete MIDI note', clipId });
     set({

--- a/tests/unit/cloudStorageService.test.ts
+++ b/tests/unit/cloudStorageService.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { cloudStorage, resetCloudStorage } from '../../src/services/cloudStorageService';
+import type { Project } from '../../src/types/project';
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: overrides.id ?? 'proj-1',
+    name: overrides.name ?? 'Test Project',
+    createdAt: overrides.createdAt ?? 1000,
+    updatedAt: overrides.updatedAt ?? 2000,
+    bpm: 120,
+    keyScale: 'C major',
+    timeSignature: 4,
+    totalDuration: 60,
+    tracks: overrides.tracks ?? [],
+    generationDefaults: {
+      inferenceSteps: 100,
+      guidanceScale: 15,
+      shift: 5,
+      thinking: false,
+      model: 'ace-step-v1',
+    },
+    ...overrides,
+  };
+}
+
+describe('cloudStorageService', () => {
+  beforeEach(() => {
+    resetCloudStorage();
+  });
+
+  describe('save', () => {
+    it('saves a project and returns a CloudProject with version 1', async () => {
+      const project = makeProject();
+      const record = await cloudStorage.save(project, 'alice');
+
+      expect(record.projectId).toBe('proj-1');
+      expect(record.owner).toBe('alice');
+      expect(record.version).toBe(1);
+      expect(record.cloudId).toMatch(/^cloud_proj-1_v1_/);
+      expect(record.project.name).toBe('Test Project');
+    });
+
+    it('increments version on subsequent saves', async () => {
+      const project = makeProject();
+      const r1 = await cloudStorage.save(project, 'alice');
+      expect(r1.version).toBe(1);
+
+      project.name = 'Updated';
+      const r2 = await cloudStorage.save(project, 'alice');
+      expect(r2.version).toBe(2);
+
+      const r3 = await cloudStorage.save(project, 'alice');
+      expect(r3.version).toBe(3);
+    });
+
+    it('deep-clones the project (mutation does not affect stored copy)', async () => {
+      const project = makeProject({ tracks: [{ id: 't1' } as any] });
+      const record = await cloudStorage.save(project, 'alice');
+
+      project.tracks.push({ id: 't2' } as any);
+      expect(record.project.tracks).toHaveLength(1);
+
+      const loaded = await cloudStorage.load('proj-1');
+      expect(loaded!.project.tracks).toHaveLength(1);
+    });
+  });
+
+  describe('load', () => {
+    it('returns null for non-existent project', async () => {
+      const result = await cloudStorage.load('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('returns the latest saved record', async () => {
+      const project = makeProject();
+      await cloudStorage.save(project, 'alice');
+      project.name = 'V2';
+      await cloudStorage.save(project, 'alice');
+
+      const loaded = await cloudStorage.load('proj-1');
+      expect(loaded!.version).toBe(2);
+      expect(loaded!.project.name).toBe('V2');
+    });
+  });
+
+  describe('list', () => {
+    it('returns empty array when no projects saved', async () => {
+      const list = await cloudStorage.list();
+      expect(list).toEqual([]);
+    });
+
+    it('returns summaries for all saved projects', async () => {
+      await cloudStorage.save(makeProject({ id: 'p1', name: 'Alpha' }), 'alice');
+      await cloudStorage.save(makeProject({ id: 'p2', name: 'Beta', tracks: [{ id: 't1' } as any] }), 'bob');
+
+      const list = await cloudStorage.list();
+      expect(list).toHaveLength(2);
+
+      const p2Summary = list.find((s) => s.projectId === 'p2');
+      expect(p2Summary!.name).toBe('Beta');
+      expect(p2Summary!.owner).toBe('bob');
+      expect(p2Summary!.trackCount).toBe(1);
+    });
+
+    it('sorts by updatedAt descending', async () => {
+      await cloudStorage.save(makeProject({ id: 'p1', updatedAt: 1000 }), 'a');
+      await cloudStorage.save(makeProject({ id: 'p2', updatedAt: 3000 }), 'b');
+      await cloudStorage.save(makeProject({ id: 'p3', updatedAt: 2000 }), 'c');
+
+      const list = await cloudStorage.list();
+      expect(list.map((s) => s.projectId)).toEqual(['p2', 'p3', 'p1']);
+    });
+  });
+
+  describe('delete', () => {
+    it('returns false for non-existent project', async () => {
+      const result = await cloudStorage.delete('nonexistent');
+      expect(result).toBe(false);
+    });
+
+    it('removes the project and its version history', async () => {
+      const project = makeProject();
+      await cloudStorage.save(project, 'alice');
+      await cloudStorage.save(project, 'alice');
+
+      const deleted = await cloudStorage.delete('proj-1');
+      expect(deleted).toBe(true);
+
+      const loaded = await cloudStorage.load('proj-1');
+      expect(loaded).toBeNull();
+
+      const history = await cloudStorage.getVersionHistory('proj-1');
+      expect(history).toEqual([]);
+    });
+  });
+
+  describe('getVersionHistory', () => {
+    it('returns empty array for unknown project', async () => {
+      const history = await cloudStorage.getVersionHistory('unknown');
+      expect(history).toEqual([]);
+    });
+
+    it('tracks all saved versions', async () => {
+      const project = makeProject();
+      await cloudStorage.save(project, 'alice');
+      await cloudStorage.save(project, 'alice');
+      await cloudStorage.save(project, 'alice');
+
+      const history = await cloudStorage.getVersionHistory('proj-1');
+      expect(history).toHaveLength(3);
+      expect(history[0].version).toBe(1);
+      expect(history[1].version).toBe(2);
+      expect(history[2].version).toBe(3);
+      expect(history[0].cloudId).toMatch(/^cloud_proj-1_v1_/);
+    });
+  });
+
+  describe('resetCloudStorage', () => {
+    it('clears all data', async () => {
+      await cloudStorage.save(makeProject({ id: 'p1' }), 'alice');
+      await cloudStorage.save(makeProject({ id: 'p2' }), 'bob');
+
+      resetCloudStorage();
+
+      const list = await cloudStorage.list();
+      expect(list).toEqual([]);
+      expect(await cloudStorage.load('p1')).toBeNull();
+    });
+  });
+});

--- a/tests/unit/viewerModeEnforcement.test.ts
+++ b/tests/unit/viewerModeEnforcement.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useCollaborationStore } from '../../src/store/collaborationStore';
+
+// Helper: reset both stores before each test
+function resetStores() {
+  useCollaborationStore.getState().reset();
+  useProjectStore.getState().createProject({ name: 'Viewer Test' });
+}
+
+describe('viewer mode enforcement', () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  describe('when viewer mode is OFF, mutations work normally', () => {
+    it('addTrack creates a track', () => {
+      const track = useProjectStore.getState().addTrack('drums');
+      expect(track).toBeDefined();
+      expect(track.trackName).toBe('drums');
+      expect(useProjectStore.getState().project!.tracks.length).toBeGreaterThan(0);
+    });
+
+    it('updateProject changes the project name', () => {
+      useProjectStore.getState().updateProject({ name: 'New Name' });
+      expect(useProjectStore.getState().project!.name).toBe('New Name');
+    });
+  });
+
+  describe('when viewer mode is ON, mutations are blocked', () => {
+    beforeEach(() => {
+      useCollaborationStore.getState().setViewerMode(true);
+    });
+
+    it('updateProject does not change project', () => {
+      const nameBefore = useProjectStore.getState().project!.name;
+      useProjectStore.getState().updateProject({ name: 'Hacked' });
+      expect(useProjectStore.getState().project!.name).toBe(nameBefore);
+    });
+
+    it('updateTrackMixer does not change track', () => {
+      // Temporarily disable viewer mode to add a track
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('drums');
+      useCollaborationStore.getState().setViewerMode(true);
+
+      useProjectStore.getState().updateTrackMixer(track.id, { pan: 0.75 });
+      const updated = useProjectStore.getState().project!.tracks.find(t => t.id === track.id);
+      expect(updated!.pan).not.toBe(0.75);
+    });
+
+    it('addTrack returns undefined-cast and does not add', () => {
+      const trackCountBefore = useProjectStore.getState().project!.tracks.length;
+      const result = useProjectStore.getState().addTrack('guitar');
+      expect(result).toBeUndefined();
+      expect(useProjectStore.getState().project!.tracks.length).toBe(trackCountBefore);
+    });
+
+    it('removeTrack does not remove', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('bass');
+      useCollaborationStore.getState().setViewerMode(true);
+
+      const countBefore = useProjectStore.getState().project!.tracks.length;
+      useProjectStore.getState().removeTrack(track.id);
+      expect(useProjectStore.getState().project!.tracks.length).toBe(countBefore);
+    });
+
+    it('duplicateTrack returns undefined', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('synth');
+      useCollaborationStore.getState().setViewerMode(true);
+
+      const result = useProjectStore.getState().duplicateTrack(track.id);
+      expect(result).toBeUndefined();
+    });
+
+    it('updateTrack does not modify track', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('drums');
+      useCollaborationStore.getState().setViewerMode(true);
+
+      useProjectStore.getState().updateTrack(track.id, { displayName: 'Modified' });
+      const found = useProjectStore.getState().project!.tracks.find(t => t.id === track.id);
+      expect(found!.displayName).not.toBe('Modified');
+    });
+
+    it('addClip returns undefined-cast and does not add', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('vocals');
+      useCollaborationStore.getState().setViewerMode(true);
+
+      const clipsBefore = useProjectStore.getState().project!.tracks.find(t => t.id === track.id)!.clips.length;
+      const result = useProjectStore.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 4,
+        prompt: 'test',
+        lyrics: '',
+      });
+      expect(result).toBeUndefined();
+      expect(useProjectStore.getState().project!.tracks.find(t => t.id === track.id)!.clips.length).toBe(clipsBefore);
+    });
+
+    it('updateClip does not change clip', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('vocals');
+      const clip = useProjectStore.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 4,
+        prompt: 'original',
+        lyrics: '',
+      });
+      useCollaborationStore.getState().setViewerMode(true);
+
+      useProjectStore.getState().updateClip(clip.id, { prompt: 'modified' });
+      const found = useProjectStore.getState().project!.tracks
+        .flatMap(t => t.clips)
+        .find(c => c.id === clip.id);
+      expect(found!.prompt).toBe('original');
+    });
+
+    it('removeClip does not remove', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('vocals');
+      const clip = useProjectStore.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 4,
+        prompt: 'keep',
+        lyrics: '',
+      });
+      useCollaborationStore.getState().setViewerMode(true);
+
+      useProjectStore.getState().removeClip(clip.id);
+      const found = useProjectStore.getState().project!.tracks
+        .flatMap(t => t.clips)
+        .find(c => c.id === clip.id);
+      expect(found).toBeDefined();
+    });
+
+    it('duplicateClip returns undefined', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('vocals');
+      const clip = useProjectStore.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 4,
+        prompt: 'dup',
+        lyrics: '',
+      });
+      useCollaborationStore.getState().setViewerMode(true);
+
+      const result = useProjectStore.getState().duplicateClip(clip.id);
+      expect(result).toBeUndefined();
+    });
+
+    it('toggleSequencerStep does not toggle', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('drums', 'sequencer');
+      const pattern = useProjectStore.getState().project!.tracks.find(t => t.id === track.id)?.sequencerPattern;
+      if (!pattern || pattern.rows.length === 0) return; // skip if no pattern
+
+      const rowId = pattern.rows[0].id;
+      const stepBefore = pattern.rows[0].steps[0].active;
+      useCollaborationStore.getState().setViewerMode(true);
+
+      useProjectStore.getState().toggleSequencerStep(track.id, rowId, 0);
+      const stepAfter = useProjectStore.getState().project!.tracks
+        .find(t => t.id === track.id)?.sequencerPattern?.rows[0].steps[0].active;
+      expect(stepAfter).toBe(stepBefore);
+    });
+
+    it('addMidiNote returns undefined', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = useProjectStore.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 4,
+        prompt: '',
+        lyrics: '',
+        midiData: { notes: [], grid: '1/16' },
+      });
+      useCollaborationStore.getState().setViewerMode(true);
+
+      const result = useProjectStore.getState().addMidiNote(clip.id, {
+        pitch: 60,
+        startBeat: 0,
+        durationBeats: 1,
+        velocity: 0.8,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('updateMidiNote does not change note', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = useProjectStore.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 4,
+        prompt: '',
+        lyrics: '',
+        midiData: { notes: [], grid: '1/16' },
+      });
+      const noteId = useProjectStore.getState().addMidiNote(clip.id, {
+        pitch: 60,
+        startBeat: 0,
+        durationBeats: 1,
+        velocity: 0.8,
+      })!;
+      useCollaborationStore.getState().setViewerMode(true);
+
+      useProjectStore.getState().updateMidiNote(clip.id, noteId, { pitch: 72 });
+      const notes = useProjectStore.getState().project!.tracks
+        .flatMap(t => t.clips)
+        .find(c => c.id === clip.id)?.midiData?.notes;
+      expect(notes?.find(n => n.id === noteId)?.pitch).toBe(60);
+    });
+
+    it('removeMidiNote does not remove', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+      const clip = useProjectStore.getState().addClip(track.id, {
+        startTime: 0,
+        duration: 4,
+        prompt: '',
+        lyrics: '',
+        midiData: { notes: [], grid: '1/16' },
+      });
+      const noteId = useProjectStore.getState().addMidiNote(clip.id, {
+        pitch: 60,
+        startBeat: 0,
+        durationBeats: 1,
+        velocity: 0.8,
+      })!;
+      useCollaborationStore.getState().setViewerMode(true);
+
+      useProjectStore.getState().removeMidiNote(clip.id, noteId);
+      const notes = useProjectStore.getState().project!.tracks
+        .flatMap(t => t.clips)
+        .find(c => c.id === clip.id)?.midiData?.notes;
+      expect(notes?.find(n => n.id === noteId)).toBeDefined();
+    });
+  });
+
+  describe('read-only state access still works in viewer mode', () => {
+    it('project state is readable', () => {
+      useCollaborationStore.getState().setViewerMode(true);
+      const project = useProjectStore.getState().project;
+      expect(project).toBeDefined();
+      expect(project!.name).toBeDefined();
+    });
+
+    it('tracks are readable', () => {
+      useCollaborationStore.getState().setViewerMode(false);
+      useProjectStore.getState().addTrack('drums');
+      useCollaborationStore.getState().setViewerMode(true);
+
+      const tracks = useProjectStore.getState().project!.tracks;
+      expect(tracks.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of real-time collaboration (#238):

- **Cloud storage service** (`cloudStorageService.ts`): In-memory simulation with save/load/list/delete/versioning — same interface for Phase 2 backend swap
- **Viewer mode enforcement**: `_isViewerMode()` guard on 14 projectStore mutation actions (addTrack, removeTrack, addClip, removeClip, updateProject, updateTrack, addMidiNote, etc.)
- **Collaboration store extensions**: `isCloudProject`, `cloudProjects`, `cloudBusy` state + actions

Builds on PR #253 which added share bundles, share links, ShareDialog UI, and the useShareLink hook.

## Test plan

- [x] 13 cloud storage tests: CRUD, versioning, deep copy, sorting, reset
- [x] 18 viewer mode enforcement tests: all 14 mutations blocked, normal mode works, read-only access works
- [x] Full test suite: 1391 passed, 0 failed
- [x] TypeScript: 0 errors
- [x] Build: succeeds

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)