### PR TITLE
fix: #268 — add overflow-hidden to channel strip to prevent fader clipping

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -70,7 +70,7 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
       data-keyboard-context="mixer"
       role="group"
       tabIndex={0}
-      className={`flex h-full min-h-0 min-w-[120px] flex-col border-r border-[#3a3a3a] bg-[#2a2a2a] px-3 py-2 ${isFrozen ? 'opacity-70' : ''}`}
+      className={`flex h-full min-h-0 min-w-[120px] flex-col overflow-hidden border-r border-[#3a3a3a] bg-[#2a2a2a] px-3 py-2 ${isFrozen ? 'opacity-70' : ''}`}
       onFocus={() => {
         setExpandedTrackId(track.id);
         setKeyboardContext('mixer', track.id);

--- a/tests/unit/faderVisibility.test.tsx
+++ b/tests/unit/faderVisibility.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MixerPanel } from '../../src/components/mixer/MixerPanel';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useUIStore } from '../../src/store/uiStore';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    masterVolume: 1,
+    getMasterLevel: () => 0,
+    getTrackLevel: () => 0,
+    getMasterMeter: () => ({ level: 0, clipped: false }),
+    getTrackMeter: () => ({ level: 0, clipped: false }),
+    resetTrackClip: vi.fn(),
+    resetMasterClip: vi.fn(),
+  }),
+}));
+
+function setupProject() {
+  useProjectStore.getState().createProject({ name: 'Fader Visibility Test' });
+  useProjectStore.getState().addTrack('drums');
+  useUIStore.getState().setShowMixer(true);
+  useUIStore.getState().setMixerHeight(500);
+}
+
+describe('Fader visibility — issue #268', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useUIStore.setState(useUIStore.getInitialState(), true);
+    setupProject();
+  });
+
+  it('channel strip has overflow-hidden to prevent fader clipping', () => {
+    render(<MixerPanel />);
+    const strip = screen.getAllByTestId('channel-strip')[0];
+    expect(strip.className).toMatch(/overflow-hidden/);
+  });
+
+  it('fader region is rendered with shrink-0 to guarantee its space', () => {
+    render(<MixerPanel />);
+    const faderRegion = screen.getAllByTestId('fader-region')[0];
+    expect(faderRegion.className).toMatch(/shrink-0/);
+  });
+
+  it('fader region has a minimum height of at least 96px', () => {
+    render(<MixerPanel />);
+    const faderRegion = screen.getAllByTestId('fader-region')[0];
+    expect(faderRegion.className).toMatch(/min-h-\[96px\]/);
+  });
+
+  it('volume fader is fully interactive at minimum mixer height', () => {
+    useUIStore.getState().setMixerHeight(360);
+    render(<MixerPanel />);
+    const fader = screen.getByRole('slider', { name: 'Drums volume fader' });
+    expect(fader).toBeInTheDocument();
+    expect(fader).not.toBeDisabled();
+  });
+
+  it('master fader region also has shrink-0 and min-height', () => {
+    render(<MixerPanel />);
+    const masterFaderRegion = screen.getByTestId('master-fader-region');
+    expect(masterFaderRegion.className).toMatch(/shrink-0/);
+    expect(masterFaderRegion.className).toMatch(/min-h-\[96px\]/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `overflow-hidden` to the channel strip container so flex children stay within bounds
- Adds regression tests for fader visibility (5 tests in `faderVisibility.test.tsx`)
- Complements the existing fader fix (shrink-0 + min-h-[96px]) by ensuring the channel strip itself constrains its overflow

## Root Cause

The channel strip's flex column layout allowed content to overflow when the controls section (name, M/S, pan, inserts, sends, EQ, compressor) exceeded the available height. Without `overflow-hidden`, the fader region was pushed below the visible area and clipped by the parent's `overflow-y-hidden`.

## Test Plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — all 1094+ unit tests pass (including 5 new fader visibility regression tests)
- [x] `npm run build` — succeeds
- [ ] Visual check: volume fader fully visible at minimum mixer height (360px)
- [ ] Fader thumb reachable at both ends of range (0 to max)

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)