### PR TITLE
fix: widen clip resize handles and correct fade triangle visuals

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -501,6 +501,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
             {fadeInWidth > 0 && (
               <div
                 className="absolute inset-y-0 left-0 pointer-events-none"
+                data-testid="fade-in-overlay"
                 style={{
                   width: fadeInWidth,
                   background: 'linear-gradient(90deg, rgba(10, 12, 18, 0.35) 0%, rgba(10, 12, 18, 0.05) 100%)',
@@ -511,6 +512,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
             {fadeOutWidth > 0 && (
               <div
                 className="absolute inset-y-0 right-0 pointer-events-none"
+                data-testid="fade-out-overlay"
                 style={{
                   width: fadeOutWidth,
                   background: 'linear-gradient(270deg, rgba(10, 12, 18, 0.35) 0%, rgba(10, 12, 18, 0.05) 100%)',

--- a/tests/unit/clipResizeAndFadeVisuals.test.tsx
+++ b/tests/unit/clipResizeAndFadeVisuals.test.tsx
@@ -80,9 +80,7 @@ describe('Clip resize handle width and fade visuals', () => {
   it('fade-in triangle uses correct clip path (upper-left triangle)', () => {
     useProjectStore.getState().setClipFade('clip-1', { fadeInDuration: 1 });
     const { container } = renderClip();
-    const fadeOverlays = container.querySelectorAll('.pointer-events-none.absolute.inset-y-0');
-    // First overlay is fade-in (left-positioned)
-    const fadeIn = fadeOverlays[0] as HTMLElement;
+    const fadeIn = container.querySelector('[data-testid="fade-in-overlay"]') as HTMLElement;
     expect(fadeIn).toBeTruthy();
     expect(fadeIn.style.clipPath).toBe('polygon(0 0, 100% 0, 0 100%)');
   });
@@ -90,21 +88,19 @@ describe('Clip resize handle width and fade visuals', () => {
   it('fade-out triangle uses correct clip path (upper-right triangle)', () => {
     useProjectStore.getState().setClipFade('clip-1', { fadeOutDuration: 1 });
     const { container } = renderClip();
-    const fadeOverlays = container.querySelectorAll('.pointer-events-none.absolute.inset-y-0');
-    // Find the right-positioned one
-    const fadeOut = Array.from(fadeOverlays).find(
-      (el) => (el as HTMLElement).className.includes('right-0'),
-    ) as HTMLElement;
+    const fadeOut = container.querySelector('[data-testid="fade-out-overlay"]') as HTMLElement;
     expect(fadeOut).toBeTruthy();
     expect(fadeOut.style.clipPath).toBe('polygon(0 0, 100% 0, 100% 100%)');
   });
 
-  it('fade overlay uses reduced opacity', () => {
-    useProjectStore.getState().setClipFade('clip-1', { fadeInDuration: 1 });
+  it('fade overlays use reduced opacity', () => {
+    useProjectStore.getState().setClipFade('clip-1', { fadeInDuration: 1, fadeOutDuration: 1 });
     const { container } = renderClip();
-    const fadeOverlays = container.querySelectorAll('.pointer-events-none.absolute.inset-y-0');
-    const fadeIn = fadeOverlays[0] as HTMLElement;
+    const fadeIn = container.querySelector('[data-testid="fade-in-overlay"]') as HTMLElement;
+    const fadeOut = container.querySelector('[data-testid="fade-out-overlay"]') as HTMLElement;
     expect(fadeIn.style.background).toContain('0.35');
     expect(fadeIn.style.background).not.toContain('0.72');
+    expect(fadeOut.style.background).toContain('0.35');
+    expect(fadeOut.style.background).not.toContain('0.72');
   });
 });


### PR DESCRIPTION
## Summary

- Increase clip resize handle width from 6px to 10px — the 6px target was too narrow to reliably grab, especially with fade handles (14px, z-20) positioned immediately adjacent and stealing click events
- Fix inverted fade-in/fade-out triangle clip paths — the dark overlay suggested gain decreasing for fade-in and increasing for fade-out, opposite of FL Studio/Logic Pro conventions
- Reduce fade overlay opacity from 0.72/0.18 to 0.35/0.05 for a more subtle, professional appearance

## What changed

- `EDGE_HANDLE_PX`: 6 → 10 (propagates to `getDragMode()`, cursor detection, fade handle positioning)
- Resize handle DOM: `w-[6px]` → `w-[10px]`
- Fade-in clipPath: `polygon(0 100%, 0 0, 100% 100%)` → `polygon(0 0, 100% 0, 0 100%)` (upper-left triangle)
- Fade-out clipPath: `polygon(0 100%, 100% 0, 100% 100%)` → `polygon(0 0, 100% 0, 100% 100%)` (upper-right triangle)
- Fade gradient max opacity: 0.72 → 0.35

## Test plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 1647 passed (4 new tests added)
- [x] `npm run build` — succeeds
- [ ] Manual: resize clip edges — should be noticeably easier to grab
- [ ] Manual: add fade-in — dark triangle should show gain increasing left-to-right
- [ ] Manual: add fade-out — dark triangle should show gain decreasing left-to-right
- [ ] Manual: fade overlays should be subtle, not dominant

Closes #536
Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)