### PR TITLE
fix: add drumMachine keyboard context to resolve pad key conflicts with global shortcuts

### DIFF
--- a/src/components/sequencer/DrumMachineEditor.tsx
+++ b/src/components/sequencer/DrumMachineEditor.tsx
@@ -88,9 +88,11 @@ export function DrumMachineEditor() {
     [triggerPad],
   );
 
-  // Keyboard mapping
+  // Keyboard mapping — only process pad keys when drum machine has keyboard focus
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      const scope = useUIStore.getState().keyboardContext.scope;
+      if (scope !== 'drumMachine') return;
       const tag = (e.target as HTMLElement).tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
       const key = e.key.toLowerCase();
@@ -103,6 +105,13 @@ export function DrumMachineEditor() {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [triggerPad]);
+
+  // Set keyboard context to drumMachine when clicking inside the editor
+  const handleEditorFocus = useCallback(() => {
+    if (trackId) {
+      useUIStore.getState().setKeyboardContext('drumMachine', trackId);
+    }
+  }, [trackId]);
 
   // Cleanup timeouts
   useEffect(() => {
@@ -139,8 +148,8 @@ export function DrumMachineEditor() {
       className="flex flex-col border-t border-white/10 bg-[#1a1a2e]"
       style={{ height: editorHeight }}
       data-track-id={trackId}
-      onMouseDownCapture={() => setHistoryFocusScope('track')}
-      onFocusCapture={() => setHistoryFocusScope('track')}
+      onMouseDownCapture={() => { setHistoryFocusScope('track'); handleEditorFocus(); }}
+      onFocusCapture={() => { setHistoryFocusScope('track'); handleEditorFocus(); }}
     >
       {/* Resize handle */}
       <div

--- a/src/hooks/__tests__/drumMachineKeyboardScope.test.ts
+++ b/src/hooks/__tests__/drumMachineKeyboardScope.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for drum machine keyboard scope — ensures drum pad keys
+ * are deferred to the drum machine when its scope is active,
+ * and global shortcuts are not suppressed otherwise.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { shouldDeferToDrumMachine } from '../useKeyboardShortcuts';
+import { useUIStore } from '../../store/uiStore';
+
+function makeKeyEvent(code: string, opts: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    code,
+    key: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...opts,
+  } as unknown as KeyboardEvent;
+}
+
+describe('shouldDeferToDrumMachine', () => {
+  beforeEach(() => {
+    // Reset keyboard context to timeline
+    useUIStore.getState().setKeyboardContext('timeline', null);
+  });
+
+  it('returns true for pad key when scope is drumMachine', () => {
+    useUIStore.getState().setKeyboardContext('drumMachine', 'track-1');
+    expect(shouldDeferToDrumMachine(makeKeyEvent('KeyZ'))).toBe(true);
+    expect(shouldDeferToDrumMachine(makeKeyEvent('KeyQ'))).toBe(true);
+    expect(shouldDeferToDrumMachine(makeKeyEvent('Digit1'))).toBe(true);
+    expect(shouldDeferToDrumMachine(makeKeyEvent('KeyF'))).toBe(true);
+  });
+
+  it('returns false when scope is timeline', () => {
+    useUIStore.getState().setKeyboardContext('timeline', null);
+    expect(shouldDeferToDrumMachine(makeKeyEvent('KeyZ'))).toBe(false);
+    expect(shouldDeferToDrumMachine(makeKeyEvent('Digit1'))).toBe(false);
+  });
+
+  it('returns false when scope is pianoRoll', () => {
+    useUIStore.getState().setKeyboardContext('pianoRoll', 'track-1');
+    expect(shouldDeferToDrumMachine(makeKeyEvent('KeyA'))).toBe(false);
+  });
+
+  it('returns false when modifier keys are pressed even in drumMachine scope', () => {
+    useUIStore.getState().setKeyboardContext('drumMachine', 'track-1');
+    expect(shouldDeferToDrumMachine(makeKeyEvent('KeyZ', { metaKey: true }))).toBe(false);
+    expect(shouldDeferToDrumMachine(makeKeyEvent('KeyZ', { ctrlKey: true }))).toBe(false);
+    expect(shouldDeferToDrumMachine(makeKeyEvent('KeyZ', { altKey: true }))).toBe(false);
+  });
+
+  it('returns false for non-pad keys even in drumMachine scope', () => {
+    useUIStore.getState().setKeyboardContext('drumMachine', 'track-1');
+    expect(shouldDeferToDrumMachine(makeKeyEvent('Space'))).toBe(false);
+    expect(shouldDeferToDrumMachine(makeKeyEvent('KeyG'))).toBe(false);
+    expect(shouldDeferToDrumMachine(makeKeyEvent('Escape'))).toBe(false);
+  });
+
+  it('recognizes all 16 drum pad key codes', () => {
+    useUIStore.getState().setKeyboardContext('drumMachine', 'track-1');
+    const padKeys = [
+      'KeyZ', 'KeyX', 'KeyC', 'KeyV',
+      'KeyA', 'KeyS', 'KeyD', 'KeyF',
+      'KeyQ', 'KeyW', 'KeyE', 'KeyR',
+      'Digit1', 'Digit2', 'Digit3', 'Digit4',
+    ];
+    for (const code of padKeys) {
+      expect(shouldDeferToDrumMachine(makeKeyEvent(code))).toBe(true);
+    }
+  });
+});
+
+describe('uiStore drumMachine keyboard context', () => {
+  beforeEach(() => {
+    useUIStore.getState().setKeyboardContext('timeline', null);
+  });
+
+  it('sets keyboard context to drumMachine when opening drum machine', () => {
+    useUIStore.getState().setOpenDrumMachineTrackId('track-1');
+    const ctx = useUIStore.getState().keyboardContext;
+    expect(ctx.scope).toBe('drumMachine');
+    expect(ctx.trackId).toBe('track-1');
+  });
+
+  it('resets keyboard context to timeline when closing drum machine', () => {
+    useUIStore.getState().setOpenDrumMachineTrackId('track-1');
+    useUIStore.getState().setOpenDrumMachineTrackId(null);
+    const ctx = useUIStore.getState().keyboardContext;
+    expect(ctx.scope).toBe('timeline');
+  });
+});

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -86,6 +86,19 @@ function shouldDeferToPianoRollTools(event: KeyboardEvent): boolean {
   return ['Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5', 'KeyB'].includes(event.code);
 }
 
+export function shouldDeferToDrumMachine(event: KeyboardEvent): boolean {
+  const ui = useUIStore.getState();
+  if (ui.keyboardContext.scope !== 'drumMachine') return false;
+  if (event.metaKey || event.ctrlKey || event.altKey) return false;
+  // All 16 drum pad key codes
+  return [
+    'KeyZ', 'KeyX', 'KeyC', 'KeyV',
+    'KeyA', 'KeyS', 'KeyD', 'KeyF',
+    'KeyQ', 'KeyW', 'KeyE', 'KeyR',
+    'Digit1', 'Digit2', 'Digit3', 'Digit4',
+  ].includes(event.code);
+}
+
 export function useKeyboardShortcuts() {
   const { play, pause, stop, seek } = useTransport();
   const { toggleRecord, toggleArmTrack } = useRecording();
@@ -290,6 +303,7 @@ export function useKeyboardShortcuts() {
       if (mod) return;
       if (anyModalOpen) return;
       if (shouldDeferToPianoRollTools(event)) return;
+      if (shouldDeferToDrumMachine(event)) return;
 
       if (matches('view.toggleSessionView')) {
         event.preventDefault();

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -598,13 +598,16 @@ export const useUIStore = create<UIState>()(
     historyFocusTrackId: id,
     historyFocusClipId: null,
   }),
-  setOpenDrumMachineTrackId: (id) => set({
+  setOpenDrumMachineTrackId: (id) => set((state) => ({
+    keyboardContext: id
+      ? { scope: 'drumMachine' as const, trackId: id }
+      : { scope: 'timeline' as const, trackId: state.keyboardContext.trackId },
     openDrumMachineTrackId: id,
     activeBottomPanel: id ? 'drumMachine' : null,
     historyFocusScope: id ? 'track' : 'arrangement',
     historyFocusTrackId: id,
     historyFocusClipId: null,
-  }),
+  })),
   setOpenPianoRoll: (trackId, clipId = null) => set((state) => ({
     keyboardContext: trackId ? { scope: 'pianoRoll', trackId } : state.keyboardContext,
     openPianoRollTrackId: trackId,

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -46,7 +46,8 @@ export type ShortcutContext =
   | 'global'
   | 'timeline'
   | 'pianoRoll'
-  | 'mixer';
+  | 'mixer'
+  | 'drumMachine';
 
 /** A complete set of overrides keyed by actionId. */
 export type ShortcutMap = Record<string, KeyCombo>;


### PR DESCRIPTION
## Summary
- Added `'drumMachine'` to `ShortcutContext` type union
- `setOpenDrumMachineTrackId` now sets keyboard scope to `'drumMachine'` (same pattern as pianoRoll)
- Added `shouldDeferToDrumMachine()` in useKeyboardShortcuts.ts to skip global shortcuts when drum machine has focus
- DrumMachineEditor now checks scope before processing pad keys, and claims focus on click
- 8 unit tests for scope-based key deferral

## Resolved Conflicts
| Key | Drum Pad | Global Shortcut |
|-----|----------|----------------|
| R | Tom Low | transport.record |
| F | Cowbell | transport.captureMidi |
| X | Bongo | panels.mixer |
| S | Ride | tracks.solo |
| E | Tom High | clips.edit |
| Z | Conga | view.zoomToSelection |

## Test plan
- [ ] Open drum machine, press R/S/E/F/X/Z — triggers drum pads (not global shortcuts)
- [ ] Click timeline, press R/S/E/F/X/Z — triggers global shortcuts (not drum pads)
- [ ] Modifier keys (Cmd+R, etc.) always trigger global shortcuts
- [ ] All 1623 unit tests pass
- [ ] Build succeeds

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)