### PR TITLE
fix: add tabular-nums to LCD transport display

### DIFF
--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -31,11 +31,11 @@ function LCDDisplay() {
 
   return (
     <div className="gb-lcd flex items-center gap-3 px-3 py-1 min-w-[200px] justify-center">
-      <span className={`text-[13px] font-mono tracking-wider ${barsBeatsColor}`}>{displayBarsBeats}</span>
-      <span className="text-[11px] font-mono text-zinc-400">{formatTime(currentTime)}</span>
+      <span className={`text-[13px] font-mono tabular-nums tracking-wider ${barsBeatsColor}`}>{displayBarsBeats}</span>
+      <span className="text-[11px] font-mono tabular-nums text-zinc-400">{formatTime(currentTime)}</span>
       {project && !countInActive && (
         <>
-          <span className="text-[11px] font-mono text-zinc-400">{project.bpm} bpm</span>
+          <span className="text-[11px] font-mono tabular-nums text-zinc-400">{project.bpm} bpm</span>
           <span className="text-[10px] text-emerald-600/60" title="Project auto-saved to browser storage">●</span>
         </>
       )}


### PR DESCRIPTION
## Summary

- Add `tabular-nums` CSS class to all numeric spans in the toolbar LCD display (bars.beats.ticks, elapsed time, BPM)
- Prevents layout shift that caused the play button to jump during playback

Fixes #586

## Root Cause

The `LCDDisplay` component used `font-mono` but lacked `tabular-nums` (`font-variant-numeric: tabular-nums`). Proportional digit widths meant the display width changed as numbers updated during playback, shifting adjacent transport controls.

## Changes

- `src/components/layout/Toolbar.tsx`: Added `tabular-nums` to the 3 numeric `<span>` elements in `LCDDisplay`

## Test Plan

- [ ] Start playback — verify play button no longer shifts position
- [ ] Observe LCD display digits maintain consistent spacing across all digit values
- [ ] Verify no visual regression in the transport bar layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)