### PR TITLE
fix: improve settings project controls and add tap tempo audio feedback

### DIFF
--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { listModels, initModel, getBackendUrl, setBackendUrl } from '../../services/aceStepApi';
 import { DEFAULT_GENERATION, DEFAULT_MEASURES } from '../../constants/defaults';
 import { normalizePlaybackLatencySettings } from '../../utils/playbackLatency';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
 import type { ModelEntry, LmModelEntry } from '../../types/api';
 
 function modelSupportsThinking(modelName: string): boolean {
@@ -21,6 +22,7 @@ export function SettingsDialog() {
   const tapResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleTapTempo = useCallback(() => {
+    void getAudioEngine().previewMetronomeClick();
     const now = Date.now();
     const taps = tapTimesRef.current;
 
@@ -259,8 +261,8 @@ export function SettingsDialog() {
 
           <h3 className="text-xs font-medium text-zinc-300 pt-2">Project</h3>
 
-          <div className="grid grid-cols-4 gap-3">
-            <div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
               <label className="block text-xs text-zinc-400 mb-1">BPM</label>
               <div className="flex gap-1.5">
                 <input
@@ -289,7 +291,7 @@ export function SettingsDialog() {
               </div>
             </div>
             <div>
-              <label className="block text-xs text-zinc-400 mb-1">Key / Scale</label>
+              <label className="block text-xs text-zinc-400 mb-1">Key</label>
               <input
                 type="text"
                 value={keyScale}

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -243,6 +243,32 @@ export class AudioEngine {
     }
   }
 
+  async previewMetronomeClick(accent = false) {
+    await this.resume();
+    const now = this.ctx.currentTime;
+    const freq = accent ? 1200 : 800;
+    const clickDuration = 0.03;
+
+    const osc = this.ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.value = freq;
+
+    const env = this.ctx.createGain();
+    env.gain.setValueAtTime(1, now);
+    env.gain.exponentialRampToValueAtTime(0.001, now + clickDuration);
+
+    osc.connect(env);
+    env.connect(this._metronomeGain);
+
+    osc.start(now);
+    osc.stop(now + clickDuration + 0.01);
+
+    osc.addEventListener('ended', () => {
+      osc.disconnect();
+      env.disconnect();
+    }, { once: true });
+  }
+
   setTimeUpdateCallback(cb: (time: number) => void) {
     this._onTimeUpdate = cb;
   }

--- a/tests/unit/bpmInput.test.tsx
+++ b/tests/unit/bpmInput.test.tsx
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { NewProjectDialog } from '../../src/components/dialogs/NewProjectDialog';
 import { SettingsDialog } from '../../src/components/dialogs/SettingsDialog';
 import { useUIStore } from '../../src/store/uiStore';
 import { useProjectStore } from '../../src/store/projectStore';
+import { getAudioEngine } from '../../src/hooks/useAudioEngine';
 
 vi.mock('../../src/services/aceStepApi', () => ({
   listModels: vi.fn().mockResolvedValue([]),
@@ -20,6 +21,12 @@ vi.mock('../../src/services/projectStorage', () => ({
   listTemplates: vi.fn().mockResolvedValue([]),
   loadTemplate: vi.fn().mockResolvedValue(null),
   deleteTemplate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(() => ({
+    previewMetronomeClick: vi.fn().mockResolvedValue(undefined),
+  })),
 }));
 
 describe('BPM input — clamp on blur, not keystroke', () => {
@@ -83,6 +90,12 @@ describe('BPM input — clamp on blur, not keystroke', () => {
   });
 
   describe('SettingsDialog', () => {
+    beforeEach(() => {
+      vi.mocked(getAudioEngine).mockReturnValue({
+        previewMetronomeClick: vi.fn().mockResolvedValue(undefined),
+      } as unknown as ReturnType<typeof getAudioEngine>);
+    });
+
     function getSettingsBpmInput(container: HTMLElement): HTMLInputElement {
       // Settings dialog has multiple number inputs; BPM is the one with min=40
       const inputs = container.querySelectorAll('input[type="number"]');
@@ -123,6 +136,49 @@ describe('BPM input — clamp on blur, not keystroke', () => {
       fireEvent.blur(input);
       // Should clamp to min (30)
       expect(Number(input.value)).toBeGreaterThanOrEqual(30);
+    });
+
+    it('plays a metronome-style preview click on tap', () => {
+      const previewMetronomeClick = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(getAudioEngine).mockReturnValue({
+        previewMetronomeClick,
+      } as unknown as ReturnType<typeof getAudioEngine>);
+
+      render(<SettingsDialog />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Tap tempo' }));
+
+      expect(previewMetronomeClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates BPM from sequential tap tempo input', () => {
+      const { container } = render(<SettingsDialog />);
+      const input = getSettingsBpmInput(container);
+      const tapButton = screen.getByRole('button', { name: 'Tap tempo' });
+      let currentNow = 1000;
+      const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => currentNow);
+
+      act(() => {
+        fireEvent.click(tapButton);
+        currentNow = 1500;
+        fireEvent.click(tapButton);
+      });
+      expect(input.value).toBe('120');
+
+      act(() => {
+        currentNow = 2000;
+        fireEvent.click(tapButton);
+      });
+      expect(input.value).toBe('120');
+
+      nowSpy.mockRestore();
+    });
+
+    it('shows the Key label and removes Key / Scale copy', () => {
+      render(<SettingsDialog />);
+
+      expect(screen.getByText('Key')).toBeInTheDocument();
+      expect(screen.queryByText('Key / Scale')).not.toBeInTheDocument();
     });
 
     it('shows detected playback latency and saves a manual override', () => {


### PR DESCRIPTION
## Summary

- add metronome-style audio feedback to the Settings tap-tempo button
- reorganize the Settings > Project controls into a stable 2-column layout so BPM/TAP and Key no longer feel cramped
- rename `Key / Scale` to `Key`
- add focused SettingsDialog regression tests for tap preview, tap BPM updates, and label copy

## What changed

- added `previewMetronomeClick()` to `AudioEngine` so UI actions can reuse the existing metronome click voice without changing transport/metronome state
- updated `SettingsDialog` to call the one-shot click preview on every TAP press
- changed the Project controls grid from 4 columns to 2 columns to separate BPM/TAP, Key, Time Sig, and Measures more cleanly
- renamed the Settings field label from `Key / Scale` to `Key`
- extended `tests/unit/bpmInput.test.tsx` to cover tap-audio invocation, sequential tap BPM calculation, and the label rename

## Verification

- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `npx vitest run tests/unit/bpmInput.test.tsx`
- [x] Browser verification on local Vite preview at `http://127.0.0.1:4173/`
- [x] Code review check: no unused imports, no stray `console.log`, no new untyped `any`, TAP feedback does not toggle transport metronome state

## Screenshots

- Local verification screenshot: `test-screenshots/settings-project-controls-fix.png`

Closes #523
