### PR TITLE
fix: wire floating toolbar buttons & disable auto-open modal

### DIFF
--- a/src/components/timeline/SelectionFloatingToolbar.tsx
+++ b/src/components/timeline/SelectionFloatingToolbar.tsx
@@ -16,6 +16,8 @@ interface SelectionFloatingToolbarProps {
  */
 export function SelectionFloatingToolbar({ selLeft, selWidth, selBottom }: SelectionFloatingToolbarProps) {
   const selectWindow = useUIStore((s) => s.selectWindow);
+  const setMusicEnhancerOpen = useUIStore((s) => s.setMusicEnhancerOpen);
+  const setAddLayerOpen = useUIStore((s) => s.setAddLayerOpen);
   const ensureMidiClip = useProjectStore((s) => s.ensureMidiClip);
 
   if (!selectWindow || selLeft === null || selWidth === null || selBottom === null) {
@@ -26,13 +28,11 @@ export function SelectionFloatingToolbar({ selLeft, selWidth, selBottom }: Selec
   const topY = selBottom + 8;
 
   const handleMusicEnhancer = () => {
-    // Future: open music enhancer modal
-    // For now, placeholder — will be wired when musicEnhancerOpen state is added
+    setMusicEnhancerOpen(true);
   };
 
   const handleAddLayer = () => {
-    // Future: open add layer modal
-    // For now, placeholder — will be wired when addLayerOpen state is added
+    setAddLayerOpen(true);
   };
 
   const handleAddMidi = () => {

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -566,15 +566,8 @@ export function Timeline() {
         </div>
       </div>
 
-      {selectWindow && (
-        <MultiTrackGenerateModal
-          selectWindow={selectWindow}
-          contextWindow={contextWindow}
-          onClose={() => {
-            setSelectWindow(null);
-          }}
-        />
-      )}
+      {/* MultiTrackGenerateModal is now accessed via GENR button or toolbar —
+           no longer auto-opens on selectWindow creation (#577) */}
 
       {/* Region context menu — right-click on select window */}
       {regionCtxMenu && selectWindow && (


### PR DESCRIPTION
## Summary
- **SelectionFloatingToolbar**: Music Enhancer and Add Layer buttons now correctly open their respective floating panels via `uiStore.setMusicEnhancerOpen()` / `uiStore.setAddLayerOpen()`
- **Timeline**: `MultiTrackGenerateModal` no longer auto-opens when a `selectWindow` is created — users access generation via the GENR toolbar button or the floating toolbar instead (#577)

Found during QA testing of #583, #584, #585.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 1854 tests pass
- [ ] Drag-select a region → floating toolbar appears → click Music Enhancer → panel opens
- [ ] Drag-select a region → floating toolbar appears → click Add Layer → panel opens
- [ ] Drag-select a region → MultiTrackGenerateModal does NOT auto-open

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)