### PR TITLE
fix: redesign empty state + CoverModal (Music Enhancer)

### DIFF
--- a/src/components/generation/CoverModal.tsx
+++ b/src/components/generation/CoverModal.tsx
@@ -1,9 +1,31 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useGenerationStore } from '../../store/generationStore';
 import { useUIStore } from '../../store/uiStore';
 import { generateCoverClip } from '../../services/generationPipeline';
 import { modelSupportsTaskType } from '../../services/aceStepApi';
+
+type ConsistencyLevel = 'low' | 'medium' | 'high';
+const CONSISTENCY_VALUES: Record<ConsistencyLevel, number> = {
+  low: 0.25,
+  medium: 0.5,
+  high: 0.75,
+};
+
+interface SessionEntry {
+  id: string;
+  label: string;
+  clipId: string;
+  timestamp: number;
+}
+
+interface ResultEntry {
+  id: string;
+  clipId: string;
+  title: string;
+  duration: string;
+  timestamp: number;
+}
 
 export function CoverModal() {
   const coverClipId = useUIStore((s) => s.coverClipId);
@@ -17,16 +39,31 @@ export function CoverModal() {
 
   const [caption, setCaption] = useState('');
   const [lyrics, setLyrics] = useState('');
-  const [coverStrength, setCoverStrength] = useState(0.5);
+  const [consistency, setConsistency] = useState<ConsistencyLevel>('medium');
   const [createNew, setCreateNew] = useState(true);
+  const [sessions, setSessions] = useState<SessionEntry[]>([]);
+  const [results, setResults] = useState<ResultEntry[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const sessionCounterRef = useRef(0);
 
   // Reset form when clip changes
   useEffect(() => {
     if (clip) {
       setCaption(clip.prompt ?? '');
       setLyrics(clip.lyrics ?? '');
-      setCoverStrength(0.5);
+      setConsistency('medium');
       setCreateNew(true);
+      // Create initial session
+      const sessionId = `session-${Date.now()}`;
+      sessionCounterRef.current = 1;
+      setSessions([{
+        id: sessionId,
+        label: 'Enhancement 1',
+        clipId: coverClipId!,
+        timestamp: Date.now(),
+      }]);
+      setActiveSessionId(sessionId);
+      setResults([]);
     }
   }, [coverClipId]);
 
@@ -40,146 +77,297 @@ export function CoverModal() {
     return () => window.removeEventListener('keydown', handleEsc);
   }, [onClose]);
 
+  const handleNewSession = useCallback(() => {
+    sessionCounterRef.current += 1;
+    const sessionId = `session-${Date.now()}`;
+    const entry: SessionEntry = {
+      id: sessionId,
+      label: `Enhancement ${sessionCounterRef.current}`,
+      clipId: coverClipId!,
+      timestamp: Date.now(),
+    };
+    setSessions((prev) => [entry, ...prev]);
+    setActiveSessionId(sessionId);
+    setCaption(clip?.prompt ?? '');
+    setLyrics(clip?.lyrics ?? '');
+    setConsistency('medium');
+    setResults([]);
+  }, [coverClipId, clip]);
+
   const handleGenerate = useCallback(async () => {
     if (!coverClipId || isGenerating) return;
-    onClose();
+
+    const coverStrength = CONSISTENCY_VALUES[consistency];
+
+    // Add result entry optimistically
+    const resultId = `result-${Date.now()}`;
+    setResults((prev) => [...prev, {
+      id: resultId,
+      clipId: coverClipId,
+      title: caption || 'Untitled enhancement',
+      duration: '--:--',
+      timestamp: Date.now(),
+    }]);
+
     await generateCoverClip({ clipId: coverClipId, caption, lyrics, coverStrength, createNew });
-  }, [coverClipId, caption, lyrics, coverStrength, createNew, isGenerating, onClose]);
+  }, [coverClipId, caption, lyrics, consistency, createNew, isGenerating]);
 
   if (!coverClipId || !clip || !track) return null;
 
   const hasAudio = !!(clip.isolatedAudioKey || clip.cumulativeMixKey);
   const coverSupported = modelSupportsTaskType('cover');
