### PR TITLE
feat: direct drag selection without modifier key (#576)

### DIFF
--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -80,7 +80,6 @@ export function Timeline() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const trackAreaRef = useRef<HTMLDivElement>(null);
 
-  const selectClips = useUIStore((s) => s.selectClips);
   const deselectAllTracks = useUIStore((s) => s.deselectAllTracks);
   const setRegionRegenerateTarget = useUIStore((s) => s.setRegionRegenerateTarget);
   const regionRegenerateTarget = useUIStore((s) => s.regionRegenerateTarget);
@@ -90,7 +89,6 @@ export function Timeline() {
   const [regionCtxMenu, setRegionCtxMenu] = useState<{ x: number; y: number } | null>(null);
   const [ctxDrag, setCtxDrag] = useState<DragRect | null>(null);
   const [selDrag, setSelDrag] = useState<DragRect | null>(null);
-  const [normalDrag, setNormalDrag] = useState<DragRect | null>(null);
   const [fileDragOver, setFileDragOver] = useState(false);
   const dragCounterRef = useRef(0);
   const { importMultipleFiles, importLoopToTrack, importAssetToTrack, importAudioFileAsNewQuickSampler, importAssetAsQuickSampler } = useAudioImport();
@@ -268,8 +266,7 @@ export function Timeline() {
       if (target.closest?.('[data-timeline-scrubber="true"]')) return;
 
       const isCtx = e.altKey;
-      const isSel = !isCtx && (e.metaKey || e.ctrlKey);
-      const isNormal = !isCtx && !isSel;
+      const isSel = !isCtx;
 
       e.preventDefault();
       e.stopPropagation();
@@ -290,7 +287,7 @@ export function Timeline() {
       const startViewY = startClientY - cRect.top + container.scrollTop;
 
       let hasDragged = false;
-      const setDrag = isCtx ? setCtxDrag : isSel ? setSelDrag : setNormalDrag;
+      const setDrag = isCtx ? setCtxDrag : setSelDrag;
 
       const onMouseMove = (ev: MouseEvent) => {
         const dx = ev.clientX - startClientX;
@@ -306,18 +303,13 @@ export function Timeline() {
         const minY = Math.min(startViewY, curViewY);
         const maxY = Math.max(startViewY, curViewY);
 
-        if (isNormal) {
-          const trackAreaTop = trackArea.getBoundingClientRect().top - cRect.top + container.scrollTop;
-          setDrag({ left, width, top: minY - trackAreaTop, height: maxY - minY });
-        } else {
-          const vRange = getTrackVerticalRange(
-            container, getIntersectedTrackIds(container, minY, maxY),
-          );
-          const trackAreaTop = trackArea.getBoundingClientRect().top - cRect.top + container.scrollTop;
-          const top = vRange ? vRange.top - trackAreaTop : minY - trackAreaTop;
-          const height = vRange ? vRange.height : maxY - minY;
-          setDrag({ left, width, top, height });
-        }
+        const vRange = getTrackVerticalRange(
+          container, getIntersectedTrackIds(container, minY, maxY),
+        );
+        const trackAreaTop = trackArea.getBoundingClientRect().top - cRect.top + container.scrollTop;
+        const top = vRange ? vRange.top - trackAreaTop : minY - trackAreaTop;
+        const height = vRange ? vRange.height : maxY - minY;
+        setDrag({ left, width, top, height });
       };
 
       const onMouseUp = (ev: MouseEvent) => {
@@ -337,35 +329,17 @@ export function Timeline() {
         const minY = Math.min(startViewY, endViewY);
         const maxY = Math.max(startViewY, endViewY);
 
-        if (isNormal) {
-          const rawStart = leftPx / pixelsPerSecond;
-          const rawEnd = rightPx / pixelsPerSecond;
-          const trackIds = new Set(getIntersectedTrackIds(container, minY, maxY));
-          const tracks = project?.tracks ?? [];
-          const hitClipIds: string[] = [];
-          for (const t of tracks) {
-            if (!trackIds.has(t.id)) continue;
-            for (const c of t.clips) {
-              const clipEnd = c.startTime + c.duration;
-              if (clipEnd > rawStart && c.startTime < rawEnd) {
-                hitClipIds.push(c.id);
-              }
-            }
-          }
-          selectClips(hitClipIds);
-        } else {
-          const rawStart = leftPx / pixelsPerSecond;
-          const rawEnd = rightPx / pixelsPerSecond;
-          const startTime = Math.max(0, snapToGrid(rawStart, bpm, 1));
-          const endTime = snapToGrid(rawEnd, bpm, 1);
-          const trackIds = getIntersectedTrackIds(container, minY, maxY);
+        const rawStart = leftPx / pixelsPerSecond;
+        const rawEnd = rightPx / pixelsPerSecond;
+        const startTime = Math.max(0, snapToGrid(rawStart, bpm, 1));
+        const endTime = snapToGrid(rawEnd, bpm, 1);
+        const trackIds = getIntersectedTrackIds(container, minY, maxY);
 
-          if (endTime > startTime && trackIds.length > 0) {
-            if (isCtx) {
-              setContextWindow({ startTime, endTime, trackIds });
-            } else {
-              setSelectWindow({ startTime, endTime, trackIds });
-            }
+        if (endTime > startTime && trackIds.length > 0) {
+          if (isCtx) {
+            setContextWindow({ startTime, endTime, trackIds });
+          } else {
+            setSelectWindow({ startTime, endTime, trackIds });
           }
         }
         setDrag(null);
@@ -374,7 +348,7 @@ export function Timeline() {
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onMouseUp);
     },
-    [pixelsPerSecond, project, setContextWindow, setSelectWindow, selectClips, deselectAllTracks],
+    [pixelsPerSecond, project, setContextWindow, setSelectWindow, deselectAllTracks],
   );
 
 
@@ -550,20 +524,6 @@ export function Timeline() {
               />
             )}
 
-            {/* Live rubber-band clip selection overlay — Apple Blue (#007AFF) */}
-            {normalDrag && (
-              <div
-                className="absolute pointer-events-none z-10"
-                style={{
-                  left: normalDrag.left,
-                  width: normalDrag.width,
-                  top: normalDrag.top,
-                  height: normalDrag.height,
-                  background: 'rgba(0, 122, 255, 0.10)',
-                  border: '1px solid rgba(0, 122, 255, 0.45)',
-                }}
-              />
-            )}
 
             {sortedTracks.map((track) => (
               <TrackLane key={track.id} track={track} />

--- a/src/components/timeline/__tests__/TimelineDirectDrag.test.tsx
+++ b/src/components/timeline/__tests__/TimelineDirectDrag.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useUIStore } from '../../../store/uiStore';
+
+/**
+ * Tests for the direct-drag selection behavior (#576).
+ *
+ * The drag handler in Timeline.tsx decides:
+ *   - Alt + drag → contextWindow (teal)
+ *   - Plain drag on empty area → selectWindow (purple)
+ *
+ * Since the Timeline component relies heavily on DOM measurements
+ * (getBoundingClientRect, scrollLeft, querySelectorAll), we test the
+ * modifier-key decision logic and store integration in isolation.
+ */
+
+// Mock projectStorage to avoid browser API issues
+vi.mock('../../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('Timeline direct drag selection (#576)', () => {
+  beforeEach(() => {
+    useUIStore.setState({
+      selectWindow: null,
+      contextWindow: null,
+      selectedClipIds: new Set(),
+    });
+  });
+
+  it('setSelectWindow stores selection region in uiStore', () => {
+    const store = useUIStore.getState();
+    store.setSelectWindow({ startTime: 1, endTime: 5, trackIds: ['track-1'] });
+    expect(useUIStore.getState().selectWindow).toEqual({
+      startTime: 1,
+      endTime: 5,
+      trackIds: ['track-1'],
+    });
+  });
+
+  it('setContextWindow stores context region in uiStore', () => {
+    const store = useUIStore.getState();
+    store.setContextWindow({ startTime: 2, endTime: 6, trackIds: ['track-2'] });
+    expect(useUIStore.getState().contextWindow).toEqual({
+      startTime: 2,
+      endTime: 6,
+      trackIds: ['track-2'],
+    });
+  });
+
+  it('selectWindow and contextWindow are independent', () => {
+    const store = useUIStore.getState();
+    store.setSelectWindow({ startTime: 0, endTime: 4, trackIds: ['t1'] });
+    store.setContextWindow({ startTime: 1, endTime: 3, trackIds: ['t2'] });
+    expect(useUIStore.getState().selectWindow).toEqual({
+      startTime: 0,
+      endTime: 4,
+      trackIds: ['t1'],
+    });
+    expect(useUIStore.getState().contextWindow).toEqual({
+      startTime: 1,
+      endTime: 3,
+      trackIds: ['t2'],
+    });
+  });
+
+  it('selectWindow can be cleared by setting null', () => {
+    const store = useUIStore.getState();
+    store.setSelectWindow({ startTime: 0, endTime: 4, trackIds: ['t1'] });
+    store.setSelectWindow(null);
+    expect(useUIStore.getState().selectWindow).toBeNull();
+  });
+
+  describe('modifier key decision logic', () => {
+    // These mirror the exact logic from handleMouseDownCapture in Timeline.tsx:
+    //   const isCtx = e.altKey;
+    //   const isSel = !isCtx;
+
+    function classifyDrag(altKey: boolean, metaKey: boolean, ctrlKey: boolean) {
+      const isCtx = altKey;
+      const isSel = !isCtx;
+      return { isCtx, isSel };
+    }
+
+    it('plain drag (no modifiers) → selectWindow', () => {
+      const { isCtx, isSel } = classifyDrag(false, false, false);
+      expect(isSel).toBe(true);
+      expect(isCtx).toBe(false);
+    });
+
+    it('Cmd+drag → selectWindow (modifier ignored for selection)', () => {
+      const { isCtx, isSel } = classifyDrag(false, true, false);
+      expect(isSel).toBe(true);
+      expect(isCtx).toBe(false);
+    });
+
+    it('Ctrl+drag → selectWindow (modifier ignored for selection)', () => {
+      const { isCtx, isSel } = classifyDrag(false, false, true);
+      expect(isSel).toBe(true);
+      expect(isCtx).toBe(false);
+    });
+
+    it('Alt+drag → contextWindow', () => {
+      const { isCtx, isSel } = classifyDrag(true, false, false);
+      expect(isCtx).toBe(true);
+      expect(isSel).toBe(false);
+    });
+
+    it('Alt+Cmd+drag → contextWindow (Alt takes precedence)', () => {
+      const { isCtx, isSel } = classifyDrag(true, true, false);
+      expect(isCtx).toBe(true);
+      expect(isSel).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Plain drag on empty timeline area now creates a selectWindow (purple) directly, without requiring Cmd/Ctrl modifier
- Alt+drag for contextWindow remains unchanged
- Drag starting on a clip still moves/selects the clip (unchanged)
- Removed unused rubber-band clip selection overlay and `normalDrag` state

## Test plan
- [x] Unit tests for modifier-key decision logic (plain drag → selectWindow, Alt+drag → contextWindow)
- [x] Unit tests for uiStore selectWindow/contextWindow integration
- [ ] Manual: drag on empty timeline area → purple selectWindow appears
- [ ] Manual: Alt+drag on empty timeline area → teal contextWindow appears
- [ ] Manual: drag starting on a clip → clip moves (not selectWindow)
- [ ] Manual: click on empty area → clears selection

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)