### PR TITLE
fix: clean up StatusBar — remove redundancy, improve readability

### DIFF
--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -7,6 +7,11 @@ const HEALTH_POLL_INTERVAL_MS = 10_000;
 
 let lastKnownBackendConnection = false;
 
+/** @internal Reset module state for tests */
+export function _resetLastKnownConnection() {
+  lastKnownBackendConnection = false;
+}
+
 export function StatusBar() {
   const [connected, setConnected] = useState(lastKnownBackendConnection);
   const jobs = useGenerationStore((s) => s.jobs);
@@ -39,34 +44,28 @@ export function StatusBar() {
     };
   }, []);
 
+  const jobCount = activeJobs.length;
+  const jobLabel = jobCount === 1 ? '1 job' : `${jobCount} jobs`;
+
   return (
-    <div className="flex items-center h-5 px-3 gap-4 bg-gradient-to-b from-[#2a2a2a] to-[#232323] border-t border-[#1a1a1a] text-[10px] text-zinc-400">
-      <div className="flex items-center gap-1.5">
+    <div className="flex items-center h-6 px-3 gap-3 bg-gradient-to-b from-[#2a2a2a] to-[#232323] border-t border-[#1a1a1a] text-[10px] text-zinc-400">
+      <div
+        className="flex items-center"
+        title={connected ? 'Backend connected' : 'Backend offline'}
+      >
         <div className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-emerald-500' : 'bg-red-500'}`} />
-        <span>{connected ? 'Connected' : 'Offline'}</span>
       </div>
       {model && <span className="text-zinc-400">{model}</span>}
       {activeJobs.length > 0 && (
-        <span className="text-daw-accent">
-          Generating: {activeJobs.length}
-          {primaryJob ? ` • ${primaryJob.trackName} • ${primaryJob.stage ?? primaryJob.progress}${primaryJob.progressPercent != null ? ` ${Math.round(primaryJob.progressPercent)}%` : ''}` : ''}
-        </span>
-      )}
-      {primaryJob && (
-        <span className="truncate text-zinc-500">
-          {primaryJob.trackName}: {primaryJob.stage ?? primaryJob.status} {Math.round(primaryJob.progressPercent ?? 0)}%
+        <span className="text-daw-accent truncate">
+          Generating: {primaryJob?.trackName ?? 'unknown'}
+          {primaryJob?.stage ? ` \u2022 ${primaryJob.stage}` : ''}
+          {primaryJob?.progressPercent != null ? ` ${Math.round(primaryJob.progressPercent)}%` : ''}
+          {' '}({jobLabel})
         </span>
       )}
       <span className="flex-1" />
-      <a
-        href="http://acestudio.ai/"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="flex items-center gap-1 text-zinc-400 hover:text-daw-accent transition-colors"
-      >
-        <img src="/logo.png" alt="" width={12} height={12} className="rounded-sm opacity-50" />
-        ACE Studio
-      </a>
+      <img src="/logo.png" alt="" width={12} height={12} className="rounded-sm opacity-30" />
     </div>
   );
 }

--- a/tests/unit/StatusBar.test.tsx
+++ b/tests/unit/StatusBar.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
-import { StatusBar } from '../../src/components/layout/StatusBar';
+import { StatusBar, _resetLastKnownConnection } from '../../src/components/layout/StatusBar';
 import { useGenerationStore } from '../../src/store/generationStore';
 import { useProjectStore } from '../../src/store/projectStore';
 
