### PR TITLE
feat: add canvas right-click context menu with AI Tools submenu

### DIFF
--- a/src/components/timeline/CanvasContextMenu.tsx
+++ b/src/components/timeline/CanvasContextMenu.tsx
@@ -1,0 +1,113 @@
+import { useState, useCallback } from 'react';
+import {
+  ContextMenuWrapper,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSubmenu,
+  CONTEXT_MENU,
+} from '../ui/ContextMenu';
+import { useUIStore } from '../../store/uiStore';
+import { useTransportStore } from '../../store/transportStore';
+import { useProjectStore } from '../../store/projectStore';
+
+interface CanvasContextMenuProps {
+  x: number;
+  y: number;
+  onClose: () => void;
+}
+
+export function CanvasContextMenu({ x, y, onClose }: CanvasContextMenuProps) {
+  const [showAISubmenu, setShowAISubmenu] = useState(false);
+
+  const handleInspireMe = useCallback(() => {
+    useUIStore.getState().setShowGenerationPanel(true);
+    onClose();
+  }, [onClose]);
+
+  const handleAddLayer = useCallback(() => {
+    useUIStore.getState().setShowGenerationPanel(true);
+    onClose();
+  }, [onClose]);
+
+  const handleMusicEnhancer = useCallback(() => {
+    useUIStore.getState().setShowGenerationPanel(true);
+    onClose();
+  }, [onClose]);
+
+  const handleSelectAll = useCallback(() => {
+    const project = useProjectStore.getState().project;
+    if (project) {
+      const allClipIds = project.tracks.flatMap((t) => t.clips.map((c) => c.id));
+      useUIStore.getState().selectClips(allClipIds);
+    }
+    onClose();
+  }, [onClose]);
+
+  const handleLoopSelection = useCallback(() => {
+    const selectWindow = useUIStore.getState().selectWindow;
+    if (selectWindow) {
+      useTransportStore.getState().setLoopRegion(selectWindow.startTime, selectWindow.endTime);
+      if (!useTransportStore.getState().loopEnabled) {
+        useTransportStore.getState().toggleLoop();
+      }
+    }
+    onClose();
+  }, [onClose]);
+
+  return (
+    <ContextMenuWrapper x={x} y={y} onClose={onClose} minWidth={180} testId="canvas-context-menu">
+      {/* AI Tools with hover submenu */}
+      <div
+        className="relative"
+        onMouseEnter={() => setShowAISubmenu(true)}
+        onMouseLeave={() => setShowAISubmenu(false)}
+      >
+        <button
+          className="w-full text-left flex items-center justify-between cursor-pointer"
+          style={{
+            padding: '5px 12px',
+            fontSize: CONTEXT_MENU.fontSize,
+            border: 'none',
+            background: showAISubmenu ? CONTEXT_MENU.hoverBg : 'transparent',
+            color: showAISubmenu ? '#fff' : CONTEXT_MENU.textColor,
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = CONTEXT_MENU.hoverBg;
+            e.currentTarget.style.color = '#fff';
+          }}
+          onMouseLeave={(e) => {
+            if (!showAISubmenu) {
+              e.currentTarget.style.background = 'transparent';
+              e.currentTarget.style.color = CONTEXT_MENU.textColor;
+            }
+          }}
+        >
+          <span>AI Tools</span>
+          <span style={{ fontSize: 10, color: '#666', marginLeft: 12 }}>&#9654;</span>
+        </button>
+
+        {showAISubmenu && (
+          <div className="absolute left-full top-0" style={{ marginLeft: -2 }}>
+            <ContextMenuSubmenu>
+              <ContextMenuItem label="Inspire Me" onClick={handleInspireMe} color="#a78bfa" />
+              <ContextMenuItem label="Add a Layer" onClick={handleAddLayer} color="#67e8f9" />
+              <ContextMenuItem label="Music Enhancer" onClick={handleMusicEnhancer} color="#6ee7b7" />
+              <ContextMenuSeparator />
+              <ContextMenuItem label="Voice Changer" onClick={() => {}} disabled />
+              <ContextMenuItem label="Stem Splitter" onClick={() => {}} disabled />
+              <ContextMenuItem label="Sound Effects" onClick={() => {}} disabled />
+            </ContextMenuSubmenu>
+          </div>
+        )}
+      </div>
+
+      <ContextMenuSeparator />
+      <ContextMenuItem label="Paste" onClick={() => onClose()} shortcut="⌘V" disabled />
+      <ContextMenuItem label="Select All" onClick={handleSelectAll} shortcut="⌘A" />
+      <ContextMenuSeparator />
+      <ContextMenuItem label="Import" onClick={() => onClose()} disabled />
+      <ContextMenuItem label="Loop Selection" onClick={handleLoopSelection} shortcut="⌘L" />
+      <ContextMenuItem label="Grid & Snap" onClick={() => onClose()} disabled />
+    </ContextMenuWrapper>
+  );
+}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -9,6 +9,7 @@ import { snapToGrid } from '../../utils/time';
 import { MultiTrackGenerateModal } from '../generation/MultiTrackGenerateModal';
 import { RegionRegenerateModal } from '../generation/RegionRegenerateModal';
 import { RegionContextMenu } from './RegionContextMenu';
