### PR TITLE
fix: resolve UI/UX issues in toolbar, timeline, settings panel and generation panel

### DIFF
--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -241,7 +241,7 @@ export function SettingsDialog() {
           </button>
         </div>
 
-        <div className="p-4 space-y-3">
+        <div className="p-4 space-y-3 max-h-[calc(100vh-200px)] overflow-y-auto">
           <h3 className="text-xs font-medium text-zinc-300">Backend Connection</h3>
           <div>
             <label className="block text-xs text-zinc-400 mb-1">Backend URL</label>

--- a/src/components/generation/GenerationSidePanel.tsx
+++ b/src/components/generation/GenerationSidePanel.tsx
@@ -66,7 +66,10 @@ export function GenerationSidePanel() {
   const [showLyrics, setShowLyrics] = useState(false);
   const [styleTagsInput, setStyleTagsInput] = useState('');
 
-  const stemsTracks = project?.tracks.filter((track) => track.trackType === 'stems') ?? [];
+  const stemsTracks = useMemo(
+    () => project?.tracks.filter((track) => track.trackType === 'stems') ?? [],
+    [project?.tracks],
+  );
   const activeJobs = jobs.filter((job) => job.status === 'queued' || job.status === 'generating' || job.status === 'processing');
   const projectBpm = project?.bpm;
   const projectKeyScale = project?.keyScale;

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -204,11 +204,10 @@ export function Toolbar() {
         </button>
       </div>
 
-      {/* Left-center: Project actions */}
+      <div className="w-px h-6 bg-[#555]" />
+
+      {/* Generation actions */}
       <div className="flex items-center gap-0.5">
-        <button onClick={toggleArrangementView} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Toggle Arrangement / Session (Tab)">
-          {arrangementView === 'arrangement' ? 'Session' : 'Arrange'}
-        </button>
         <button
           onClick={() => setBatchGenerateMode('silence')}
           disabled={!project}
@@ -232,6 +231,12 @@ export function Toolbar() {
         >
           AI
         </button>
+      </div>
+
+      <div className="w-px h-6 bg-[#555]" />
+
+      {/* Project actions */}
+      <div className="flex items-center gap-0.5">
         <button onClick={() => setShowProjectListDialog(true)} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors" title="Projects">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" className="inline -mt-px mr-1">
             <path d="M1.5 4.5L7 1.5l5.5 3M1.5 7l5.5 3 5.5-3M1.5 9.5l5.5 3 5.5-3" />
@@ -241,19 +246,25 @@ export function Toolbar() {
         <button onClick={() => setShowNewProjectDialog(true)} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors" title="New Project">
           New
         </button>
-        <button onClick={() => setShowExportDialog(true)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Export Audio">
+      </div>
+
+      <div className="w-px h-6 bg-[#555]" />
+
+      {/* File actions */}
+      <div className="flex items-center gap-0.5">
+        <button onClick={() => setShowExportDialog(true)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-400 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Export Audio">
           Export
         </button>
-        <button onClick={() => useProjectStore.getState().exportProjectMidi()} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Export all MIDI tracks as .mid file">
-          Export MIDI
+        <button onClick={() => useProjectStore.getState().exportProjectMidi()} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-400 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Export all MIDI tracks as .mid file">
+          MIDI
         </button>
-        <button onClick={openFilePicker} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Import Audio or MIDI">
+        <button onClick={openFilePicker} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-400 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Import Audio or MIDI">
           Import
         </button>
-        <button onClick={() => setShowUndoHistoryPanel(!showUndoHistoryPanel)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Undo History (Cmd/Ctrl+Alt+Z)">
+        <button onClick={() => setShowUndoHistoryPanel(!showUndoHistoryPanel)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-400 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Undo History (Cmd/Ctrl+Alt+Z)">
           History
         </button>
-        <button onClick={() => setShowShareDialog(true)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Share Project">
+        <button onClick={() => setShowShareDialog(true)} disabled={!project} className="px-2 py-1 text-[11px] text-zinc-400 hover:text-white hover:bg-daw-surface-2 rounded transition-colors disabled:opacity-30" title="Share Project">
           Share
         </button>
       </div>

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -418,7 +418,7 @@ export function Timeline() {
         role="grid"
         tabIndex={0}
         data-onboarding-target="timeline"
-        className="flex-1 overflow-auto bg-[#242424] relative"
+        className="flex-1 overflow-auto bg-[#242424] relative group"
         onWheel={handleWheel}
         onMouseDownCapture={handleMouseDownCapture}
         onFocus={() => setKeyboardContext('timeline')}
@@ -441,7 +441,7 @@ export function Timeline() {
           aria-label="Timeline navigation status"
           role="status"
           aria-live="polite"
-          className="absolute right-3 top-3 z-30 rounded border border-white/10 bg-black/40 px-2 py-1 text-[10px] text-zinc-200"
+          className="sticky right-3 top-3 z-30 ml-auto mr-3 mt-3 w-fit rounded border border-white/10 bg-black/40 px-2 py-1 text-[10px] text-zinc-200 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"
         >
           Scope: <span className="text-white">Timeline</span> · Focus: <span className="text-white">{focusedTrackLabel}</span> · Clip: <span className="text-white">{selectedClipLabel}</span>
         </div>


### PR DESCRIPTION
## Summary

- **Fix infinite render loop** in GenerationSidePanel — `stemsTracks` array was recreated every render, triggering an infinite useEffect loop that crashed the app after project creation
- **Improve toolbar hierarchy** — add separators between logical groups, remove redundant view toggle, dim secondary actions
- **Hide scope/focus status text** — show only on timeline hover instead of always visible
- **Fix settings panel truncation** — add scrollable overflow so content isn't cut off on small viewports

Closes #513, closes #514, closes #515, closes #516

## Test plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 1593 tests passed
- [x] `npm run build` — success
- [x] Visual verification via preview server

🤖 Generated with [Claude Code](https://claude.com/claude-code)