### PR TITLE
fix: restore stems lane gridlines in arrangement view

### DIFF
--- a/docs/plans/fix-stems-empty-lane-gridlines.md
+++ b/docs/plans/fix-stems-empty-lane-gridlines.md
@@ -1,0 +1,28 @@
+# fix: empty stems lanes hide arrangement grid lines
+
+## User Story
+As a user, I want newly created empty stems tracks to keep their bar and beat grid visible, so that I can place clips against the timeline rhythm without guessing.
+
+## Problem
+Issue [#525](https://github.com/ace-step/ACE-Step-DAW/issues/525) reports that creating a new empty stems track produces a dark lane with no visible bar or beat lines even though the time ruler still shows them.
+
+## Root Cause
+- `src/components/timeline/GridOverlay.tsx` renders the arrangement grid behind the track lanes.
+- `src/components/timeline/TrackLane.tsx` applies `ARRANGEMENT_EMPTY_LANE_BG` directly to empty non-editor lanes via `backgroundColor`.
+- Because the fill is opaque, the empty stems lane visually masks the grid lines that are already present behind it.
+
+## Solution
+- Update `src/components/timeline/TrackLane.tsx` so empty non-editor lanes use a translucent overlay surface instead of an opaque lane background.
+- Keep the existing arrangement separator and empty-lane affordance so the row still reads as aligned with its header.
+- Add a focused regression test in `tests/unit/trackLaneAlignment.test.tsx` that checks the empty-lane surface is rendered as an overlay instead of an opaque lane fill.
+- Add a browser screenshot case in `tests/e2e/visual-regression.spec.ts` covering a newly created empty stems lane.
+
+## Verification
+- `npx vitest run tests/unit/trackLaneAlignment.test.tsx`
+- `npm run build`
+- `npx playwright test tests/e2e/visual-regression.spec.ts --grep "empty stems lane gridlines screenshot"`
+
+## Files To Touch
+- `src/components/timeline/TrackLane.tsx`
+- `tests/unit/trackLaneAlignment.test.tsx`
+- `tests/e2e/visual-regression.spec.ts`

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -85,6 +85,7 @@ function LaneContextMenu({ x, y, onAddLayer, onOpenSequencer, onOpenPianoRoll, o
 
 const MIN_LANE_HEIGHT = 40;
 const MAX_LANE_HEIGHT = 400;
+const EMPTY_LANE_SURFACE_OVERLAY_OPACITY = 0.55;
 
 export function TrackLane({ track }: TrackLaneProps) {
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
@@ -300,7 +301,6 @@ export function TrackLane({ track }: TrackLaneProps) {
           width: totalWidth,
           height: laneHeight,
           opacity: track.muted ? 0.4 : 1,
-          backgroundColor: fileDragOver ? undefined : shouldHighlightEmptyLane ? ARRANGEMENT_EMPTY_LANE_BG : undefined,
           borderColor: ARRANGEMENT_ROW_SEPARATOR_COLOR,
         }}
         onContextMenu={handleContextMenu}
@@ -309,6 +309,18 @@ export function TrackLane({ track }: TrackLaneProps) {
         onDragLeave={handleFileDragLeave}
         onDrop={handleFileDrop}
       >
+        {shouldHighlightEmptyLane && !fileDragOver && (
+          <div
+            aria-hidden="true"
+            data-testid={`track-lane-surface-overlay-${track.id}`}
+            className="absolute inset-0 pointer-events-none"
+            style={{
+              backgroundColor: ARRANGEMENT_EMPTY_LANE_BG,
+              opacity: EMPTY_LANE_SURFACE_OVERLAY_OPACITY,
+            }}
+          />
+        )}
+
         {fileDragOver && (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-30 border border-dashed border-blue-400/60 rounded-sm">
             <span className="text-[10px] text-blue-300 bg-blue-950/80 px-2 py-0.5 rounded">Drop audio or MIDI here {track.trackType !== 'pianoRoll' ? '(Alt = Quick Sampler)' : ''}</span>

--- a/tests/e2e/visual-regression.spec.ts
+++ b/tests/e2e/visual-regression.spec.ts
@@ -46,6 +46,24 @@ test.describe('Visual Regression Screenshots', () => {
     await page.screenshot({ path: 'test-screenshots/vr-arrangement-empty-lanes.png', fullPage: true });
   });
 
+  test('empty stems lane gridlines screenshot', async ({ page }) => {
+    await page.evaluate(() => {
+      const store = (window as any).__store;
+      const uiStore = (window as any).__uiStore;
+      uiStore.getState().setShowOnboarding(false);
+      uiStore.getState().setShowNewProjectDialog(false);
+      uiStore.setState({
+        dismissedOnboardingTipIds: ['genr-first-pass', 'loop-browser', 'timeline-selection'],
+      });
+      store.getState().createProject({ name: 'Empty Stems Lane Gridline Test' });
+      store.getState().addTrack('drums');
+      store.getState().addTrack('keyboard', 'pianoRoll');
+    });
+    await page.mouse.click(1100, 120);
+    await page.waitForTimeout(500);
+    await page.screenshot({ path: 'test-screenshots/vr-empty-stems-lane-gridlines.png', fullPage: true });
+  });
+
   test('arrangement track-header alignment with clips screenshot', async ({ page }) => {
     await page.evaluate(() => {
       const store = (window as any).__store;

--- a/tests/unit/trackLaneAlignment.test.tsx
+++ b/tests/unit/trackLaneAlignment.test.tsx
@@ -56,9 +56,11 @@ describe('TrackLane empty-lane alignment', () => {
     render(<TrackLane track={track} />);
 
     const lane = screen.getByTestId(`track-lane-${track.id}`);
+    const overlay = screen.getByTestId(`track-lane-surface-overlay-${track.id}`);
     expect(lane).toHaveAttribute('data-lane-surface', 'empty');
-    expect(lane.getAttribute('style')).toContain('background-color: var(--color-daw-arrangement-empty-lane-bg)');
     expect(lane.getAttribute('style')).toContain('border-color: var(--color-daw-arrangement-separator)');
+    expect(overlay.getAttribute('style')).toContain('background-color: var(--color-daw-arrangement-empty-lane-bg)');
+    expect(overlay.getAttribute('style')).toContain('opacity: 0.55');
   });
 
   it('keeps populated lanes on the default surface', () => {
@@ -76,8 +78,6 @@ describe('TrackLane empty-lane alignment', () => {
 
     const lane = screen.getByTestId(`track-lane-${track.id}`);
     expect(lane).toHaveAttribute('data-lane-surface', 'default');
-    expect(lane).not.toHaveStyle({
-      backgroundColor: 'var(--color-daw-arrangement-empty-lane-bg)',
-    });
+    expect(screen.queryByTestId(`track-lane-surface-overlay-${track.id}`)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- restore visible bar and beat grid lines for newly created empty stems lanes in Arrangement view
- replace the opaque empty-lane fill with a translucent surface overlay so header alignment still reads correctly
- add a focused unit regression test, a visual regression screenshot case, and a user-story plan doc for issue #525

## User Story
As a user, I want newly created empty stems tracks to keep the arrangement bar and beat grid visible, so I can place clips against the timeline rhythm without guessing.

## Root Cause
- `src/components/timeline/GridOverlay.tsx` draws the arrangement grid behind the track lanes.
- `src/components/timeline/TrackLane.tsx` painted `ARRANGEMENT_EMPTY_LANE_BG` directly onto empty non-editor lanes.
- That opaque lane fill masked the grid inside new empty stems tracks, so the ruler still showed bars while the lane body looked blank.

## Solution
- render the empty-lane arrangement surface as a translucent overlay instead of an opaque lane background
- keep the existing separator and empty-lane affordance so the row still aligns with its header
- cover the regression with unit and browser screenshot verification

## Verification
- `npx vitest run tests/unit/trackLaneAlignment.test.tsx`
- `npm run build`
- `npx playwright test tests/e2e/visual-regression.spec.ts --grep "empty stems lane gridlines screenshot"`

Closes #525
