### PR TITLE
fix: unify context menu styling across DAW

### DIFF
--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Knob } from '../ui/Knob';
 import { PrecisionInput, clampValue, roundToStep } from '../ui/PrecisionInput';
+import { ContextMenuWrapper, ContextMenuItem } from '../ui/ContextMenu';
 import { useProjectStore } from '../../store/projectStore';
 import { effectsEngine } from '../../engine/EffectsEngine';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
@@ -185,46 +186,25 @@ function AutomationControlShell({
         {children}
       </div>
       {menu && (
-        <>
-          <div
-            className="fixed inset-0 z-40"
-            onClick={() => setMenu(null)}
-            onContextMenu={(e) => {
-              e.preventDefault();
+        <ContextMenuWrapper x={menu.x} y={menu.y} onClose={() => setMenu(null)} minWidth={170}>
+          <ContextMenuItem
+            label="Show Automation Lane"
+            onClick={() => {
+              ensureAutomationLane(trackId, parameter, normalizedValue);
               setMenu(null);
             }}
           />
-          <div
-            className="fixed z-50 min-w-[170px] rounded-md border border-white/10 bg-[#16162b] p-1 shadow-xl"
-            style={{
-              left: Math.min(menu.x, window.innerWidth - 190),
-              top: Math.min(menu.y, window.innerHeight - (hasLane ? 88 : 54)),
-            }}
-            onClick={(e) => e.stopPropagation()}
-            onContextMenu={(e) => e.preventDefault()}
-          >
-            <button
-              className="w-full rounded px-2 py-1 text-left text-[11px] text-white/75 hover:bg-white/8"
+          {hasLane && (
+            <ContextMenuItem
+              label="Hide Automation Lane"
               onClick={() => {
-                ensureAutomationLane(trackId, parameter, normalizedValue);
+                clearAutomationLane(trackId, parameter);
                 setMenu(null);
               }}
-            >
-              Show Automation Lane
-            </button>
-            {hasLane && (
-              <button
-                className="w-full rounded px-2 py-1 text-left text-[11px] text-white/55 hover:bg-white/8"
-                onClick={() => {
-                  clearAutomationLane(trackId, parameter);
-                  setMenu(null);
-                }}
-              >
-                Hide Automation Lane
-              </button>
-            )}
-          </div>
-        </>
+              color="#a1a1aa"
+            />
+          )}
+        </ContextMenuWrapper>
       )}
     </>
   );

--- a/src/components/pianoroll/PianoRollCanvas.tsx
+++ b/src/components/pianoroll/PianoRollCanvas.tsx
@@ -3,6 +3,7 @@ import { synthEngine } from '../../engine/SynthEngine';
 import { samplerEngine } from '../../engine/SamplerEngine';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
+import { ContextMenuWrapper, ContextMenuItem } from '../ui/ContextMenu';
 import { useTransportStore } from '../../store/transportStore';
 import type { Clip, MidiNote, PianoRollGrid, Track } from '../../types/project';
 import { drawPianoRollKeyboard } from './PianoRollKeyboard';
@@ -1329,33 +1330,18 @@ export function PianoRollCanvas({
         onMouseLeave={handleCanvasMouseLeave}
       />
       {contextMenu && (
-        <>
-          <div
-            className="fixed inset-0 z-40"
-            onClick={() => setContextMenu(null)}
-            onContextMenu={(e) => { e.preventDefault(); setContextMenu(null); }}
+        <ContextMenuWrapper x={contextMenu.x} y={contextMenu.y} onClose={() => setContextMenu(null)}>
+          <ContextMenuItem
+            label="Quantize"
+            onClick={handleContextMenuQuickQuantize}
+            shortcut="Q"
           />
-          <div
-            className="fixed z-50 bg-[#1a1a2e] border border-[#333] rounded shadow-xl py-1 min-w-[160px]"
-            style={{
-              left: Math.min(contextMenu.x, window.innerWidth - 180),
-              top: Math.min(contextMenu.y, window.innerHeight - 120),
-            }}
-          >
-            <button
-              className="w-full text-left px-3 py-1.5 text-xs text-zinc-300 hover:bg-violet-600/30 hover:text-white transition-colors"
-              onClick={handleContextMenuQuickQuantize}
-            >
-              Quantize (Q)
-            </button>
-            <button
-              className="w-full text-left px-3 py-1.5 text-xs text-zinc-300 hover:bg-violet-600/30 hover:text-white transition-colors"
-              onClick={handleContextMenuQuantize}
-            >
-              Quantize with options... ({navigator.platform?.includes('Mac') ? '\u2318' : 'Ctrl'}+Q)
-            </button>
-          </div>
-        </>
+          <ContextMenuItem
+            label="Quantize with options..."
+            onClick={handleContextMenuQuantize}
+            shortcut={`${navigator.platform?.includes('Mac') ? '\u2318' : 'Ctrl'}+Q`}
+          />
+        </ContextMenuWrapper>
       )}
     </div>
   );

--- a/src/components/sequencer/SequencerContextMenu.tsx
+++ b/src/components/sequencer/SequencerContextMenu.tsx
@@ -1,5 +1,6 @@
 import type { SequencerRow } from '../../types/project';
-import { FL, ROW_COLORS } from './SequencerConstants';
+import { ROW_COLORS } from './SequencerConstants';
+import { ContextMenuWrapper, ContextMenuItem, ContextMenuSeparator } from '../ui/ContextMenu';
 
 export interface RowContextMenuState {
   rowId: string;
@@ -37,100 +38,40 @@ export function SequencerContextMenu({
   const row = rows.find((candidate) => candidate.id === menu.rowId);
 
   return (
-    <>
-      <div
-        className="fixed inset-0 z-40"
-        onClick={onClose}
-        onContextMenu={(e) => {
-          e.preventDefault();
-          onClose();
-        }}
-      />
-      <div
-        className="fixed z-50 py-1"
-        style={{
-          left: Math.min(menu.x, window.innerWidth - 180),
-          top: Math.min(menu.y, window.innerHeight - 260),
-          background: FL.headerBg,
-          border: `1px solid ${FL.borderLight}`,
-          borderRadius: 4,
-          boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
-          minWidth: 160,
-        }}
-      >
-        <CtxMenuItem label="Rename / Color..." onClick={() => onRename(menu.rowId)} />
-        <CtxMenuSep />
-        <div style={{ padding: '4px 8px', display: 'flex', gap: 3, flexWrap: 'wrap' }}>
-          {ROW_COLORS.map((color) => (
-            <button
-              key={color}
-              type="button"
-              aria-label={`Set row color ${color}`}
-              style={{
-                width: 14,
-                height: 14,
-                borderRadius: 3,
-                background: color,
-                cursor: 'pointer',
-                border: row?.color === color
-                  ? '2px solid #fff'
-                  : '1px solid rgba(255,255,255,0.1)',
-              }}
-              onClick={() => onSetColor(menu.rowId, color)}
-            />
-          ))}
-        </div>
-        <CtxMenuSep />
-        <CtxMenuItem label="Clone Channel" onClick={() => onClone(menu.rowId)} />
-        <CtxMenuSep />
-        <CtxMenuItem label="Fill every 2 steps" onClick={() => onFill(menu.rowId, 2)} />
-        <CtxMenuItem label="Fill every 4 steps" onClick={() => onFill(menu.rowId, 4)} />
-        <CtxMenuItem label="Fill every 8 steps" onClick={() => onFill(menu.rowId, 8)} />
-        <CtxMenuSep />
-        <CtxMenuItem label="Clear Steps" onClick={() => onClear(menu.rowId)} />
-        <CtxMenuItem label="Preview Sound" onClick={() => onPreview(menu.rowId)} />
-        <CtxMenuSep />
-        <CtxMenuItem label="Delete Channel" danger onClick={() => onDelete(menu.rowId)} />
+    <ContextMenuWrapper x={menu.x} y={menu.y} onClose={onClose}>
+      <ContextMenuItem label="Rename / Color..." onClick={() => onRename(menu.rowId)} />
+      <ContextMenuSeparator />
+      <div style={{ padding: '4px 8px', display: 'flex', gap: 3, flexWrap: 'wrap' }}>
+        {ROW_COLORS.map((color) => (
+          <button
+            key={color}
+            type="button"
+            aria-label={`Set row color ${color}`}
+            style={{
+              width: 14,
+              height: 14,
+              borderRadius: 3,
+              background: color,
+              cursor: 'pointer',
+              border: row?.color === color
+                ? '2px solid #fff'
+                : '1px solid rgba(255,255,255,0.1)',
+            }}
+            onClick={() => onSetColor(menu.rowId, color)}
+          />
+        ))}
       </div>
-    </>
+      <ContextMenuSeparator />
+      <ContextMenuItem label="Clone Channel" onClick={() => onClone(menu.rowId)} />
+      <ContextMenuSeparator />
+      <ContextMenuItem label="Fill every 2 steps" onClick={() => onFill(menu.rowId, 2)} />
+      <ContextMenuItem label="Fill every 4 steps" onClick={() => onFill(menu.rowId, 4)} />
+      <ContextMenuItem label="Fill every 8 steps" onClick={() => onFill(menu.rowId, 8)} />
+      <ContextMenuSeparator />
+      <ContextMenuItem label="Clear Steps" onClick={() => onClear(menu.rowId)} />
+      <ContextMenuItem label="Preview Sound" onClick={() => onPreview(menu.rowId)} />
+      <ContextMenuSeparator />
+      <ContextMenuItem label="Delete Channel" danger onClick={() => onDelete(menu.rowId)} />
+    </ContextMenuWrapper>
   );
-}
-
-export function CtxMenuItem({
-  label,
-  onClick,
-  danger,
-}: {
-  label: string;
-  onClick: () => void;
-  danger?: boolean;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      style={{
-        display: 'block',
-        width: '100%',
-        textAlign: 'left',
-        padding: '4px 12px',
-        fontSize: 11,
-        border: 'none',
-        cursor: 'pointer',
-        background: 'transparent',
-        color: danger ? '#e74c3c' : FL.text,
-      }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.background = danger ? 'rgba(231,76,60,0.15)' : FL.stepOff;
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.background = 'transparent';
-      }}
-    >
-      {label}
-    </button>
-  );
-}
-
-export function CtxMenuSep() {
-  return <div style={{ margin: '2px 8px', height: 1, background: FL.border }} />;
 }

--- a/src/components/sequencer/SequencerGrid.tsx
+++ b/src/components/sequencer/SequencerGrid.tsx
@@ -6,6 +6,7 @@ import { useTransportStore } from '../../store/transportStore';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
 import { getSample, cacheUserSample } from '../../services/sampleManager';
 import { DEFAULT_DRUM_KIT } from '../../constants/tracks';
+import { ContextMenuWrapper, ContextMenuItem, ContextMenuSeparator } from '../ui/ContextMenu';
 
 const FL = {
   bg: '#2a2a2a',
@@ -428,41 +429,22 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
 
       {/* Row context menu */}
       {rowCtxMenu && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={() => setRowCtxMenu(null)} onContextMenu={(e) => { e.preventDefault(); setRowCtxMenu(null); }} />
-          <div
-            className="fixed z-50 py-1"
-            style={{
-              left: Math.min(rowCtxMenu.x, window.innerWidth - 160),
-              top: Math.min(rowCtxMenu.y, window.innerHeight - 100),
-              background: FL.bg,
-              border: `1px solid ${FL.borderLight}`,
-              borderRadius: 4,
-              boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
-              minWidth: 140,
-            }}
-          >
-            <button
-              onClick={() => { clearRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); }}
-              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '4px 12px', fontSize: 11, border: 'none', cursor: 'pointer', background: 'transparent', color: FL.text }}
-            >
-              Clear Steps
-            </button>
-            <button
-              onClick={() => { previewSample(pattern.rows.find(r => r.id === rowCtxMenu.rowId)?.sampleKey ?? '', 0.8); }}
-              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '4px 12px', fontSize: 11, border: 'none', cursor: 'pointer', background: 'transparent', color: FL.text }}
-            >
-              Preview Sound
-            </button>
-            <div style={{ margin: '2px 8px', height: 1, background: FL.border }} />
-            <button
-              onClick={() => { removeRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); if (selectedRow === rowCtxMenu.rowId) setSelectedRow(null); }}
-              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '4px 12px', fontSize: 11, border: 'none', cursor: 'pointer', background: 'transparent', color: '#e74c3c' }}
-            >
-              Delete Row
-            </button>
-          </div>
-        </>
+        <ContextMenuWrapper x={rowCtxMenu.x} y={rowCtxMenu.y} onClose={() => setRowCtxMenu(null)} minWidth={140}>
+          <ContextMenuItem
+            label="Clear Steps"
+            onClick={() => { clearRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); }}
+          />
+          <ContextMenuItem
+            label="Preview Sound"
+            onClick={() => { previewSample(pattern.rows.find(r => r.id === rowCtxMenu.rowId)?.sampleKey ?? '', 0.8); }}
+          />
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            label="Delete Row"
+            danger
+            onClick={() => { removeRow(track.id, rowCtxMenu.rowId); setRowCtxMenu(null); if (selectedRow === rowCtxMenu.rowId) setSelectedRow(null); }}
+          />
+        </ContextMenuWrapper>
       )}
     </div>
   );

