### PR TITLE
fix: align piano roll background with DAW color palette (#554)

### DIFF
--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -200,7 +200,7 @@ export function PianoRoll() {
       data-keyboard-context="pianoRoll"
       role="region"
       tabIndex={0}
-      className="border-t border-[#1a1a1a] bg-[#0a0a1e] flex flex-col select-none shrink-0"
+      className="border-t border-[#1a1a1a] bg-[#1a1a1e] flex flex-col select-none shrink-0"
       style={{ height: pianoRollHeight }}
       onMouseDownCapture={() => setHistoryFocusScope('pianoRoll')}
       onFocusCapture={() => setHistoryFocusScope('pianoRoll')}
@@ -213,7 +213,7 @@ export function PianoRoll() {
         onMouseDown={handleResizeMouseDown}
       />
 
-      <div className="px-3 py-2 border-b border-[#2a2a2a] bg-[#0e0e24] flex items-center gap-2 shrink-0 flex-wrap">
+      <div className="px-3 py-2 border-b border-[#2a2a2a] bg-[#1e1e22] flex items-center gap-2 shrink-0 flex-wrap">
         <div className="text-xs font-medium text-zinc-200">{track.displayName}</div>
 
         {PIANO_ROLL_TOOL_BUTTONS.map(({ tool, label, icon }) => {

--- a/src/components/pianoroll/PianoRollCanvas.tsx
+++ b/src/components/pianoroll/PianoRollCanvas.tsx
@@ -307,7 +307,7 @@ export function PianoRollCanvas({
     const height = rect.height;
     const noteAreaHeight = height - velocityHeight;
 
-    ctx.fillStyle = '#0a0a1e';
+    ctx.fillStyle = '#1a1a1e';
     ctx.fillRect(0, 0, width, height);
 
     drawPianoRollKeyboard({

--- a/tests/unit/pianoRollBackground.test.tsx
+++ b/tests/unit/pianoRollBackground.test.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PianoRoll } from '../../src/components/pianoroll/PianoRoll';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useUIStore } from '../../src/store/uiStore';
+import { useTransportStore } from '../../src/store/transportStore';
+
+vi.mock('../../src/hooks/useAudioImport', () => ({
+  useAudioImport: () => ({
+    importAudioFileAsSampler: vi.fn(),
+    importAssetAsQuickSampler: vi.fn(),
+    openSamplerFilePicker: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/components/pianoroll/PianoRollCanvas', () => ({
+  PianoRollCanvas: () => <div aria-label="Piano roll canvas stub">canvas</div>,
+}));
+
+vi.mock('../../src/components/pianoroll/QuickSamplerEditor', () => ({
+  QuickSamplerEditor: () => <div>sampler</div>,
+}));
+
+vi.mock('../../src/components/pianoroll/GeneratePatternDialog', () => ({
+  GeneratePatternDialog: () => null,
+}));
+
+vi.mock('../../src/components/pianoroll/QuantizeDialog', () => ({
+  QuantizeDialog: () => null,
+}));
+
+vi.mock('../../src/components/pianoroll/TransformMenu', () => ({
+  TransformMenu: () => <div>transform</div>,
+}));
+
+describe('Piano roll background colors (#554)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useUIStore.setState(useUIStore.getInitialState(), true);
+    useTransportStore.setState(useTransportStore.getInitialState(), true);
+
+    useProjectStore.getState().createProject({ name: 'BG Test' });
+    const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+    const clip = useProjectStore.getState().ensureMidiClip(track.id);
+    useUIStore.getState().setOpenPianoRoll(track.id, clip.id);
+  });
+
+  it('uses neutral gray background (#1a1a1e) on the container instead of dark blue (#0a0a1e)', () => {
+    render(<PianoRoll />);
+    const container = screen.getByRole('region');
+    // The container should have the neutral gray background class, not the old dark blue
+    expect(container.className).toContain('bg-[#1a1a1e]');
+    expect(container.className).not.toContain('bg-[#0a0a1e]');
+  });
+
+  it('uses neutral gray background (#1e1e22) on the toolbar instead of dark blue (#0e0e24)', () => {
+    render(<PianoRoll />);
+    const container = screen.getByRole('region');
+    // The toolbar is the first div with border-b inside the container (after the resize handle)
+    const toolbar = container.querySelector('.border-b');
+    expect(toolbar).not.toBeNull();
+    expect(toolbar!.className).toContain('bg-[#1e1e22]');
+    expect(toolbar!.className).not.toContain('bg-[#0e0e24]');
+  });
+});
+
+describe('PianoRollCanvas background fill', () => {
+  it('uses neutral gray (#1a1a1e) as the canvas background fill color', async () => {
+    // Verify the source code uses the correct color by importing the module
+    // We read the actual source to confirm the canvas fill color
+    const source = await import('../../src/components/pianoroll/PianoRollCanvas?raw');
+    const code = typeof source === 'string' ? source : source.default;
+    expect(code).toContain("'#1a1a1e'");
+    expect(code).not.toContain("'#0a0a1e'");
+  });
+});


### PR DESCRIPTION
## Summary
- Changed piano roll container background from `#0a0a1e` (dark blue-black) to `#1a1a1e` (neutral dark gray with very subtle blue tint)
- Changed piano roll toolbar background from `#0e0e24` to `#1e1e22` to match
- Changed canvas fill color from `#0a0a1e` to `#1a1a1e` for consistency
- Note colors (blue-to-pink gradient) and grid line tints are preserved as-is

Closes #554

## Test plan
- [x] Unit test verifies container uses `bg-[#1a1a1e]` instead of `bg-[#0a0a1e]`
- [x] Unit test verifies toolbar uses `bg-[#1e1e22]` instead of `bg-[#0e0e24]`
- [x] Unit test verifies canvas source code uses `#1a1a1e` fill color
- [x] All 1654 existing tests pass
- [x] TypeScript check passes with 0 errors
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)