### PR TITLE
feat: dedicated repaint pipeline with mode selector, model capability check, and GPU test stories

### DIFF
--- a/src/components/generation/AudioAnalysisPanel.tsx
+++ b/src/components/generation/AudioAnalysisPanel.tsx
@@ -74,7 +74,7 @@ export function AudioAnalysisPanel() {
         task_type: 'cover' as const,
         caption: 'analyze audio properties',
         lyrics: '',
-        cover_strength: 0.0, // No transformation — just analyze
+        audio_cover_strength: 0.0, // No transformation — just analyze
         audio_duration: clip.duration,
         inference_steps: 10, // Minimal steps for fast analysis
         guidance_scale: 1.0,

--- a/src/components/generation/CoverModal.tsx
+++ b/src/components/generation/CoverModal.tsx
@@ -3,6 +3,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { useGenerationStore } from '../../store/generationStore';
 import { useUIStore } from '../../store/uiStore';
 import { generateCoverClip } from '../../services/generationPipeline';
+import { modelSupportsTaskType } from '../../services/aceStepApi';
 
 export function CoverModal() {
   const coverClipId = useUIStore((s) => s.coverClipId);
@@ -48,6 +49,7 @@ export function CoverModal() {
   if (!coverClipId || !clip || !track) return null;
 
   const hasAudio = !!(clip.isolatedAudioKey || clip.cumulativeMixKey);
+  const coverSupported = modelSupportsTaskType('cover');
 
   return (
     <div
@@ -83,6 +85,11 @@ export function CoverModal() {
             {!hasAudio && (
               <p className="text-[10px] text-amber-400 mt-1">
                 No audio generated yet — generate the clip first before creating a cover.
+              </p>
+            )}
+            {!coverSupported && (
+              <p className="text-[10px] text-amber-400 mt-1">
+                The currently loaded model does not support cover generation. Load a model that supports the &quot;cover&quot; task type.
               </p>
             )}
           </div>
@@ -164,9 +171,9 @@ export function CoverModal() {
           </button>
           <button
             onClick={handleGenerate}
-            disabled={isGenerating || !hasAudio}
+            disabled={isGenerating || !hasAudio || !coverSupported}
             className={`px-4 py-1.5 rounded text-xs font-medium transition-colors ${
-              isGenerating || !hasAudio
+              isGenerating || !hasAudio || !coverSupported
                 ? 'bg-[#444] text-zinc-500 cursor-not-allowed'
                 : 'bg-amber-600 hover:bg-amber-500 text-white'
             }`}

--- a/src/components/generation/RepaintModal.tsx
+++ b/src/components/generation/RepaintModal.tsx
@@ -4,6 +4,8 @@ import { useGenerationStore } from '../../store/generationStore';
 import { useUIStore } from '../../store/uiStore';
 import { generateRepaintClip } from '../../services/generationPipeline';
 import { DualRangeSlider } from '../ui/DualRangeSlider';
+import type { RepaintMode } from '../../types/api';
+import { modelSupportsTaskType } from '../../services/aceStepApi';
 
 function fmt(s: number) {
   return `${s.toFixed(2)}s`;
@@ -27,6 +29,8 @@ export function RepaintModal() {
   const [selEnd, setSelEnd] = useState(clipEnd);
   const [prompt, setPrompt] = useState('');
   const [globalCaption, setGlobalCaption] = useState('');
+  const [repaintMode, setRepaintMode] = useState<RepaintMode>('balanced');
+  const [repaintStrength, setRepaintStrength] = useState(0.5);
 
   // Initialise form when clip/range changes
   useEffect(() => {
@@ -64,12 +68,15 @@ export function RepaintModal() {
       repaintEnd: selEnd,
       prompt,
       globalCaption: globalCaption || undefined,
+      repaintMode,
+      repaintStrength,
     });
-  }, [repaintClipId, selStart, selEnd, prompt, globalCaption, isGenerating, onClose]);
+  }, [repaintClipId, selStart, selEnd, prompt, globalCaption, repaintMode, repaintStrength, isGenerating, onClose]);
 
   if (!repaintClipId || !clip || !track) return null;
 
   const hasAudio = !!(clip.isolatedAudioKey || clip.cumulativeMixKey);
+  const repaintSupported = modelSupportsTaskType('repaint');
   const totalDur = project?.totalDuration ?? clipEnd;
 
   return (
@@ -108,6 +115,11 @@ export function RepaintModal() {
             {!hasAudio && (
               <p className="text-[10px] text-rose-400 mt-1">
                 No audio generated yet — generate the clip first.
+              </p>
+            )}
+            {!repaintSupported && (
+              <p className="text-[10px] text-rose-400 mt-1">
+                The currently loaded model does not support repaint. Load a model that supports the &quot;repaint&quot; task type.
               </p>
             )}
           </div>
@@ -197,6 +209,59 @@ export function RepaintModal() {
             />
           </div>
 
+          {/* Repaint mode & strength */}
+          <div className="bg-[#222]/60 rounded px-3 py-2.5 border border-[#3a3a3a] space-y-2.5">
+            <div>
+              <label className="block text-[10px] font-medium text-zinc-400 uppercase tracking-wide mb-1">
+                Repaint mode
+              </label>
+              <div className="flex gap-1">
+                {(['conservative', 'balanced', 'aggressive'] as const).map((mode) => (
+                  <button
+                    key={mode}
+                    onClick={() => setRepaintMode(mode)}
+                    className={`flex-1 px-2 py-1.5 rounded text-[10px] font-medium transition-colors ${
+                      repaintMode === mode
+                        ? 'bg-rose-600/80 text-white border border-rose-500'
+                        : 'bg-[#333] text-zinc-400 border border-[#444] hover:bg-[#3a3a3a]'
+                    }`}
+                  >
+                    {mode.charAt(0).toUpperCase() + mode.slice(1)}
+                  </button>
+                ))}
+              </div>
+              <p className="text-[8px] text-zinc-600 mt-1">
+                {repaintMode === 'conservative' && 'Maximum source preservation — subtle changes only.'}
+                {repaintMode === 'balanced' && 'Tunable blend between source preservation and fresh generation.'}
+                {repaintMode === 'aggressive' && 'Pure diffusion — fully regenerates the region.'}
+              </p>
+            </div>
+
+            {repaintMode === 'balanced' && (
+              <div>
+                <div className="flex items-center justify-between mb-1">
+                  <label className="text-[10px] font-medium text-zinc-400">
+                    Repaint strength
+                  </label>
+                  <span className="text-[10px] font-mono text-rose-300">{repaintStrength.toFixed(2)}</span>
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={repaintStrength}
+                  onChange={(e) => setRepaintStrength(Number(e.target.value))}
+                  className="w-full h-1.5 accent-rose-500 cursor-pointer"
+                />
+                <div className="flex justify-between text-[8px] text-zinc-600 mt-0.5">
+                  <span>Preserve source</span>
+                  <span>Fresh generation</span>
+                </div>
+              </div>
+            )}
+          </div>
+
           <p className="text-[9px] text-zinc-600">
             Only the selected range will be regenerated. Audio outside the repaint region is preserved.
           </p>
@@ -212,9 +277,9 @@ export function RepaintModal() {
           </button>
           <button
             onClick={handleGenerate}
-            disabled={isGenerating || !hasAudio || selEnd <= selStart}
+            disabled={isGenerating || !hasAudio || !repaintSupported || selEnd <= selStart}
             className={`px-4 py-1.5 rounded text-xs font-medium transition-colors ${
-              isGenerating || !hasAudio || selEnd <= selStart
+              isGenerating || !hasAudio || !repaintSupported || selEnd <= selStart
                 ? 'bg-[#444] text-zinc-500 cursor-not-allowed'
                 : 'bg-rose-600 hover:bg-rose-500 text-white'
             }`}

--- a/src/services/aceStepApi.ts
+++ b/src/services/aceStepApi.ts
@@ -120,13 +120,30 @@ export async function listModels(): Promise<ModelsListResponse> {
   }
 
   const data = envelopeData;
-  return {
+  const result: ModelsListResponse = {
     models: Array.isArray(data?.models) ? data.models : [],
     default_model: data?.default_model ?? null,
     lm_models: Array.isArray(data?.lm_models) ? data.lm_models : [],
     loaded_lm_model: data?.loaded_lm_model ?? null,
     llm_initialized: Boolean(data?.llm_initialized),
   };
+  _cachedInventory = result;
+  return result;
+}
+
+let _cachedInventory: ModelsListResponse | null = null;
+
+/**
+ * Check whether the currently loaded (or default) model supports a given task type.
+ * Uses the cached model inventory from the last `listModels()` call.
+ * Returns true if the information is unavailable (optimistic fallback).
+ */
+export function modelSupportsTaskType(taskType: string): boolean {
+  if (!_cachedInventory) return true;
+  const loaded = _cachedInventory.models.find((m) => m.is_loaded);
+  if (!loaded) return true;
+  if (!loaded.supported_task_types || loaded.supported_task_types.length === 0) return true;
+  return loaded.supported_task_types.includes(taskType);
 }
 
 export async function initModel(req: InitModelRequest): Promise<InitModelResponse> {

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -7,7 +7,7 @@ import {
   type VariationStatus,
 } from '../store/generationStore';
 import { useUIStore } from '../store/uiStore';
-import type { LegoTaskParams, CoverTaskParams, TaskResultEntry, TaskResultItem } from '../types/api';
+import type { LegoTaskParams, CoverTaskParams, RepaintTaskParams, RepaintMode, TaskResultEntry, TaskResultItem } from '../types/api';
 import type { InferredMetas } from '../types/project';
 import * as api from './aceStepApi';
 import { generateSilenceWav } from './silenceGenerator';
@@ -441,8 +441,17 @@ async function generateClipInternal(
       `audioDuration=${audioDuration}s`,
     );
 
-    // Build instruction
-    const instruction = `Generate the ${track.trackName.toUpperCase().replace('_', ' ')} track based on the audio context:`;
+    // Build instruction — detect chunk vs full mode based on whether the
+    // generation region covers the entire audio duration.  The backend's
+    // conditioning_text.py checks for "a segment" in the instruction to
+    // switch caption formatting (chunk omits Global: prefix).
+    const trackLabel = track.trackName.toUpperCase().replace('_', ' ');
+    const repaintStart = options.repaintRange?.start ?? clip.startTime;
+    const repaintEnd = options.repaintRange?.end ?? (clip.startTime + clip.duration);
+    const isChunkMode = repaintStart > 0.5 || repaintEnd < audioDuration - 0.5;
+    const instruction = isChunkMode
+      ? `Generate a segment of the ${trackLabel} track based on the audio context:`
+      : `Generate the ${trackLabel} track based on the audio context:`;
 
     // Build params — 'auto' = ACE-Step infers, null/undefined = project defaults, value = manual
     const resolvedBpm = clip.bpm === 'auto' ? null : (clip.bpm ?? project.bpm);
@@ -464,8 +473,8 @@ async function generateClipInternal(
       global_caption: effectiveGlobalCaption,
       lyrics: effectiveLyrics,
       instruction,
-      repainting_start: options.repaintRange?.start ?? clip.startTime,
-      repainting_end: options.repaintRange?.end ?? (clip.startTime + clip.duration),
+      repainting_start: repaintStart,
+      repainting_end: repaintEnd,
       audio_duration: audioDuration,
       bpm: resolvedBpm,
       key_scale: resolvedKey,
@@ -1339,7 +1348,7 @@ export async function generateCoverClip(opts: GenerateCoverOptions): Promise<voi
         task_type: 'cover',
         caption,
         lyrics,
-        cover_strength: coverStrength,
+        audio_cover_strength: coverStrength,
         audio_duration: sourceClip.duration,
         inference_steps: project.generationDefaults.inferenceSteps,
         guidance_scale: project.generationDefaults.guidanceScale,
@@ -1430,6 +1439,233 @@ export async function generateCoverClip(opts: GenerateCoverOptions): Promise<voi
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// generateRepaintInternal — sends task_type='repaint' with proper instruction
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function generateRepaintInternal(
+  clipId: string,
+  srcAudioBlob: Blob,
+  repaintStart: number,
+  repaintEnd: number,
+  prompt: string,
+  globalCaption: string,
+  repaintMode: RepaintMode = 'balanced',
+  repaintStrength: number = 0.5,
+): Promise<GenerationOutcome> {
+  const store = useProjectStore.getState();
+  const genStore = useGenerationStore.getState();
+  const project = store.project;
+  if (!project) return { cumulativeBlob: null, succeeded: false, errorMessage: 'No project' };
+
+  const clip = store.getClipById(clipId);
+  const track = store.getTrackForClip(clipId);
+  if (!clip || !track) {
+    return { cumulativeBlob: null, succeeded: false, errorMessage: 'Clip or track not found' };
+  }
+
+  const jobId = uuidv4();
+  genStore.addJob({
+    id: jobId,
+    clipId,
+    trackName: track.trackName,
+    status: 'queued',
+    progress: 'Queued',
+    stage: 'Queued',
+    progressPercent: null,
+    etaSeconds: null,
+    etaConfidence: 'none',
+  });
+  store.updateClipStatus(clipId, 'queued', { generationJobId: jobId });
+
+  try {
+    const audioDuration = useProjectStore.getState().getAudioDuration();
+
+    const params: RepaintTaskParams = {
+      task_type: 'repaint',
+      prompt,
+      global_caption: globalCaption,
+      lyrics: clip.lyrics || '',
+      instruction: 'Repaint the mask area based on the given conditions:',
+      repainting_start: repaintStart,
+      repainting_end: repaintEnd,
+      audio_duration: audioDuration,
+      inference_steps: project.generationDefaults.inferenceSteps,
+      guidance_scale: project.generationDefaults.guidanceScale,
+      shift: project.generationDefaults.shift,
+      batch_size: 1,
+      audio_format: 'wav',
+      thinking: project.generationDefaults.thinking,
+      model: project.generationDefaults.model,
+      repaint_mode: repaintMode,
+      repaint_strength: repaintStrength,
+    };
+
+    const jobStartedAt = Date.now();
+    {
+      const currentJob = genStore.jobs.find((job) => job.id === jobId);
+      genStore.updateJob(jobId, {
+        status: 'generating',
+        startedAt: jobStartedAt,
+        ...deriveGenerationJobProgress(currentJob, {
+          status: 'generating',
+          progress: 'Submitting...',
+          stage: 'Submitting request',
+          now: jobStartedAt,
+        }),
+      });
+    }
+    store.updateClipStatus(clipId, 'generating');
+
+    const releaseResp = await api.releaseLegoTask(srcAudioBlob, params);
+    const taskId = releaseResp.task_id;
+    genStore.updateJob(jobId, { taskId });
+
+    const startTime = Date.now();
+    let resultAudioPath: string | null = null;
+    let firstResult: TaskResultItem | null = null;
+
+    while (Date.now() - startTime < MAX_POLL_DURATION_MS) {
+      await sleep(POLL_INTERVAL_MS);
+
+      const entries = await api.queryResult([taskId]);
+      const entry = entries?.[0];
+      if (!entry) continue;
+
+      const { stage, progressPercent } = extractProgressMetadata(entry);
+      const etaSeconds = computeEta(jobStartedAt, progressPercent ?? undefined) ?? undefined;
+
+      {
+        const currentJob = useGenerationStore.getState().jobs.find((job) => job.id === jobId);
+        useGenerationStore.getState().updateJob(jobId, {
+          ...deriveGenerationJobProgress(currentJob, {
+            status: 'generating',
+            progress: entry.progress_text || 'Repainting...',
+            stage,
+            progressPercent,
+          }),
+        });
+      }
+
+      if (entry.status === 1) {
+        const resultItems: TaskResultItem[] = JSON.parse(entry.result);
+        firstResult = resultItems?.[0] ?? null;
+        resultAudioPath = firstResult?.file ?? null;
+        break;
+      } else if (entry.status === 2) {
+        throw new Error(`Repaint failed: ${entry.result}`);
+      }
+    }
+
+    if (!resultAudioPath) {
+      throw new Error('Repaint timed out — the server did not return a result within the time limit.');
+    }
+
+    {
+      const currentJob = useGenerationStore.getState().jobs.find((job) => job.id === jobId);
+      useGenerationStore.getState().updateJob(jobId, {
+        status: 'processing',
+        ...deriveGenerationJobProgress(currentJob, {
+          status: 'processing',
+          progress: 'Downloading audio...',
+          stage: 'Downloading audio',
+          progressPercent: 95,
+        }),
+      });
+    }
+    useProjectStore.getState().updateClipStatus(clipId, 'processing');
+
+    const cumulativeBlob = await api.downloadAudio(resultAudioPath);
+    logger.debug(`Downloaded repaint audio: size=${cumulativeBlob.size}, path=${resultAudioPath}`);
+
+    const cumulativeKey = await saveAudioBlob(project.id, clipId, 'cumulative', cumulativeBlob);
+
+    const engine = getAudioEngine();
+    const fullBuffer = await engine.decodeAudioData(cumulativeBlob);
+
+    const currentClip = useProjectStore.getState().getClipById(clipId);
+    const clipStart = currentClip?.startTime ?? clip.startTime;
+    const clipDuration = currentClip?.duration ?? clip.duration;
+
+    const sampleRate = fullBuffer.sampleRate;
+    const startSample = Math.round(clipStart * sampleRate);
+    const endSample = Math.min(
+      Math.round((clipStart + clipDuration) * sampleRate),
+      fullBuffer.length,
+    );
+    const trimmedLength = Math.max(1, endSample - startSample);
+    const trimmedBuffer = engine.ctx.createBuffer(
+      fullBuffer.numberOfChannels,
+      trimmedLength,
+      sampleRate,
+    );
+    for (let ch = 0; ch < fullBuffer.numberOfChannels; ch++) {
+      const src = fullBuffer.getChannelData(ch);
+      const dst = trimmedBuffer.getChannelData(ch);
+      for (let i = 0; i < trimmedLength; i++) {
+        dst[i] = src[startSample + i];
+      }
+    }
+
+    const isolatedBlob = audioBufferToWavBlob(trimmedBuffer);
+    const isolatedKey = await saveAudioBlob(project.id, clipId, 'isolated', isolatedBlob);
+    const peaks = computeWaveformPeaks(trimmedBuffer, 200);
+
+    const inferredMetas: InferredMetas | undefined = firstResult
+      ? {
+          bpm: firstResult.metas?.bpm,
+          keyScale: firstResult.metas?.keyscale,
+          timeSignature: firstResult.metas?.timesignature,
+          genres: firstResult.metas?.genres,
+          seed: firstResult.seed_value,
+          ditModel: firstResult.dit_model,
+        }
+      : undefined;
+
+    useProjectStore.getState().updateClipStatus(clipId, 'ready', {
+      cumulativeMixKey: cumulativeKey,
+      isolatedAudioKey: isolatedKey,
+      waveformPeaks: peaks,
+      inferredMetas,
+      audioDuration: clipDuration,
+      audioOffset: 0,
+      generatedFromContext: true,
+      serverCumulativePath: extractServerPath(resultAudioPath) ?? undefined,
+    });
+
+    {
+      const currentJob = useGenerationStore.getState().jobs.find((job) => job.id === jobId);
+      useGenerationStore.getState().updateJob(jobId, {
+        status: 'done',
+        ...deriveGenerationJobProgress(currentJob, {
+          status: 'done',
+          progress: 'Done',
+          stage: 'Complete',
+          progressPercent: 100,
+        }),
+      });
+    }
+
+    return { cumulativeBlob, succeeded: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    useProjectStore.getState().updateClipStatus(clipId, 'error', { errorMessage: message });
+    {
+      const currentJob = useGenerationStore.getState().jobs.find((job) => job.id === jobId);
+      useGenerationStore.getState().updateJob(jobId, {
+        status: 'error',
+        ...deriveGenerationJobProgress(currentJob, {
+          status: 'error',
+          progress: message,
+          stage: 'Repaint failed',
+          error: message,
+        }),
+      });
+    }
+    return { cumulativeBlob: null, succeeded: false, errorMessage: message };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // generateRepaintClip — regenerates a selected sub-range of an existing clip
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -1439,6 +1675,8 @@ export interface GenerateRepaintOptions {
   repaintEnd: number;
   prompt: string;
   globalCaption?: string;
+  repaintMode?: RepaintMode;
+  repaintStrength?: number;
 }
 
 export async function generateRepaintClip(opts: GenerateRepaintOptions): Promise<void> {
@@ -1458,13 +1696,23 @@ export async function generateRepaintClip(opts: GenerateRepaintOptions): Promise
       if (clip.cumulativeMixKey) {
         srcBlob = (await loadAudioBlobByKey(clip.cumulativeMixKey)) ?? null;
       }
+      if (!srcBlob) {
+        const audioDuration = store.getAudioDuration();
+        srcBlob = generateSilenceWav(audioDuration);
+      }
 
-      const outcome = await generateClipInternal(opts.clipId, srcBlob, {
-        forceSilence: !srcBlob,
-        localDescription: opts.prompt,
-        globalCaptionOverride: opts.globalCaption,
-        repaintRange: { start: opts.repaintStart, end: opts.repaintEnd },
-      });
+      const globalCaption = opts.globalCaption || store.project?.globalCaption || '';
+
+      const outcome = await generateRepaintInternal(
+        opts.clipId,
+        srcBlob,
+        opts.repaintStart,
+        opts.repaintEnd,
+        opts.prompt,
+        globalCaption,
+        opts.repaintMode ?? 'balanced',
+        opts.repaintStrength ?? 0.5,
+      );
 
       if (outcome.succeeded) {
         store.saveClipVersion(opts.clipId);
@@ -1492,6 +1740,8 @@ export interface RegionRegenerateOptions {
   prompt: string;
   /** Optional global song description override */
   globalCaption?: string;
+  repaintMode?: RepaintMode;
+  repaintStrength?: number;
 }
 
 /**
@@ -1532,6 +1782,8 @@ export async function regenerateTimelineRegion(opts: RegionRegenerateOptions): P
 
       if (affectedClips.length === 0) return false;
 
+      const globalCaption = opts.globalCaption || project.globalCaption || '';
+
       let allSucceeded = true;
       for (const { clipId, repaintStart, repaintEnd } of affectedClips) {
         const clip = store.getClipById(clipId);
@@ -1543,13 +1795,21 @@ export async function regenerateTimelineRegion(opts: RegionRegenerateOptions): P
         if (clip.cumulativeMixKey) {
           srcBlob = (await loadAudioBlobByKey(clip.cumulativeMixKey)) ?? null;
         }
+        if (!srcBlob) {
+          const audioDuration = store.getAudioDuration();
+          srcBlob = generateSilenceWav(audioDuration);
+        }
 
-        const outcome = await generateClipInternal(clipId, srcBlob, {
-          forceSilence: !srcBlob,
-          localDescription: opts.prompt,
-          globalCaptionOverride: opts.globalCaption,
-          repaintRange: { start: repaintStart, end: repaintEnd },
-        });
+        const outcome = await generateRepaintInternal(
+          clipId,
+          srcBlob,
+          repaintStart,
+          repaintEnd,
+          opts.prompt,
+          globalCaption,
+          opts.repaintMode ?? 'balanced',
+          opts.repaintStrength ?? 0.5,
+        );
 
         allSucceeded = allSucceeded && outcome.succeeded;
         if (outcome.succeeded) {
@@ -1639,7 +1899,7 @@ export async function generateVocal2BGM(opts: Vocal2BGMOptions): Promise<void> {
         task_type: 'cover',
         caption: `accompaniment for vocals: ${caption}`,
         lyrics: '',
-        cover_strength: 0.8,
+        audio_cover_strength: 0.8,
         audio_duration: sourceClip.duration,
         inference_steps: project.generationDefaults.inferenceSteps,
         guidance_scale: project.generationDefaults.guidanceScale,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -3,7 +3,7 @@ export interface CoverTaskParams {
   task_type: 'cover';
   caption: string;        // Style/genre description
   lyrics: string;
-  cover_strength: number; // 0.0–1.0: how much to deviate from original
+  audio_cover_strength: number; // 0.0–1.0: how much to deviate from original
   audio_duration: number;
   inference_steps: number;
   guidance_scale: number;
@@ -16,12 +16,15 @@ export interface CoverTaskParams {
   use_random_seed?: boolean;
 }
 
+export type RepaintMode = 'conservative' | 'balanced' | 'aggressive';
+
 /** Parameters for repaint — partially regenerates a section of an existing clip */
 export interface RepaintTaskParams {
   task_type: 'repaint';
   prompt: string;
   global_caption: string;
   lyrics: string;
+  instruction: string;
   repainting_start: number;
   repainting_end: number;
   audio_duration: number;
@@ -32,8 +35,11 @@ export interface RepaintTaskParams {
   audio_format: 'wav';
   thinking: boolean;
   model: string;
+  repaint_mode?: RepaintMode;
+  repaint_strength?: number; // 0.0–1.0: balanced-mode intensity (0=conservative, 1=aggressive)
   seed?: number;
   use_random_seed?: boolean;
+  src_audio_path?: string;
 }
 
 export type StemCount = 2 | 4 | 6;
@@ -132,6 +138,7 @@ export interface ModelEntry {
   name: string;
   is_default: boolean;
   is_loaded: boolean;
+  supported_task_types?: string[];
 }
 
 export interface LmModelEntry {

--- a/tests/gpu-integration/README.md
+++ b/tests/gpu-integration/README.md
@@ -15,7 +15,10 @@ tests/gpu-integration/
     ├── 02-batch-context.md          # Suite 2: Batch Generate from Context (LEGO)
     ├── 03-add-layer.md              # Suite 3: Add Layer Modal
     ├── 04-multi-track.md            # Suite 4: Multi-Track Generate Modal
-    └── 05-error-handling.md         # Suite 5: Error handling and edge cases
+    ├── 05-error-handling.md         # Suite 5: Error handling and edge cases
+    ├── 06-cover-generation.md       # Suite 6: Cover Generation (CoverModal, Vocal2BGM)
+    ├── 07-repaint-generation.md     # Suite 7: Repaint Generation (RepaintModal, RegionRegenerate)
+    └── 08-mask-modes.md             # Suite 8: Mask Modes (Auto vs Explicit)
 ```
 
 ## How It Works
@@ -113,8 +116,6 @@ Every story file follows this structure:
 
 ## Scope
 
-Currently covers **from silence** and **from context** generation only:
-
 | Suite | Feature | Mode |
 |-------|---------|------|
 | 0 | Backend connectivity | — |
@@ -123,5 +124,8 @@ Currently covers **from silence** and **from context** generation only:
 | 3 | Add Layer Modal | context |
 | 4 | Multi-Track Generate Modal | context/silence |
 | 5 | Error handling | — |
+| 6 | Cover Generation | cover (CoverModal, Vocal2BGM) |
+| 7 | Repaint Generation | repaint (RepaintModal, RegionRegenerate) |
+| 8 | Mask Modes | auto/explicit mask, chunk/full instruction |
 
-Out of scope (to be added when model support is ready): Cover, Repaint, Vocal2BGM, Stem Separation, Audio Analysis.
+Out of scope (to be added when model support is ready): Stem Separation, Audio Analysis.

--- a/tests/gpu-integration/agent-prompt.md
+++ b/tests/gpu-integration/agent-prompt.md
@@ -21,6 +21,9 @@ Run suites in order. Stop if Suite 0 fails.
 4. Suite 3 — Add Layer Modal (`stories/03-add-layer.md`)
 5. Suite 4 — Multi-Track Generate Modal (`stories/04-multi-track.md`)
 6. Suite 5 — Error Handling (`stories/05-error-handling.md`)
+7. Suite 6 — Cover Generation (`stories/06-cover-generation.md`)
+8. Suite 7 — Repaint Generation (`stories/07-repaint-generation.md`)
+9. Suite 8 — Mask Modes (`stories/08-mask-modes.md`)
 
 ## MCP Browser Tool Workflow
 
@@ -187,6 +190,9 @@ After all suites complete, produce a summary:
 | 3 — Add Layer | 8 | ? | ? | ? | ? |
 | 4 — Multi-Track | 5 | ? | ? | ? | ? |
 | 5 — Error | 3 | ? | ? | ? | ? |
+| 6 — Cover | 9 | ? | ? | ? | ? |
+| 7 — Repaint | 9 | ? | ? | ? | ? |
+| 8 — Mask Modes | 9 | ? | ? | ? | ? |
 
 ### Issues Filed
 - #NNN — [title]

--- a/tests/gpu-integration/stories/06-cover-generation.md
+++ b/tests/gpu-integration/stories/06-cover-generation.md
@@ -1,0 +1,179 @@
+# Suite 6: Cover Generation
+
+> Verdict type: human-checkpoint (audio quality requires listening)
+> Entry point: Right-click a generated clip -> "Create Cover" (CoverModal), or right-click a vocal clip -> "Generate Accompaniment" (Vocal2BGMModal)
+> Preconditions: Suite 0 passes; a project is open with Stems tracks; at least one track has a generated clip with audio
+
+The Cover feature transforms existing audio into a new style using `task_type: 'cover'`. The Vocal2BGM feature generates accompaniment from a vocal reference clip using the same backend task type.
+
+---
+
+## US-6.1 — Open CoverModal from clip context menu
+
+**Preconditions**: At least one clip has been generated (status = ready) on any Stems track
+
+**Steps**:
+1. Right-click a generated clip on the timeline
+2. Select "Create Cover" from the context menu
+
+**Expected**:
+- `CoverModal` opens with title "Create Cover"
+- Source clip info is displayed (track name, prompt)
+- Style description textarea is pre-filled with the clip's prompt
+- Lyrics textarea is visible
+- Cover strength slider is visible (default 0.50)
+- "Create new clip" checkbox is checked by default
+- Generate button reads "Generate Cover"
+
+**Verdict**: automated
+**Screenshot**: `suite-6/us-6.1-modal-open.png`
+
+---
+
+## US-6.2 — Generate cover with default settings
+
+**Steps**:
+1. Open CoverModal on a generated clip
+2. Enter style description: `jazz arrangement, smooth saxophone, soft piano`
+3. Leave cover strength at 0.50
+4. Leave "Create new clip" checked
+5. Click "Generate Cover"
+
+**Expected**:
+- Modal closes
+- A generation job appears in the GenerationPanel
+- After completion, a new clip appears on the same track (original clip is preserved)
+- The new clip has a rendered waveform
+
+**Verdict**: human-checkpoint
+**Human prompt**: "A cover was generated. Please play both the original and the cover clip. Does the cover sound like a jazz re-arrangement of the original?"
+**Screenshot**: `suite-6/us-6.2-generating.png`, `suite-6/us-6.2-complete.png`
+
+---
+
+## US-6.3 — Cover strength slider affects output
+
+**Steps**:
+1. Open CoverModal on a generated clip
+2. Set cover strength to 0.1 (close to original)
+3. Enter style description: `electronic remix, heavy synths`
+4. Generate cover
+5. Note the result
+6. Repeat with cover strength at 0.9 (fully reimagined)
+
+**Expected**:
+- Both generations complete without error
+- The 0.1-strength cover sounds closer to the original
+- The 0.9-strength cover sounds more dramatically different
+
+**Verdict**: human-checkpoint
+**Human prompt**: "Two covers were generated with different strengths (0.1 and 0.9). Does the low-strength version sound closer to the original than the high-strength version?"
+
+---
+
+## US-6.4 — Cover replaces original clip when unchecked
+
+**Steps**:
+1. Open CoverModal on a generated clip
+2. Uncheck "Create new clip (leave original intact)"
+3. Enter style description: `acoustic folk arrangement`
+4. Click "Generate Cover"
+
+**Expected**:
+- The original clip is replaced (not preserved as a separate clip)
+- The clip's version history contains the previous audio (can be restored)
+- The replaced clip has a rendered waveform
+
+**Verdict**: automated (check clip count unchanged) + human-checkpoint (audio)
+
+---
+
+## US-6.5 — Cover on clip without audio shows warning
+
+**Preconditions**: A clip exists that has NOT been generated yet (status != ready)
+
+**Steps**:
+1. Right-click the ungenerated clip
+2. Select "Create Cover"
+
+**Expected**:
+- CoverModal opens
+- A warning message is displayed: "No audio generated yet"
+- The "Generate Cover" button is disabled
+
+**Verdict**: automated
+**Screenshot**: `suite-6/us-6.5-no-audio.png`
+
+---
+
+## US-6.6 — Open Vocal2BGM modal from vocal clip
+
+**Preconditions**: A Vocals track has a generated clip with audio
+
+**Steps**:
+1. Right-click the generated vocal clip
+2. Select "Generate Accompaniment"
+
+**Expected**:
+- `Vocal2BGMModal` opens with title "Generate Accompaniment"
+- Source vocal info is displayed (track name, prompt, duration, BPM/key if inferred)
+- Target track dropdown shows non-vocal Stems tracks
+- Style preset selector is visible
+- Style description textarea is visible
+- BPM and Key radio buttons default to "Project"
+- Generate button reads "Generate Accompaniment"
+
+**Verdict**: automated
+**Screenshot**: `suite-6/us-6.6-v2bgm-modal.png`
+
+---
+
+## US-6.7 — Generate accompaniment from vocal
+
+**Steps**:
+1. Open Vocal2BGMModal on a generated vocal clip
+2. Select a target track (e.g. Guitar)
+3. Enter style description: `jazzy guitar chords, warm tone, following the vocal melody`
+4. Click "Generate Accompaniment"
+
+**Expected**:
+- Modal closes
+- A generation job appears in the GenerationPanel
+- After completion, a new clip appears on the target track (Guitar)
+- The new clip has a rendered waveform and matches the vocal clip's time position
+
+**Verdict**: human-checkpoint
+**Human prompt**: "An accompaniment was generated from a vocal clip. Please play both the vocal and the accompaniment together. Does the accompaniment complement the vocals?"
+**Screenshot**: `suite-6/us-6.7-v2bgm-complete.png`
+
+---
+
+## US-6.8 — Vocal2BGM with style preset
+
+**Steps**:
+1. Open Vocal2BGMModal on a generated vocal clip
+2. Click a style preset category (e.g. "Jazz")
+3. Click a preset to apply it
+4. Verify the style description textarea is filled with the preset caption
+5. Generate
+
+**Expected**:
+- Preset caption is applied to the style description
+- Generation completes without error
+- Result clip is present on the target track
+
+**Verdict**: automated (preset application) + human-checkpoint (audio quality)
+
+---
+
+## US-6.9 — Close modals without generating
+
+**Steps**:
+1. Open CoverModal, press Escape
+2. Open Vocal2BGMModal, press Escape
+
+**Expected**:
+- Both modals close without creating generation jobs
+- No clips are added to the timeline
+
+**Verdict**: automated

--- a/tests/gpu-integration/stories/07-repaint-generation.md
+++ b/tests/gpu-integration/stories/07-repaint-generation.md
@@ -1,0 +1,182 @@
+# Suite 7: Repaint Generation
+
+> Verdict type: human-checkpoint (audio quality requires listening)
+> Entry point: Right-click a generated clip -> "Repaint Selection" (RepaintModal), or timeline region selection -> "Regenerate Region" (RegionRegenerateModal)
+> Preconditions: Suite 0 passes; a project is open with Stems tracks; at least one track has a generated clip with audio
+
+The Repaint feature regenerates a selected sub-range of an existing clip using `task_type: 'repaint'`. The Region Regenerate feature repaints overlapping clips within a timeline selection.
+
+---
+
+## US-7.1 — Open RepaintModal from clip context menu
+
+**Preconditions**: At least one clip has been generated (status = ready)
+
+**Steps**:
+1. Right-click a generated clip on the timeline
+2. Select "Repaint Selection" from the context menu
+
+**Expected**:
+- `RepaintModal` opens with title "Repaint Selection"
+- Target clip info is displayed (track name, clip time range)
+- Repaint range slider is visible, defaulting to the full clip range
+- Mini timeline diagram shows clip region and repaint region
+- Prompt textarea is pre-filled with the clip's prompt
+- Global song description textarea is visible
+- Repaint mode buttons are visible (Conservative / Balanced / Aggressive), with "Balanced" selected by default
+- Repaint strength slider is visible (default 0.50), only shown in Balanced mode
+- Generate button reads "Repaint Selection"
+
+**Verdict**: automated
+**Screenshot**: `suite-7/us-7.1-modal-open.png`
+
+---
+
+## US-7.2 — Repaint a sub-range with balanced mode
+
+**Steps**:
+1. Open RepaintModal on a generated clip
+2. Adjust the repaint range slider to select the middle third of the clip
+3. Enter prompt: `energetic drum fill, building intensity`
+4. Leave repaint mode as "Balanced" with strength 0.50
+5. Click "Repaint Selection"
+
+**Expected**:
+- Modal closes
+- A generation job appears in the GenerationPanel with "Repainting..." progress
+- After completion, the clip is updated with the repainted audio
+- Audio outside the repaint region is preserved unchanged
+- The clip's version history contains the previous audio
+
+**Verdict**: human-checkpoint
+**Human prompt**: "A sub-range was repainted. Please play the clip and verify: (1) the repainted section sounds different from before, (2) the audio outside the repaint range sounds unchanged, (3) there are no obvious glitches at the boundaries."
+**Screenshot**: `suite-7/us-7.2-repaint-complete.png`
+
+---
+
+## US-7.3 — Repaint mode: Conservative
+
+**Steps**:
+1. Open RepaintModal on a generated clip
+2. Select the first half of the clip as repaint range
+3. Click "Conservative" mode button
+4. Enter prompt: `subtle variation, same feel`
+5. Generate
+
+**Expected**:
+- Repaint strength slider is hidden (conservative mode has fixed parameters)
+- Generation completes without error
+- The repainted section sounds very close to the original with subtle changes
+
+**Verdict**: human-checkpoint
+**Human prompt**: "Conservative repaint was applied. Does the repainted section sound very similar to the original with only subtle differences?"
+
+---
+
+## US-7.4 — Repaint mode: Aggressive
+
+**Steps**:
+1. Open RepaintModal on a generated clip
+2. Select a sub-range
+3. Click "Aggressive" mode button
+4. Enter prompt: `completely different rhythm, heavy distortion`
+5. Generate
+
+**Expected**:
+- Repaint strength slider is hidden (aggressive mode has fixed parameters)
+- Generation completes without error
+- The repainted section sounds dramatically different from the original
+
+**Verdict**: human-checkpoint
+**Human prompt**: "Aggressive repaint was applied. Does the repainted section sound significantly different from the original?"
+
+---
+
+## US-7.5 — Repaint strength slider in balanced mode
+
+**Steps**:
+1. Open RepaintModal on a generated clip
+2. Ensure "Balanced" mode is selected
+3. Set repaint strength to 0.1
+4. Generate and note the result
+5. Repeat with repaint strength at 0.9
+
+**Expected**:
+- Both generations complete without error
+- Strength 0.1 produces subtle changes (closer to conservative)
+- Strength 0.9 produces dramatic changes (closer to aggressive)
+
+**Verdict**: human-checkpoint
+**Human prompt**: "Two repaints with different strengths (0.1 and 0.9). Does the low-strength version preserve more of the original?"
+
+---
+
+## US-7.6 — Repaint on clip without audio shows warning
+
+**Preconditions**: A clip exists that has NOT been generated yet
+
+**Steps**:
+1. Right-click the ungenerated clip
+2. Select "Repaint Selection"
+
+**Expected**:
+- RepaintModal opens
+- Warning: "No audio generated yet"
+- "Repaint Selection" button is disabled
+
+**Verdict**: automated
+**Screenshot**: `suite-7/us-7.6-no-audio.png`
+
+---
+
+## US-7.7 — Region Regenerate modal
+
+**Preconditions**: Multiple tracks have generated clips that overlap a common time range
+
+**Steps**:
+1. Select a time range on the timeline that overlaps generated clips on multiple tracks
+2. Right-click the selection and choose "Regenerate Region"
+
+**Expected**:
+- `RegionRegenerateModal` opens with title "Regenerate Region"
+- Selected region time range is displayed
+- Affected tracks and clip count are listed
+- Prompt textarea and global caption textarea are visible
+- Generate button shows the count of clips to regenerate
+
+**Verdict**: automated
+**Screenshot**: `suite-7/us-7.7-region-modal.png`
+
+---
+
+## US-7.8 — Region Regenerate execution
+
+**Steps**:
+1. Open RegionRegenerateModal for a region with 2+ overlapping clips
+2. Enter prompt: `more energetic, faster rhythm`
+3. Click "Regenerate N Clips"
+
+**Expected**:
+- Modal closes
+- Generation jobs appear for each affected clip
+- After completion, all affected clips are updated
+- Audio outside the selected region is preserved
+- Version history is saved for each clip before regeneration
+
+**Verdict**: human-checkpoint
+**Human prompt**: "Multiple clips were regenerated in a region. Please play back and verify: (1) the regenerated sections sound different, (2) audio outside the region is unchanged."
+**Screenshot**: `suite-7/us-7.8-region-complete.png`
+
+---
+
+## US-7.9 — Close modals without generating
+
+**Steps**:
+1. Open RepaintModal, press Escape
+2. Open RegionRegenerateModal, press Escape
+
+**Expected**:
+- Both modals close without creating generation jobs
+- No clips are modified
+
+**Verdict**: automated

--- a/tests/gpu-integration/stories/08-mask-modes.md
+++ b/tests/gpu-integration/stories/08-mask-modes.md
@@ -1,0 +1,173 @@
+# Suite 8: Mask Modes (Auto vs Explicit)
+
+> Verdict type: human-checkpoint (audio behavior requires listening)
+> Entry point: AddLayerModal or MultiTrackGenerateModal mask mode toggle
+> Preconditions: Suite 0 passes; a project is open with Stems tracks; ideally some tracks have existing generated audio for context
+
+The mask mode controls how the model handles the generation region within the context window:
+
+- **Auto** (`chunk_mask_mode: 'auto'`): The model decides where each instrument starts and stops. All mask values are set to 2.0. Caption format uses "Mask Control: false".
+- **Explicit** (`chunk_mask_mode: 'explicit'`): The generation region is precisely defined by the 0/1 mask from the select window. Caption format uses "Mask Control: true".
+
+This suite also verifies that chunk vs full mode instructions are sent correctly based on whether the generation covers a sub-range or the full audio duration.
+
+---
+
+## US-8.1 — AddLayer modal shows mask mode toggle
+
+**Steps**:
+1. Right-click on a track lane at a specific time position
+2. Select "Add Layer" from the context menu
+
+**Expected**:
+- `AddLayerModal` opens
+- A mask mode toggle is visible with two options: "Auto (model decides)" and "Explicit (select window only)"
+- Default selection is "Auto"
+
+**Verdict**: automated
+**Screenshot**: `suite-8/us-8.1-mask-toggle.png`
+
+---
+
+## US-8.2 — Generate with Auto mask mode
+
+**Preconditions**: At least one track has existing audio for context
+
+**Steps**:
+1. Open AddLayerModal with a context window that includes existing audio
+2. Ensure mask mode is set to "Auto"
+3. Enter a local description: `melodic guitar riff, blues scale`
+4. Click Generate
+
+**Expected**:
+- Generation completes without error
+- A new clip appears on the timeline
+- The model may have generated audio that extends beyond or starts before the strict select window, as it decides instrument timing autonomously
+
+**Verdict**: human-checkpoint
+**Human prompt**: "Auto mask mode was used. Does the generated audio sound natural in context? The model was free to decide instrument timing."
+**Screenshot**: `suite-8/us-8.2-auto-mask.png`
+
+---
+
+## US-8.3 — Generate with Explicit mask mode
+
+**Preconditions**: At least one track has existing audio for context
+
+**Steps**:
+1. Open AddLayerModal with a context window
+2. Switch mask mode to "Explicit"
+3. Enter a local description: `staccato piano chords`
+4. Click Generate
+
+**Expected**:
+- Generation completes without error
+- A new clip appears on the timeline
+- The generated audio should be precisely within the select window boundaries
+
+**Verdict**: human-checkpoint
+**Human prompt**: "Explicit mask mode was used. Does the generated audio start and stop precisely at the selection boundaries?"
+**Screenshot**: `suite-8/us-8.3-explicit-mask.png`
+
+---
+
+## US-8.4 — MultiTrack modal mask mode toggle
+
+**Steps**:
+1. Drag-select a time range across multiple track lanes
+2. Verify the MultiTrackGenerateModal opens
+
+**Expected**:
+- Mask mode toggle is visible (Auto / Explicit)
+- Default is "Auto"
+
+**Verdict**: automated
+**Screenshot**: `suite-8/us-8.4-multitrack-mask.png`
+
+---
+
+## US-8.5 — MultiTrack generate with Auto mask
+
+**Preconditions**: Some tracks have existing audio in the selected range
+
+**Steps**:
+1. Open MultiTrackGenerateModal for a range with existing context
+2. Ensure mask mode is "Auto"
+3. Check 2-3 tracks, enter descriptions
+4. Generate
+
+**Expected**:
+- All selected tracks generate without error
+- Clips appear in the selected time range
+- The model may have varied instrument timing per track
+
+**Verdict**: human-checkpoint
+**Human prompt**: "Multi-track generation with Auto mask. Do the generated tracks sound musically coherent together?"
+**Screenshot**: `suite-8/us-8.5-multitrack-auto.png`
+
+---
+
+## US-8.6 — MultiTrack generate with Explicit mask
+
+**Steps**:
+1. Open MultiTrackGenerateModal
+2. Switch mask mode to "Explicit"
+3. Check 2-3 tracks, enter descriptions
+4. Generate
+
+**Expected**:
+- All selected tracks generate without error
+- Generated audio is precisely bounded to the selection range
+
+**Verdict**: human-checkpoint
+**Human prompt**: "Multi-track generation with Explicit mask. Does the audio start and stop precisely at the selection boundaries?"
+**Screenshot**: `suite-8/us-8.6-multitrack-explicit.png`
+
+---
+
+## US-8.7 — Chunk mode instruction for sub-range generation
+
+**Preconditions**: A project with total audio duration > 30s
+
+**Steps**:
+1. Open AddLayerModal targeting a sub-range (e.g. 10s-20s within a 60s project)
+2. Generate a clip
+
+**Expected**:
+- The backend receives instruction containing "a segment of the" (chunk mode format)
+- Generation completes without error
+- The generated clip covers the specified sub-range
+
+**Verdict**: automated (inspect network request or backend logs for instruction format)
+
+---
+
+## US-8.8 — Full mode instruction for full-range generation
+
+**Steps**:
+1. Use Batch Generate from Silence (Ctrl+G) to generate a single track
+2. The clip covers the full audio duration (0 to totalDuration)
+
+**Expected**:
+- The backend receives instruction containing "Generate the ... track based on the audio context:" (full mode format, without "a segment of")
+- Generation completes without error
+
+**Verdict**: automated (inspect network request or backend logs for instruction format)
+
+---
+
+## US-8.9 — Batch from silence uses full mode for all tracks
+
+**Steps**:
+1. Start with a fresh project (no clips)
+2. Open Batch Generate from Silence (Ctrl+G)
+3. Check all tracks
+4. Generate
+
+**Expected**:
+- All tracks generate in parallel (silence mode)
+- Each track's request uses the full mode instruction (no "a segment of")
+- All clips span the full audio duration
+
+**Verdict**: automated (verify clip durations and instruction format)
+**Screenshot**: `suite-8/us-8.9-batch-full-mode.png`


### PR DESCRIPTION
## Summary

- Add dedicated `generateRepaintInternal()` pipeline with proper repaint API params (mode, strength, instruction, src_audio_path)
- Add repaint mode selector (conservative/balanced/aggressive) and strength slider to RepaintModal
- Add model capability checks to CoverModal and RepaintModal — show warnings and disable buttons when loaded model doesn't support the task type
- Rename `cover_strength` -> `audio_cover_strength` to match backend API
- Add GPU integration test suites 6-8 (cover, repaint, mask modes — 27 user stories)

## What changed

### API types (`src/types/api.ts`)
- Add `RepaintMode` type (`conservative | balanced | aggressive`)
- Add `repaint_mode`, `repaint_strength`, `instruction`, `src_audio_path` to `RepaintTaskParams`
- Rename `cover_strength` -> `audio_cover_strength` in `CoverTaskParams`
- Add `supported_task_types` to `ModelEntry`

### API service (`src/services/aceStepApi.ts`)
- Cache model inventory from `listModels()` response
- Add `modelSupportsTaskType()` helper for UI capability checks

### Generation pipeline (`src/services/generationPipeline.ts`)
- Add `generateRepaintInternal()` (~200 lines) — dedicated repaint flow with proper API params
- Refactor `generateRepaintClip()` and `regenerateTimelineRegion()` to use `generateRepaintInternal()` instead of piggybacking on `generateClipInternal()`
- Fix `cover_strength` -> `audio_cover_strength` in Vocal2BGM flow

### UI components
- `RepaintModal.tsx` — Add repaint mode buttons, strength slider (balanced mode only), model support warning
- `CoverModal.tsx` — Add model support warning, disable button when unsupported
- `AudioAnalysisPanel.tsx` — Fix `cover_strength` -> `audio_cover_strength`

### GPU integration tests
- Add Suite 6: Cover Generation (9 user stories)
- Add Suite 7: Repaint Generation (9 user stories)
- Add Suite 8: Mask Modes (9 user stories)
- Update README.md and agent-prompt.md with suites 6-8

## Test plan

- [ ] `npx tsc --noEmit` — 0 type errors
- [ ] `npm test` — all pass
- [ ] `npm run build` — succeeds
- [ ] Manual: open RepaintModal, verify mode buttons and strength slider
- [ ] Manual: load a model without cover support, verify CoverModal shows warning

Closes #541
Closes #542

Made with [Cursor](https://cursor.com)