+import { CanvasContextMenu } from './CanvasContextMenu';
 import { InlineSuggestionBadge } from './InlineSuggestionBadge';
 import { useAudioImport } from '../../hooks/useAudioImport';
 import { Minimap } from './Minimap';
@@ -88,6 +89,7 @@ export function Timeline() {
   const suggestionFrequency = useUIStore((s) => s.suggestionFrequency);
 
   const [regionCtxMenu, setRegionCtxMenu] = useState<{ x: number; y: number } | null>(null);
+  const [canvasCtxMenu, setCanvasCtxMenu] = useState<{ x: number; y: number } | null>(null);
   const [ctxDrag, setCtxDrag] = useState<DragRect | null>(null);
   const [selDrag, setSelDrag] = useState<DragRect | null>(null);
   const [normalDrag, setNormalDrag] = useState<DragRect | null>(null);
@@ -432,6 +434,19 @@ export function Timeline() {
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
+        onContextMenu={(e) => {
+          // Only show canvas context menu on empty area
+          const target = e.target as HTMLElement;
+          if (target.closest?.('[data-clip-block]')) return;
+          if (target.closest?.('[data-sequencer-grid]')) return;
+          // Don't interfere with select window region context menu
+          if (selectWindow) {
+            const selEl = target.closest?.('[style]');
+            if (selEl && (selEl as HTMLElement).style.borderLeft?.includes('175, 82, 222')) return;
+          }
+          e.preventDefault();
+          setCanvasCtxMenu({ x: e.clientX, y: e.clientY });
+        }}
         style={{ cursor: 'default' }}
       >
         {fileDragOver && (
@@ -622,6 +637,15 @@ export function Timeline() {
 
       {/* Region regeneration modal */}
       {regionRegenerateTarget && <RegionRegenerateModal />}
+
+      {/* Canvas context menu — right-click on empty timeline area */}
+      {canvasCtxMenu && (
+        <CanvasContextMenu
+          x={canvasCtxMenu.x}
+          y={canvasCtxMenu.y}
+          onClose={() => setCanvasCtxMenu(null)}
+        />
+      )}
     </>
   );
 }

--- a/tests/unit/canvasContextMenu.test.tsx
+++ b/tests/unit/canvasContextMenu.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CanvasContextMenu } from '../../src/components/timeline/CanvasContextMenu';
+
+describe('CanvasContextMenu', () => {
+  const defaultProps = {
+    x: 100,
+    y: 200,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with correct test id', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    expect(screen.getByTestId('canvas-context-menu')).toBeInTheDocument();
+  });
+
+  it('renders AI Tools submenu trigger', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    expect(screen.getByText('AI Tools')).toBeInTheDocument();
+  });
+
+  it('renders Paste item with shortcut', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    expect(screen.getByText('Paste')).toBeInTheDocument();
+  });
+
+  it('renders Select All item with shortcut', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    expect(screen.getByText('Select All')).toBeInTheDocument();
+  });
+
+  it('renders Import item', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    expect(screen.getByText('Import')).toBeInTheDocument();
+  });
+
+  it('renders Loop Selection item', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    expect(screen.getByText('Loop Selection')).toBeInTheDocument();
+  });
+
+  it('renders Grid & Snap item', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    expect(screen.getByText('Grid & Snap')).toBeInTheDocument();
+  });
+
+  it('shows AI Tools submenu on hover', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    const aiToolsBtn = screen.getByText('AI Tools').closest('div')!;
+    fireEvent.mouseEnter(aiToolsBtn);
+    expect(screen.getByText('Inspire Me')).toBeInTheDocument();
+    expect(screen.getByText('Add a Layer')).toBeInTheDocument();
+    expect(screen.getByText('Music Enhancer')).toBeInTheDocument();
+    expect(screen.getByText('Voice Changer')).toBeInTheDocument();
+    expect(screen.getByText('Stem Splitter')).toBeInTheDocument();
+    expect(screen.getByText('Sound Effects')).toBeInTheDocument();
+  });
+
+  it('hides AI Tools submenu on mouse leave', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    const aiToolsBtn = screen.getByText('AI Tools').closest('div')!;
+    fireEvent.mouseEnter(aiToolsBtn);
+    expect(screen.getByText('Inspire Me')).toBeInTheDocument();
+    fireEvent.mouseLeave(aiToolsBtn);
+    expect(screen.queryByText('Inspire Me')).not.toBeInTheDocument();
+  });
+
+  it('marks Voice Changer, Stem Splitter, Sound Effects as disabled', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    const aiToolsBtn = screen.getByText('AI Tools').closest('div')!;
+    fireEvent.mouseEnter(aiToolsBtn);
+
+    const voiceChanger = screen.getByText('Voice Changer').closest('button')!;
+    const stemSplitter = screen.getByText('Stem Splitter').closest('button')!;
+    const soundEffects = screen.getByText('Sound Effects').closest('button')!;
+
+    expect(voiceChanger).toBeDisabled();
+    expect(stemSplitter).toBeDisabled();
+    expect(soundEffects).toBeDisabled();
+  });
+
+  it('calls onClose when clicking Inspire Me', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    const aiToolsBtn = screen.getByText('AI Tools').closest('div')!;
+    fireEvent.mouseEnter(aiToolsBtn);
+    fireEvent.click(screen.getByText('Inspire Me'));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when clicking Select All', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    fireEvent.click(screen.getByText('Select All'));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when backdrop is clicked', () => {
+    render(<CanvasContextMenu {...defaultProps} />);
+    const menu = screen.getByTestId('canvas-context-menu');
+    const backdrop = menu.previousElementSibling! as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a context menu when right-clicking on empty timeline canvas area (closes #578)
- "AI Tools" item with hover-to-expand submenu containing: Inspire Me, Add a Layer, Music Enhancer (active), and Voice Changer, Stem Splitter, Sound Effects (disabled/coming soon)
- Additional items: Paste, Select All, Import, Loop Selection, Grid & Snap
- Does not interfere with existing clip context menus (ClipContextMenu) or region context menus (RegionContextMenu)

## Test plan
- [x] 13 unit tests covering all menu items, submenu hover/unhover, disabled states, and action callbacks
- [ ] Manual: right-click on empty timeline area shows the context menu
- [ ] Manual: right-click on a clip still shows the clip context menu (not canvas menu)
- [ ] Manual: hover over "AI Tools" expands the submenu; moving away collapses it
- [ ] Manual: clicking "Inspire Me" opens the generation side panel
- [ ] Manual: clicking "Select All" selects all clips
- [ ] Manual: disabled items (Voice Changer, Stem Splitter, Sound Effects) are visually dimmed and not clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)