### PR TITLE
fix: #268 — mixer channel volume fader clipped/hidden at bottom of panel

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -205,7 +205,7 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
         </div>
       </div>
 
-      <div className="mt-1 flex min-h-0 flex-1 flex-col items-center justify-end gap-1 self-stretch pb-1">
+      <div data-testid="fader-region" className="mt-1 flex shrink-0 min-h-[96px] flex-col items-center justify-end gap-1 self-stretch pb-1" style={{ height: faderHeight + 24 }}>
         <div className="relative flex items-stretch justify-center gap-2" style={{ height: faderHeight }}>
           <LevelMeter trackId={track.id} />
           <input
@@ -236,7 +236,7 @@ function MasterStrip({ faderHeight }: MasterStripProps) {
   const handleChange = (v: number) => { updateProject({ masterVolume: v }); getAudioEngine().masterVolume = v; };
 
   return (
-    <div className="flex h-full min-h-0 min-w-[250px] flex-col border-l-2 border-[#555] bg-[#252525] px-4 py-2">
+    <div className="flex h-full min-h-0 min-w-[250px] flex-col overflow-hidden border-l-2 border-[#555] bg-[#252525] px-4 py-2">
       <div className="flex w-full shrink-0 items-center gap-2">
         <span className="text-xs font-bold uppercase tracking-widest text-zinc-300">Master</span>
         <button
@@ -254,7 +254,7 @@ function MasterStrip({ faderHeight }: MasterStripProps) {
         {showSpectrum && <SpectrumAnalyzer width={220} height={120} />}
         <MasteringPanel />
       </div>
-      <div data-testid="master-fader-region" className="mt-1 flex min-h-[96px] flex-1 flex-col items-center justify-end gap-1 self-stretch pb-1">
+      <div data-testid="master-fader-region" className="mt-1 flex shrink-0 min-h-[96px] flex-col items-center justify-end gap-1 self-stretch pb-1" style={{ height: faderHeight + 24 }}>
         <div className="relative flex justify-center gap-2" style={{ height: faderHeight }}>
           <LevelMeter masterStage="input" />
           <LevelMeter masterStage="output" />

--- a/tests/unit/mixerPanel.test.tsx
+++ b/tests/unit/mixerPanel.test.tsx
@@ -45,4 +45,19 @@ describe('MixerPanel', () => {
     expect(trackFader).toBeInTheDocument();
     expect(trackFader).toHaveStyle({ minHeight: '96px', height: '100%' });
   });
+
+  it('fader section does not shrink when mixer panel is small (#268)', () => {
+    useUIStore.getState().setMixerHeight(160);
+    render(<MixerPanel />);
+
+    // Channel strip fader region must have shrink-0 to prevent clipping
+    const trackStrips = screen.getAllByTestId('channel-strip');
+    const faderRegion = trackStrips[0].querySelector('[data-testid="fader-region"]');
+    expect(faderRegion).toBeInTheDocument();
+    expect(faderRegion).toHaveClass('shrink-0');
+
+    // Master fader region must also not shrink
+    const masterFaderRegion = screen.getByTestId('master-fader-region');
+    expect(masterFaderRegion).toHaveClass('shrink-0');
+  });
 });


### PR DESCRIPTION
## Summary
- **Channel strip fader**: Changed from `flex-1 min-h-0` to `shrink-0` with explicit height (`faderHeight + 24`), added `data-testid="fader-region"` for testing
- **Master strip fader**: Changed from `flex-1` to `shrink-0` with explicit height, preventing flex compression
- The controls section above (with `overflow-y-auto`) now absorbs overflow instead of the fader being clipped

## Test plan
- [x] Regression test: `fader section does not shrink when mixer panel is small (#268)` verifies both channel and master fader regions have `shrink-0`
- [ ] Manual: resize mixer panel to minimum height — fader should remain fully visible and interactive
- [ ] Manual: drag fader to lowest volume — full range accessible without clipping

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)