+  const canGenerate = hasAudio && coverSupported && !isGenerating;
 
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="bg-daw-surface border border-daw-border rounded-lg shadow-2xl w-[460px] max-h-[85vh] flex flex-col text-xs text-zinc-200">
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-daw-border">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-semibold text-white">Create Cover</span>
-            <span className="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wide bg-amber-700/60 text-amber-200">
-              Cover
-            </span>
+      <div
+        data-testid="cover-modal"
+        className="bg-[#1a1a1e] border border-[#2a2a2e] rounded-xl shadow-2xl w-[820px] max-h-[85vh] flex text-xs text-zinc-200 overflow-hidden"
+      >
+        {/* Left Sidebar — Session History */}
+        <div className="w-[160px] min-w-[160px] border-r border-[#2a2a2e] flex flex-col bg-[#161618]">
+          <div className="px-3 pt-3 pb-2">
+            <button
+              data-testid="new-session-btn"
+              onClick={handleNewSession}
+              className="w-full flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-[#2a2a2e] hover:bg-[#333338] text-zinc-300 text-[11px] font-medium transition-colors"
+            >
+              <span className="text-sm leading-none">+</span>
+              New Enhancement
+            </button>
           </div>
-          <button
-            onClick={onClose}
-            className="text-zinc-400 hover:text-zinc-200 transition-colors text-base leading-none"
-          >
-            ✕
-          </button>
+          <div className="flex-1 overflow-y-auto px-1.5 pb-2 space-y-0.5">
+            {sessions.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => setActiveSessionId(s.id)}
+                className={`w-full text-left px-2.5 py-2 rounded-md text-[11px] transition-colors truncate ${
+                  s.id === activeSessionId
+                    ? 'bg-[#2a2a2e] text-zinc-100'
+                    : 'text-zinc-500 hover:bg-[#222226] hover:text-zinc-300'
+                }`}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
         </div>
 
-        {/* Body */}
-        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0">
-          {/* Source clip info */}
-          <div className="bg-[#222]/60 rounded px-3 py-2.5 border border-[#3a3a3a] space-y-0.5">
-            <p className="text-[10px] text-zinc-400 uppercase tracking-wide">Source clip</p>
-            <p className="text-[11px] font-medium text-zinc-200">
-              {track.displayName ?? track.trackName}
-            </p>
-            <p className="text-[10px] text-zinc-400 truncate">{clip.prompt || '(no prompt)'}</p>
-            {!hasAudio && (
-              <p className="text-[10px] text-amber-400 mt-1">
-                No audio generated yet — generate the clip first before creating a cover.
-              </p>
-            )}
-            {!coverSupported && (
-              <p className="text-[10px] text-amber-400 mt-1">
-                The currently loaded model does not support cover generation. Load a model that supports the &quot;cover&quot; task type.
-              </p>
-            )}
+        {/* Center Panel — Controls */}
+        <div className="flex-1 min-w-0 flex flex-col border-r border-[#2a2a2e]">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2e]">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold text-white">Music Enhancer</span>
+              <span className="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wide bg-teal-700/60 text-teal-200">
+                Cover
+              </span>
+            </div>
+            <button
+              data-testid="cover-modal-close"
+              onClick={onClose}
+              className="text-zinc-400 hover:text-zinc-200 transition-colors text-base leading-none"
+            >
+              ✕
+            </button>
           </div>
 
