### PR TITLE
feat: add drum machine as track type option in Instrument Picker

### DIFF
--- a/src/components/dialogs/InstrumentPicker.tsx
+++ b/src/components/dialogs/InstrumentPicker.tsx
@@ -50,7 +50,7 @@ export function InstrumentPicker() {
     close();
   };
 
-  const typeOrder: TrackType[] = ['stems', 'sample', 'sequencer', 'pianoRoll'];
+  const typeOrder: TrackType[] = ['stems', 'sample', 'sequencer', 'drumMachine', 'pianoRoll'];
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={(e) => { if (e.target === e.currentTarget) close(); }}>
@@ -218,6 +218,29 @@ export function InstrumentPicker() {
               <div>
                 <div className="text-sm font-medium">Step Sequencer</div>
                 <div className="text-[11px] text-zinc-400">16-step pattern with Kick, Snare, Hi-Hat and more — fully customizable</div>
+              </div>
+            </button>
+          </div>
+        )}
+
+        {step === 'instrument' && selectedType === 'drumMachine' && (
+          <div className="p-5 flex flex-col gap-3">
+            <div className="text-center mb-2">
+              <span className="text-3xl">🥁</span>
+              <p className="text-xs text-zinc-400 mt-2">Creates an MPC-style drum machine track with 16 pads for triggering samples. Fully customizable kit and pattern.</p>
+            </div>
+            <button
+              onClick={() => {
+                addTrack('percussion', 'drumMachine');
+                close();
+              }}
+              className="flex items-center gap-3 p-3 rounded-lg bg-daw-surface-2 hover:bg-[#484848] transition-colors text-left"
+              style={{ borderLeft: `3px solid ${TRACK_TYPE_CATALOG.drumMachine.color}` }}
+            >
+              <span className="text-xl">🥁</span>
+              <div>
+                <div className="text-sm font-medium">Drum Machine</div>
+                <div className="text-[11px] text-zinc-400">16-pad sample trigger with velocity-sensitive pads and pattern sequencing</div>
               </div>
             </button>
           </div>

--- a/src/components/dialogs/__tests__/InstrumentPicker.test.tsx
+++ b/src/components/dialogs/__tests__/InstrumentPicker.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InstrumentPicker } from '../InstrumentPicker';
+import { useUIStore } from '../../../store/uiStore';
+import { useProjectStore } from '../../../store/projectStore';
+
+// Mock modules that use browser APIs not available in jsdom
+vi.mock('../../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+vi.mock('../../../hooks/useAudioImport', () => ({
+  useAudioImport: () => ({
+    openFilePicker: vi.fn(),
+    openQuickSamplerFilePicker: vi.fn(),
+  }),
+}));
+vi.mock('../../../hooks/useRecording', () => ({
+  useRecording: () => ({
+    armedTrackIds: [],
+    toggleArmTrack: vi.fn(),
+  }),
+}));
+vi.mock('../../../hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    getTrackLevel: () => 0,
+  }),
+}));
+
+describe('InstrumentPicker', () => {
+  beforeEach(() => {
+    // Initialize project so the picker renders
+    useProjectStore.getState().createProject('Test Project');
+    // Open the picker
+    useUIStore.getState().setShowInstrumentPicker(true);
+  });
+
+  it('renders all track type options including Drum Machine', () => {
+    render(<InstrumentPicker />);
+
+    expect(screen.getByText('Stems')).toBeInTheDocument();
+    expect(screen.getByText('Sample')).toBeInTheDocument();
+    expect(screen.getByText('Sequencer')).toBeInTheDocument();
+    expect(screen.getByText('Piano Roll')).toBeInTheDocument();
+    expect(screen.getByText('Drum Machine')).toBeInTheDocument();
+  });
+
+  it('shows drum machine instrument step when Drum Machine type is selected', () => {
+    render(<InstrumentPicker />);
+
+    // Click on the Drum Machine type button
+    fireEvent.click(screen.getByText('Drum Machine'));
+
+    // Should show the drum machine instrument view
+    expect(screen.getByText('Add Drum Machine Track')).toBeInTheDocument();
+  });
+
+  it('creates a drum machine track when the button is clicked', () => {
+    const addTrackSpy = vi.spyOn(useProjectStore.getState(), 'addTrack');
+    render(<InstrumentPicker />);
+
+    // Select Drum Machine type
+    fireEvent.click(screen.getByText('Drum Machine'));
+
+    // Click the drum machine creation button
+    const drumMachineButton = screen.getByText('Drum Machine', { selector: '.text-sm.font-medium' });
+    fireEvent.click(drumMachineButton);
+
+    expect(addTrackSpy).toHaveBeenCalledWith('percussion', 'drumMachine');
+  });
+});


### PR DESCRIPTION
## Summary
- Added `'drumMachine'` to `typeOrder` array in InstrumentPicker between sequencer and pianoRoll
- Added drum machine instrument selection panel with "Drum Machine" creation button
- Added 3 unit tests for rendering and track creation

## Test plan
- [ ] Verify "Drum Machine" appears as 5th option in Add Track dialog
- [ ] Clicking it shows instrument selection with "Drum Machine" button
- [ ] Creating track produces a drumMachine track with 16 pads and 808 kit
- [ ] All 1618 unit tests pass
- [ ] Build succeeds

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)