### PR TITLE
feat: add selection floating toolbar with AI tool quick actions

### DIFF
--- a/src/components/timeline/SelectionFloatingToolbar.tsx
+++ b/src/components/timeline/SelectionFloatingToolbar.tsx
@@ -1,0 +1,102 @@
+import { useUIStore } from '../../store/uiStore';
+import { useProjectStore } from '../../store/projectStore';
+
+interface SelectionFloatingToolbarProps {
+  /** Left edge of the selection in pixels (absolute within trackArea) */
+  selLeft: number | null;
+  /** Width of the selection in pixels */
+  selWidth: number | null;
+  /** Bottom edge of the selection in pixels (absolute within trackArea) */
+  selBottom: number | null;
+}
+
+/**
+ * Floating pill toolbar that appears below a committed selectWindow.
+ * Provides quick actions: Music Enhancer, Add Layer, + MIDI.
+ */
+export function SelectionFloatingToolbar({ selLeft, selWidth, selBottom }: SelectionFloatingToolbarProps) {
+  const selectWindow = useUIStore((s) => s.selectWindow);
+  const ensureMidiClip = useProjectStore((s) => s.ensureMidiClip);
+
+  if (!selectWindow || selLeft === null || selWidth === null || selBottom === null) {
+    return null;
+  }
+
+  const centerX = selLeft + selWidth / 2;
+  const topY = selBottom + 8;
+
+  const handleMusicEnhancer = () => {
+    // Future: open music enhancer modal
+    // For now, placeholder — will be wired when musicEnhancerOpen state is added
+  };
+
+  const handleAddLayer = () => {
+    // Future: open add layer modal
+    // For now, placeholder — will be wired when addLayerOpen state is added
+  };
+
+  const handleAddMidi = () => {
+    const duration = selectWindow.endTime - selectWindow.startTime;
+    for (const trackId of selectWindow.trackIds) {
+      ensureMidiClip(trackId, selectWindow.startTime, duration);
+    }
+  };
+
+  return (
+    <div
+      data-testid="selection-floating-toolbar"
+      className="absolute z-20 flex items-center gap-1 px-2 py-1.5 rounded-full border border-[#444] bg-[#2a2a2a]/95 backdrop-blur-sm shadow-lg transition-opacity duration-150 pointer-events-auto"
+      style={{
+        left: centerX,
+        top: topY,
+        transform: 'translateX(-50%)',
+      }}
+    >
+      {/* Music Enhancer */}
+      <button
+        type="button"
+        aria-label="Music Enhancer"
+        className="flex items-center justify-center w-8 h-8 rounded-full text-zinc-400 hover:text-white hover:bg-white/10 transition-colors"
+        onClick={handleMusicEnhancer}
+      >
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M10 3v14M6 7l4-4 4 4M6 13l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {/* Add Layer */}
+      <button
+        type="button"
+        aria-label="Add Layer"
+        className="flex items-center justify-center w-8 h-8 rounded-full text-zinc-400 hover:text-white hover:bg-white/10 transition-colors"
+        onClick={handleAddLayer}
+      >
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M11 3L5 11h4l-1 6 6-8h-4l1-6z"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {/* + MIDI */}
+      <button
+        type="button"
+        aria-label="+ MIDI"
+        className="flex items-center justify-center h-8 px-2.5 rounded-full text-zinc-400 hover:text-white hover:bg-white/10 transition-colors text-xs font-medium whitespace-nowrap"
+        onClick={handleAddMidi}
+      >
+        + MIDI
+      </button>
+    </div>
+  );
+}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -16,6 +16,7 @@ import { Minimap } from './Minimap';
 import { TempoLane } from './TempoLane';
 import { ArrangementMarkers } from './ArrangementMarkers';
 import { TimelineEmptyState } from './TimelineEmptyState';
+import { SelectionFloatingToolbar } from './SelectionFloatingToolbar';
 import { toastInfo } from '../../hooks/useToast';
 import { getTimelineFitViewport } from '../../utils/timelineZoom';
 
@@ -502,6 +503,13 @@ export function Timeline() {
                 </span>
               </div>
             )}