-          {/* Style/caption */}
-          <div>
-            <label className="block text-[10px] font-medium text-zinc-400 uppercase tracking-wide mb-1">
-              Style description
-              <span className="ml-1 normal-case font-normal text-zinc-600">(caption)</span>
-            </label>
-            <textarea
-              value={caption}
-              onChange={(e) => setCaption(e.target.value)}
-              placeholder="e.g. jazz arrangement, acoustic guitar, slow tempo…"
-              rows={3}
-              className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent"
-            />
-          </div>
+          <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0">
+            {/* Source audio preview */}
+            <div className="bg-[#222226] rounded-lg px-3 py-3 border border-[#2e2e32]">
+              <p className="text-[10px] text-zinc-500 uppercase tracking-wide mb-1.5">Source</p>
+              <div className="flex items-center gap-2">
+                <button
+                  data-testid="source-play-btn"
+                  className="w-7 h-7 flex items-center justify-center rounded-full bg-[#2a2a2e] text-zinc-400 hover:text-zinc-200 transition-colors"
+                  aria-label="Play source"
+                >
+                  <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                </button>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[11px] font-medium text-zinc-200 truncate">
+                    {track.displayName ?? track.trackName}
+                  </p>
+                  <p className="text-[10px] text-zinc-500 truncate">{clip.prompt || '(no prompt)'}</p>
+                </div>
+              </div>
+              {/* Waveform placeholder */}
+              <div className="mt-2 h-10 bg-[#1a1a1e] rounded flex items-center justify-center">
+                <div className="flex items-end gap-px h-6">
+                  {Array.from({ length: 40 }).map((_, i) => (
+                    <div
+                      key={i}
+                      className="w-1 bg-teal-600/40 rounded-sm"
+                      style={{ height: `${Math.max(2, Math.sin(i * 0.3) * 16 + Math.random() * 8)}px` }}
+                    />
+                  ))}
+                </div>
+              </div>
+              {!hasAudio && (
+                <p className="text-[10px] text-amber-400 mt-2">
+                  No audio generated yet — generate the clip first before enhancing.
+                </p>
+              )}
+              {!coverSupported && (
+                <p className="text-[10px] text-amber-400 mt-2">
+                  The currently loaded model does not support cover generation.
+                </p>
+              )}
+            </div>
 
-          {/* Lyrics */}
-          <div>
-            <label className="block text-[10px] font-medium text-zinc-400 uppercase tracking-wide mb-1">
-              Lyrics
-              <span className="ml-1 normal-case font-normal text-zinc-600">(optional)</span>
-            </label>
-            <textarea
-              value={lyrics}
-              onChange={(e) => setLyrics(e.target.value)}
-              placeholder="Override lyrics for this cover…"
-              rows={3}
-              className="w-full bg-[#222] border border-[#444] rounded px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-daw-accent font-mono"
-            />
-          </div>
-
-          {/* Cover strength */}
-          <div>
-            <div className="flex items-center justify-between mb-1">
-              <label className="text-[10px] font-medium text-zinc-400 uppercase tracking-wide">
-                Cover strength
+            {/* Lyrics */}
+            <div>
+              <label className="block text-[10px] font-medium text-zinc-400 uppercase tracking-wide mb-1">
+                Lyrics
               </label>
-              <span className="text-[10px] font-mono text-amber-300">{coverStrength.toFixed(2)}</span>
-            </div>
-            <input
-              type="range"
-              min={0}
-              max={1}
-              step={0.01}
-              value={coverStrength}
-              onChange={(e) => setCoverStrength(Number(e.target.value))}
-              className="w-full h-1.5 accent-amber-400 cursor-pointer"
-            />
-            <div className="flex justify-between text-[10px] text-zinc-600 mt-0.5">
-              <span>0.0 — close to original</span>
-              <span>1.0 — fully reimagined</span>
-            </div>
-          </div>
-
-          {/* Create new vs replace */}
-          <div className="flex items-center gap-3 pt-1">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={createNew}
-                onChange={(e) => setCreateNew(e.target.checked)}
-                className="w-3.5 h-3.5 rounded border-[#444] bg-[#222] accent-daw-accent"
+              <textarea
+                data-testid="lyrics-input"
+                value={lyrics}
+                onChange={(e) => setLyrics(e.target.value)}
+                placeholder="Override lyrics for this enhancement..."
+                rows={4}
+                className="w-full bg-[#222226] border border-[#2e2e32] rounded-lg px-3 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-teal-500/60 font-mono"
               />
