### PR TITLE
refactor: add scoped debug logger for noisy services

### DIFF
--- a/src/services/aceStepApi.ts
+++ b/src/services/aceStepApi.ts
@@ -18,6 +18,7 @@ export type AceStepTaskParams =
   | RepaintTaskParams
   | StemSeparationTaskParams;
 import { downsampleWavBlob } from '../utils/audioDownsample';
+import { createDebugLogger } from '../utils/debugLogger';
 
 const BACKEND_URL_KEY = 'ace-step-daw-backend-url';
 const HEALTH_CHECK_MIN_RETRY_DELAY_MS = 30_000;
@@ -25,6 +26,7 @@ const HEALTH_CHECK_MAX_RETRY_DELAY_MS = 5 * 60 * 1000;
 
 let healthCheckRetryDelayMs = 0;
 let healthCheckBlockedUntil = 0;
+const logger = createDebugLogger('ace-step:api');
 
 function resetHealthCheckBackoff() {
   healthCheckRetryDelayMs = 0;
@@ -162,7 +164,7 @@ async function releaseTask(
   const taskParams = params as Partial<LegoTaskParams>;
   const usePath = Boolean(taskParams.src_audio_path);
 
-  console.log(
+  logger.debug(
     `[aceStepApi] releaseTask: ${usePath ? `src_audio_path=${taskParams.src_audio_path}` : `src_audio blob size=${srcAudioBlob.size}`}`,
     `task_type=${params.task_type}`,
     'audio_duration' in params ? `audio_duration=${params.audio_duration}` : 'audio_duration=n/a',
@@ -190,7 +192,7 @@ async function releaseTask(
 
     try {
       if (attempt > 1) {
-        console.warn(`[aceStepApi] releaseLegoTask retry ${attempt}/${RELEASE_TASK_MAX_RETRIES}`);
+        logger.warn(`releaseLegoTask retry ${attempt}/${RELEASE_TASK_MAX_RETRIES}`);
       }
 
       const res = await fetch(`${base}/release_task`, {
@@ -214,10 +216,7 @@ async function releaseTask(
         lastError.message.includes('Failed to fetch') ||
         lastError.message.includes('network');
 
-      console.error(
-        `[aceStepApi] releaseLegoTask attempt ${attempt} failed:`,
-        lastError.message,
-      );
+      logger.error(`releaseLegoTask attempt ${attempt} failed:`, lastError.message);
 
       if (!isRetryable || attempt === RELEASE_TASK_MAX_RETRIES) break;
 
@@ -278,14 +277,14 @@ export async function downloadAudio(audioPath: string): Promise<Blob> {
 
     try {
       if (attempt > 1) {
-        console.warn(`[aceStepApi] downloadAudio retry ${attempt}/${DOWNLOAD_AUDIO_MAX_RETRIES}`);
+        logger.warn(`downloadAudio retry ${attempt}/${DOWNLOAD_AUDIO_MAX_RETRIES}`);
       }
       const res = await fetch(url, { signal: controller.signal });
       if (!res.ok) throw new Error(`downloadAudio failed: ${res.status} ${res.statusText}`);
       return await res.blob();
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
-      console.error(`[aceStepApi] downloadAudio attempt ${attempt} failed:`, lastError.message);
+      logger.error(`downloadAudio attempt ${attempt} failed:`, lastError.message);
 
       const isRetryable =
         lastError.name === 'AbortError' ||

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -19,6 +19,9 @@ import { computeWaveformPeaks } from '../utils/waveformPeaks';
 import { POLL_INTERVAL_MS, MAX_POLL_DURATION_MS } from '../constants/defaults';
 import { extractContextAudioLazy } from './lazyContextAudioExtractor';
 import { computeEta } from '../utils/generationProgress';
+import { createDebugLogger } from '../utils/debugLogger';
+
+const logger = createDebugLogger('ace-step:generation');
 
 function extractProgressMetadata(entry: TaskResultEntry): { stage: string | null; progressPercent: number | null } {
   let stage: string | null = null;
@@ -133,7 +136,7 @@ export async function generateAllTracks(): Promise<void> {
       let previousCumulativeBlob: Blob | null = null;
       let allSucceeded = true;
 
-      console.log(`[GenerationPipeline] generateAllTracks: ${tracks.length} stems tracks (of ${allTracks.length} total) in order:`,
+      logger.debug(`generateAllTracks: ${tracks.length} stems tracks (of ${allTracks.length} total) in order:`,
         tracks.map(t => t.trackName));
 
       for (const track of tracks) {
@@ -143,20 +146,20 @@ export async function generateAllTracks(): Promise<void> {
               const blob = await loadAudioBlobByKey(clip.cumulativeMixKey);
               if (blob) {
                 previousCumulativeBlob = blob;
-                console.log(`[GenerationPipeline] Loaded existing cumulative for clip=${clip.id} (${track.trackName}), size=${blob.size}`);
+                logger.debug(`Loaded existing cumulative for clip=${clip.id} (${track.trackName}), size=${blob.size}`);
               }
             }
             continue;
           }
 
-          console.log(`[GenerationPipeline] Generating clip=${clip.id} (${track.trackName}), previousCumulative=${previousCumulativeBlob ? `${previousCumulativeBlob.size} bytes` : 'null'}`);
+          logger.debug(`Generating clip=${clip.id} (${track.trackName}), previousCumulative=${previousCumulativeBlob ? `${previousCumulativeBlob.size} bytes` : 'null'}`);
           const outcome = await generateClipInternal(
             clip.id,
             previousCumulativeBlob,
           );
           previousCumulativeBlob = outcome.cumulativeBlob;
           allSucceeded = allSucceeded && outcome.succeeded;
-          console.log(`[GenerationPipeline] After generate clip=${clip.id}, cumulativeBlob=${previousCumulativeBlob ? `${previousCumulativeBlob.size} bytes` : 'null'}`);
+          logger.debug(`After generate clip=${clip.id}, cumulativeBlob=${previousCumulativeBlob ? `${previousCumulativeBlob.size} bytes` : 'null'}`);
         }
       }
 
@@ -205,7 +208,7 @@ export async function generateSingleClip(clipId: string, options?: { sharedSeed?
 
     try {
       const previousBlob = await getPreviousCumulativeBlob(clipId);
-      console.log(`[GenerationPipeline] generateSingleClip: clip=${clipId}, previousBlob=${previousBlob ? `${previousBlob.size} bytes` : 'null'}`);
+      logger.debug(`generateSingleClip: clip=${clipId}, previousBlob=${previousBlob ? `${previousBlob.size} bytes` : 'null'}`);
       const outcome = await generateClipInternal(clipId, previousBlob, options ? { sharedSeed: options.sharedSeed } : {});
 
       if (outcome.succeeded) {
@@ -317,8 +320,8 @@ async function getPreviousCumulativeBlob(clipId: string): Promise<Blob | null> {
   if (!clipTrack) return null;
 
   const trackIndex = tracks.indexOf(clipTrack);
-  console.log(`[GenerationPipeline] getPreviousCumulativeBlob: clip=${clipId}, trackIndex=${trackIndex}/${tracks.length}, track=${clipTrack.trackName}`);
-  console.log(`[GenerationPipeline] Generation order:`, tracks.map((t, i) => `${i}:${t.trackName}(order=${t.order})`));
+  logger.debug(`getPreviousCumulativeBlob: clip=${clipId}, trackIndex=${trackIndex}/${tracks.length}, track=${clipTrack.trackName}`);
+  logger.debug('Generation order:', tracks.map((t, i) => `${i}:${t.trackName}(order=${t.order})`));
 
   // Strategy: Look for cumulative audio from already-generated tracks.
   //
@@ -338,7 +341,7 @@ async function getPreviousCumulativeBlob(clipId: string): Promise<Blob | null> {
       const prevClip = prevTrack.clips[j];
       if (prevClip.cumulativeMixKey) {
         const blob = await loadAudioBlobByKey(prevClip.cumulativeMixKey) ?? null;
-        console.log(`[GenerationPipeline] Found predecessor cumulative: track=${prevTrack.trackName}, key=${prevClip.cumulativeMixKey}, blob=${blob ? `${blob.size} bytes` : 'null'}`);
+        logger.debug(`Found predecessor cumulative: track=${prevTrack.trackName}, key=${prevClip.cumulativeMixKey}, blob=${blob ? `${blob.size} bytes` : 'null'}`);
         return blob;
       }
     }
@@ -354,13 +357,13 @@ async function getPreviousCumulativeBlob(clipId: string): Promise<Blob | null> {
       const laterClip = laterTrack.clips[j];
       if (laterClip.cumulativeMixKey) {
         const blob = await loadAudioBlobByKey(laterClip.cumulativeMixKey) ?? null;
-        console.log(`[GenerationPipeline] Found successor cumulative (out-of-order): track=${laterTrack.trackName}, key=${laterClip.cumulativeMixKey}, blob=${blob ? `${blob.size} bytes` : 'null'}`);
+        logger.debug(`Found successor cumulative (out-of-order): track=${laterTrack.trackName}, key=${laterClip.cumulativeMixKey}, blob=${blob ? `${blob.size} bytes` : 'null'}`);
         return blob;
       }
     }
   }
 
-  console.log(`[GenerationPipeline] No previous cumulative blob found for clip=${clipId}`);
+  logger.debug(`No previous cumulative blob found for clip=${clipId}`);
   return null;
 }
 
@@ -382,7 +385,7 @@ async function generateClipInternal(
 
   const trackType = track.trackType ?? 'stems';
   if (trackType !== 'stems') {
-    console.warn(`[GenerationPipeline] Skipping generation for non-stems track (type=${trackType}, track=${track.displayName})`);
+    logger.warn(`Skipping generation for non-stems track (type=${trackType}, track=${track.displayName})`);
     return { cumulativeBlob: previousCumulativeBlob, succeeded: false, errorMessage: 'Track type is not generatable' };
   }
 
@@ -425,8 +428,8 @@ async function generateClipInternal(
       : (options.forceSilence ? null : previousCumulativeBlob);
     const srcAudioBlob = srcBlob ?? generateSilenceWav(audioDuration);
 
-    console.log(
-      `[GenerationPipeline] clip=${clipId} track=${track.trackName}`,
+    logger.debug(
+      `clip=${clipId} track=${track.trackName}`,
       options.srcAudioPath
         ? `srcAudioPath=${options.srcAudioPath}`
         : `srcAudio: ${srcBlob ? 'previousCumulative' : 'silence'}`,
@@ -599,7 +602,7 @@ async function generateClipInternal(
     });
 
     const cumulativeBlob = await api.downloadAudio(resultAudioPath);
-    console.log(`[GenerationPipeline] Downloaded cumulative audio: size=${cumulativeBlob.size}, type=${cumulativeBlob.type}, path=${resultAudioPath}`);
+    logger.debug(`Downloaded cumulative audio: size=${cumulativeBlob.size}, type=${cumulativeBlob.type}, path=${resultAudioPath}`);
 
     // Store cumulative mix
     const cumulativeKey = await saveAudioBlob(project.id, clipId, 'cumulative', cumulativeBlob);

--- a/src/utils/audioDownsample.ts
+++ b/src/utils/audioDownsample.ts
@@ -1,7 +1,10 @@
+import { createDebugLogger } from './debugLogger';
+
 const UPLOAD_SAMPLE_RATE = 16000;
 const UPLOAD_CHANNELS = 1;
 
 const SKIP_THRESHOLD_BYTES = 500_000; // 500KB — already small enough, skip
+const logger = createDebugLogger('ace-step:audio-downsample');
 
 /**
  * Downsample a WAV blob to 16kHz mono for faster upload over slow networks.
@@ -10,7 +13,7 @@ const SKIP_THRESHOLD_BYTES = 500_000; // 500KB — already small enough, skip
  */
 export async function downsampleWavBlob(blob: Blob): Promise<Blob> {
   if (blob.size < SKIP_THRESHOLD_BYTES) {
-    console.log(`[downsampleWavBlob] blob already small (${(blob.size / 1024).toFixed(0)}KB), skipping`);
+    logger.debug(`blob already small (${(blob.size / 1024).toFixed(0)}KB), skipping`);
     return blob;
   }
   const arrayBuffer = await blob.arrayBuffer();
@@ -19,7 +22,7 @@ export async function downsampleWavBlob(blob: Blob): Promise<Blob> {
   try {
     decoded = await audioCtx.decodeAudioData(arrayBuffer);
   } catch {
-    console.warn('[downsampleWavBlob] decode failed, returning original blob');
+    logger.warn('decode failed, returning original blob');
     return blob;
   }
 
@@ -36,8 +39,8 @@ export async function downsampleWavBlob(blob: Blob): Promise<Blob> {
   const rendered = await offlineCtx.startRendering();
   const result = audioBufferToWav16(rendered);
 
-  console.log(
-    `[downsampleWavBlob] ${(blob.size / 1024).toFixed(0)}KB → ${(result.size / 1024).toFixed(0)}KB` +
+  logger.debug(
+    `${(blob.size / 1024).toFixed(0)}KB → ${(result.size / 1024).toFixed(0)}KB` +
     ` (${decoded.sampleRate}Hz/${decoded.numberOfChannels}ch → ${UPLOAD_SAMPLE_RATE}Hz/${UPLOAD_CHANNELS}ch)`,
   );
   return result;

--- a/src/utils/debugLogger.ts
+++ b/src/utils/debugLogger.ts
@@ -1,0 +1,89 @@
+const DEBUG_LOG_STORAGE_KEY = 'ace-step-daw-debug';
+
+function getEnabledScopes(): Set<string> {
+  if (typeof localStorage === 'undefined') {
+    return new Set();
+  }
+
+  try {
+    const raw = localStorage.getItem(DEBUG_LOG_STORAGE_KEY) ?? '';
+    return new Set(
+      raw
+        .split(',')
+        .map((entry) => entry.trim().toLowerCase())
+        .filter(Boolean),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+function isScopeEnabled(scope: string): boolean {
+  const normalizedScope = scope.trim().toLowerCase();
+  if (!normalizedScope) return false;
+
+  const enabledScopes = getEnabledScopes();
+  if (enabledScopes.has('*') || enabledScopes.has(normalizedScope)) {
+    return true;
+  }
+
+  const scopeParts = normalizedScope.split(':');
+  while (scopeParts.length > 1) {
+    scopeParts.pop();
+    if (enabledScopes.has(scopeParts.join(':'))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function withScope(scope: string, args: unknown[]) {
+  return [`[${scope}]`, ...args];
+}
+
+export interface DebugLogger {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+export function createDebugLogger(scope: string): DebugLogger {
+  return {
+    debug: (...args) => {
+      if (!isScopeEnabled(scope)) return;
+      console.debug(...withScope(scope, args));
+    },
+    info: (...args) => {
+      if (!isScopeEnabled(scope)) return;
+      console.info(...withScope(scope, args));
+    },
+    warn: (...args) => {
+      if (!isScopeEnabled(scope)) return;
+      console.warn(...withScope(scope, args));
+    },
+    error: (...args) => {
+      console.error(...withScope(scope, args));
+    },
+  };
+}
+
+export function setDebugLoggingScopes(scopes: string[]): void {
+  if (typeof localStorage === 'undefined') return;
+
+  const normalized = scopes
+    .map((scope) => scope.trim().toLowerCase())
+    .filter(Boolean)
+    .join(',');
+
+  if (normalized) {
+    localStorage.setItem(DEBUG_LOG_STORAGE_KEY, normalized);
+  } else {
+    localStorage.removeItem(DEBUG_LOG_STORAGE_KEY);
+  }
+}
+
+export function getDebugLoggingStorageKey() {
+  return DEBUG_LOG_STORAGE_KEY;
+}

--- a/tests/unit/debugLogger.test.ts
+++ b/tests/unit/debugLogger.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDebugLogger,
+  getDebugLoggingStorageKey,
+  setDebugLoggingScopes,
+} from '../../src/utils/debugLogger';
+
+describe('debugLogger', () => {
+  const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('stays silent by default for debug/info/warn logs', () => {
+    const logger = createDebugLogger('ace-step:generation');
+
+    logger.debug('debug message');
+    logger.info('info message');
+    logger.warn('warn message');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits scoped logs when the scope is enabled', () => {
+    setDebugLoggingScopes(['ace-step:generation']);
+    const logger = createDebugLogger('ace-step:generation');
+
+    logger.debug('debug message');
+    logger.warn('warn message');
+
+    expect(debugSpy).toHaveBeenCalledWith('[ace-step:generation]', 'debug message');
+    expect(warnSpy).toHaveBeenCalledWith('[ace-step:generation]', 'warn message');
+  });
+
+  it('supports parent scope matching and wildcard matching', () => {
+    localStorage.setItem(getDebugLoggingStorageKey(), 'ace-step,*');
+
+    createDebugLogger('ace-step:api').info('api info');
+    createDebugLogger('another-scope').debug('other debug');
+
+    expect(infoSpy).toHaveBeenCalledWith('[ace-step:api]', 'api info');
+    expect(debugSpy).toHaveBeenCalledWith('[another-scope]', 'other debug');
+  });
+
+  it('always emits errors even when debug logging is disabled', () => {
+    const logger = createDebugLogger('ace-step:api');
+
+    logger.error('failed');
+
+    expect(errorSpy).toHaveBeenCalledWith('[ace-step:api]', 'failed');
+  });
+});


### PR DESCRIPTION
## Summary
- add a scoped debug logger that can be enabled per feature area via localStorage
- migrate the noisy API, generation pipeline, and audio downsample debug paths off ad hoc console output
- keep error logging always-on while making debug/info/warn opt-in for QA and local diagnosis

## Verification
- npx tsc --noEmit
- npx vitest run tests/unit/debugLogger.test.ts tests/unit/audioDownsample.test.ts src/services/__tests__/aceStepApi.test.ts tests/unit/generationProgress.test.ts
- npm run build

Closes #501