@@ -16,6 +16,7 @@ describe('StatusBar', () => {
     vi.clearAllMocks();
     useGenerationStore.setState(useGenerationStore.getInitialState(), true);
     useProjectStore.setState(useProjectStore.getInitialState(), true);
+    _resetLastKnownConnection();
   });
 
   it('delays the first health probe until the polling window', async () => {
@@ -23,7 +24,8 @@ describe('StatusBar', () => {
 
     render(<StatusBar />);
 
-    expect(screen.getByText('Offline')).toBeInTheDocument();
+    // After the fix, there should be no "Offline" text — only a dot with title
+    expect(screen.queryByText('Offline')).not.toBeInTheDocument();
     expect(healthCheckMock).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -35,5 +37,146 @@ describe('StatusBar', () => {
       await vi.advanceTimersByTimeAsync(1);
     });
     expect(healthCheckMock).toHaveBeenCalledTimes(1);
+  });
+
+  describe('height', () => {
+    it('uses h-6 (24px) instead of h-5 (20px)', () => {
+      healthCheckMock.mockResolvedValue(false);
+      const { container } = render(<StatusBar />);
+      const bar = container.firstElementChild as HTMLElement;
+      expect(bar.className).toContain('h-6');
+      expect(bar.className).not.toContain('h-5');
+    });
+  });
+
+  describe('connection status', () => {
+    it('does not render "Connected" or "Offline" text', () => {
+      healthCheckMock.mockResolvedValue(false);
+      render(<StatusBar />);
+      expect(screen.queryByText('Connected')).not.toBeInTheDocument();
+      expect(screen.queryByText('Offline')).not.toBeInTheDocument();
+    });
+
+    it('renders a dot with title="Backend offline" when disconnected', () => {
+      healthCheckMock.mockResolvedValue(false);
+      render(<StatusBar />);
+      const dotContainer = screen.getByTitle('Backend offline');
+      expect(dotContainer).toBeInTheDocument();
+    });
+
+    it('renders a dot with title="Backend connected" when connected', async () => {
+      healthCheckMock.mockResolvedValue(true);
+      render(<StatusBar />);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      const dotContainer = screen.getByTitle('Backend connected');
+      expect(dotContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('spacing', () => {
+    it('uses gap-3 instead of gap-4', () => {
+      healthCheckMock.mockResolvedValue(false);
+      const { container } = render(<StatusBar />);
+      const bar = container.firstElementChild as HTMLElement;
+      expect(bar.className).toContain('gap-3');
+      expect(bar.className).not.toContain('gap-4');
+    });
+  });
+
+  describe('branding', () => {
+    it('does not render "ACE Studio" text link', () => {
+      healthCheckMock.mockResolvedValue(false);
+      render(<StatusBar />);
+      expect(screen.queryByText('ACE Studio')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('job info', () => {
+    it('does not render the duplicate primaryJob span', () => {
+      healthCheckMock.mockResolvedValue(false);
+      useGenerationStore.setState({
+        jobs: [
+          {
+            id: 'job-1',
+            clipId: 'clip-1',
+            trackName: 'My Track',
+            status: 'generating',
+            progress: 'generating',
+            stage: 'Rendering',
+            progressPercent: 42,
+            lastUpdatedAt: Date.now(),
+          },
+        ],
+      });
+
+      render(<StatusBar />);
+
+      // The old duplicate span showed "My Track: Rendering 42%"
+      // It should not exist anymore
+      const duplicateSpans = screen.queryAllByText(/My Track: Rendering 42%/);
+      expect(duplicateSpans).toHaveLength(0);
+    });
+
+    it('renders combined job info with track name, stage, percent, and job count', () => {
+      healthCheckMock.mockResolvedValue(false);
+      useGenerationStore.setState({
+        jobs: [
+          {
+            id: 'job-1',
+            clipId: 'clip-1',
+            trackName: 'My Track',
+            status: 'generating',
+            progress: 'generating',
+            stage: 'Rendering',
+            progressPercent: 42,
+            lastUpdatedAt: Date.now(),
+          },
+        ],
+      });
+
+      render(<StatusBar />);
+
+      // Should show the new combined format
+      expect(screen.getByText(/Generating:.*My Track/)).toBeInTheDocument();
+      expect(screen.getByText(/Rendering/)).toBeInTheDocument();
+      expect(screen.getByText(/42%/)).toBeInTheDocument();
+      expect(screen.getByText(/1 job/)).toBeInTheDocument();
+    });
+
+    it('renders plural "jobs" when multiple active', () => {
+      healthCheckMock.mockResolvedValue(false);
+      useGenerationStore.setState({
+        jobs: [
+          {
+            id: 'job-1',
+            clipId: 'clip-1',
+            trackName: 'Track A',
+            status: 'generating',
+            progress: 'generating',
+            stage: 'Rendering',
+            progressPercent: 50,
+            lastUpdatedAt: Date.now(),
+          },
+          {
+            id: 'job-2',
+            clipId: 'clip-2',
+            trackName: 'Track B',
+            status: 'queued',
+            progress: 'queued',
+            stage: null,
+            progressPercent: 0,
+            lastUpdatedAt: Date.now() + 1,
+          },
+        ],
+      });
+
+      render(<StatusBar />);
+
+      expect(screen.getByText(/2 jobs/)).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #551 — StatusBar had wasted space and redundant information.

- **Height**: Changed from `h-5` (20px) to `h-6` (24px) for better readability
- **Connection status**: Removed "Connected"/"Offline" text; kept only the colored dot with a `title` attribute for accessibility (`Backend connected` / `Backend offline`)
- **Job info**: Removed duplicate `primaryJob` span; consolidated into a single line: `Generating: {trackName} . {stage} {percent}% ({N} jobs)`
- **Branding**: Removed "ACE Studio" text link; kept only a subtle logo at opacity-30
- **Spacing**: Changed from `gap-4` to `gap-3` for tighter layout

## Test plan

- [x] 10 unit tests covering all changes (height, connection dot title, no text labels, spacing, branding removal, job info format, plural jobs)
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] All 1660 unit tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)