-              <span className="text-[10px] text-zinc-400">Create new clip (leave original intact)</span>
-            </label>
+            </div>
+
+            {/* Styles (caption) */}
+            <div>
+              <label className="block text-[10px] font-medium text-zinc-400 uppercase tracking-wide mb-1">
+                Styles
+              </label>
+              <textarea
+                data-testid="styles-input"
+                value={caption}
+                onChange={(e) => setCaption(e.target.value)}
+                placeholder="e.g. jazz arrangement, acoustic guitar, slow tempo..."
+                rows={3}
+                className="w-full bg-[#222226] border border-[#2e2e32] rounded-lg px-3 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-teal-500/60"
+              />
+            </div>
+
+            {/* Consistency with selection */}
+            <div>
+              <label className="block text-[10px] font-medium text-zinc-400 uppercase tracking-wide mb-2">
+                Consistency with selection
+              </label>
+              <div className="flex gap-1" data-testid="consistency-toggle">
+                {(['low', 'medium', 'high'] as ConsistencyLevel[]).map((level) => (
+                  <button
+                    key={level}
+                    onClick={() => setConsistency(level)}
+                    className={`flex-1 py-1.5 rounded-md text-[11px] font-medium capitalize transition-colors ${
+                      consistency === level
+                        ? 'bg-teal-600 text-white'
+                        : 'bg-[#222226] text-zinc-500 hover:bg-[#2a2a2e] hover:text-zinc-300'
+                    }`}
+                  >
+                    {level}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Create new vs replace */}
+            <div className="flex items-center gap-3 pt-1">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={createNew}
+                  onChange={(e) => setCreateNew(e.target.checked)}
+                  className="w-3.5 h-3.5 rounded border-[#444] bg-[#222] accent-teal-500"
+                />
+                <span className="text-[10px] text-zinc-400">Create new clip (leave original intact)</span>
+              </label>
+            </div>
+
+            {/* Enhance button */}
+            <button
+              data-testid="enhance-btn"
+              onClick={handleGenerate}
+              disabled={!canGenerate}
+              className={`w-full py-2.5 rounded-lg text-sm font-semibold transition-colors ${
+                canGenerate
+                  ? 'bg-teal-600 hover:bg-teal-500 text-white'
+                  : 'bg-[#2a2a2e] text-zinc-500 cursor-not-allowed'
+              }`}
+            >
+              {isGenerating ? 'Enhancing...' : 'Enhance'}
+            </button>
           </div>
         </div>
 
-        {/* Footer */}
-        <div className="flex items-center justify-between px-4 py-3 border-t border-daw-border">
-          <button
-            onClick={onClose}
-            className="px-3 py-1.5 rounded text-xs font-medium bg-[#333] hover:bg-[#444] text-zinc-300 transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleGenerate}
-            disabled={isGenerating || !hasAudio || !coverSupported}
-            className={`px-4 py-1.5 rounded text-xs font-medium transition-colors ${
-              isGenerating || !hasAudio || !coverSupported
-                ? 'bg-[#444] text-zinc-400 cursor-not-allowed'
-                : 'bg-amber-600 hover:bg-amber-500 text-white'
-            }`}
-          >
-            {isGenerating ? 'Generating…' : 'Generate Cover'}
-          </button>
+        {/* Right Panel — Results */}
+        <div className="w-[240px] min-w-[240px] flex flex-col bg-[#161618]">
+          <div className="px-3 py-3 border-b border-[#2a2a2e]">
+            <p className="text-[11px] font-semibold text-zinc-300 uppercase tracking-wide">Results</p>
+          </div>
+          <div className="flex-1 overflow-y-auto px-2 py-2 space-y-1" data-testid="results-list">
+            {results.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-full text-center px-4">
+                <svg className="w-8 h-8 text-zinc-700 mb-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M9 18V5l12-2v13" strokeLinecap="round" strokeLinejoin="round" />
+                  <circle cx="6" cy="18" r="3" />
+                  <circle cx="18" cy="16" r="3" />
+                </svg>
+                <p className="text-[11px] text-zinc-600">
+                  Enhanced results will appear here
+                </p>
+              </div>
+            ) : (
+              results.map((r) => (
+                <div
+                  key={r.id}
+                  className="flex items-center gap-2 px-2 py-2 rounded-md hover:bg-[#222226] transition-colors group"
+                >
+                  <button
+                    className="w-6 h-6 flex items-center justify-center rounded-full bg-[#2a2a2e] text-zinc-400 hover:text-zinc-200 transition-colors flex-shrink-0"
+                    aria-label="Play result"
+                  >
+                    <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                  </button>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-[11px] text-zinc-300 truncate">{r.title}</p>
+                    <p className="text-[10px] text-zinc-600">{r.duration}</p>
+                  </div>
+                  <button
+                    className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-zinc-300 transition-opacity"
+                    aria-label="More options"
+                  >
+                    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                      <circle cx="12" cy="5" r="1.5" />
+                      <circle cx="12" cy="12" r="1.5" />
+                      <circle cx="12" cy="19" r="1.5" />
+                    </svg>
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Mini player */}
+          {results.length > 0 && (
+            <div className="border-t border-[#2a2a2e] px-3 py-2.5" data-testid="mini-player">
+              <div className="flex items-center gap-2">
+                <button className="text-zinc-500 hover:text-zinc-300 transition-colors" aria-label="Previous">
+                  <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" /></svg>
+                </button>
+                <button className="text-zinc-300 hover:text-white transition-colors" aria-label="Play">
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                </button>
+                <button className="text-zinc-500 hover:text-zinc-300 transition-colors" aria-label="Next">
+                  <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M16 18h2V6h-2zm-2-6L5.5 6v12z" /></svg>
+                </button>
+                <div className="flex-1 mx-1.5">
+                  <div className="h-1 bg-[#2a2a2e] rounded-full">
+                    <div className="h-1 bg-teal-600 rounded-full w-0" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/generation/__tests__/CoverModal.test.tsx
+++ b/src/components/generation/__tests__/CoverModal.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { CoverModal } from '../CoverModal';
+import { useProjectStore } from '../../../store/projectStore';
+import { useUIStore } from '../../../store/uiStore';
+import { useGenerationStore } from '../../../store/generationStore';
+
+// Mock external dependencies
+vi.mock('../../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../../services/generationPipeline', () => ({
+  generateCoverClip: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../services/aceStepApi', () => ({
+  modelSupportsTaskType: vi.fn().mockReturnValue(true),
+}));
+
+function setupClipAndModal() {
+  // Create a project with a track
+  useProjectStore.setState({ project: null });
+  useProjectStore.getState().createProject();
+  useProjectStore.getState().addTrack('custom', 'stems');
+
+  const state = useProjectStore.getState();
+  const track = state.project!.tracks[0];
+
+  // Add a clip to the track
+  const clip = useProjectStore.getState().addClip(track.id, {
+    startTime: 0,
+    duration: 10,
+    prompt: 'pop song',
+    lyrics: 'la la la',
+  });
+
+  // Give the clip audio so enhance is enabled
+  useProjectStore.getState().updateClip(clip.id, {
+    isolatedAudioKey: 'test-audio-key',
+  });
+
+  // Open the cover modal for this clip
+  useUIStore.getState().setCoverModal(clip.id);
+
+  return { clipId: clip.id, trackId: track.id };
+}
+
+describe('CoverModal', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useUIStore.setState({ coverClipId: null });
+    useGenerationStore.setState({ isGenerating: false });
+  });
+
+  it('does not render when coverClipId is null', () => {
+    const { container } = render(<CoverModal />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the modal with "Music Enhancer" title', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    expect(screen.getByText('Music Enhancer')).toBeDefined();
+  });
+
+  it('has a 3-panel layout', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    const modal = screen.getByTestId('cover-modal');
+    // Left sidebar with new session button
+    expect(screen.getByTestId('new-session-btn')).toBeDefined();
+    // Center with controls
+    expect(screen.getByTestId('styles-input')).toBeDefined();
+    expect(screen.getByTestId('lyrics-input')).toBeDefined();
+    // Right with results
+    expect(screen.getByTestId('results-list')).toBeDefined();
+  });
+
+  it('shows consistency toggle with Low/Medium/High instead of slider', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    const toggle = screen.getByTestId('consistency-toggle');
+    expect(within(toggle).getByText('low')).toBeDefined();
+    expect(within(toggle).getByText('medium')).toBeDefined();
+    expect(within(toggle).getByText('high')).toBeDefined();
+  });
+
+  it('sets medium as default consistency', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    const toggle = screen.getByTestId('consistency-toggle');
+    const mediumBtn = within(toggle).getByText('medium');
+    expect(mediumBtn.className).toContain('bg-teal-600');
+  });
+
+  it('switches consistency when clicked', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    const toggle = screen.getByTestId('consistency-toggle');
+    const lowBtn = within(toggle).getByText('low');
+    fireEvent.click(lowBtn);
+    expect(lowBtn.className).toContain('bg-teal-600');
+    const mediumBtn = within(toggle).getByText('medium');
+    expect(mediumBtn.className).not.toContain('bg-teal-600');
+  });
+
+  it('shows the "Enhance" button instead of "Generate Cover"', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    expect(screen.getByTestId('enhance-btn')).toBeDefined();
+    expect(screen.getByTestId('enhance-btn').textContent).toBe('Enhance');
+  });
+
+  it('disables the Enhance button when generating', () => {
+    setupClipAndModal();
+    useGenerationStore.setState({ isGenerating: true });
+    render(<CoverModal />);
+    const btn = screen.getByTestId('enhance-btn');
+    expect(btn.textContent).toBe('Enhancing...');
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('creates a new session when "New Enhancement" is clicked', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    // Initially one session
+    expect(screen.getByText('Enhancement 1')).toBeDefined();
+    fireEvent.click(screen.getByTestId('new-session-btn'));
+    expect(screen.getByText('Enhancement 2')).toBeDefined();
+  });
+
+  it('closes on Escape key', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    expect(screen.getByTestId('cover-modal')).toBeDefined();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    // After Escape, coverClipId should be null
+    expect(useUIStore.getState().coverClipId).toBeNull();
+  });
+
+  it('closes when close button is clicked', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    fireEvent.click(screen.getByTestId('cover-modal-close'));
+    expect(useUIStore.getState().coverClipId).toBeNull();
+  });
+
+  it('shows empty results message initially', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    expect(screen.getByText('Enhanced results will appear here')).toBeDefined();
+  });
+
+  it('populates lyrics and styles from clip data', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    const lyricsInput = screen.getByTestId('lyrics-input') as HTMLTextAreaElement;
+    const stylesInput = screen.getByTestId('styles-input') as HTMLTextAreaElement;
+    expect(lyricsInput.value).toBe('la la la');
+    expect(stylesInput.value).toBe('pop song');
+  });
+
+  it('calls generateCoverClip when Enhance is clicked', async () => {
+    const { generateCoverClip } = await import('../../../services/generationPipeline');
+    setupClipAndModal();
+    render(<CoverModal />);
+    fireEvent.click(screen.getByTestId('enhance-btn'));
+    expect(generateCoverClip).toHaveBeenCalled();
+  });
+
+  it('adds a result entry after clicking Enhance', () => {
+    setupClipAndModal();
+    render(<CoverModal />);
+    fireEvent.click(screen.getByTestId('enhance-btn'));
+    // A result should appear in the results list
+    const resultsList = screen.getByTestId('results-list');
+    expect(resultsList.textContent).toContain('pop song');
+  });
+});

