### PR TITLE
fix: standardize button styling across components

### DIFF
--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -19,6 +19,7 @@ import {
   estimateFileSize,
   formatFileSize,
 } from '../../utils/audioEncoders';
+import { Button } from '../ui/Button';
 
 const FORMAT_OPTIONS: { value: ExportFormat; label: string }[] = [
   { value: 'wav', label: 'WAV' },
@@ -347,19 +348,17 @@ export function ExportDialog() {
         </div>
 
         <div className="flex justify-end px-4 py-3 border-t border-daw-border gap-2">
-          <button
-            onClick={() => setShow(false)}
-            className="px-4 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
-          >
+          <Button variant="default" size="md" onClick={() => setShow(false)}>
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
             onClick={handleExport}
             disabled={exporting || !hasExportableContent}
-            className="px-4 py-1.5 text-xs font-medium bg-daw-accent text-white rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed enabled:hover:bg-daw-accent-hover"
           >
             {exporting ? `Exporting... ${progress}%` : `Export ${exportOptions.format.toUpperCase()}`}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
+import { Button } from '../ui/Button';
 import { KEY_SCALES, TIME_SIGNATURES } from '../../constants/tracks';
 import {
   DEFAULT_BPM,
@@ -303,18 +304,12 @@ export function NewProjectDialog() {
         </div>
 
         <div className="flex justify-end px-4 py-3 border-t border-daw-border gap-2">
-          <button
-            onClick={() => setShow(false)}
-            className="px-4 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
-          >
+          <Button variant="default" size="md" onClick={() => setShow(false)}>
             Cancel
-          </button>
-          <button
-            onClick={handleCreate}
-            className="px-4 py-1.5 text-xs font-medium bg-daw-accent hover:bg-daw-accent-hover text-white rounded transition-colors"
-          >
+          </Button>
+          <Button variant="primary" size="md" onClick={handleCreate}>
             Create
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -3,6 +3,7 @@ import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
 import { listModels, initModel, getBackendUrl, setBackendUrl } from '../../services/aceStepApi';
 import { DEFAULT_GENERATION, DEFAULT_MEASURES } from '../../constants/defaults';
+import { Button } from '../ui/Button';
 import { normalizePlaybackLatencySettings } from '../../utils/playbackLatency';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
 import type { ModelEntry, LmModelEntry } from '../../types/api';
@@ -611,18 +612,12 @@ export function SettingsDialog() {
         </div>
 
         <div className="flex justify-end px-4 py-3 border-t border-daw-border gap-2">
-          <button
-            onClick={() => setShow(false)}
-            className="px-4 py-1.5 text-xs font-medium bg-daw-surface-2 hover:bg-[#484848] rounded transition-colors"
-          >
+          <Button variant="default" size="md" onClick={() => setShow(false)}>
             Cancel
-          </button>
-          <button
-            onClick={handleSave}
-            className="px-4 py-1.5 text-xs font-medium bg-daw-accent hover:bg-daw-accent-hover text-white rounded transition-colors"
-          >
+          </Button>
+          <Button variant="primary" size="md" onClick={handleSave}>
             Save
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -8,6 +8,7 @@ import { useTransport } from '../../hooks/useTransport';
 import { useRecording } from '../../hooks/useRecording';
 import { getMidiCaptureService } from '../../services/midiCaptureService';
 import { formatTime, formatBarsBeats } from '../../utils/time';
+import { Button } from '../ui/Button';
 
 function LCDDisplay() {
   const currentTime = useTransportStore((s) => s.currentTime);
@@ -73,20 +74,19 @@ function ControlBarButton({
   children: React.ReactNode;
 }) {
   return (
-    <button
+    <Button
+      size="md"
+      variant="ghost"
+      icon
+      active={active}
       onClick={onClick}
       disabled={disabled}
       title={title}
       aria-label={title.replace(/\s*\(.+?\)$/, '')}
       data-onboarding-target={dataTarget}
-      className={`w-8 h-7 flex items-center justify-center rounded transition-colors ${
-        active
-          ? 'bg-daw-accent text-white shadow-sm'
-          : 'text-zinc-400 hover:text-zinc-200 hover:bg-daw-surface-2 disabled:opacity-30 disabled:hover:bg-transparent'
-      }`}
     >
       {children}
-    </button>
+    </Button>
   );
 }
 
@@ -251,30 +251,26 @@ export function Toolbar() {
       <ToolbarSeparator />
 
       <div className="flex items-center gap-0.5 rounded-lg border border-[#4b4b4b] bg-[#242424] p-0.5">
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
+          active={mainView === 'arrangement'}
           onClick={() => setMainView('arrangement')}
-          className={`px-2.5 py-1 text-[11px] rounded-md transition-colors ${
-            mainView === 'arrangement'
-              ? 'bg-daw-accent text-white'
-              : 'text-zinc-400 hover:text-white'
-          }`}
           title="Arrangement View (Tab)"
           aria-label="Switch to Arrangement View"
         >
           Arrangement
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          active={mainView === 'session'}
           onClick={() => setMainView('session')}
-          className={`px-2.5 py-1 text-[11px] rounded-md transition-colors ${
-            mainView === 'session'
-              ? 'bg-daw-accent text-white'
-              : 'text-zinc-400 hover:text-white'
-          }`}
           title="Session View (Tab)"
           aria-label="Switch to Session View"
         >
           Session
-        </button>
+        </Button>
       </div>
 
       <ToolbarSeparator />
@@ -310,15 +306,15 @@ export function Toolbar() {
 
       {/* Project actions + File menu */}
       <div className="flex items-center gap-0.5 bg-[#2a2a2a]/60 rounded-lg px-1.5 py-0.5" data-testid="toolbar-group">
-        <button onClick={() => setShowProjectListDialog(true)} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors" title="Projects">
+        <Button variant="ghost" size="sm" onClick={() => setShowProjectListDialog(true)} title="Projects">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" className="inline -mt-px mr-1">
             <path d="M1.5 4.5L7 1.5l5.5 3M1.5 7l5.5 3 5.5-3M1.5 9.5l5.5 3 5.5-3" />
           </svg>
           Projects
-        </button>
-        <button onClick={() => setShowNewProjectDialog(true)} className="px-2 py-1 text-[11px] text-zinc-300 hover:text-white hover:bg-daw-surface-2 rounded transition-colors" title="New Project">
+        </Button>
+        <Button variant="ghost" size="sm" onClick={() => setShowNewProjectDialog(true)} title="New Project">
           New
-        </button>
+        </Button>
         <FileMenu disabled={!project} />
       </div>
 
@@ -482,9 +478,11 @@ export function Toolbar() {
             Cmd+K
           </span>
         </button>
-        <button
+        <Button
+          variant="ghost"
+          size="md"
+          icon
           onClick={() => setShowSettingsDialog(true)}
-          className="w-8 h-7 flex items-center justify-center text-zinc-400 hover:text-white hover:bg-daw-surface-2 rounded transition-colors"
           title="Settings"
           aria-label="Settings"
         >
@@ -492,14 +490,16 @@ export function Toolbar() {
             <circle cx="7" cy="7" r="2" />
             <path d="M7 1v1.5M7 11.5V13M1 7h1.5M11.5 7H13M2.8 2.8l1 1M10.2 10.2l1 1M11.2 2.8l-1 1M3.8 10.2l-1 1" />
           </svg>
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          icon
           onClick={() => setShowKeyboardShortcutsDialog(true)}
           title="Keyboard Shortcuts (?)"
-          className="w-6 h-6 text-[11px] font-bold text-zinc-400 hover:text-white hover:bg-daw-surface-2 rounded transition-colors flex items-center justify-center"
         >
           ?
-        </button>
+        </Button>
       </div>
 
       {/* Viewer mode badge */}
@@ -512,12 +512,12 @@ export function Toolbar() {
       {/* Zoom controls */}
       <ToolbarSeparator />
       <div className="flex items-center gap-0.5">
-        <button onClick={zoomOut} className="w-6 h-6 text-zinc-400 hover:text-white flex items-center justify-center rounded hover:bg-daw-surface-2 transition-colors text-sm" title="Zoom Out">
+        <Button variant="ghost" size="sm" icon onClick={zoomOut} title="Zoom Out">
           −
-        </button>
-        <button onClick={zoomIn} className="w-6 h-6 text-zinc-400 hover:text-white flex items-center justify-center rounded hover:bg-daw-surface-2 transition-colors text-sm" title="Zoom In">
+        </Button>
+        <Button variant="ghost" size="sm" icon onClick={zoomIn} title="Zoom In">
           +
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/tracks/TrackEditModal.tsx
+++ b/src/components/tracks/TrackEditModal.tsx
@@ -3,6 +3,7 @@ import type { Track, TrackType } from '../../types/project';
 import { useProjectStore } from '../../store/projectStore';
 import { TRACK_CATALOG, TRACK_TYPE_CATALOG } from '../../constants/tracks';
 import { Knob } from '../ui/Knob';
+import { Button } from '../ui/Button';
 
 interface TrackEditModalProps {
   track: Track;
@@ -250,18 +251,12 @@ export function TrackEditModal({ track, onClose }: TrackEditModalProps) {
 
         {/* Footer */}
         <div className="flex items-center justify-between px-4 py-3 border-t border-daw-border shrink-0">
-          <button
-            onClick={handleDelete}
-            className="px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/30 rounded transition-colors"
-          >
+          <Button variant="danger" size="md" onClick={handleDelete}>
             Delete Track
-          </button>
-          <button
-            onClick={onClose}
-            className="px-4 py-1.5 text-xs bg-daw-accent hover:bg-daw-accent-hover text-white rounded transition-colors"
-          >
+          </Button>
+          <Button variant="primary" size="md" onClick={onClose}>
             Done
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -12,6 +12,7 @@ import {
   ARRANGEMENT_HEADER_ROW_BG,
   ARRANGEMENT_ROW_SEPARATOR_COLOR,
 } from '../arrangement/rowSurface';
+import { getButtonClasses } from '../ui/Button';
 
 const MIN_LANE_HEIGHT = 40;
 const MAX_LANE_HEIGHT = 400;
@@ -125,8 +126,8 @@ export function TrackHeader({
   const showSecondaryActions = monitorMode !== 'off' || track.frozen || isFreezing || hasAutomationLane;
   const headerBackgroundColor = track.isGroup ? ARRANGEMENT_GROUP_ROW_BG : ARRANGEMENT_HEADER_ROW_BG;
   const isTwoRow = laneHeight >= 60;
-  const primaryButtonClass = 'w-6 h-6 min-w-[20px] min-h-[20px] flex items-center justify-center rounded-md transition-colors';
-  const secondaryButtonClass = 'w-5 h-5 flex items-center justify-center rounded-md transition-colors';
+  const primaryButtonClass = getButtonClasses({ size: 'sm', variant: 'ghost', icon: true, className: 'min-w-[20px] min-h-[20px]' });
+  const secondaryButtonClass = getButtonClasses({ size: 'sm', variant: 'ghost', icon: true, className: 'w-5 h-5' });
 
   const cycleMonitor = useCallback(() => {
     const next: Record<InputMonitoringMode, InputMonitoringMode> = { off: 'auto', auto: 'on', on: 'off' };

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,102 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+
+export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonVariant = 'default' | 'primary' | 'ghost' | 'danger';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: ButtonSize;
+  variant?: ButtonVariant;
+  /** Render as a square icon button instead of a text button */
+  icon?: boolean;
+  /** Active/pressed state styling (overrides variant) */
+  active?: boolean;
+  children?: ReactNode;
+}
+
+/* ── Size tokens ── */
+const SIZE_CLASSES: Record<ButtonSize, string> = {
+  sm: 'px-2 py-1 text-[11px]',
+  md: 'px-3 py-1.5 text-xs',
+  lg: 'px-4 py-2 text-sm',
+};
+
+const ICON_SIZE_CLASSES: Record<ButtonSize, string> = {
+  sm: 'w-6 h-6',
+  md: 'w-7 h-7',
+  lg: 'w-8 h-8',
+};
+
+/* ── Variant tokens ── */
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  default:
+    'bg-daw-surface-2 hover:bg-[#484848] text-zinc-300 font-medium',
+  primary:
+    'bg-daw-accent hover:bg-daw-accent-hover text-white font-medium',
+  ghost:
+    'bg-transparent hover:bg-daw-surface-2 text-zinc-400 hover:text-zinc-200',
+  danger:
+    'bg-transparent hover:bg-red-900/30 text-red-400 hover:text-red-300',
+};
+
+const ACTIVE_CLASSES = 'bg-daw-accent text-white shadow-sm';
+
+const BASE_CLASSES =
+  'inline-flex items-center justify-center rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed select-none';
+
+/**
+ * Build the full className string for button styling.
+ * Useful when you need the classes outside of the <Button> component
+ * (e.g., on a native <button> you cannot easily swap).
+ */
+export function getButtonClasses(opts: {
+  size?: ButtonSize;
+  variant?: ButtonVariant;
+  icon?: boolean;
+  active?: boolean;
+  className?: string;
+} = {}): string {
+  const {
+    size = 'md',
+    variant = 'default',
+    icon = false,
+    active = false,
+    className = '',
+  } = opts;
+
+  const sizeClasses = icon ? ICON_SIZE_CLASSES[size] : SIZE_CLASSES[size];
+  const variantClasses = active ? ACTIVE_CLASSES : VARIANT_CLASSES[variant];
+
+  return [BASE_CLASSES, sizeClasses, variantClasses, className]
+    .filter(Boolean)
+    .join(' ');
+}
+
+/**
+ * Shared DAW button with consistent sizing, border-radius, and hover states.
+ *
+ * @example
+ * <Button variant="primary" size="md" onClick={save}>Save</Button>
+ * <Button variant="ghost" size="sm" icon title="Settings"><GearIcon /></Button>
+ */
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    size = 'md',
+    variant = 'default',
+    icon = false,
+    active = false,
+    className = '',
+    children,
+    ...rest
+  },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      className={getButtonClasses({ size, variant, icon, active, className })}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+});

--- a/src/components/ui/__tests__/Button.test.tsx
+++ b/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Button, getButtonClasses } from '../Button';
+
+describe('Button component', () => {
+  describe('rendering', () => {
+    it('renders children text', () => {
+      render(<Button>Click me</Button>);
+      expect(screen.getByRole('button', { name: 'Click me' })).toBeDefined();
+    });
+
+    it('renders as a button element by default', () => {
+      render(<Button>Test</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.tagName).toBe('BUTTON');
+    });
+
+    it('forwards additional HTML attributes', () => {
+      render(<Button title="My tooltip" data-testid="my-btn">Test</Button>);
+      expect(screen.getByTestId('my-btn')).toBeDefined();
+      expect(screen.getByRole('button').getAttribute('title')).toBe('My tooltip');
+    });
+  });
+
+  describe('size variants', () => {
+    it('applies sm size classes', () => {
+      render(<Button size="sm">Small</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('px-2');
+      expect(btn.className).toContain('py-1');
+      expect(btn.className).toContain('text-[11px]');
+    });
+
+    it('applies md size classes (default)', () => {
+      render(<Button>Medium</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('px-3');
+      expect(btn.className).toContain('py-1.5');
+      expect(btn.className).toContain('text-xs');
+    });
+
+    it('applies lg size classes', () => {
+      render(<Button size="lg">Large</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('px-4');
+      expect(btn.className).toContain('py-2');
+      expect(btn.className).toContain('text-sm');
+    });
+  });
+
+  describe('variant styles', () => {
+    it('applies default variant classes', () => {
+      render(<Button variant="default">Default</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('bg-daw-surface-2');
+      expect(btn.className).toContain('hover:bg-[#484848]');
+    });
+
+    it('applies primary variant classes', () => {
+      render(<Button variant="primary">Primary</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('bg-daw-accent');
+      expect(btn.className).toContain('text-white');
+    });
+
+    it('applies ghost variant classes', () => {
+      render(<Button variant="ghost">Ghost</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('bg-transparent');
+      expect(btn.className).toContain('hover:bg-daw-surface-2');
+    });
+
+    it('applies danger variant classes', () => {
+      render(<Button variant="danger">Danger</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('text-red-400');
+    });
+  });
+
+  describe('consistent border-radius', () => {
+    it('uses rounded-md for all sizes', () => {
+      const { rerender } = render(<Button size="sm">S</Button>);
+      expect(screen.getByRole('button').className).toContain('rounded-md');
+
+      rerender(<Button size="md">M</Button>);
+      expect(screen.getByRole('button').className).toContain('rounded-md');
+
+      rerender(<Button size="lg">L</Button>);
+      expect(screen.getByRole('button').className).toContain('rounded-md');
+    });
+  });
+
+  describe('consistent transitions', () => {
+    it('includes transition-colors on all variants', () => {
+      const variants = ['default', 'primary', 'ghost', 'danger'] as const;
+      variants.forEach((variant) => {
+        const { unmount } = render(<Button variant={variant}>Test</Button>);
+        expect(screen.getByRole('button').className).toContain('transition-colors');
+        unmount();
+      });
+    });
+  });
+
+  describe('disabled state', () => {
+    it('applies disabled styles when disabled', () => {
+      render(<Button disabled>Disabled</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('disabled:opacity-50');
+      expect(btn.className).toContain('disabled:cursor-not-allowed');
+      expect(btn).toHaveProperty('disabled', true);
+    });
+
+    it('does not fire onClick when disabled', () => {
+      const onClick = vi.fn();
+      render(<Button disabled onClick={onClick}>No click</Button>);
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('active state', () => {
+    it('applies active styling when active prop is true', () => {
+      render(<Button active>Active</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('bg-daw-accent');
+      expect(btn.className).toContain('text-white');
+    });
+  });
+
+  describe('icon-only variant', () => {
+    it('applies icon size classes for sm', () => {
+      render(<Button size="sm" icon>X</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('w-6');
+      expect(btn.className).toContain('h-6');
+    });
+
+    it('applies icon size classes for md', () => {
+      render(<Button size="md" icon>X</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('w-7');
+      expect(btn.className).toContain('h-7');
+    });
+
+    it('applies icon size classes for lg', () => {
+      render(<Button size="lg" icon>X</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('w-8');
+      expect(btn.className).toContain('h-8');
+    });
+  });
+
+  describe('onClick handler', () => {
+    it('fires onClick when clicked', () => {
+      const onClick = vi.fn();
+      render(<Button onClick={onClick}>Click</Button>);
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('className merging', () => {
+    it('allows custom className to be appended', () => {
+      render(<Button className="my-custom-class">Custom</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('my-custom-class');
+      // Also still has the base classes
+      expect(btn.className).toContain('rounded-md');
+    });
+  });
+
+  describe('getButtonClasses utility', () => {
+    it('returns class string for use outside the component', () => {
+      const classes = getButtonClasses({ size: 'sm', variant: 'primary' });
+      expect(classes).toContain('rounded-md');
+      expect(classes).toContain('bg-daw-accent');
+      expect(classes).toContain('px-2');
+    });
+
+    it('uses defaults when no options provided', () => {
+      const classes = getButtonClasses();
+      expect(classes).toContain('rounded-md');
+      expect(classes).toContain('px-3');
+      expect(classes).toContain('bg-daw-surface-2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Created a shared `Button` component (`src/components/ui/Button.tsx`) with consistent size variants (`sm`, `md`, `lg`), style variants (`default`, `primary`, `ghost`, `danger`), icon mode, and active state
- Exported a `getButtonClasses()` utility for cases where native `<button>` elements must be retained (e.g. TrackHeader inline buttons)
- Updated the most visible button inconsistencies across **Toolbar**, **ExportDialog**, **SettingsDialog**, **NewProjectDialog**, **TrackEditModal**, and **TrackHeader** to use the shared styles
- All buttons now use standardized `rounded-md` border-radius, consistent padding per size, and uniform hover/active/disabled states

## Test plan
- [x] 22 new unit tests for Button component (sizes, variants, disabled, active, icon, className merging, getButtonClasses utility)
- [x] All 1715 existing tests pass
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm run build` — succeeds

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)