### PR TITLE
fix: improve minimap contrast and viewport indicator (#559)

### DIFF
--- a/src/components/timeline/Minimap.tsx
+++ b/src/components/timeline/Minimap.tsx
@@ -2,19 +2,35 @@
  * Minimap.tsx — Project overview strip at top of timeline.
  * Shows all tracks and clips as colored blocks. Click to navigate.
  */
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useEffect, useState } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { TIMELINE_MINIMAP_HEIGHT } from './timelineLayout';
 
-const TRACK_ROW_HEIGHT = 4;
+const TRACK_ROW_HEIGHT = 6;
 const TRACK_GAP = 1;
 
 export function Minimap() {
   const project = useProjectStore((s) => s.project);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
-  const setPixelsPerSecond = useUIStore((s) => s.setPixelsPerSecond);
+  const scrollX = useUIStore((s) => s.scrollX);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [viewportWidthPx, setViewportWidthPx] = useState(0);
+
+  // Observe the scroll container width so the viewport indicator stays accurate
+  useEffect(() => {
+    const scrollContainer = containerRef.current?.parentElement?.querySelector(
+      '.overflow-auto',
+    ) as HTMLElement | null;
+    if (!scrollContainer) return;
+
+    const update = () => setViewportWidthPx(scrollContainer.clientWidth);
+    update();
+
+    const ro = new ResizeObserver(update);
+    ro.observe(scrollContainer);
+    return () => ro.disconnect();
+  }, []);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -41,8 +57,12 @@ export function Minimap() {
   return (
     <div
       ref={containerRef}
-      className="relative bg-[#1a1a1a] border-b border-[#333] cursor-pointer select-none"
-      style={{ height: TIMELINE_MINIMAP_HEIGHT }}
+      className="relative cursor-pointer select-none"
+      style={{
+        height: TIMELINE_MINIMAP_HEIGHT,
+        background: 'linear-gradient(to bottom, #111111, #161616)',
+        borderBottom: '1px solid #444',
+      }}
       onClick={handleClick}
       title="Click to navigate"
       data-testid="timeline-minimap"
@@ -58,12 +78,13 @@ export function Minimap() {
                 <div
                   key={clip.id}
                   className="absolute rounded-[1px]"
+                  data-testid="minimap-clip"
                   style={{
                     left,
                     width,
                     height: TRACK_ROW_HEIGHT,
                     backgroundColor: track.color,
-                    opacity: clip.generationStatus === 'ready' ? 0.8 : 0.4,
+                    opacity: clip.generationStatus === 'ready' ? 1.0 : 0.6,
                   }}
                 />
               );
@@ -73,7 +94,12 @@ export function Minimap() {
       </div>
 
       {/* Viewport indicator — shows which portion of the timeline is currently visible */}
-      <ViewportIndicator totalDuration={totalDur} pixelsPerSecond={pixelsPerSecond} />
+      <ViewportIndicator
+        totalDuration={totalDur}
+        pixelsPerSecond={pixelsPerSecond}
+        scrollX={scrollX}
+        viewportWidthPx={viewportWidthPx}
+      />
     </div>
   );
 }
@@ -81,15 +107,54 @@ export function Minimap() {
 function ViewportIndicator({
   totalDuration,
   pixelsPerSecond,
+  scrollX,
+  viewportWidthPx,
 }: {
   totalDuration: number;
   pixelsPerSecond: number;
+  scrollX: number;
+  viewportWidthPx: number;
 }) {
-  // We'd need a ref to the scroll container to calculate viewport.
-  // For now, show a subtle gradient indicating the overview is navigable.
+  const totalWidthPx = totalDuration * pixelsPerSecond;
+  if (totalWidthPx <= 0) return null;
+
+  const leftFraction = Math.max(0, scrollX / totalWidthPx);
+  const widthFraction = Math.min(1 - leftFraction, viewportWidthPx / totalWidthPx);
+
+  const leftPercent = `${leftFraction * 100}%`;
+  const widthPercent = `${widthFraction * 100}%`;
+
   return (
-    <div className="absolute inset-0 pointer-events-none">
-      <div className="absolute left-0 top-0 bottom-0 w-1 bg-daw-accent/40 rounded" />
+    <div className="absolute inset-0 pointer-events-none" data-testid="minimap-viewport">
+      {/* Dimmed regions outside the viewport */}
+      <div
+        className="absolute top-0 bottom-0 left-0"
+        style={{
+          width: leftPercent,
+          backgroundColor: 'rgba(0, 0, 0, 0.45)',
+        }}
+        data-testid="minimap-dim-left"
+      />
+      <div
+        className="absolute top-0 bottom-0 right-0"
+        style={{
+          left: `${(leftFraction + widthFraction) * 100}%`,
+          backgroundColor: 'rgba(0, 0, 0, 0.45)',
+        }}
+        data-testid="minimap-dim-right"
+      />
+      {/* Viewport rectangle */}
+      <div
+        className="absolute top-0 bottom-0 rounded-sm"
+        style={{
+          left: leftPercent,
+          width: widthPercent,
+          border: '1.5px solid rgba(99, 179, 237, 0.8)',
+          backgroundColor: 'rgba(99, 179, 237, 0.08)',
+          boxShadow: '0 0 4px rgba(99, 179, 237, 0.3)',
+        }}
+        data-testid="minimap-viewport-rect"
+      />
     </div>
   );
 }

--- a/src/components/timeline/__tests__/Minimap.test.tsx
+++ b/src/components/timeline/__tests__/Minimap.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Minimap } from '../Minimap';
+import { useProjectStore } from '../../../store/projectStore';
+import { useUIStore } from '../../../store/uiStore';
+
+// Mock projectStorage to avoid browser API issues
+vi.mock('../../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+// Mock ResizeObserver
+const mockObserve = vi.fn();
+const mockDisconnect = vi.fn();
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe = mockObserve;
+    unobserve = vi.fn();
+    disconnect = mockDisconnect;
+  },
+);
+
+describe('Minimap', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useUIStore.setState({ pixelsPerSecond: 50, scrollX: 0 });
+    useProjectStore.getState().createProject();
+  });
+
+  it('renders nothing when there are no tracks', () => {
+    const { container } = render(<Minimap />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the minimap container when tracks exist', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    render(<Minimap />);
+    expect(screen.getByTestId('timeline-minimap')).toBeDefined();
+  });
+
+  it('has a dark gradient background for contrast', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    render(<Minimap />);
+    const minimap = screen.getByTestId('timeline-minimap');
+    expect(minimap.style.background).toContain('linear-gradient');
+  });
+
+  it('has a visible bottom border', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    render(<Minimap />);
+    const minimap = screen.getByTestId('timeline-minimap');
+    expect(minimap.style.borderBottom).toContain('1px solid');
+  });
+
+  it('renders clip blocks with full opacity for ready clips', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('custom', 'stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+    const track = tracks[0];
+    // Add a clip manually
+    useProjectStore.setState({
+      project: {
+        ...useProjectStore.getState().project!,
+        tracks: [
+          {
+            ...track,
+            clips: [
+              {
+                id: 'clip-1',
+                trackId: track.id,
+                startTime: 0,
+                duration: 5,
+                type: 'audio' as const,
+                generationStatus: 'ready' as const,
+                name: 'Test Clip',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(<Minimap />);
+    const clips = screen.getAllByTestId('minimap-clip');
+    expect(clips.length).toBe(1);
+    // Ready clips should have full opacity (1.0)
+    expect(clips[0].style.opacity).toBe('1');
+  });
+
+  it('renders clip blocks with reduced opacity for non-ready clips', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('custom', 'stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+    const track = tracks[0];
+    useProjectStore.setState({
+      project: {
+        ...useProjectStore.getState().project!,
+        tracks: [
+          {
+            ...track,
+            clips: [
+              {
+                id: 'clip-2',
+                trackId: track.id,
+                startTime: 0,
+                duration: 5,
+                type: 'audio' as const,
+                generationStatus: 'generating' as const,
+                name: 'Generating Clip',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(<Minimap />);
+    const clips = screen.getAllByTestId('minimap-clip');
+    expect(clips[0].style.opacity).toBe('0.6');
+  });
+
+  it('renders the viewport indicator', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    render(<Minimap />);
+    expect(screen.getByTestId('minimap-viewport')).toBeDefined();
+  });
+
+  it('renders viewport rectangle with visible border', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    render(<Minimap />);
+    const rect = screen.getByTestId('minimap-viewport-rect');
+    expect(rect.style.border).toContain('rgba(99, 179, 237');
+  });
+
+  it('renders dimming overlays outside the viewport', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    render(<Minimap />);
+    expect(screen.getByTestId('minimap-dim-left')).toBeDefined();
+    expect(screen.getByTestId('minimap-dim-right')).toBeDefined();
+  });
+
+  it('viewport rect has a subtle fill', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    render(<Minimap />);
+    const rect = screen.getByTestId('minimap-viewport-rect');
+    expect(rect.style.backgroundColor).toContain('rgba(99, 179, 237');
+  });
+
+  it('viewport rect has a glow shadow', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    render(<Minimap />);
+    const rect = screen.getByTestId('minimap-viewport-rect');
+    expect(rect.style.boxShadow).toContain('rgba(99, 179, 237');
+  });
+
+  it('handles click events for navigation', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    render(<Minimap />);
+    const minimap = screen.getByTestId('timeline-minimap');
+    // Should not throw when clicked
+    fireEvent.click(minimap, { clientX: 100 });
+  });
+
+  it('dim left region reflects scrollX position', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+    const totalDur = useProjectStore.getState().project!.totalDuration || 60;
+    const pps = 50;
+    const totalWidthPx = totalDur * pps;
+    // Set scrollX to 50% of the total width
+    const scrollX = totalWidthPx * 0.5;
+    useUIStore.setState({ scrollX, pixelsPerSecond: pps });
+    render(<Minimap />);
+    const dimLeft = screen.getByTestId('minimap-dim-left');
+    expect(dimLeft.style.width).toBe('50%');
+  });
+});


### PR DESCRIPTION
## Summary
- Increased clip block opacity from 0.8/0.4 to 1.0/0.6 and row height from 4px to 6px for better visibility
- Replaced flat `#1a1a1a` background with a dark gradient (`#111111` to `#161616`) for better contrast against the `#242424` timeline
- Changed border separator from `#333` to `#444` for a clearer division between minimap and timeline
- Replaced stub viewport indicator with a proper one that tracks `scrollX` and viewport width via ResizeObserver
- Added dimming overlays outside the viewport and a visible viewport rectangle with blue border, subtle fill, and glow

## Test plan
- [x] 13 new unit tests covering rendering, contrast, opacity, viewport indicator, and scroll position
- [x] All 1706 existing tests pass
- [x] `npx tsc --noEmit` passes with 0 errors

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)