--- a/src/components/timeline/TimelineEmptyState.tsx
+++ b/src/components/timeline/TimelineEmptyState.tsx
@@ -1,10 +1,9 @@
 import { useProjectStore } from '../../store/projectStore';
 
-const EMPTY_STATE_THRESHOLD = 3;
+const EMPTY_STATE_THRESHOLD = 1;
 
 export function TimelineEmptyState() {
   const tracks = useProjectStore((s) => s.project?.tracks ?? []);
-  const addTrack = useProjectStore((s) => s.addTrack);
 
   if (tracks.length >= EMPTY_STATE_THRESHOLD) {
     return null;
@@ -13,11 +12,11 @@ export function TimelineEmptyState() {
   return (
     <div
       data-testid="timeline-empty-state"
-      className="flex flex-col items-center justify-center gap-4 py-16 mx-6 my-4 border-2 border-dashed border-zinc-700/40 rounded-xl"
+      className="flex flex-col items-center justify-center gap-2 py-20"
     >
       {/* Music note icon */}
       <svg
-        className="w-10 h-10 text-zinc-600"
+        className="w-8 h-8 text-zinc-700"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
@@ -31,33 +30,9 @@ export function TimelineEmptyState() {
         <circle cx="18" cy="16" r="3" />
       </svg>
 
-      <p className="text-zinc-500 text-sm">
-        Drop audio files here or add a track to get started
+      <p className="text-zinc-600 text-sm">
+        Drop audio files here or click + Track to get started
       </p>
-
-      <div className="flex gap-3">
-        <button
-          type="button"
-          className="bg-daw-surface-2 hover:bg-daw-surface-3 rounded-lg px-4 py-2 text-zinc-300 text-xs transition-colors"
-          onClick={() => addTrack('custom', 'stems')}
-        >
-          Add Stems Track
-        </button>
-        <button
-          type="button"
-          className="bg-daw-surface-2 hover:bg-daw-surface-3 rounded-lg px-4 py-2 text-zinc-300 text-xs transition-colors"
-          onClick={() => addTrack('custom', 'sample')}
-        >
-          Add Sample Track
-        </button>
-        <button
-          type="button"
-          className="bg-daw-surface-2 hover:bg-daw-surface-3 rounded-lg px-4 py-2 text-zinc-300 text-xs transition-colors"
-          onClick={() => addTrack('custom', 'sequencer')}
-        >
-          Add Sequencer
-        </button>
-      </div>
     </div>
   );
 }

--- a/src/components/timeline/__tests__/TimelineEmptyState.test.tsx
+++ b/src/components/timeline/__tests__/TimelineEmptyState.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { TimelineEmptyState } from '../TimelineEmptyState';
 import { useProjectStore } from '../../../store/projectStore';
 
@@ -14,76 +14,52 @@ describe('TimelineEmptyState', () => {
     useProjectStore.getState().createProject();
   });
 
-  it('renders the empty state message', () => {
+  it('renders the empty state message when there are 0 tracks', () => {
     render(<TimelineEmptyState />);
     expect(
-      screen.getByText(/drop audio files here or add a track to get started/i),
+      screen.getByText(/drop audio files here or click \+ track to get started/i),
     ).toBeDefined();
   });
 
-  it('renders quick-action buttons for stems, sample, and sequencer', () => {
-    render(<TimelineEmptyState />);
-    expect(screen.getByRole('button', { name: /add stems track/i })).toBeDefined();
-    expect(screen.getByRole('button', { name: /add sample track/i })).toBeDefined();
-    expect(screen.getByRole('button', { name: /add sequencer/i })).toBeDefined();
-  });
-
-  it('calls addTrack with correct type when "Add Stems Track" is clicked', () => {
-    const addTrack = vi.spyOn(useProjectStore.getState(), 'addTrack');
-    render(<TimelineEmptyState />);
-    fireEvent.click(screen.getByRole('button', { name: /add stems track/i }));
-    expect(addTrack).toHaveBeenCalledWith('custom', 'stems');
-    addTrack.mockRestore();
-  });
-
-  it('calls addTrack with correct type when "Add Sample Track" is clicked', () => {
-    const addTrack = vi.spyOn(useProjectStore.getState(), 'addTrack');
-    render(<TimelineEmptyState />);
-    fireEvent.click(screen.getByRole('button', { name: /add sample track/i }));
-    expect(addTrack).toHaveBeenCalledWith('custom', 'sample');
-    addTrack.mockRestore();
-  });
-
-  it('calls addTrack with correct type when "Add Sequencer" is clicked', () => {
-    const addTrack = vi.spyOn(useProjectStore.getState(), 'addTrack');
-    render(<TimelineEmptyState />);
-    fireEvent.click(screen.getByRole('button', { name: /add sequencer/i }));
-    expect(addTrack).toHaveBeenCalledWith('custom', 'sequencer');
-    addTrack.mockRestore();
-  });
-
-  it('has a dashed border drop zone', () => {
+  it('renders a music note icon', () => {
     render(<TimelineEmptyState />);
     const container = screen.getByTestId('timeline-empty-state');
-    expect(container.className).toContain('border-dashed');
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
   });
 
-  it('is not visible when there are 3 or more tracks', () => {
-    // Add 3 tracks
+  it('does not render action buttons', () => {
+    render(<TimelineEmptyState />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('does not have a dashed border', () => {
+    render(<TimelineEmptyState />);
+    const container = screen.getByTestId('timeline-empty-state');
+    expect(container.className).not.toContain('border-dashed');
+  });
+
+  it('is not visible when there is 1 or more tracks', () => {
+    useProjectStore.getState().addTrack('custom', 'stems');
+
+    const { container } = render(<TimelineEmptyState />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('is not visible when there are 3 tracks', () => {
     const store = useProjectStore.getState();
     store.addTrack('custom', 'stems');
     store.addTrack('custom', 'sample');
     store.addTrack('custom', 'sequencer');
 
     const { container } = render(<TimelineEmptyState />);
-    // Component should render nothing when 3+ tracks exist
     expect(container.innerHTML).toBe('');
-  });
-
-  it('is visible when there are fewer than 3 tracks', () => {
-    // Add 1 track
-    useProjectStore.getState().addTrack('custom', 'stems');
-
-    render(<TimelineEmptyState />);
-    expect(
-      screen.getByText(/drop audio files here or add a track to get started/i),
-    ).toBeDefined();
   });
 
   it('is visible when there are 0 tracks', () => {
     render(<TimelineEmptyState />);
     expect(
-      screen.getByText(/drop audio files here or add a track to get started/i),
+      screen.getByText(/drop audio files here or click \+ track to get started/i),
     ).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- **TimelineEmptyState**: Changed threshold from 3 to 1 so it only shows when there are 0 tracks. Removed the three awkward action buttons and replaced with a subtle ghost message: "Drop audio files here or click + Track to get started" with a small music note icon. No dashed border.
- **CoverModal**: Redesigned as a 3-panel "Music Enhancer" layout matching ACE Studio's design:
  - Left sidebar (~160px): "+ New Enhancement" button and session history list
  - Center panel: Source audio preview with waveform placeholder, Lyrics textarea, Styles textarea, Low/Medium/High consistency toggle (maps to coverStrength 0.25/0.5/0.75), full-width teal "Enhance" button
  - Right panel (~240px): Results list with play buttons and 3-dot menus, mini player at bottom
- Updated all existing tests and added 15 new CoverModal tests

## Test plan
- [x] `npx tsc --noEmit` -- 0 type errors
- [x] `npm test` -- all 1789 tests pass (187 files)
- [x] `npm run build` -- succeeds
- [ ] Manual: open DAW with 0 tracks, verify empty state shows subtle message
- [ ] Manual: add 1 track, verify empty state disappears
- [ ] Manual: right-click clip > Create Cover, verify Music Enhancer 3-panel layout
- [ ] Manual: verify consistency toggle switches between Low/Medium/High
- [ ] Manual: verify Enhance button triggers generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)