### PR TITLE
fix: wire all AI tool actions to new floating panels

### DIFF
--- a/src/components/timeline/CanvasContextMenu.tsx
+++ b/src/components/timeline/CanvasContextMenu.tsx
@@ -25,12 +25,12 @@ export function CanvasContextMenu({ x, y, onClose }: CanvasContextMenuProps) {
   }, [onClose]);
 
   const handleAddLayer = useCallback(() => {
-    useUIStore.getState().setShowGenerationPanel(true);
+    useUIStore.getState().setAddLayerOpen(true);
     onClose();
   }, [onClose]);
 
   const handleMusicEnhancer = useCallback(() => {
-    useUIStore.getState().setShowGenerationPanel(true);
+    useUIStore.getState().setMusicEnhancerOpen(true);
     onClose();
   }, [onClose]);
 

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -749,10 +749,10 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           onDuplicate={() => { closeCtxMenu(); duplicateClip(clip.id); }}
           onConsolidate={() => { void handleConsolidate(); }}
           onDelete={() => { closeCtxMenu(); removeClip(clip.id); }}
-          onAddLayer={() => { closeCtxMenu(); setAddLayerOpen(true); }}
+          onAddLayer={() => { closeCtxMenu(); useUIStore.getState().setAddLayerOpen(true); }}
           onCreateCover={() => {
             closeCtxMenu();
-            setCoverModal(clip.id);
+            useUIStore.getState().setMusicEnhancerOpen(true);
           }}
           onRepaint={() => {
             closeCtxMenu();

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -569,30 +569,12 @@ export function Timeline() {
       {/* MultiTrackGenerateModal is now accessed via GENR button or toolbar —
            no longer auto-opens on selectWindow creation (#577) */}
 
-      {/* Region context menu — right-click on select window */}
+      {/* Region context menu — right-click on select window → same as canvas context menu with AI Tools */}
       {regionCtxMenu && selectWindow && (
-        <RegionContextMenu
+        <CanvasContextMenu
           x={regionCtxMenu.x}
           y={regionCtxMenu.y}
-          onRegenerateRegion={() => {
-            setRegionCtxMenu(null);
-            setRegionRegenerateTarget({
-              startTime: selectWindow.startTime,
-              endTime: selectWindow.endTime,
-              trackIds: selectWindow.trackIds,
-            });
-          }}
           onClose={() => setRegionCtxMenu(null)}
-          hasReadyClips={
-            project.tracks.some((t) =>
-              selectWindow.trackIds.includes(t.id) &&
-              t.clips.some((c) => {
-                const clipEnd = c.startTime + c.duration;
-                return Math.min(selectWindow.endTime, clipEnd) > Math.max(selectWindow.startTime, c.startTime)
-                  && c.generationStatus === 'ready';
-              }),
-            )
-          }
         />
       )}
 

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -175,17 +175,13 @@ export function TrackLane({ track }: TrackLaneProps) {
       return;
     }
 
+    // For stems/sample/audio tracks, double-click on empty space opens the Add Layer panel
     e.stopPropagation();
     const rect = e.currentTarget.getBoundingClientRect();
     const laneX = e.clientX - rect.left;
     const clickTime = laneX / pixelsPerSecond;
     if (hitsClip(clickTime)) return;
-    const rawTime = laneX / pixelsPerSecond;
-    const startTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1));
-    const remaining = project.totalDuration - startTime;
-    const duration = Math.max(10, Math.min(30, remaining));
-    setCtxMenu({ x: e.clientX, y: e.clientY, startTime, duration });
-    setAddLayerTarget(null);
+    useUIStore.getState().setAddLayerOpen(true);
   }, [isSequencer, isPianoRoll, pixelsPerSecond, project.bpm, project.totalDuration, project.timeSignature, hitsClip, track.id, setOpenSequencerTrackId, ensureMidiClip, setOpenPianoRoll]);
 
   const clearSel = useCallback(() => {


### PR DESCRIPTION
## Summary
- **CanvasContextMenu**: "Music Enhancer" → opens `MusicEnhancerPanel`, "Add a Layer" → opens `AddLayerPanel` (was incorrectly calling `setShowGenerationPanel`)
- **Select window right-click**: Now shows `CanvasContextMenu` with full AI Tools submenu (replaced old `RegionContextMenu` that only had "Regenerate Selected Region...")
- **Clip context menu "Create Cover..."**: Opens `MusicEnhancerPanel` floating panel (was opening old `CoverModal`)
- **Clip context menu "Add Layer here..."**: Opens `AddLayerPanel` via `uiStore` (was using local state + old `AddLayerModal`)
- **Double-click empty track area**: Directly opens `AddLayerPanel` for stems/sample tracks (was showing confusing `LaneContextMenu` popup with "Create Quick Sampler..." / "Add Layer...")

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 1854 tests pass
- [ ] Right-click on select window → AI Tools submenu → Music Enhancer → floating panel opens
- [ ] Right-click on clip → Create Cover... → MusicEnhancerPanel opens (not old modal)
- [ ] Right-click on clip → Add Layer here... → AddLayerPanel opens (not old modal)
- [ ] Double-click empty area on stems track → AddLayerPanel opens directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)