### PR TITLE
feat: add timeline empty state with quick-start guidance

### DIFF
--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -14,6 +14,7 @@ import { useAudioImport } from '../../hooks/useAudioImport';
 import { Minimap } from './Minimap';
 import { TempoLane } from './TempoLane';
 import { ArrangementMarkers } from './ArrangementMarkers';
+import { TimelineEmptyState } from './TimelineEmptyState';
 import { toastInfo } from '../../hooks/useToast';
 import { getTimelineFitViewport } from '../../utils/timelineZoom';
 
@@ -568,11 +569,7 @@ export function Timeline() {
               <TrackLane key={track.id} track={track} />
             ))}
 
-            {sortedTracks.length === 0 && (
-              <div className="flex items-center justify-center h-32 text-zinc-600 text-xs">
-                Add a track to begin
-              </div>
-            )}
+            <TimelineEmptyState />
 
             {/* Inline AI suggestion badges */}
             {suggestionFrequency !== 'off' && inlineSuggestions.map((s) => (

--- a/src/components/timeline/TimelineEmptyState.tsx
+++ b/src/components/timeline/TimelineEmptyState.tsx
@@ -1,0 +1,63 @@
+import { useProjectStore } from '../../store/projectStore';
+
+const EMPTY_STATE_THRESHOLD = 3;
+
+export function TimelineEmptyState() {
+  const tracks = useProjectStore((s) => s.project?.tracks ?? []);
+  const addTrack = useProjectStore((s) => s.addTrack);
+
+  if (tracks.length >= EMPTY_STATE_THRESHOLD) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="timeline-empty-state"
+      className="flex flex-col items-center justify-center gap-4 py-16 mx-6 my-4 border-2 border-dashed border-zinc-700/40 rounded-xl"
+    >
+      {/* Music note icon */}
+      <svg
+        className="w-10 h-10 text-zinc-600"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M9 18V5l12-2v13" />
+        <circle cx="6" cy="18" r="3" />
+        <circle cx="18" cy="16" r="3" />
+      </svg>
+
+      <p className="text-zinc-500 text-sm">
+        Drop audio files here or add a track to get started
+      </p>
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          className="bg-daw-surface-2 hover:bg-daw-surface-3 rounded-lg px-4 py-2 text-zinc-300 text-xs transition-colors"
+          onClick={() => addTrack('custom', 'stems')}
+        >
+          Add Stems Track
+        </button>
+        <button
+          type="button"
+          className="bg-daw-surface-2 hover:bg-daw-surface-3 rounded-lg px-4 py-2 text-zinc-300 text-xs transition-colors"
+          onClick={() => addTrack('custom', 'sample')}
+        >
+          Add Sample Track
+        </button>
+        <button
+          type="button"
+          className="bg-daw-surface-2 hover:bg-daw-surface-3 rounded-lg px-4 py-2 text-zinc-300 text-xs transition-colors"
+          onClick={() => addTrack('custom', 'sequencer')}
+        >
+          Add Sequencer
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/timeline/__tests__/TimelineEmptyState.test.tsx
+++ b/src/components/timeline/__tests__/TimelineEmptyState.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TimelineEmptyState } from '../TimelineEmptyState';
+import { useProjectStore } from '../../../store/projectStore';
+
+// Mock projectStorage to avoid browser API issues
+vi.mock('../../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('TimelineEmptyState', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+  });
+
+  it('renders the empty state message', () => {
+    render(<TimelineEmptyState />);
+    expect(
+      screen.getByText(/drop audio files here or add a track to get started/i),
+    ).toBeDefined();
+  });
+
+  it('renders quick-action buttons for stems, sample, and sequencer', () => {
+    render(<TimelineEmptyState />);
+    expect(screen.getByRole('button', { name: /add stems track/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /add sample track/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /add sequencer/i })).toBeDefined();
+  });
+
+  it('calls addTrack with correct type when "Add Stems Track" is clicked', () => {
+    const addTrack = vi.spyOn(useProjectStore.getState(), 'addTrack');
+    render(<TimelineEmptyState />);
+    fireEvent.click(screen.getByRole('button', { name: /add stems track/i }));
+    expect(addTrack).toHaveBeenCalledWith('custom', 'stems');
+    addTrack.mockRestore();
+  });
+
+  it('calls addTrack with correct type when "Add Sample Track" is clicked', () => {
+    const addTrack = vi.spyOn(useProjectStore.getState(), 'addTrack');
+    render(<TimelineEmptyState />);
+    fireEvent.click(screen.getByRole('button', { name: /add sample track/i }));
+    expect(addTrack).toHaveBeenCalledWith('custom', 'sample');
+    addTrack.mockRestore();
+  });
+
+  it('calls addTrack with correct type when "Add Sequencer" is clicked', () => {
+    const addTrack = vi.spyOn(useProjectStore.getState(), 'addTrack');
+    render(<TimelineEmptyState />);
+    fireEvent.click(screen.getByRole('button', { name: /add sequencer/i }));
+    expect(addTrack).toHaveBeenCalledWith('custom', 'sequencer');
+    addTrack.mockRestore();
+  });
+
+  it('has a dashed border drop zone', () => {
+    render(<TimelineEmptyState />);
+    const container = screen.getByTestId('timeline-empty-state');
+    expect(container.className).toContain('border-dashed');
+  });
+
+  it('is not visible when there are 3 or more tracks', () => {
+    // Add 3 tracks
+    const store = useProjectStore.getState();
+    store.addTrack('custom', 'stems');
+    store.addTrack('custom', 'sample');
+    store.addTrack('custom', 'sequencer');
+
+    const { container } = render(<TimelineEmptyState />);
+    // Component should render nothing when 3+ tracks exist
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('is visible when there are fewer than 3 tracks', () => {
+    // Add 1 track
+    useProjectStore.getState().addTrack('custom', 'stems');
+
+    render(<TimelineEmptyState />);
+    expect(
+      screen.getByText(/drop audio files here or add a track to get started/i),
+    ).toBeDefined();
+  });
+
+  it('is visible when there are 0 tracks', () => {
+    render(<TimelineEmptyState />);
+    expect(
+      screen.getByText(/drop audio files here or add a track to get started/i),
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #545: Empty state shows no guidance when project has few tracks
- Adds a new `TimelineEmptyState` component that renders when the project has fewer than 3 tracks
- Displays a centered music note icon, guidance text ("Drop audio files here or add a track to get started"), and quick-action buttons for Stems, Sample, and Sequencer tracks
- Includes a dashed border drop zone to hint at drag-and-drop support
- Component automatically hides once 3+ tracks exist

## Test plan
- [x] 9 unit tests covering: rendering, button actions calling correct store methods, visibility threshold (0/1/3+ tracks), dashed border styling
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm test` passes (1660 tests, 0 failures)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)