### PR TITLE
feat: Add Layer floating panel with progressive disclosure

### DIFF
--- a/src/components/generation/AddLayerPanel.tsx
+++ b/src/components/generation/AddLayerPanel.tsx
@@ -1,0 +1,439 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { useGenerationStore } from '../../store/generationStore';
+import { useUIStore } from '../../store/uiStore';
+import { generateFromAddLayer } from '../../services/generationPipeline';
+import { extractContextAudioLazy } from '../../services/lazyContextAudioExtractor';
+import type { TrackName } from '../../types/project';
+
+const VOCAL_TRACK_NAMES = new Set<string>(['vocals', 'backing_vocals']);
+
+const LAYER_TYPES = [
+  { id: 'song', label: 'Song Track', trackName: 'custom' as TrackName },
+  { id: 'vocal', label: 'Vocal', trackName: 'vocals' as TrackName, showLyrics: true },
+  { id: 'backing', label: 'Backing', trackName: 'backing_vocals' as TrackName, showLyrics: true },
+  { id: 'custom', label: 'Custom', trackName: 'custom' as TrackName },
+] as const;
+
+type LayerTypeId = (typeof LAYER_TYPES)[number]['id'];
+
+function fmt(s: number) {
+  return `${s.toFixed(1)}s`;
+}
+
+function fmtTime(s: number) {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${sec.toString().padStart(2, '0')}`;
+}
+
+export function AddLayerPanel() {
+  const isOpen = useUIStore((s) => s.addLayerOpen);
+  const setAddLayerOpen = useUIStore((s) => s.setAddLayerOpen);
+  const selectWindow = useUIStore((s) => s.selectWindow);
+  const contextWindow = useUIStore((s) => s.contextWindow);
+
+  const project = useProjectStore((s) => s.project);
+  const addTrack = useProjectStore((s) => s.addTrack);
+  const setTrackLocalCaption = useProjectStore((s) => s.setTrackLocalCaption);
+  const isGenerating = useGenerationStore((s) => s.isGenerating);
+
+  const [layerType, setLayerType] = useState<LayerTypeId>('song');
+  const [style, setStyle] = useState('');
+  const [lyrics, setLyrics] = useState('');
+  const [globalCaption, setGlobalCaption] = useState('');
+
+  // Advanced options
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [chunkMaskMode, setChunkMaskMode] = useState<'auto' | 'explicit'>('auto');
+  const [sampleMode, setSampleMode] = useState(false);
+  const [autoExpandPrompt, setAutoExpandPrompt] = useState(true);
+  const [seedValue, setSeedValue] = useState('');
+
+  // Context audio preview
+  type PreviewState = 'idle' | 'loading' | 'playing';
+  const [previewState, setPreviewState] = useState<PreviewState>('idle');
+  const [previewCurrentTime, setPreviewCurrentTime] = useState(0);
+  const [previewDuration, setPreviewDuration] = useState(0);
+  const previewAudioRef = useRef<HTMLAudioElement | null>(null);
+  const previewUrlRef = useRef<string | null>(null);
+  const scrubIntervalRef = useRef<number | null>(null);
+
+  const stopPreview = useCallback(() => {
+    if (scrubIntervalRef.current) {
+      clearInterval(scrubIntervalRef.current);
+      scrubIntervalRef.current = null;
+    }
+    previewAudioRef.current?.pause();
+    previewAudioRef.current = null;
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+    setPreviewState('idle');
+    setPreviewCurrentTime(0);
+    setPreviewDuration(0);
+  }, []);
+
+  useEffect(() => stopPreview, [stopPreview]);
+
+  const handleClose = useCallback(() => {
+    stopPreview();
+    setAddLayerOpen(false);
+  }, [stopPreview, setAddLayerOpen]);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        handleClose();
+      }
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [isOpen, handleClose]);
+
+  // Reset form when panel opens
+  useEffect(() => {
+    if (isOpen) {
+      setStyle('');
+      setLyrics('');
+      setGlobalCaption(project?.globalCaption ?? '');
+      setSeedValue('');
+      setSampleMode(false);
+      setAutoExpandPrompt(true);
+      setChunkMaskMode('auto');
+    }
+  }, [isOpen, project?.globalCaption]);
+
+  const handlePreviewContext = useCallback(async () => {
+    if (previewState === 'playing') { stopPreview(); return; }
+    if (!contextWindow) return;
+    setPreviewState('loading');
+    try {
+      const blob = await extractContextAudioLazy(contextWindow);
+      if (!blob) { setPreviewState('idle'); return; }
+      const url = URL.createObjectURL(blob);
+      previewUrlRef.current = url;
+      const audio = new Audio(url);
+      previewAudioRef.current = audio;
+      audio.onloadedmetadata = () => setPreviewDuration(audio.duration);
+      audio.onended = () => stopPreview();
+      audio.onerror = () => stopPreview();
+      scrubIntervalRef.current = window.setInterval(() => {
+        if (previewAudioRef.current) setPreviewCurrentTime(previewAudioRef.current.currentTime);
+      }, 100);
+      await audio.play();
+      setPreviewState('playing');
+    } catch {
+      stopPreview();
+    }
+  }, [previewState, contextWindow, stopPreview]);
+
+  const handleScrub = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const t = Number(e.target.value);
+    if (previewAudioRef.current) previewAudioRef.current.currentTime = t;
+    setPreviewCurrentTime(t);
+  }, []);
+
+  if (!isOpen || !project) return null;
+
+  const selectedLayerType = LAYER_TYPES.find((lt) => lt.id === layerType)!;
+  const showLyrics = 'showLyrics' in selectedLayerType && selectedLayerType.showLyrics;
+  const hasContext = contextWindow !== null;
+
+  const startTime = selectWindow?.startTime ?? 0;
+  const endTime = selectWindow?.endTime ?? project.totalDuration;
+  const duration = endTime - startTime;
+
+  const parsedSeed = seedValue.trim() ? parseInt(seedValue, 10) : undefined;
+
+  const handleSelectWholeSong = () => {
+    useUIStore.getState().setSelectWindow({
+      startTime: 0,
+      endTime: project.totalDuration,
+      trackIds: selectWindow?.trackIds ?? [],
+    });
+  };
+
+  const handleGenerate = async () => {
+    stopPreview();
+
+    // Find or create a track for this layer type
+    const targetTrackName = selectedLayerType.trackName;
+    let targetTrack = project.tracks.find((t) => t.trackName === targetTrackName);
+    if (!targetTrack) {
+      targetTrack = addTrack(targetTrackName, 'stems');
+    }
+
+    if (style) {
+      setTrackLocalCaption(targetTrack.id, style);
+    }
+
+    handleClose();
+
+    await generateFromAddLayer({
+      trackId: targetTrack.id,
+      startTime,
+      duration,
+      localDescription: style,
+      globalCaption,
+      lyrics: showLyrics ? lyrics : '',
+      contextWindow: hasContext ? contextWindow : null,
+      chunkMaskMode,
+    });
+  };
+
+  return (
+    <div
+      data-testid="add-layer-panel"
+      className="fixed left-1/2 -translate-x-1/2 bottom-[60px] w-[420px] max-h-[70vh] flex flex-col bg-[#1e1e22] border border-[#3a3a3a] rounded-xl shadow-2xl text-xs text-zinc-200"
+      style={{ zIndex: 60 }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[#3a3a3a]">
+        <span className="text-sm font-semibold text-white">Add a Layer</span>
+        <button
+          onClick={handleClose}
+          className="text-zinc-400 hover:text-zinc-200 transition-colors text-base leading-none"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0">
+        {/* Selection display */}
+        <div>
+          <div className="text-zinc-400 text-xs">
+            Selection: {fmt(startTime)} - {fmt(endTime)}
+          </div>
+          {(startTime > 0 || endTime < project.totalDuration) && (
+            <button
+              onClick={handleSelectWholeSong}
+              className="text-teal-400 hover:text-teal-300 text-[11px] mt-0.5 transition-colors"
+            >
+              + Select the whole song
+            </button>
+          )}
+        </div>
+
+        {/* Layer Type */}
+        <div>
+          <label className="text-[10px] uppercase tracking-wide text-zinc-500 block mb-1.5">
+            Layer Type
+          </label>
+          <div className="flex gap-1.5 flex-wrap">
+            {LAYER_TYPES.map((lt) => (
+              <button
+                key={lt.id}
+                onClick={() => setLayerType(lt.id)}
+                className={`px-3 py-1.5 rounded-full text-[11px] font-medium transition-colors ${
+                  layerType === lt.id
+                    ? 'bg-teal-600 text-white'
+                    : 'bg-[#2a2a2a] text-zinc-400 hover:text-zinc-300 hover:bg-[#333]'
+                }`}
+              >
+                {lt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Style */}
+        {!sampleMode && (
+          <div>
+            <label className="text-[10px] uppercase tracking-wide text-zinc-500 block mb-1">
+              Style
+            </label>
+            <textarea
+              value={style}
+              onChange={(e) => setStyle(e.target.value)}
+              placeholder="Describe the sound..."
+              rows={2}
+              className="w-full bg-[#161618] border border-[#333] rounded-lg px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-teal-600"
+            />
+          </div>
+        )}
+
+        {sampleMode && (
+          <div>
+            <label className="text-[10px] uppercase tracking-wide text-zinc-500 block mb-1">
+              Description
+            </label>
+            <textarea
+              value={style}
+              onChange={(e) => setStyle(e.target.value)}
+              placeholder="Describe the sample you want..."
+              rows={2}
+              className="w-full bg-[#161618] border border-[#333] rounded-lg px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-teal-600"
+            />
+          </div>
+        )}
+
+        {/* Lyrics (vocal types only) */}
+        {showLyrics && !sampleMode && (
+          <div>
+            <label className="text-[10px] uppercase tracking-wide text-zinc-500 block mb-1">
+              Lyrics
+            </label>
+            <textarea
+              value={lyrics}
+              onChange={(e) => setLyrics(e.target.value)}
+              placeholder="Song lyrics..."
+              rows={3}
+              className="w-full bg-[#161618] border border-[#333] rounded-lg px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-teal-600 font-mono"
+            />
+          </div>
+        )}
+
+        {/* Advanced section */}
+        <div className="border-t border-[#3a3a3a] pt-2">
+          <button
+            type="button"
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="text-zinc-500 hover:text-zinc-300 text-[11px] transition-colors"
+          >
+            {showAdvanced ? '\u25BE' : '\u25B8'} Advanced
+          </button>
+          {showAdvanced && (
+            <div className="mt-2 space-y-2.5">
+              {/* Context window info */}
+              {hasContext && (
+                <div>
+                  <label className="text-[10px] uppercase tracking-wide text-zinc-500 block mb-1">
+                    Context
+                  </label>
+                  <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-950/50 border border-blue-800/40">
+                    <button
+                      onClick={handlePreviewContext}
+                      disabled={previewState === 'loading'}
+                      className="w-6 h-6 flex items-center justify-center rounded bg-blue-800/60 hover:bg-blue-700/60 text-blue-200 text-[10px] disabled:opacity-50 shrink-0 transition-colors"
+                      title={previewState === 'playing' ? 'Stop preview' : 'Preview context audio'}
+                    >
+                      {previewState === 'loading' ? '\u2026' : previewState === 'playing' ? '\u25A0' : '\u25B6'}
+                    </button>
+                    <input
+                      type="range"
+                      min={0}
+                      max={previewDuration || 1}
+                      step={0.01}
+                      value={previewCurrentTime}
+                      onChange={handleScrub}
+                      disabled={previewState !== 'playing'}
+                      className="flex-1 h-1 accent-blue-400 cursor-pointer disabled:opacity-40"
+                    />
+                    <span className="text-[10px] font-mono text-blue-300 shrink-0 w-[60px] text-right">
+                      {fmtTime(previewCurrentTime)} / {fmtTime(previewDuration)}
+                    </span>
+                  </div>
+                  <span className="text-[10px] text-blue-300 mt-1 block">
+                    {fmt(contextWindow.startTime)} — {fmt(contextWindow.endTime)}
+                  </span>
+                </div>
+              )}
+              {!hasContext && (
+                <div className="text-[10px] text-zinc-500">
+                  Context: none (Alt+drag on timeline to set)
+                </div>
+              )}
+
+              {/* Mask mode */}
+              <div className="flex items-center gap-2">
+                <label className="text-[10px] text-zinc-500">Mask mode:</label>
+                <div className="flex gap-1">
+                  <button
+                    onClick={() => setChunkMaskMode('auto')}
+                    className={`px-2 py-0.5 rounded text-[10px] border transition-colors ${
+                      chunkMaskMode === 'auto'
+                        ? 'bg-teal-900/50 border-teal-700/50 text-teal-300'
+                        : 'bg-[#2a2a2a] border-[#3a3a3a] text-zinc-500 hover:text-zinc-400'
+                    }`}
+                  >
+                    Auto
+                  </button>
+                  <button
+                    onClick={() => setChunkMaskMode('explicit')}
+                    className={`px-2 py-0.5 rounded text-[10px] border transition-colors ${
+                      chunkMaskMode === 'explicit'
+                        ? 'bg-teal-900/50 border-teal-700/50 text-teal-300'
+                        : 'bg-[#2a2a2a] border-[#3a3a3a] text-zinc-500 hover:text-zinc-400'
+                    }`}
+                  >
+                    Explicit
+                  </button>
+                </div>
+              </div>
+
+              {/* Checkboxes */}
+              <div className="flex items-center gap-4">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={sampleMode}
+                    onChange={(e) => setSampleMode(e.target.checked)}
+                    className="w-3.5 h-3.5 rounded border-[#444] bg-[#222] accent-teal-600"
+                  />
+                  <span className="text-[10px] text-zinc-400">Sample mode</span>
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={autoExpandPrompt}
+                    onChange={(e) => setAutoExpandPrompt(e.target.checked)}
+                    className="w-3.5 h-3.5 rounded border-[#444] bg-[#222] accent-teal-600"
+                  />
+                  <span className="text-[10px] text-zinc-400">Auto-expand prompt</span>
+                </label>
+              </div>
+
+              {/* Seed */}
+              <div>
+                <label className="text-[10px] text-zinc-500 block mb-1">Seed</label>
+                <input
+                  type="number"
+                  value={seedValue}
+                  onChange={(e) => setSeedValue(e.target.value)}
+                  placeholder="Leave empty for random"
+                  className="w-full bg-[#161618] border border-[#333] rounded-lg px-2.5 py-1.5 text-xs text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-teal-600"
+                />
+              </div>
+
+              {/* Global caption */}
+              {!sampleMode && (
+                <div>
+                  <label className="text-[10px] text-zinc-500 block mb-1">Global caption</label>
+                  <textarea
+                    value={globalCaption}
+                    onChange={(e) => setGlobalCaption(e.target.value)}
+                    placeholder="e.g. upbeat pop song with energetic drums..."
+                    rows={2}
+                    className="w-full bg-[#161618] border border-[#333] rounded-lg px-2.5 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-teal-600"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="px-4 py-3 border-t border-[#3a3a3a]">
+        <button
+          onClick={handleGenerate}
+          disabled={isGenerating}
+          className={`w-full py-2.5 rounded-lg text-xs font-medium transition-colors ${
+            isGenerating
+              ? 'bg-[#444] text-zinc-400 cursor-not-allowed'
+              : 'bg-teal-600 hover:bg-teal-500 text-white'
+          }`}
+        >
+          {isGenerating ? 'Generating\u2026' : 'Generate'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/generation/__tests__/AddLayerPanel.test.tsx
+++ b/src/components/generation/__tests__/AddLayerPanel.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AddLayerPanel } from '../AddLayerPanel';
+import { useProjectStore } from '../../../store/projectStore';
+import { useUIStore } from '../../../store/uiStore';
+import { useGenerationStore } from '../../../store/generationStore';
+
+// Mock external dependencies
+vi.mock('../../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../../services/generationPipeline', () => ({
+  generateFromAddLayer: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../services/lazyContextAudioExtractor', () => ({
+  extractContextAudioLazy: vi.fn().mockResolvedValue(null),
+}));
+
+function setupProject() {
+  useProjectStore.setState({ project: null });
+  useProjectStore.getState().createProject();
+  useUIStore.setState({
+    addLayerOpen: true,
+    selectWindow: { startTime: 3, endTime: 7, trackIds: [] },
+    contextWindow: null,
+  });
+}
+
+describe('AddLayerPanel', () => {
+  beforeEach(() => {
+    setupProject();
+  });
+
+  it('renders nothing when addLayerOpen is false', () => {
+    useUIStore.setState({ addLayerOpen: false });
+    const { container } = render(<AddLayerPanel />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the panel when addLayerOpen is true', () => {
+    render(<AddLayerPanel />);
+    expect(screen.getByTestId('add-layer-panel')).toBeInTheDocument();
+    expect(screen.getByText('Add a Layer')).toBeInTheDocument();
+  });
+
+  it('displays the selection range from uiStore selectWindow', () => {
+    render(<AddLayerPanel />);
+    expect(screen.getByText(/3\.0s/)).toBeInTheDocument();
+    expect(screen.getByText(/7\.0s/)).toBeInTheDocument();
+  });
+
+  it('renders layer type buttons', () => {
+    render(<AddLayerPanel />);
+    expect(screen.getByText('Song Track')).toBeInTheDocument();
+    expect(screen.getByText('Vocal')).toBeInTheDocument();
+    expect(screen.getByText('Backing')).toBeInTheDocument();
+    expect(screen.getByText('Custom')).toBeInTheDocument();
+  });
+
+  it('shows lyrics textarea when Vocal layer type is selected', () => {
+    render(<AddLayerPanel />);
+    // Lyrics should not be visible by default (Song Track selected)
+    expect(screen.queryByPlaceholderText('Song lyrics...')).not.toBeInTheDocument();
+
+    // Click Vocal
+    fireEvent.click(screen.getByText('Vocal'));
+    expect(screen.getByPlaceholderText('Song lyrics...')).toBeInTheDocument();
+  });
+
+  it('shows lyrics textarea when Backing layer type is selected', () => {
+    render(<AddLayerPanel />);
+    fireEvent.click(screen.getByText('Backing'));
+    expect(screen.getByPlaceholderText('Song lyrics...')).toBeInTheDocument();
+  });
+
+  it('hides lyrics textarea when Song Track layer type is selected', () => {
+    render(<AddLayerPanel />);
+    fireEvent.click(screen.getByText('Vocal'));
+    expect(screen.getByPlaceholderText('Song lyrics...')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Song Track'));
+    expect(screen.queryByPlaceholderText('Song lyrics...')).not.toBeInTheDocument();
+  });
+
+  it('has a collapsed Advanced section by default', () => {
+    render(<AddLayerPanel />);
+    expect(screen.getByText(/Advanced/)).toBeInTheDocument();
+    // Seed input should not be visible
+    expect(screen.queryByPlaceholderText('Leave empty for random')).not.toBeInTheDocument();
+  });
+
+  it('expands Advanced section on click', () => {
+    render(<AddLayerPanel />);
+    fireEvent.click(screen.getByText(/Advanced/));
+    expect(screen.getByPlaceholderText('Leave empty for random')).toBeInTheDocument();
+    expect(screen.getByText('Sample mode')).toBeInTheDocument();
+    expect(screen.getByText('Auto-expand prompt')).toBeInTheDocument();
+    expect(screen.getByText(/Mask mode/)).toBeInTheDocument();
+  });
+
+  it('shows context info in Advanced when contextWindow is set', () => {
+    useUIStore.setState({
+      contextWindow: { startTime: 1, endTime: 5, trackIds: [] },
+    });
+    render(<AddLayerPanel />);
+    fireEvent.click(screen.getByText(/Advanced/));
+    expect(screen.getByText(/1\.0s/)).toBeInTheDocument();
+    expect(screen.getByText(/5\.0s/)).toBeInTheDocument();
+  });
+
+  it('shows "none" context message when no contextWindow', () => {
+    render(<AddLayerPanel />);
+    fireEvent.click(screen.getByText(/Advanced/));
+    expect(screen.getByText(/Context: none/)).toBeInTheDocument();
+  });
+
+  it('has no backdrop overlay — floating panel only', () => {
+    const { container } = render(<AddLayerPanel />);
+    // The panel should not have a fixed inset-0 backdrop
+    const backdrop = container.querySelector('.fixed.inset-0');
+    expect(backdrop).toBeNull();
+  });
+
+  it('closes the panel when close button is clicked', () => {
+    render(<AddLayerPanel />);
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(useUIStore.getState().addLayerOpen).toBe(false);
+  });
+
+  it('closes the panel on Escape key', () => {
+    render(<AddLayerPanel />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().addLayerOpen).toBe(false);
+  });
+
+  it('has a Generate button', () => {
+    render(<AddLayerPanel />);
+    expect(screen.getByText('Generate')).toBeInTheDocument();
+  });
+
+  it('disables Generate button when generating', () => {
+    useGenerationStore.setState({ isGenerating: true });
+    render(<AddLayerPanel />);
+    const btn = screen.getByText(/Generating/);
+    expect(btn).toBeDisabled();
+  });
+
+  it('shows "Select the whole song" button when selection is partial', () => {
+    render(<AddLayerPanel />);
+    expect(screen.getByText('+ Select the whole song')).toBeInTheDocument();
+  });
+
+  it('does not show "Select the whole song" when selection covers full song', () => {
+    const totalDuration = useProjectStore.getState().project!.totalDuration;
+    useUIStore.setState({
+      selectWindow: { startTime: 0, endTime: totalDuration, trackIds: [] },
+    });
+    render(<AddLayerPanel />);
+    expect(screen.queryByText('+ Select the whole song')).not.toBeInTheDocument();
+  });
+
+  it('renders style textarea', () => {
+    render(<AddLayerPanel />);
+    expect(screen.getByPlaceholderText('Describe the sound...')).toBeInTheDocument();
+  });
+
+  it('applies active styling to selected layer type pill', () => {
+    render(<AddLayerPanel />);
+    const songBtn = screen.getByText('Song Track');
+    // Song Track should have teal active styling
+    expect(songBtn.className).toContain('bg-teal-600');
+
+    const vocalBtn = screen.getByText('Vocal');
+    expect(vocalBtn.className).not.toContain('bg-teal-600');
+  });
+});

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import { TrackList } from '../tracks/TrackList';
 import { Timeline } from '../timeline/Timeline';
 import { Z } from '../../utils/zIndex';
 import { GenerationPanel } from '../generation/GenerationPanel';
+import { AddLayerPanel } from '../generation/AddLayerPanel';
 import { GenerationSidePanel } from '../generation/GenerationSidePanel';
 import { CoverModal } from '../generation/CoverModal';
 import { RepaintModal } from '../generation/RepaintModal';
@@ -174,6 +175,7 @@ export function AppShell() {
       {project && <MixerPanel />}
       {project && <GenerationPanel />}
       {project && <GenerationSidePanel />}
+      {project && <AddLayerPanel />}
       <StatusBar />
       <ToastContainer />
       <UndoHistoryPanel />

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -141,6 +141,9 @@ export interface UIState {
   showGeneratePatternDialog: boolean;
   generatePatternClipId: string | null;
 
+  // Add Layer Panel (floating, no backdrop)
+  addLayerOpen: boolean;
+
   // Generation Side Panel
   showGenerationPanel: boolean;
 
@@ -262,6 +265,9 @@ export interface UIState {
   // Generate pattern dialog
   setShowGeneratePatternDialog: (v: boolean) => void;
   openGeneratePatternDialog: (clipId: string) => void;
+
+  // Add Layer Panel
+  setAddLayerOpen: (v: boolean) => void;
 
   // Generation Side Panel
   toggleGenerationPanel: () => void;
@@ -422,6 +428,8 @@ export const useUIStore = create<UIState>()(
 
   showGeneratePatternDialog: false,
   generatePatternClipId: null,
+
+  addLayerOpen: false,
 
   showGenerationPanel: false,
 
@@ -678,6 +686,8 @@ export const useUIStore = create<UIState>()(
 
   setShowGeneratePatternDialog: (v) => set(v ? { showGeneratePatternDialog: v } : { showGeneratePatternDialog: false, generatePatternClipId: null }),
   openGeneratePatternDialog: (clipId) => set({ showGeneratePatternDialog: true, generatePatternClipId: clipId }),
+
+  setAddLayerOpen: (v) => set({ addLayerOpen: v }),
 
   toggleGenerationPanel: () => set((s) => ({ showGenerationPanel: !s.showGenerationPanel })),
   setShowGenerationPanel: (v) => set({ showGenerationPanel: v }),


### PR DESCRIPTION
## Summary
- Adds a new `AddLayerPanel` component — a floating panel (no backdrop overlay) positioned at the bottom center of the viewport, replacing the modal pattern for the "Add Layer" workflow
- Layer type selector with pill buttons (Song Track, Vocal, Backing, Custom) that conditionally shows lyrics textarea for vocal types
- Progressive disclosure: Advanced section (collapsed by default) contains context preview, mask mode toggle, sample mode, auto-expand prompt, seed input, and global caption
- Reads `selectWindow` and `contextWindow` from uiStore instead of receiving props
- Adds `addLayerOpen` / `setAddLayerOpen` state to uiStore
- Keeps existing `AddLayerModal` intact for edit mode (double-click clip)

## Test plan
- [x] 20 unit tests covering rendering, layer type switching, lyrics visibility, advanced section toggle, context info display, close behavior, generate button state
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — all 1831 tests pass
- [x] `npm run build` — succeeds

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)