### PR TITLE
fix: AddLayerPanel generates on selected track instead of creating new one

### DIFF
--- a/src/components/generation/AddLayerPanel.tsx
+++ b/src/components/generation/AddLayerPanel.tsx
@@ -161,11 +161,18 @@ export function AddLayerPanel() {
   const handleGenerate = async () => {
     stopPreview();
 
-    // Find or create a track for this layer type
-    const targetTrackName = selectedLayerType.trackName;
-    let targetTrack = project.tracks.find((t) => t.trackName === targetTrackName);
+    // Prefer the track the user actually selected via selectWindow;
+    // fall back to finding/creating a track by layer type name (#590)
+    let targetTrack: typeof project.tracks[number] | undefined;
+    if (selectWindow && selectWindow.trackIds.length > 0) {
+      targetTrack = project.tracks.find((t) => selectWindow.trackIds.includes(t.id));
+    }
     if (!targetTrack) {
-      targetTrack = addTrack(targetTrackName, 'stems');
+      const targetTrackName = selectedLayerType.trackName;
+      targetTrack = project.tracks.find((t) => t.trackName === targetTrackName);
+      if (!targetTrack) {
+        targetTrack = addTrack(targetTrackName, 'stems');
+      }
     }
 
     if (style) {


### PR DESCRIPTION
## Summary
- When a `selectWindow` is active, `AddLayerPanel.handleGenerate` now uses the first track from `selectWindow.trackIds` as the generation target
- Only falls back to finding/creating a track by layer type name when no `selectWindow` exists
- This ensures the clip appears on the track the user actually selected, not a new track below

## Root Cause
`handleGenerate` was always resolving the target track by `selectedLayerType.trackName` (e.g., "vocals"), completely ignoring `selectWindow.trackIds`. So if the user selected a "Drums" track but chose "Vocal" layer type, a new "vocals" track would be created.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 1854 tests pass
- [ ] Drag-select region on Drums track → Add Layer → Generate → clip appears on Drums track (not new track)
- [ ] Open Add Layer without selectWindow → generates on layer-type track (existing behavior preserved)

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)