--- a/src/components/timeline/ClipContextMenu.tsx
+++ b/src/components/timeline/ClipContextMenu.tsx
@@ -1,3 +1,5 @@
+import { ContextMenuWrapper, ContextMenuItem, ContextMenuSeparator } from '../ui/ContextMenu';
+
 interface ClipContextMenuProps {
   x: number;
   y: number;
@@ -61,109 +63,54 @@ export function ClipContextMenu({
   hasWarpMarkers,
   canConsolidate,
 }: ClipContextMenuProps) {
-  const clampedX = Math.min(x, window.innerWidth - 210);
-  const clampedY = Math.min(y, window.innerHeight - 300);
-
   return (
-    <>
-      <div className="fixed inset-0 z-40" onClick={onClose} onContextMenu={(e) => { e.preventDefault(); onClose(); }} />
-      <div
-        className="fixed z-50 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[190px] backdrop-blur-sm"
-        style={{ left: clampedX, top: clampedY }}
-      >
-        <button onClick={onEdit} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors">
-          Edit Clip
-        </button>
-        {isMidiClip ? (
-          <>
-            <button onClick={onOpenMidi} className="w-full text-left px-3 py-1.5 text-[11px] text-violet-200 hover:bg-daw-accent hover:text-white transition-colors">
-              Open Piano Roll
-            </button>
-            <button
-              onClick={onExportMidi}
-              aria-label="Export MIDI Clip"
-              className="w-full text-left px-3 py-1.5 text-[11px] text-cyan-200 hover:bg-daw-accent hover:text-white transition-colors"
-            >
-              Export MIDI Clip…
-            </button>
-          </>
-        ) : isReady ? (
-          <button onClick={onRegenerate} disabled={!hasPrompt} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors disabled:text-zinc-600 disabled:cursor-not-allowed">
-            Regenerate
-          </button>
-        ) : (
-          <button onClick={onGenerate} disabled={!hasPrompt} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors disabled:text-zinc-600 disabled:cursor-not-allowed">
-            Generate
-          </button>
-        )}
+    <ContextMenuWrapper x={x} y={y} onClose={onClose} minWidth={190}>
+      <ContextMenuItem label="Edit Clip" onClick={onEdit} />
+      {isMidiClip ? (
+        <>
+          <ContextMenuItem label="Open Piano Roll" onClick={onOpenMidi} color="#ddd6fe" />
+          <ContextMenuItem label="Export MIDI Clip..." onClick={onExportMidi} color="#a5f3fc" />
+        </>
+      ) : isReady ? (
+        <ContextMenuItem label="Regenerate" onClick={onRegenerate} disabled={!hasPrompt} />
+      ) : (
+        <ContextMenuItem label="Generate" onClick={onGenerate} disabled={!hasPrompt} />
+      )}
 
-        {!isMidiClip && isReady && (
-          <>
-            <button onClick={onCreateCover} className="w-full text-left px-3 py-1.5 text-[11px] text-amber-300 hover:bg-daw-accent hover:text-white transition-colors">
-              Create Cover…
-            </button>
-            <button onClick={onRepaint} className="w-full text-left px-3 py-1.5 text-[11px] text-rose-300 hover:bg-daw-accent hover:text-white transition-colors">
-              Repaint Selection…
-            </button>
-            {hasAudio && (
-              <button onClick={onSeparateStems} className="w-full text-left px-3 py-1.5 text-[11px] text-sky-300 hover:bg-daw-accent hover:text-white transition-colors">
-                Separate Stems…
-              </button>
-            )}
-            {isVocalTrack && (
-              <button onClick={onVocal2BGM} className="w-full text-left px-3 py-1.5 text-[11px] text-emerald-300 hover:bg-daw-accent hover:text-white transition-colors">
-                Generate Accompaniment…
-              </button>
-            )}
-            <button onClick={onAnalyze} className="w-full text-left px-3 py-1.5 text-[11px] text-cyan-300 hover:bg-daw-accent hover:text-white transition-colors">
-              Analyze Audio…
-            </button>
-          </>
-        )}
+      {!isMidiClip && isReady && (
+        <>
+          <ContextMenuItem label="Create Cover..." onClick={onCreateCover} color="#fcd34d" />
+          <ContextMenuItem label="Repaint Selection..." onClick={onRepaint} color="#fda4af" />
+          {hasAudio && (
+            <ContextMenuItem label="Separate Stems..." onClick={onSeparateStems} color="#7dd3fc" />
+          )}
+          {isVocalTrack && (
+            <ContextMenuItem label="Generate Accompaniment..." onClick={onVocal2BGM} color="#6ee7b7" />
+          )}
+          <ContextMenuItem label="Analyze Audio..." onClick={onAnalyze} color="#67e8f9" />
+        </>
+      )}
 
-        {!isMidiClip && hasAudio && (
-          <>
-            <button onClick={onConvertToMidi} className="w-full text-left px-3 py-1.5 text-[11px] text-violet-300 hover:bg-daw-accent hover:text-white transition-colors">
-              Convert to MIDI…
-            </button>
-            <button onClick={onCreateQuickSampler} className="w-full text-left px-3 py-1.5 text-[11px] text-orange-300 hover:bg-daw-accent hover:text-white transition-colors">
-              Create Quick Sampler
-            </button>
-            <button onClick={onQuantizeAudio} className="w-full text-left px-3 py-1.5 text-[11px] text-teal-300 hover:bg-daw-accent hover:text-white transition-colors">
-              Quantize Audio
-            </button>
-            {hasWarpMarkers && (
-              <button onClick={onClearAudioQuantize} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-400 hover:bg-daw-accent hover:text-white transition-colors">
-                Clear Audio Quantize
-              </button>
-            )}
-          </>
-        )}
+      {!isMidiClip && hasAudio && (
+        <>
+          <ContextMenuItem label="Convert to MIDI..." onClick={onConvertToMidi} color="#c4b5fd" />
+          <ContextMenuItem label="Create Quick Sampler" onClick={onCreateQuickSampler} color="#fdba74" />
+          <ContextMenuItem label="Quantize Audio" onClick={onQuantizeAudio} color="#5eead4" />
+          {hasWarpMarkers && (
+            <ContextMenuItem label="Clear Audio Quantize" onClick={onClearAudioQuantize} color="#a1a1aa" />
+          )}
+        </>
+      )}
 
-        <div className="my-1 border-t border-[#555]" />
-        <button onClick={onSplitAtPlayhead} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors">
-          Split at Playhead <span className="float-right text-zinc-400 text-[10px]">S</span>
-        </button>
-        <button onClick={onDuplicate} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors">
-          Duplicate
-        </button>
-        <button
-          onClick={onConsolidate}
-          disabled={!canConsolidate}
-          className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors disabled:text-zinc-600 disabled:cursor-not-allowed"
-        >
-          Consolidate
-        </button>
-        {!isMidiClip && (
-          <button onClick={onAddLayer} className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors">
-            Add Layer here…
-          </button>
-        )}
-        <div className="my-1 border-t border-[#555]" />
-        <button onClick={onDelete} className="w-full text-left px-3 py-1.5 text-[11px] text-red-400 hover:bg-red-600 hover:text-white transition-colors">
-          Delete
-        </button>
-      </div>
-    </>
+      <ContextMenuSeparator />
+      <ContextMenuItem label="Split at Playhead" onClick={onSplitAtPlayhead} shortcut="S" />
+      <ContextMenuItem label="Duplicate" onClick={onDuplicate} />
+      <ContextMenuItem label="Consolidate" onClick={onConsolidate} disabled={!canConsolidate} />
+      {!isMidiClip && (
+        <ContextMenuItem label="Add Layer here..." onClick={onAddLayer} />
+      )}
+      <ContextMenuSeparator />
+      <ContextMenuItem label="Delete" onClick={onDelete} danger />
+    </ContextMenuWrapper>
   );
 }

--- a/src/components/timeline/RegionContextMenu.tsx
+++ b/src/components/timeline/RegionContextMenu.tsx
@@ -1,3 +1,5 @@
+import { ContextMenuWrapper, ContextMenuItem } from '../ui/ContextMenu';
+
 interface RegionContextMenuProps {
   x: number;
   y: number;
@@ -13,29 +15,14 @@ export function RegionContextMenu({
   onClose,
   hasReadyClips,
 }: RegionContextMenuProps) {
-  const clampedX = Math.min(x, window.innerWidth - 210);
-  const clampedY = Math.min(y, window.innerHeight - 100);
-
   return (
-    <>
-      <div
-        className="fixed inset-0 z-40"
-        onClick={onClose}
-        onContextMenu={(e) => { e.preventDefault(); onClose(); }}
+    <ContextMenuWrapper x={x} y={y} onClose={onClose} minWidth={200} testId="region-context-menu">
+      <ContextMenuItem
+        label="Regenerate Selected Region..."
+        onClick={onRegenerateRegion}
+        disabled={!hasReadyClips}
+        color="#ddd6fe"
       />
-      <div
-        className="fixed z-50 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[200px] backdrop-blur-sm"
-        style={{ left: clampedX, top: clampedY }}
-        data-testid="region-context-menu"
-      >
-        <button
-          onClick={onRegenerateRegion}
-          disabled={!hasReadyClips}
-          className="w-full text-left px-3 py-1.5 text-[11px] text-violet-200 hover:bg-daw-accent hover:text-white transition-colors disabled:text-zinc-600 disabled:cursor-not-allowed"
-        >
-          Regenerate Selected Region…
-        </button>
-      </div>
-    </>
+    </ContextMenuWrapper>
   );
 }

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -8,6 +8,7 @@ import { AutomationLaneView } from './AutomationLaneView';
 import { AddLayerModal } from '../generation/AddLayerModal';
 import { snapToGrid } from '../../utils/time';
 import { useAudioImport } from '../../hooks/useAudioImport';
+import { ContextMenuWrapper, ContextMenuItem } from '../ui/ContextMenu';
 import { CrossfadeOverlay } from './CrossfadeOverlay';
 import { TRACK_TYPE_CATALOG } from '../../constants/tracks';
 import {
@@ -35,51 +36,19 @@ interface LaneContextMenuProps {
 }
 
 function LaneContextMenu({ x, y, onAddLayer, onOpenSequencer, onOpenPianoRoll, onCreateQuickSampler, onClose }: LaneContextMenuProps) {
-  const clampedX = Math.min(x, window.innerWidth - 180);
-  const clampedY = Math.min(y, window.innerHeight - 80);
   return (
-    <>
-      <div
-        className="fixed inset-0 z-40"
-        onClick={onClose}
-        onContextMenu={(e) => { e.preventDefault(); onClose(); }}
-      />
-      <div
-        className="fixed z-50 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[160px]"
-        style={{ left: clampedX, top: clampedY }}
-      >
-        {onOpenSequencer && (
-          <button
-            onClick={() => { onClose(); onOpenSequencer(); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-emerald-300 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Open Sequencer Editor...
-          </button>
-        )}
-        {onOpenPianoRoll && (
-          <button
-            onClick={() => { onClose(); onOpenPianoRoll(); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-violet-300 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Open Piano Roll...
-          </button>
-        )}
-        {onCreateQuickSampler && (
-          <button
-            onClick={() => { onClose(); onCreateQuickSampler(); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-amber-300 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Create Quick Sampler...
-          </button>
-        )}
-        <button
-          onClick={() => { onClose(); onAddLayer(); }}
-          className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-        >
-          Add Layer...
-        </button>
-      </div>
-    </>
+    <ContextMenuWrapper x={x} y={y} onClose={onClose}>
+      {onOpenSequencer && (
+        <ContextMenuItem label="Open Sequencer Editor..." onClick={() => { onClose(); onOpenSequencer(); }} color="#6ee7b7" />
+      )}
+      {onOpenPianoRoll && (
+        <ContextMenuItem label="Open Piano Roll..." onClick={() => { onClose(); onOpenPianoRoll(); }} color="#c4b5fd" />
+      )}
+      {onCreateQuickSampler && (
+        <ContextMenuItem label="Create Quick Sampler..." onClick={() => { onClose(); onCreateQuickSampler(); }} color="#fcd34d" />
+      )}
+      <ContextMenuItem label="Add Layer..." onClick={() => { onClose(); onAddLayer(); }} />
+    </ContextMenuWrapper>
   );
 }
 

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -13,6 +13,7 @@ import {
   ARRANGEMENT_ROW_SEPARATOR_COLOR,
 } from '../arrangement/rowSurface';
 import { getButtonClasses } from '../ui/Button';
+import { ContextMenuWrapper, ContextMenuItem, ContextMenuSeparator, ContextMenuSubmenu } from '../ui/ContextMenu';
 
 const MIN_LANE_HEIGHT = 40;
 const MAX_LANE_HEIGHT = 400;
@@ -663,180 +664,112 @@ export function TrackHeader({
 
     {/* Context menu */}
     {ctxMenu && (
-      <>
-        <div className="fixed inset-0 z-40" onClick={() => setCtxMenu(null)} onContextMenu={(e) => { e.preventDefault(); setCtxMenu(null); }} />
+      <ContextMenuWrapper x={ctxMenu.x} y={ctxMenu.y} onClose={() => setCtxMenu(null)}>
+        <ContextMenuItem
+          label="Open Piano Roll..."
+          onClick={() => {
+            setCtxMenu(null);
+            if (track.trackType === 'pianoRoll') {
+              const clip = track.clips.find((candidate) => candidate.midiData);
+              setOpenPianoRoll(track.id, clip?.id ?? null);
+            }
+          }}
+          disabled={track.trackType !== 'pianoRoll'}
+        />
+        <ContextMenuItem label="Open Effect Chain..." onClick={() => { setCtxMenu(null); setOpenEffectChainTrackId(track.id); }} />
+        <ContextMenuItem label="Rename Track" onClick={() => { setCtxMenu(null); startEditing(); }} />
+        <ContextMenuItem label="Track Settings..." onClick={() => { setCtxMenu(null); setEditModalOpen(true); }} />
+        <ContextMenuItem label="Save as Track Preset..." onClick={() => { setCtxMenu(null); handleSavePreset(); }} />
+        {/* Track Height submenu */}
         <div
-          className="fixed z-50 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[160px]"
-          style={{ left: Math.min(ctxMenu.x, window.innerWidth - 180), top: Math.min(ctxMenu.y, window.innerHeight - 100) }}
+          className="relative"
+          onMouseEnter={() => setHeightSubmenu(true)}
+          onMouseLeave={() => setHeightSubmenu(false)}
         >
-          <button
-            onClick={() => {
-              setCtxMenu(null);
-              if (track.trackType === 'pianoRoll') {
-                const clip = track.clips.find((candidate) => candidate.midiData);
-                setOpenPianoRoll(track.id, clip?.id ?? null);
-              }
-            }}
-            disabled={track.trackType !== 'pianoRoll'}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors disabled:text-zinc-600 disabled:hover:bg-transparent disabled:hover:text-zinc-600"
-          >
-            Open Piano Roll...
-          </button>
-          <button
-            onClick={() => { setCtxMenu(null); setOpenEffectChainTrackId(track.id); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Open Effect Chain...
-          </button>
-          <button
-            onClick={() => { setCtxMenu(null); startEditing(); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Rename Track
-          </button>
-          <button
-            onClick={() => { setCtxMenu(null); setEditModalOpen(true); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Track Settings...
-          </button>
-          <button
-            onClick={() => { setCtxMenu(null); handleSavePreset(); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Save as Track Preset...
-          </button>
-          {/* Track Height submenu */}
-          <div
-            className="relative"
-            onMouseEnter={() => setHeightSubmenu(true)}
-            onMouseLeave={() => setHeightSubmenu(false)}
-          >
-            <button
-              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors flex items-center justify-between"
-            >
-              Track Height
-              <span className="text-zinc-400 text-[9px] ml-2">&#8250;</span>
-            </button>
-            {heightSubmenu && (
-              <div className="absolute left-full top-0 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[130px] z-50">
+          <ContextMenuItem
+            label={<span className="flex items-center justify-between w-full">Track Height<span style={{ fontSize: 9, color: '#666', marginLeft: 8 }}>&#8250;</span></span>}
+            onClick={() => {/* submenu trigger */}}
+          />
+          {heightSubmenu && (
+            <div className="absolute left-full top-0">
+              <ContextMenuSubmenu>
                 {(['small', 'medium', 'large', 'auto'] as const).map((preset) => (
-                  <button
+                  <ContextMenuItem
                     key={preset}
+                    label={<span className="capitalize">{preset}</span>}
                     onClick={() => { setCtxMenu(null); setHeightSubmenu(false); setTrackHeightPreset(track.id, preset); }}
-                    className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors capitalize"
-                  >
-                    {preset}
-                  </button>
+                  />
                 ))}
-                <div className="my-1 border-t border-[#555]" />
+                <ContextMenuSeparator />
                 {(['small', 'medium', 'large', 'auto'] as const).map((preset) => (
-                  <button
+                  <ContextMenuItem
                     key={`all-${preset}`}
+                    label={<span className="capitalize">All Tracks {preset}</span>}
                     onClick={() => { setCtxMenu(null); setHeightSubmenu(false); setAllTracksHeightPreset(preset); }}
-                    className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-400 hover:bg-daw-accent hover:text-white transition-colors capitalize"
-                  >
-                    All Tracks {preset}
-                  </button>
+                    color="#a1a1aa"
+                  />
                 ))}
-              </div>
-            )}
-          </div>
-          <button
-            onClick={() => { setCtxMenu(null); openBounceInPlaceDialog(track.id); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Bounce in Place...
-          </button>
-          <button
-            onClick={() => { setCtxMenu(null); duplicateTrack(track.id); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Duplicate Track
-          </button>
-          {/* Move to Group submenu — only for non-group tracks */}
-          {!track.isGroup && (() => {
-            const groups = project?.tracks.filter((t) => t.isGroup) ?? [];
-            return groups.length > 0 ? (
-              <div
-                className="relative"
-                onMouseEnter={() => setGroupSubmenu(true)}
-                onMouseLeave={() => setGroupSubmenu(false)}
-              >
-                <button
-                  className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors flex items-center justify-between"
-                >
-                  Move to Group
-                  <span className="text-zinc-400 text-[9px] ml-2">&#8250;</span>
-                </button>
-                {groupSubmenu && (
-                  <div className="absolute left-full top-0 bg-[#383838] border border-[#555] rounded-lg shadow-2xl py-1 min-w-[130px] z-50">
+              </ContextMenuSubmenu>
+            </div>
+          )}
+        </div>
+        <ContextMenuItem label="Bounce in Place..." onClick={() => { setCtxMenu(null); openBounceInPlaceDialog(track.id); }} />
+        <ContextMenuItem label="Duplicate Track" onClick={() => { setCtxMenu(null); duplicateTrack(track.id); }} />
+        {/* Move to Group submenu — only for non-group tracks */}
+        {!track.isGroup && (() => {
+          const groups = project?.tracks.filter((t) => t.isGroup) ?? [];
+          return groups.length > 0 ? (
+            <div
+              className="relative"
+              onMouseEnter={() => setGroupSubmenu(true)}
+              onMouseLeave={() => setGroupSubmenu(false)}
+            >
+              <ContextMenuItem
+                label={<span className="flex items-center justify-between w-full">Move to Group<span style={{ fontSize: 9, color: '#666', marginLeft: 8 }}>&#8250;</span></span>}
+                onClick={() => {/* submenu trigger */}}
+              />
+              {groupSubmenu && (
+                <div className="absolute left-full top-0">
+                  <ContextMenuSubmenu>
                     {groups.map((g) => (
-                      <button
+                      <ContextMenuItem
                         key={g.id}
+                        label={g.displayName}
                         onClick={() => { setCtxMenu(null); setGroupSubmenu(false); moveTrackToGroup(track.id, g.id); }}
-                        className={`w-full text-left px-3 py-1.5 text-[11px] transition-colors ${
-                          track.parentTrackId === g.id
-                            ? 'text-daw-accent font-medium'
-                            : 'text-zinc-200 hover:bg-daw-accent hover:text-white'
-                        }`}
-                      >
-                        {g.displayName}
-                      </button>
+                        color={track.parentTrackId === g.id ? '#4a90d9' : undefined}
+                      />
                     ))}
                     {track.parentTrackId && (
                       <>
-                        <div className="my-1 border-t border-[#555]" />
-                        <button
+                        <ContextMenuSeparator />
+                        <ContextMenuItem
+                          label="Remove from Group"
                           onClick={() => { setCtxMenu(null); setGroupSubmenu(false); moveTrackToGroup(track.id, null); }}
-                          className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-400 hover:bg-daw-accent hover:text-white transition-colors"
-                        >
-                          Remove from Group
-                        </button>
+                          color="#a1a1aa"
+                        />
                       </>
                     )}
-                  </div>
-                )}
-              </div>
-            ) : null;
-          })()}
-          <div className="my-1 border-t border-[#555]" />
-          <button
-            onClick={() => { setCtxMenu(null); openBounceInPlaceDialog(track.id); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Bounce in Place...
-          </button>
-          {track.clips.some((c) => c.midiData?.notes.length) && (
-            <button
-              onClick={() => { setCtxMenu(null); exportTrackMidi(track.id); }}
-              className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-            >
-              Export MIDI
-            </button>
-          )}
-          <div className="my-1 border-t border-[#555]" />
-          <button
-            onClick={() => { setCtxMenu(null); void handleFreeze(); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            {track.frozen ? 'Unfreeze Track' : 'Freeze Track'}
-          </button>
-          <button
-            onClick={() => { setCtxMenu(null); void handleFlatten(); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-daw-accent hover:text-white transition-colors"
-          >
-            Flatten Track
-          </button>
-          <div className="my-1 border-t border-[#555]" />
-          <button
-            onClick={() => { setCtxMenu(null); track.isGroup ? removeGroupTrack(track.id) : removeTrack(track.id); }}
-            className="w-full text-left px-3 py-1.5 text-[11px] text-red-400 hover:bg-red-600 hover:text-white transition-colors"
-          >
-            {track.isGroup ? 'Delete Group (keeps children)' : 'Delete Track'}
-          </button>
-        </div>
-      </>
+                  </ContextMenuSubmenu>
+                </div>
+              )}
+            </div>
+          ) : null;
+        })()}
+        <ContextMenuSeparator />
+        <ContextMenuItem label="Bounce in Place..." onClick={() => { setCtxMenu(null); openBounceInPlaceDialog(track.id); }} />
+        {track.clips.some((c) => c.midiData?.notes.length) && (
+          <ContextMenuItem label="Export MIDI" onClick={() => { setCtxMenu(null); exportTrackMidi(track.id); }} />
+        )}
+        <ContextMenuSeparator />
+        <ContextMenuItem label={track.frozen ? 'Unfreeze Track' : 'Freeze Track'} onClick={() => { setCtxMenu(null); void handleFreeze(); }} />
+        <ContextMenuItem label="Flatten Track" onClick={() => { setCtxMenu(null); void handleFlatten(); }} />
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          label={track.isGroup ? 'Delete Group (keeps children)' : 'Delete Track'}
+          onClick={() => { setCtxMenu(null); track.isGroup ? removeGroupTrack(track.id) : removeTrack(track.id); }}
+          danger
+        />
+      </ContextMenuWrapper>
     )}
 
     {editModalOpen && (

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -1,0 +1,180 @@
+import type { ReactNode } from 'react';
+
+/* ─── Shared context-menu design tokens ──────────────────────────────────── */
+export const CONTEXT_MENU = {
+  bg: '#2a2a2a',
+  border: '#444',
+  hoverBg: 'rgba(74, 144, 217, 0.25)', // daw-accent at 25%
+  dangerColor: '#e74c3c',
+  dangerHoverBg: 'rgba(231, 76, 60, 0.15)',
+  textColor: '#d4d4d8', // zinc-300
+  textDim: '#a1a1aa',   // zinc-400
+  separatorColor: '#444',
+  fontSize: 11,
+  borderRadius: 8,
+  minWidth: 160,
+  shadow: '0 4px 16px rgba(0,0,0,0.5)',
+} as const;
+
+/* ─── Overlay + positioned wrapper ───────────────────────────────────────── */
+
+interface ContextMenuWrapperProps {
+  x: number;
+  y: number;
+  onClose: () => void;
+  children: ReactNode;
+  minWidth?: number;
+  testId?: string;
+}
+
+/**
+ * Renders a fixed-position context menu with a click-away backdrop.
+ * Clamps position so the menu stays on-screen.
+ */
+export function ContextMenuWrapper({
+  x,
+  y,
+  onClose,
+  children,
+  minWidth = CONTEXT_MENU.minWidth,
+  testId,
+}: ContextMenuWrapperProps) {
+  const clampedX = Math.min(x, window.innerWidth - (minWidth + 20));
+  const clampedY = Math.min(y, window.innerHeight - 100);
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40"
+        onClick={onClose}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          onClose();
+        }}
+      />
+      <div
+        className="fixed z-50"
+        data-testid={testId}
+        style={{
+          left: clampedX,
+          top: clampedY,
+          background: CONTEXT_MENU.bg,
+          border: `1px solid ${CONTEXT_MENU.border}`,
+          borderRadius: CONTEXT_MENU.borderRadius,
+          boxShadow: CONTEXT_MENU.shadow,
+          padding: '4px 0',
+          minWidth,
+        }}
+      >
+        {children}
+      </div>
+    </>
+  );
+}
+
+/* ─── Menu item ──────────────────────────────────────────────────────────── */
+
+interface ContextMenuItemProps {
+  label: ReactNode;
+  onClick: () => void;
+  danger?: boolean;
+  disabled?: boolean;
+  /** Extra text shown right-aligned (e.g. keyboard shortcut) */
+  shortcut?: string;
+  /** Override text color for accent items */
+  color?: string;
+  className?: string;
+}
+
+export function ContextMenuItem({
+  label,
+  onClick,
+  danger,
+  disabled,
+  shortcut,
+  color,
+  className,
+}: ContextMenuItemProps) {
+  const textColor = danger
+    ? CONTEXT_MENU.dangerColor
+    : color ?? CONTEXT_MENU.textColor;
+
+  return (
+    <button
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      className={`w-full text-left flex items-center justify-between transition-colors ${
+        disabled
+          ? 'cursor-not-allowed'
+          : 'cursor-pointer'
+      } ${className ?? ''}`}
+      style={{
+        padding: '5px 12px',
+        fontSize: CONTEXT_MENU.fontSize,
+        border: 'none',
+        background: 'transparent',
+        color: disabled ? '#555' : textColor,
+      }}
+      onMouseEnter={(e) => {
+        if (disabled) return;
+        e.currentTarget.style.background = danger
+          ? CONTEXT_MENU.dangerHoverBg
+          : CONTEXT_MENU.hoverBg;
+        if (!color) e.currentTarget.style.color = '#fff';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'transparent';
+        e.currentTarget.style.color = disabled ? '#555' : textColor;
+      }}
+    >
+      <span>{label}</span>
+      {shortcut && (
+        <span style={{ fontSize: 10, color: '#666', marginLeft: 12 }}>
+          {shortcut}
+        </span>
+      )}
+    </button>
+  );
+}
+
+/* ─── Separator ──────────────────────────────────────────────────────────── */
+
+export function ContextMenuSeparator() {
+  return (
+    <div
+      style={{
+        margin: '4px 8px',
+        height: 1,
+        background: CONTEXT_MENU.separatorColor,
+      }}
+    />
+  );
+}
+
+/* ─── Submenu container (for nested menus) ───────────────────────────────── */
+
+interface ContextMenuSubmenuProps {
+  children: ReactNode;
+}
+
+/**
+ * Styled container for a submenu popup (absolute-positioned by parent).
+ * Does NOT include positioning logic — the parent decides left/top.
+ */
+export function ContextMenuSubmenu({ children }: ContextMenuSubmenuProps) {
+  return (
+    <div
+      style={{
+        background: CONTEXT_MENU.bg,
+        border: `1px solid ${CONTEXT_MENU.border}`,
+        borderRadius: CONTEXT_MENU.borderRadius,
+        boxShadow: CONTEXT_MENU.shadow,
+        padding: '4px 0',
+        minWidth: 130,
+      }}
+      className="z-50"
+    >
+      {children}
+    </div>
+  );
+}

--- a/tests/unit/clipContextMenuSplit.test.tsx
+++ b/tests/unit/clipContextMenuSplit.test.tsx
@@ -52,7 +52,10 @@ describe('ClipContextMenu split option', () => {
 
   it('shows S shortcut hint', () => {
     renderMenu();
-    const btn = screen.getByText(/Split at Playhead/);
-    expect(btn.querySelector('span')?.textContent).toBe('S');
+    const label = screen.getByText(/Split at Playhead/);
+    // The shortcut is rendered as a sibling span inside the button
+    const button = label.closest('button')!;
+    const shortcutSpan = button.querySelectorAll('span')[1];
+    expect(shortcutSpan?.textContent).toBe('S');
   });
 });

--- a/tests/unit/contextMenu.test.tsx
+++ b/tests/unit/contextMenu.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  ContextMenuWrapper,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSubmenu,
+  CONTEXT_MENU,
+} from '../../src/components/ui/ContextMenu';
+
+// jsdom normalizes hex colors to rgb(), so we compare against that
+const RGB_BG = 'rgb(42, 42, 42)';        // #2a2a2a
+const RGB_BORDER = 'rgb(68, 68, 68)';     // #444
+const RGB_DANGER = 'rgb(231, 76, 60)';    // #e74c3c
+
+describe('ContextMenuWrapper', () => {
+  it('renders children and positions at given x/y', () => {
+    render(
+      <ContextMenuWrapper x={100} y={200} onClose={vi.fn()}>
+        <span>Hello</span>
+      </ContextMenuWrapper>,
+    );
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('calls onClose when clicking the backdrop', () => {
+    const onClose = vi.fn();
+    render(
+      <ContextMenuWrapper x={0} y={0} onClose={onClose}>
+        <span>Menu</span>
+      </ContextMenuWrapper>,
+    );
+    // The backdrop is the first fixed div (inset-0)
+    const backdrop = screen.getByText('Menu').parentElement!.previousElementSibling! as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on right-click on backdrop', () => {
+    const onClose = vi.fn();
+    render(
+      <ContextMenuWrapper x={0} y={0} onClose={onClose}>
+        <span>Menu</span>
+      </ContextMenuWrapper>,
+    );
+    const backdrop = screen.getByText('Menu').parentElement!.previousElementSibling! as HTMLElement;
+    fireEvent.contextMenu(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies consistent background, border, and border-radius', () => {
+    render(
+      <ContextMenuWrapper x={50} y={50} onClose={vi.fn()} testId="test-menu">
+        <span>Item</span>
+      </ContextMenuWrapper>,
+    );
+    const menu = screen.getByTestId('test-menu');
+    expect(menu.style.background).toBe(RGB_BG);
+    expect(menu.style.border).toContain('1px solid');
+    expect(menu.style.borderRadius).toBe(`${CONTEXT_MENU.borderRadius}px`);
+  });
+
+  it('clamps x so menu stays on screen', () => {
+    // innerWidth defaults to 1024 in jsdom
+    render(
+      <ContextMenuWrapper x={2000} y={50} onClose={vi.fn()} testId="clamped">
+        <span>Clamped</span>
+      </ContextMenuWrapper>,
+    );
+    const menu = screen.getByTestId('clamped');
+    const left = parseInt(menu.style.left, 10);
+    expect(left).toBeLessThan(2000);
+  });
+
+  it('supports custom minWidth', () => {
+    render(
+      <ContextMenuWrapper x={50} y={50} onClose={vi.fn()} minWidth={250} testId="wide-menu">
+        <span>Wide</span>
+      </ContextMenuWrapper>,
+    );
+    const menu = screen.getByTestId('wide-menu');
+    expect(menu.style.minWidth).toBe('250px');
+  });
+});
+
+describe('ContextMenuItem', () => {
+  it('renders label and calls onClick', () => {
+    const handler = vi.fn();
+    render(<ContextMenuItem label="Cut" onClick={handler} />);
+    const btn = screen.getByText('Cut');
+    fireEvent.click(btn);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses consistent font size', () => {
+    render(<ContextMenuItem label="Paste" onClick={vi.fn()} />);
+    const btn = screen.getByText('Paste').closest('button')!;
+    expect(btn.style.fontSize).toBe(`${CONTEXT_MENU.fontSize}px`);
+  });
+
+  it('renders danger items in red', () => {
+    render(<ContextMenuItem label="Delete" onClick={vi.fn()} danger />);
+    const btn = screen.getByText('Delete').closest('button')!;
+    expect(btn.style.color).toBe(RGB_DANGER);
+  });
+
+  it('shows danger hover background on mouseEnter', () => {
+    render(<ContextMenuItem label="Delete" onClick={vi.fn()} danger />);
+    const btn = screen.getByText('Delete').closest('button')!;
+    fireEvent.mouseEnter(btn);
+    expect(btn.style.background).toContain('rgba(231, 76, 60');
+  });
+
+  it('shows normal hover background on mouseEnter', () => {
+    render(<ContextMenuItem label="Edit" onClick={vi.fn()} />);
+    const btn = screen.getByText('Edit').closest('button')!;
+    fireEvent.mouseEnter(btn);
+    expect(btn.style.background).toContain('rgba(74, 144, 217');
+  });
+
+  it('resets hover background on mouseLeave', () => {
+    render(<ContextMenuItem label="Edit" onClick={vi.fn()} />);
+    const btn = screen.getByText('Edit').closest('button')!;
+    fireEvent.mouseEnter(btn);
+    fireEvent.mouseLeave(btn);
+    expect(btn.style.background).toBe('transparent');
+  });
+
+  it('renders keyboard shortcut', () => {
+    render(<ContextMenuItem label="Split" onClick={vi.fn()} shortcut="S" />);
+    expect(screen.getByText('S')).toBeInTheDocument();
+  });
+
+  it('does not fire onClick when disabled', () => {
+    const handler = vi.fn();
+    render(<ContextMenuItem label="Disabled" onClick={handler} disabled />);
+    const btn = screen.getByText('Disabled').closest('button')!;
+    fireEvent.click(btn);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not change background on hover when disabled', () => {
+    render(<ContextMenuItem label="Disabled" onClick={vi.fn()} disabled />);
+    const btn = screen.getByText('Disabled').closest('button')!;
+    fireEvent.mouseEnter(btn);
+    expect(btn.style.background).toBe('transparent');
+  });
+
+  it('supports custom accent color', () => {
+    render(<ContextMenuItem label="Special" onClick={vi.fn()} color="#ff00ff" />);
+    const btn = screen.getByText('Special').closest('button')!;
+    expect(btn.style.color).toBe('rgb(255, 0, 255)');
+  });
+});
+
+describe('ContextMenuSeparator', () => {
+  it('renders a separator line with consistent color', () => {
+    const { container } = render(<ContextMenuSeparator />);
+    const sep = container.firstChild as HTMLElement;
+    expect(sep.style.background).toBe(RGB_BORDER); // separatorColor = #444
+    expect(sep.style.height).toBe('1px');
+  });
+});
+
+describe('ContextMenuSubmenu', () => {
+  it('renders children with consistent styling', () => {
+    const { container } = render(
+      <ContextMenuSubmenu>
+        <span>Sub item</span>
+      </ContextMenuSubmenu>,
+    );
+    expect(screen.getByText('Sub item')).toBeInTheDocument();
+    const submenu = container.firstChild as HTMLElement;
+    expect(submenu.style.background).toBe(RGB_BG);
+    expect(submenu.style.border).toContain('1px solid');
+    expect(submenu.style.borderRadius).toBe(`${CONTEXT_MENU.borderRadius}px`);
+  });
+});


### PR DESCRIPTION
## Summary
- Created shared `ContextMenuWrapper`, `ContextMenuItem`, `ContextMenuSeparator`, and `ContextMenuSubmenu` components in `src/components/ui/ContextMenu.tsx` with consistent design tokens (background: `#2a2a2a`, border: `#444`, border-radius: `8px`, font-size: `11px`)
- Migrated all 7 context menu implementations to use the shared components, fixing inconsistent backgrounds (`#383838`, `#1a1a2e`, `#16162b`), borders (`#555`, `#333`, `white/10`), border-radius (`4px`, `rounded`, `rounded-md`, `rounded-lg`), and hover states
- Added 18 unit tests for the shared ContextMenu components covering rendering, positioning, hover states, disabled states, separators, and submenus

Fixes #555

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm test` passes all 1711 tests (18 new + existing updated)
- [x] `npm run build` succeeds
- [ ] Visually verify context menus in: clip block, track header, track lane, piano roll, sequencer grid, sequencer row header, effect cards automation
- [ ] Verify hover states and disabled states render correctly
- [ ] Verify submenus (Track Height, Move to Group) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)