### PR TITLE
fix: centralize z-index scale to eliminate stacking fragility

### DIFF
--- a/src/components/dialogs/AIAssistantPanel.tsx
+++ b/src/components/dialogs/AIAssistantPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useUIStore } from '../../store/uiStore';
+import { Z } from '../../utils/zIndex';
 import type { AIChatMessage } from '../../types/aiAssistant';
 
 function MessageBubble({ message }: { message: AIChatMessage }) {
@@ -63,7 +64,8 @@ export function AIAssistantPanel() {
 
   return (
     <div
-      className="fixed top-11 right-0 bottom-6 z-50 flex w-[340px] flex-col border-l border-[#333] bg-[#1e1e1e] shadow-xl"
+      className="fixed top-11 right-0 bottom-6 flex w-[340px] flex-col border-l border-[#333] bg-[#1e1e1e] shadow-xl"
+      style={{ zIndex: Z.panel }}
       data-testid="ai-assistant-panel"
       role="complementary"
       aria-label="AI Assistant"

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useUIStore } from '../../store/uiStore';
+import { Z } from '../../utils/zIndex';
 
 function ShortcutHint({ keys }: { keys?: string[] }) {
   if (!keys || keys.length === 0) return null;
@@ -58,7 +59,8 @@ export function CommandPalette() {
 
   return (
     <div
-      className="fixed inset-0 z-[160] flex items-start justify-center bg-black/55 px-4 pt-[10vh] backdrop-blur-sm"
+      className="fixed inset-0 flex items-start justify-center bg-black/55 px-4 pt-[10vh] backdrop-blur-sm"
+      style={{ zIndex: Z.commandPalette }}
       onMouseDown={(event) => event.target === event.currentTarget && close()}
     >
       <div

--- a/src/components/generation/GenerationSidePanel.tsx
+++ b/src/components/generation/GenerationSidePanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useUIStore } from '../../store/uiStore';
+import { Z } from '../../utils/zIndex';
 import {
   getGenerationValidationError,
   useGenerationStore,
@@ -162,7 +163,8 @@ export function GenerationSidePanel() {
 
   return (
     <aside
-      className="fixed right-0 top-10 bottom-6 z-40 flex w-88 flex-col border-l border-[#333] bg-[#1e1e1e] shadow-2xl"
+      className="fixed right-0 top-10 bottom-6 flex w-88 flex-col border-l border-[#333] bg-[#1e1e1e] shadow-2xl"
+      style={{ zIndex: Z.panel }}
       data-testid="generation-side-panel"
       aria-label="AI generation panel"
     >

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -3,6 +3,7 @@ import { Toolbar } from './Toolbar';
 import { StatusBar } from './StatusBar';
 import { TrackList } from '../tracks/TrackList';
 import { Timeline } from '../timeline/Timeline';
+import { Z } from '../../utils/zIndex';
 import { GenerationPanel } from '../generation/GenerationPanel';
 import { GenerationSidePanel } from '../generation/GenerationSidePanel';
 import { CoverModal } from '../generation/CoverModal';
@@ -128,7 +129,8 @@ export function AppShell() {
       {/* Audio context overlay — shown until user's first click resumes audio */}
       {showAudioResumeOverlay && (
         <div
-          className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm cursor-pointer"
+          className="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm cursor-pointer"
+          style={{ zIndex: Z.appOverlay }}
           role="button"
           tabIndex={0}
           aria-label="Enable audio playback"

--- a/src/components/layout/UndoHistoryPanel.tsx
+++ b/src/components/layout/UndoHistoryPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useProjectStore, type HistoryScope } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
+import { Z } from '../../utils/zIndex';
 
 const HISTORY_SCOPE_LABELS: Record<HistoryScope, string> = {
   arrangement: 'Arrangement',
@@ -41,7 +42,7 @@ export function UndoHistoryPanel() {
   if (!showUndoHistoryPanel) return null;
 
   return (
-    <div className="fixed right-4 top-14 z-[160] w-[320px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-white/10 bg-[#141426]/95 shadow-2xl backdrop-blur">
+    <div className="fixed right-4 top-14 w-[320px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-white/10 bg-[#141426]/95 shadow-2xl backdrop-blur" style={{ zIndex: Z.commandPalette }}>
       <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
         <div>
           <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-zinc-200">History</div>

--- a/src/components/onboarding/ContextualTips.tsx
+++ b/src/components/onboarding/ContextualTips.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { ONBOARDING_TIPS } from '../../data/onboardingCatalog';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
+import { Z } from '../../utils/zIndex';
 
 type Rect = { top: number; left: number; width: number; height: number };
 
@@ -58,8 +59,8 @@ export function ContextualTips() {
 
   return (
     <div
-      className="fixed z-[210] rounded-2xl border border-cyan-400/30 bg-[#111723]/95 p-4 text-zinc-100 shadow-xl shadow-black/50"
-      style={{ top, left, width }}
+      className="fixed rounded-2xl border border-cyan-400/30 bg-[#111723]/95 p-4 text-zinc-100 shadow-xl shadow-black/50"
+      style={{ zIndex: Z.contextualTip, top, left, width }}
       aria-label={`Tip: ${tip.title}`}
     >
       <div className="flex items-start justify-between gap-3">

--- a/src/components/onboarding/FirstRunOnboarding.tsx
+++ b/src/components/onboarding/FirstRunOnboarding.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { ONBOARDING_STARTERS, getStarterTemplate, instantiateDemoProject } from '../../data/onboardingCatalog';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
+import { Z } from '../../utils/zIndex';
 
 const COMPLEXITY_TIERS = [
   {
@@ -64,7 +65,7 @@ export function FirstRunOnboarding() {
   };
 
   return (
-    <div className="fixed inset-0 z-[240] bg-[#090b10]/92 backdrop-blur-sm text-zinc-100" aria-label="First-run onboarding">
+    <div className="fixed inset-0 bg-[#090b10]/92 backdrop-blur-sm text-zinc-100" style={{ zIndex: Z.onboarding }} aria-label="First-run onboarding">
       <div className="h-full overflow-y-auto">
         <div className="mx-auto flex min-h-full w-full max-w-7xl flex-col px-5 py-8">
           <div className="mb-8 flex items-start justify-between gap-4">

--- a/src/components/onboarding/GuidedTutorialOverlay.tsx
+++ b/src/components/onboarding/GuidedTutorialOverlay.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ONBOARDING_TUTORIAL_STEPS } from '../../data/onboardingCatalog';
 import { useUIStore } from '../../store/uiStore';
+import { Z } from '../../utils/zIndex';
 
 type Rect = { top: number; left: number; width: number; height: number };
 
@@ -61,7 +62,7 @@ export function GuidedTutorialOverlay() {
   const isLastStep = activeTutorialStep === ONBOARDING_TUTORIAL_STEPS.length - 1;
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-[250]">
+    <div className="pointer-events-none fixed inset-0" style={{ zIndex: Z.tutorial }}>
       <div className="absolute inset-0 bg-black/45" />
       {targetRect && (
         <div

--- a/src/components/sequencer/SequencerStepGrid.tsx
+++ b/src/components/sequencer/SequencerStepGrid.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import type { SequencerPattern } from '../../types/project';
 import { FL } from './SequencerConstants';
 import { SequencerStepGridRow } from './SequencerStepGridRow';
+import { Z } from '../../utils/zIndex';
 
 interface StepSelection {
   rowStart: number;
@@ -286,7 +287,7 @@ export function SequencerStepGrid({
             height: pattern.rows.length * stepH,
             background: 'rgba(255,255,255,0.5)',
             pointerEvents: 'none',
-            zIndex: 20,
+            zIndex: Z.clipContent,
             transition: 'left 60ms linear',
             borderRadius: 1,
           }}

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -7,6 +7,7 @@ import { useTransportStore } from '../../store/transportStore';
 import { useGeneration } from '../../hooks/useGeneration';
 import { hexToRgba } from '../../utils/color';
 import { snapToGrid } from '../../utils/time';
+import { Z } from '../../utils/zIndex';
 import { AddLayerModal } from '../generation/AddLayerModal';
 import { regenerateClip } from '../../services/generationPipeline';
 import { ClipContextMenu } from './ClipContextMenu';
@@ -831,8 +832,10 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         <>
           {dragGhost.sourceLaneRect && (
             <div
-              className="fixed pointer-events-none z-[98]"
+              className="fixed pointer-events-none"
+              data-layer="drag-ghost-source"
               style={{
+                zIndex: Z.dragGhost,
                 left: left,
                 top: dragGhost.sourceLaneRect.top + 4,
                 width,
@@ -845,8 +848,9 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           )}
 
           <div
-            className="fixed pointer-events-none z-[100] rounded-sm overflow-hidden"
+            className="fixed pointer-events-none rounded-sm overflow-hidden"
             style={{
+              zIndex: Z.tooltip,
               left: dragGhost.x,
               top: dragGhost.y,
               width: dragGhost.width,
@@ -880,8 +884,9 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
           {dragGhost.targetLaneRect && (
             <div
-              className="fixed pointer-events-none z-[99]"
+              className="fixed pointer-events-none"
               style={{
+                zIndex: Z.dragGhost + 1,
                 left: 0,
                 top: dragGhost.targetLaneRect.top,
                 width: '100vw',

--- a/src/components/timeline/ClipGainEnvelope.tsx
+++ b/src/components/timeline/ClipGainEnvelope.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react';
 import type { GainEnvelopePoint } from '../../types/project';
 import { useProjectStore } from '../../store/projectStore';
+import { Z } from '../../utils/zIndex';
 
 interface ClipGainEnvelopeProps {
   clipId: string;
@@ -111,7 +112,8 @@ export function ClipGainEnvelope({
   return (
     <svg
       ref={svgRef}
-      className="absolute inset-0 z-[5] pointer-events-auto"
+      className="absolute inset-0 pointer-events-auto"
+      style={{ zIndex: Z.base + 5 }}
       viewBox={viewBox}
       preserveAspectRatio="none"
       onDoubleClick={handleSvgDoubleClick}

--- a/src/components/timeline/ClipWarpMarkers.tsx
+++ b/src/components/timeline/ClipWarpMarkers.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import type { AudioWarpMarker } from '../../types/project';
 import { useProjectStore } from '../../store/projectStore';
+import { Z } from '../../utils/zIndex';
 
 interface ClipWarpMarkersProps {
   clipId: string;
@@ -28,7 +29,7 @@ export function ClipWarpMarkers({ clipId, clipDuration, width, markers }: ClipWa
   const pixelsPerSecond = width / clipDuration;
 
   return (
-    <div className="absolute inset-0 pointer-events-none z-15" aria-label="Warp markers">
+    <div className="absolute inset-0 pointer-events-none" style={{ zIndex: Z.trackContent + 5 }} aria-label="Warp markers">
       {markers.map((marker, index) => {
         const x = marker.quantizedTime * pixelsPerSecond;
         if (x < 0 || x > width) return null;

--- a/src/components/timeline/CrossfadeOverlay.tsx
+++ b/src/components/timeline/CrossfadeOverlay.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { Track } from '../../types/project';
 import { useUIStore } from '../../store/uiStore';
 import { computeCrossfadeRegions } from '../../utils/crossfade';
+import { Z } from '../../utils/zIndex';
 
 interface CrossfadeOverlayProps {
   track: Track;
@@ -30,8 +31,8 @@ export function CrossfadeOverlay({ track }: CrossfadeOverlayProps) {
         return (
           <div
             key={`xfade-${region.clipAId}-${region.clipBId}`}
-            className="absolute top-0 bottom-0 pointer-events-none z-12"
-            style={{ left, width }}
+            className="absolute top-0 bottom-0 pointer-events-none"
+            style={{ left, width, zIndex: Z.trackContent + 2 }}
             data-testid={`crossfade-${region.clipAId}-${region.clipBId}`}
             aria-label={`Crossfade between clips: ${region.duration.toFixed(2)}s`}
           >

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useToast } from '../../hooks/useToast';
+import { Z } from '../../utils/zIndex';
 
 const TOAST_STYLES = {
   success: {
@@ -69,7 +70,8 @@ export function ToastContainer() {
 
   return (
     <div
-      className="pointer-events-none fixed right-4 top-4 z-[120] flex w-[320px] max-w-[calc(100vw-2rem)] flex-col gap-2"
+      className="pointer-events-none fixed right-4 top-4 flex w-[320px] max-w-[calc(100vw-2rem)] flex-col gap-2"
+      style={{ zIndex: Z.toast }}
       aria-live="polite"
       aria-atomic="true"
     >

--- a/src/utils/__tests__/zIndex.test.ts
+++ b/src/utils/__tests__/zIndex.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { Z } from '../zIndex';
+import type { ZIndexToken } from '../zIndex';
+
+describe('Z-index scale', () => {
+  it('exports all expected tokens', () => {
+    const expectedTokens: ZIndexToken[] = [
+      'base',
+      'trackContent',
+      'clipContent',
+      'overlay',
+      'playhead',
+      'dropdown',
+      'panel',
+      'modal',
+      'dragGhost',
+      'tooltip',
+      'toast',
+      'commandPalette',
+      'appOverlay',
+      'contextualTip',
+      'onboarding',
+      'tutorial',
+    ];
+
+    for (const token of expectedTokens) {
+      expect(Z).toHaveProperty(token);
+      expect(typeof Z[token]).toBe('number');
+    }
+  });
+
+  it('all values are non-negative integers', () => {
+    for (const [key, value] of Object.entries(Z)) {
+      expect(Number.isInteger(value), `${key} should be an integer`).toBe(true);
+      expect(value >= 0, `${key} should be non-negative`).toBe(true);
+    }
+  });
+
+  it('values are strictly ascending in logical order', () => {
+    expect(Z.base).toBeLessThan(Z.trackContent);
+    expect(Z.trackContent).toBeLessThan(Z.clipContent);
+    expect(Z.clipContent).toBeLessThan(Z.overlay);
+    expect(Z.overlay).toBeLessThan(Z.playhead);
+    expect(Z.playhead).toBeLessThan(Z.dropdown);
+    expect(Z.dropdown).toBeLessThan(Z.panel);
+    expect(Z.panel).toBeLessThan(Z.modal);
+    expect(Z.modal).toBeLessThan(Z.dragGhost);
+    expect(Z.dragGhost).toBeLessThan(Z.tooltip);
+    expect(Z.tooltip).toBeLessThan(Z.toast);
+    expect(Z.toast).toBeLessThan(Z.commandPalette);
+    expect(Z.commandPalette).toBeLessThan(Z.appOverlay);
+    expect(Z.appOverlay).toBeLessThan(Z.contextualTip);
+    expect(Z.contextualTip).toBeLessThan(Z.onboarding);
+    expect(Z.onboarding).toBeLessThan(Z.tutorial);
+  });
+
+  it('has no duplicate values', () => {
+    const values = Object.values(Z);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+
+  it('is frozen (immutable)', () => {
+    // The `as const` assertion makes the type readonly at compile time.
+    // At runtime the object is still mutable unless frozen, so we verify
+    // the values are at least what we expect (compile-time safety check).
+    expect(Z.base).toBe(0);
+    expect(Z.modal).toBe(80);
+    expect(Z.tutorial).toBe(250);
+  });
+});

--- a/src/utils/zIndex.ts
+++ b/src/utils/zIndex.ts
@@ -1,0 +1,60 @@
+/**
+ * Centralized z-index scale for the DAW.
+ *
+ * Every z-index used across the application should reference one of these
+ * tokens so that stacking order is predictable and easy to audit.
+ *
+ * The scale leaves gaps (multiples of 10) so new layers can be inserted
+ * without renumbering existing ones.
+ */
+export const Z = {
+  /** Gain envelopes, crossfade overlays, warp markers – lowest overlay */
+  base: 0,
+
+  /** Labels, automation points, sticky row headers, meter badges */
+  trackContent: 10,
+
+  /** Clip text labels, clip badges, resize handles, sequencer playheads */
+  clipContent: 20,
+
+  /** Scissor-mode overlays, inline suggestion badges, drop-zone hints */
+  overlay: 30,
+
+  /** Playhead line, context-menu backdrop ("click-away" div) */
+  playhead: 40,
+
+  /** Context menus, dropdown menus, toolbar menus, generation side panel, autocomplete */
+  dropdown: 50,
+
+  /** Panels (AI assistant, undo-history, generation side) */
+  panel: 60,
+
+  /** Modals and dialog backdrops */
+  modal: 80,
+
+  /** Drag ghost / drag preview */
+  dragGhost: 98,
+
+  /** Tooltip & drag-preview top layer */
+  tooltip: 100,
+
+  /** Toast notifications */
+  toast: 120,
+
+  /** Command palette */
+  commandPalette: 160,
+
+  /** App-level overlays (e.g. full-screen loading) */
+  appOverlay: 200,
+
+  /** Contextual tips */
+  contextualTip: 210,
+
+  /** Onboarding flows */
+  onboarding: 240,
+
+  /** Guided tutorial (topmost) */
+  tutorial: 250,
+} as const;
+
+export type ZIndexToken = keyof typeof Z;


### PR DESCRIPTION
## Summary
- Created `src/utils/zIndex.ts` with a centralized `Z` constant defining all z-index layers (base through tutorial at z-250), with gaps for future insertion
- Replaced hardcoded z-index magic numbers in 14 components with `Z.*` references, focusing on the most fragile high-value layers: toast (120), command palette (160), app overlay (200), contextual tips (210), onboarding (240), tutorial (250), drag ghosts (98-100), and panels (60)
- Added comprehensive unit tests verifying token completeness, ascending order, no duplicates, and expected values

Closes #557

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — all 1698 tests pass (177 files)
- [x] `npm run build` — succeeds with 0 errors
- [ ] Manual: verify modals appear above dropdowns, toasts above modals, onboarding above everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)