### PR TITLE
feat: add hover and active feedback to timeline clips

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -536,6 +536,9 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       <div
         ref={clipBlockRef}
         className={`absolute top-1 bottom-1 rounded-md select-none overflow-hidden
+          transition-[filter,box-shadow] duration-100
+          hover:brightness-110 hover:ring-1 hover:ring-white/10
+          active:brightness-95
           ${clip.muted ? 'opacity-30 pointer-events-none' : (statusStyles[clip.generationStatus] ?? '')}
           ${isSelected ? 'ring-2 ring-offset-1 ring-offset-transparent' : ''}
           ${dragGhost && dragGhost.targetTrackId && !dragGhost.isShiftCopy ? 'opacity-0' : ''}
@@ -557,8 +560,12 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         onMouseMove={handleMouseMoveLocal}
         onContextMenu={handleContextMenu}
       >
-        <div className="absolute top-0 bottom-0 left-0 w-[10px] cursor-col-resize z-10" />
-        <div className="absolute top-0 bottom-0 right-0 w-[10px] cursor-col-resize z-10" />
+        <div className="absolute top-0 bottom-0 left-0 w-[10px] cursor-col-resize z-10 group/resize-left" data-testid="resize-handle-left">
+          <div className="absolute top-0 bottom-0 left-0 w-[2px] bg-white/0 group-hover/resize-left:bg-white/20 transition-colors duration-100" data-testid="resize-indicator-left" />
+        </div>
+        <div className="absolute top-0 bottom-0 right-0 w-[10px] cursor-col-resize z-10 group/resize-right" data-testid="resize-handle-right">
+          <div className="absolute top-0 bottom-0 right-0 w-[2px] bg-white/0 group-hover/resize-right:bg-white/20 transition-colors duration-100" data-testid="resize-indicator-right" />
+        </div>
 
         <ClipWaveform
           peaks={peaks}

--- a/tests/unit/clipBlockHover.test.tsx
+++ b/tests/unit/clipBlockHover.test.tsx
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ClipBlock } from '../../src/components/timeline/ClipBlock';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useUIStore } from '../../src/store/uiStore';
+import type { Clip, Track } from '../../src/types/project';
+
+// Mock heavy child components to keep the test fast
+vi.mock('../../src/components/timeline/ClipContextMenu', () => ({
+  ClipContextMenu: () => null,
+}));
+vi.mock('../../src/components/timeline/ClipWaveform', () => ({
+  ClipWaveform: () => <div data-testid="clip-waveform" />,
+  ClipMidiThumbnail: () => <div data-testid="clip-midi-thumbnail" />,
+}));
+vi.mock('../../src/components/timeline/ClipGainEnvelope', () => ({
+  ClipGainEnvelope: () => null,
+}));
+vi.mock('../../src/components/timeline/ClipWarpMarkers', () => ({
+  ClipWarpMarkers: () => null,
+}));
+vi.mock('../../src/components/timeline/ClipStatusOverlay', () => ({
+  ClipStatusOverlay: () => null,
+}));
+vi.mock('../../src/components/generation/AddLayerModal', () => ({
+  AddLayerModal: () => null,
+}));
+vi.mock('../../src/services/generationPipeline', () => ({
+  regenerateClip: vi.fn(),
+}));
+vi.mock('../../src/hooks/useGeneration', () => ({
+  useGeneration: () => ({ generateClip: vi.fn() }),
+}));
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+const makeClip = (overrides?: Partial<Clip>): Clip => ({
+  id: 'clip-1',
+  trackId: 'track-1',
+  startTime: 0,
+  duration: 4,
+  prompt: 'Test clip',
+  lyrics: '',
+  generationStatus: 'ready',
+  generationJobId: null,
+  cumulativeMixKey: null,
+  isolatedAudioKey: 'some-audio-key',
+  waveformPeaks: [0.1, 0.5, 0.3],
+  ...overrides,
+});
+
+const makeTrack = (overrides?: Partial<Track>): Track => ({
+  id: 'track-1',
+  displayName: 'Track 1',
+  trackName: 'guitar',
+  trackType: 'stems',
+  color: '#4488ff',
+  volume: 0.8,
+  pan: 0,
+  mute: false,
+  solo: false,
+  clips: [],
+  effects: [],
+  sends: [],
+  armed: false,
+  inputMonitoring: 'off',
+  ...overrides,
+} as Track);
+
+describe('ClipBlock hover and active feedback', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useUIStore.setState(useUIStore.getInitialState(), true);
+    useProjectStore.getState().createProject({ name: 'Hover Test' });
+  });
+
+  it('renders clip container with hover and active transition classes', () => {
+    const clip = makeClip();
+    const track = makeTrack();
+
+    render(<ClipBlock clip={clip} track={track} />);
+
+    const clipEl = screen.getByTestId(`clip-${clip.id}`);
+    const classList = clipEl.className;
+
+    // Hover state: brightness boost or ring
+    expect(classList).toMatch(/hover:/);
+    // Active state: brightness change
+    expect(classList).toMatch(/active:/);
+    // Smooth CSS transition
+    expect(classList).toMatch(/transition/);
+  });
+
+  it('renders resize edge handles with visual indicator elements', () => {
+    const clip = makeClip();
+    const track = makeTrack();
+
+    render(<ClipBlock clip={clip} track={track} />);
+
+    // There should be resize edge handle elements with visual indicators
+    const leftHandle = screen.getByTestId('resize-handle-left');
+    const rightHandle = screen.getByTestId('resize-handle-right');
+
+    expect(leftHandle).toBeInTheDocument();
+    expect(rightHandle).toBeInTheDocument();
+
+    // Each handle should contain a visual line indicator
+    const leftLine = leftHandle.querySelector('[data-testid="resize-indicator-left"]');
+    const rightLine = rightHandle.querySelector('[data-testid="resize-indicator-right"]');
+
+    expect(leftLine).toBeInTheDocument();
+    expect(rightLine).toBeInTheDocument();
+  });
+
+  it('does not interfere with selection ring when clip is selected', () => {
+    const clip = makeClip();
+    const track = makeTrack();
+
+    // Select the clip
+    useUIStore.getState().selectClip(clip.id, false);
+
+    render(<ClipBlock clip={clip} track={track} />);
+
+    const clipEl = screen.getByTestId(`clip-${clip.id}`);
+
+    // Selected clip should still have ring-2
+    expect(clipEl.className).toContain('ring-2');
+    // And hover/active classes should still be present
+    expect(clipEl.className).toMatch(/hover:/);
+    expect(clipEl.className).toMatch(/active:/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds hover state (`hover:brightness-110`, `hover:ring-1 hover:ring-white/10`) to clip containers for visual feedback on mouseover
- Adds active/mousedown state (`active:brightness-95`) for click feedback
- Resize edge handles (left/right 10px zones) now show a 2px white line indicator on hover via Tailwind group hover
- All transitions are smooth via `transition-[filter,box-shadow] duration-100`
- Existing selection ring (blue `ring-2`) is unaffected by hover/active states

Closes #552

## Test plan
- [x] Unit tests verify hover/active CSS classes are present on clip container
- [x] Unit tests verify resize handle elements with visual indicators render correctly
- [x] Unit tests verify selection ring coexists with hover/active classes
- [x] All 1654 existing tests pass
- [x] TypeScript check passes with 0 errors
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)