+
+            {/* Floating toolbar below select window */}
+            <SelectionFloatingToolbar
+              selLeft={selLeft}
+              selWidth={selWidth}
+              selBottom={selVRange ? selVRange.top + selVRange.height : null}
+            />
 
             {/* Live context drag overlay — Apple Teal (#5AC8FA) */}
             {ctxDrag && (

--- a/src/components/timeline/__tests__/SelectionFloatingToolbar.test.tsx
+++ b/src/components/timeline/__tests__/SelectionFloatingToolbar.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SelectionFloatingToolbar } from '../SelectionFloatingToolbar';
+
+// Mock uiStore
+const mockSetSelectWindow = vi.fn();
+let mockSelectWindow: { startTime: number; endTime: number; trackIds: string[] } | null = null;
+let mockPixelsPerSecond = 100;
+
+vi.mock('../../../store/uiStore', () => ({
+  useUIStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({
+      selectWindow: mockSelectWindow,
+      pixelsPerSecond: mockPixelsPerSecond,
+      setSelectWindow: mockSetSelectWindow,
+    }),
+}));
+
+// Mock projectStore for ensureMidiClip
+const mockEnsureMidiClip = vi.fn();
+vi.mock('../../../store/projectStore', () => ({
+  useProjectStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({
+      ensureMidiClip: mockEnsureMidiClip,
+    }),
+}));
+
+describe('SelectionFloatingToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectWindow = null;
+    mockPixelsPerSecond = 100;
+  });
+
+  it('returns null when selectWindow is null', () => {
+    mockSelectWindow = null;
+    const { container } = render(
+      <SelectionFloatingToolbar selLeft={null} selWidth={null} selBottom={null} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders toolbar when selectWindow and position props are provided', () => {
+    mockSelectWindow = { startTime: 2, endTime: 6, trackIds: ['t1'] };
+    render(
+      <SelectionFloatingToolbar selLeft={200} selWidth={400} selBottom={100} />,
+    );
+    expect(screen.getByTestId('selection-floating-toolbar')).toBeInTheDocument();
+  });
+
+  it('renders three action buttons', () => {
+    mockSelectWindow = { startTime: 2, endTime: 6, trackIds: ['t1'] };
+    render(
+      <SelectionFloatingToolbar selLeft={200} selWidth={400} selBottom={100} />,
+    );
+    expect(screen.getByRole('button', { name: /music enhancer/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add layer/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /midi/i })).toBeInTheDocument();
+  });
+
+  it('positions toolbar centered below selection', () => {
+    mockSelectWindow = { startTime: 2, endTime: 6, trackIds: ['t1'] };
+    render(
+      <SelectionFloatingToolbar selLeft={200} selWidth={400} selBottom={100} />,
+    );
+    const toolbar = screen.getByTestId('selection-floating-toolbar');
+    // Centered horizontally: left + width/2 = 200 + 200 = 400, then transform translateX(-50%)
+    expect(toolbar.style.left).toBe('400px');
+    expect(toolbar.style.top).toBe('108px'); // selBottom + 8px gap
+  });
+
+  it('calls ensureMidiClip for each track when + MIDI is clicked', () => {
+    mockSelectWindow = { startTime: 2, endTime: 6, trackIds: ['t1', 't2'] };
+    render(
+      <SelectionFloatingToolbar selLeft={200} selWidth={400} selBottom={100} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /midi/i }));
+    expect(mockEnsureMidiClip).toHaveBeenCalledTimes(2);
+    expect(mockEnsureMidiClip).toHaveBeenCalledWith('t1', 2, 4);
+    expect(mockEnsureMidiClip).toHaveBeenCalledWith('t2', 2, 4);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `SelectionFloatingToolbar` component that renders a floating pill-shaped toolbar centered below the select window overlay on the timeline
- Contains 3 icon buttons: Music Enhancer, Add Layer, and + MIDI
- The + MIDI button creates MIDI clips in the selection range for all selected tracks via `ensureMidiClip`
- Toolbar is positioned absolutely within the track area, horizontally centered on the selection with an 8px gap below

Closes #577

## Test plan

- [x] Unit tests: 5 new tests covering render/hide logic, button rendering, positioning, and + MIDI action
- [x] TypeScript: 0 type errors (`npx tsc --noEmit`)
- [x] All 1816 tests pass (`npm test`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual: create a select window by Cmd+dragging on timeline, verify toolbar appears below selection
- [ ] Manual: click + MIDI button, verify MIDI clips are created in the selected tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)