### PR TITLE
fix: add distinctive font pair for DAW visual identity

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>ACE-Step DAW</title>
   </head>
   <body class="bg-zinc-950 text-zinc-100">

--- a/src/components/transport/TempoDisplay.tsx
+++ b/src/components/transport/TempoDisplay.tsx
@@ -22,7 +22,7 @@ export function TempoDisplay() {
 
   return (
     <div className="flex items-center gap-2 text-xs text-zinc-400">
-      <span className="font-medium text-zinc-300">
+      <span className="font-mono font-medium text-zinc-300">
         {currentBpm} BPM
         {hasTempoMap && currentBpm !== bpm && (
           <span className="text-amber-400/60 ml-0.5" title={`Project default: ${bpm} BPM`}>*</span>

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 
 @theme {
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
   --color-daw-bg: #1e1e1e;
   --color-daw-surface: #2d2d2d;
   --color-daw-surface-2: #3c3c3c;
@@ -29,7 +31,7 @@
 body {
   margin: 0;
   overflow: hidden;
-  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/tests/unit/customFonts.test.tsx
+++ b/tests/unit/customFonts.test.tsx
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Toolbar } from '../../src/components/layout/Toolbar';
+import { TempoDisplay } from '../../src/components/transport/TempoDisplay';
+import { TimeDisplay } from '../../src/components/transport/TimeDisplay';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useUIStore } from '../../src/store/uiStore';
+import { useTransportStore } from '../../src/store/transportStore';
+
+// Mock external dependencies (same as toolbarHierarchy test)
+vi.mock('../../src/store/collaborationStore', () => ({
+  useCollaborationStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({
+      setShowShareDialog: vi.fn(),
+      isViewerMode: false,
+    }),
+}));
+
+vi.mock('../../src/hooks/useAudioImport', () => ({
+  useAudioImport: () => ({ openFilePicker: vi.fn() }),
+}));
+
+vi.mock('../../src/hooks/useTransport', () => ({
+  useTransport: () => ({
+    isPlaying: false,
+    play: vi.fn(),
+    pause: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useRecording', () => ({
+  useRecording: () => ({ toggleRecord: vi.fn() }),
+}));
+
+vi.mock('../../src/services/midiCaptureService', () => ({
+  getMidiCaptureService: vi.fn(),
+}));
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('Custom fonts (#549)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useUIStore.setState(useUIStore.getInitialState(), true);
+    useTransportStore.setState(useTransportStore.getInitialState(), true);
+    useProjectStore.getState().createProject({ name: 'Font Test' });
+  });
+
+  describe('LCD Display uses monospace font', () => {
+    it('applies font-mono class to bars/beats display in toolbar LCD', () => {
+      const { container } = render(<Toolbar />);
+      const lcdContainer = container.querySelector('.gb-lcd');
+      expect(lcdContainer).toBeInTheDocument();
+      // All text spans inside LCD should use font-mono
+      const monoSpans = lcdContainer!.querySelectorAll('.font-mono');
+      expect(monoSpans.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('TempoDisplay uses monospace font for BPM', () => {
+    it('applies font-mono class to the BPM value', () => {
+      render(<TempoDisplay />);
+      const bpmElement = screen.getByText(/BPM/);
+      expect(bpmElement.className).toContain('font-mono');
+    });
+  });
+
+  describe('TimeDisplay uses monospace font', () => {
+    it('applies font-mono class to the time display container', () => {
+      render(<TimeDisplay />);
+      const timeContainer = document.querySelector('.font-mono');
+      expect(timeContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('Google Fonts are configured in index.html', () => {
+    it('index.html includes Google Fonts link for Inter and JetBrains Mono', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const indexPath = path.resolve(__dirname, '../../index.html');
+      const html = fs.readFileSync(indexPath, 'utf-8');
+      expect(html).toContain('fonts.googleapis.com');
+      expect(html).toContain('Inter');
+      expect(html).toContain('JetBrains+Mono');
+    });
+  });
+
+  describe('CSS configures font families', () => {
+    it('index.css sets Inter as the body font family', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const cssPath = path.resolve(__dirname, '../../src/index.css');
+      const css = fs.readFileSync(cssPath, 'utf-8');
+      expect(css).toContain("font-family: 'Inter'");
+    });
+
+    it('index.css sets JetBrains Mono as the mono font via theme', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const cssPath = path.resolve(__dirname, '../../src/index.css');
+      const css = fs.readFileSync(cssPath, 'utf-8');
+      expect(css).toContain("--font-mono: 'JetBrains Mono'");
+    });
+
+    it('index.css sets Inter as the sans font via theme', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const cssPath = path.resolve(__dirname, '../../src/index.css');
+      const css = fs.readFileSync(cssPath, 'utf-8');
+      expect(css).toContain("--font-sans: 'Inter'");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds **Inter** as the default body/UI font and **JetBrains Mono** as the monospace display font, loaded via Google Fonts CDN
- Configures Tailwind v4 theme `--font-sans` and `--font-mono` custom properties so all `font-sans` and `font-mono` utility classes resolve to the new fonts
- Applies `font-mono` to TempoDisplay BPM value for consistency with other data displays (LCD, time display already use `font-mono`)
- Adds 7 unit tests verifying font class application and CSS/HTML configuration

## Details
- **Display/data font**: JetBrains Mono -- technical, precise look for BPM, time codes, bar/beat counters
- **Body/UI font**: Inter -- highly legible at small sizes, professional feel for labels and controls
- Fonts load via Google Fonts CDN with `display=swap` for zero layout shift
- Fallback stacks preserved for offline/slow-load scenarios

Closes #549

## Test plan
- [x] `npx tsc --noEmit` -- 0 type errors
- [x] `npm test` -- 1700 tests pass (177 files)
- [x] `npm run build` -- succeeds
- [ ] Visual check: LCD display, BPM, time display show JetBrains Mono
- [ ] Visual check: all other UI text renders in Inter

🤖 Generated with [Claude Code](https://claude.com/claude-code)