### PR TITLE
feat: #598 — add auto-scroll to follow playhead during playback

### DIFF
--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -207,6 +207,8 @@ export function Toolbar() {
   const toggleMetronome = useTransportStore((s) => s.toggleMetronome);
   const zoomIn = useUIStore((s) => s.zoomIn);
   const zoomOut = useUIStore((s) => s.zoomOut);
+  const autoScrollEnabled = useUIStore((s) => s.autoScrollEnabled);
+  const toggleAutoScroll = useUIStore((s) => s.toggleAutoScroll);
 
   useEffect(() => {
     (window as unknown as Record<string, unknown>).__commandPaletteRuntime = {
@@ -411,6 +413,21 @@ export function Toolbar() {
             <path d="M4 13L7 1l3 12" />
             <path d="M3 13h8" />
             <path d="M7 5l4-2" />
+          </svg>
+        </ControlBarButton>
+        <ControlBarButton
+          active={autoScrollEnabled}
+          onClick={toggleAutoScroll}
+          title="Auto-Scroll / Follow Playhead (Shift+F)"
+          disabled={!project}
+          dataTarget="auto-scroll-button"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M7 1v12" />
+            <path d="M7 1l-2.5 3" />
+            <path d="M7 1l2.5 3" />
+            <path d="M1 5h4" />
+            <path d="M9 5h4" />
           </svg>
         </ControlBarButton>
       </div>

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -69,6 +69,7 @@ export function Timeline() {
   const addTrack = useProjectStore((s) => s.addTrack);
   const updateTrack = useProjectStore((s) => s.updateTrack);
   const seek = useTransportStore((s) => s.seek);
+  const isPlaying = useTransportStore((s) => s.isPlaying);
   const setTimelineFocused = useUIStore((s) => s.setTimelineFocused);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const setPixelsPerSecond = useUIStore((s) => s.setPixelsPerSecond);
@@ -82,8 +83,12 @@ export function Timeline() {
   const keyboardContext = useUIStore((s) => s.keyboardContext);
   const timelineZoomRequest = useUIStore((s) => s.timelineZoomRequest);
   const setScrollX = useUIStore((s) => s.setScrollX);
+  const autoScrollEnabled = useUIStore((s) => s.autoScrollEnabled);
+  const userScrolledDuringPlayback = useUIStore((s) => s.userScrolledDuringPlayback);
+  const setUserScrolledDuringPlayback = useUIStore((s) => s.setUserScrolledDuringPlayback);
   const scrollRef = useRef<HTMLDivElement>(null);
   const trackAreaRef = useRef<HTMLDivElement>(null);
+  const programmaticScrollRef = useRef(false);
 
   const deselectAllTracks = useUIStore((s) => s.deselectAllTracks);
   const setRegionRegenerateTarget = useUIStore((s) => s.setRegionRegenerateTarget);
@@ -228,6 +233,70 @@ export function Timeline() {
       toastInfo('Nothing is selected, so the timeline zoomed to the full project.');
     }
   }, [project, selectWindow, selectedClipIds, setPixelsPerSecond, setScrollX, timelineZoomRequest]);
+
+  // Reset userScrolledDuringPlayback when playback starts or stops
+  const prevIsPlayingRef = useRef(false);
+  useEffect(() => {
+    if (isPlaying && !prevIsPlayingRef.current) {
+      setUserScrolledDuringPlayback(false);
+    }
+    prevIsPlayingRef.current = isPlaying;
+  }, [isPlaying, setUserScrolledDuringPlayback]);
+
+  // Detect manual scroll during playback to temporarily disable auto-scroll
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    const handleManualScroll = () => {
+      const transport = useTransportStore.getState();
+      const ui = useUIStore.getState();
+      if (transport.isPlaying && ui.autoScrollEnabled && !ui.userScrolledDuringPlayback) {
+        if (!programmaticScrollRef.current) {
+          setUserScrolledDuringPlayback(true);
+        }
+      }
+    };
+
+    container.addEventListener('scroll', handleManualScroll, { passive: true });
+    return () => container.removeEventListener('scroll', handleManualScroll);
+  }, [setUserScrolledDuringPlayback]);
+
+  // Auto-scroll to follow playhead during playback
+  useEffect(() => {
+    if (!isPlaying || !autoScrollEnabled || userScrolledDuringPlayback) return;
+
+    const container = scrollRef.current;
+    if (!container) return;
+
+    let rafId: number;
+    const tick = () => {
+      const currentTime = useTransportStore.getState().currentTime;
+      const pps = useUIStore.getState().pixelsPerSecond;
+      const playheadX = currentTime * pps;
+      const viewportWidth = container.clientWidth;
+      const scrollLeft = container.scrollLeft;
+
+      const leftMargin = viewportWidth * 0.2;
+      const rightMargin = viewportWidth * 0.8;
+      const playheadViewX = playheadX - scrollLeft;
+
+      if (playheadViewX > rightMargin || playheadViewX < leftMargin) {
+        const targetScroll = Math.max(0, playheadX - viewportWidth * 0.4);
+        programmaticScrollRef.current = true;
+        container.scrollTo({ left: targetScroll, behavior: 'smooth' });
+        requestAnimationFrame(() => {
+          programmaticScrollRef.current = false;
+        });
+        setScrollX(targetScroll);
+      }
+
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+  }, [isPlaying, autoScrollEnabled, userScrolledDuringPlayback, setScrollX]);
 
   const handleWheel = useCallback(
     (e: React.WheelEvent) => {

--- a/src/constants/shortcutDefaults.ts
+++ b/src/constants/shortcutDefaults.ts
@@ -50,6 +50,8 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   { id: 'panels.generation',     category: 'panels',    label: 'Toggle AI Generation Panel',  defaultCombo: { code: 'KeyG' }, contexts: ['global'] },
   { id: 'panels.aiAssistant',    category: 'panels',    label: 'Toggle AI Assistant',         defaultCombo: { code: 'Slash', mod: true }, contexts: ['global'] },
 
+  { id: 'view.autoScroll',        category: 'view',      label: 'Toggle Auto-Scroll',          defaultCombo: { code: 'KeyF', shift: true }, contexts: ['global'] },
+
   { id: 'project.new',           category: 'project',   label: 'New Project',                 defaultCombo: { code: 'KeyN', mod: true }, contexts: ['global'] },
   { id: 'project.open',          category: 'project',   label: 'Open Project List',           defaultCombo: { code: 'KeyO', mod: true }, contexts: ['global'] },
   { id: 'project.bounceInPlace', category: 'project',   label: 'Bounce Selected/Focused Track', defaultCombo: { code: 'KeyB', mod: true }, contexts: ['global'] },

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -365,6 +365,7 @@ export function useKeyboardShortcuts() {
       if (matches('panels.loopBrowser')) { event.preventDefault(); ui.toggleLoopBrowser(); return; }
       if (matches('panels.tempoLane')) { event.preventDefault(); ui.toggleTempoLane(); return; }
       if (matches('panels.generation')) { event.preventDefault(); ui.toggleGenerationPanel(); return; }
+      if (matches('view.autoScroll')) { event.preventDefault(); ui.toggleAutoScroll(); return; }
 
       if (matches('tracks.mute')) {
         event.preventDefault();

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -113,6 +113,10 @@ export interface UIState {
   // Playhead focus — true when timeline area is focused (after click-to-seek)
   timelineFocused: boolean;
 
+  // Auto-scroll — follow playhead during playback
+  autoScrollEnabled: boolean;
+  userScrolledDuringPlayback: boolean;
+
   // Loop Browser
   loopBrowserOpen: boolean;
   loopBrowserCategory: 'All' | 'Drums' | 'Bass' | 'Keys' | 'Synth';
@@ -244,6 +248,11 @@ export interface UIState {
 
   // Playhead focus
   setTimelineFocused: (focused: boolean) => void;
+
+  // Auto-scroll
+  setAutoScrollEnabled: (enabled: boolean) => void;
+  setUserScrolledDuringPlayback: (scrolled: boolean) => void;
+  toggleAutoScroll: () => void;
 
   // Loop Browser
   toggleLoopBrowser: () => void;
@@ -418,6 +427,9 @@ export const useUIStore = create<UIState>()(
 
   showTempoLane: false,
   timelineFocused: false,
+
+  autoScrollEnabled: true,
+  userScrolledDuringPlayback: false,
 
   loopBrowserOpen: false,
   loopBrowserCategory: 'All',
@@ -678,6 +690,10 @@ export const useUIStore = create<UIState>()(
 
   toggleTempoLane: () => set((s) => ({ showTempoLane: !s.showTempoLane })),
   setTimelineFocused: (focused) => set({ timelineFocused: focused }),
+
+  setAutoScrollEnabled: (enabled) => set({ autoScrollEnabled: enabled }),
+  setUserScrolledDuringPlayback: (scrolled) => set({ userScrolledDuringPlayback: scrolled }),
+  toggleAutoScroll: () => set((s) => ({ autoScrollEnabled: !s.autoScrollEnabled })),
 
   toggleLoopBrowser: () => set((s) => ({ loopBrowserOpen: !s.loopBrowserOpen })),
   setLoopBrowserCategory: (v) => set({ loopBrowserCategory: v }),

--- a/tests/unit/autoScroll.test.ts
+++ b/tests/unit/autoScroll.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useUIStore } from '../../src/store/uiStore';
+import { useTransportStore } from '../../src/store/transportStore';
+
+describe('auto-scroll state (uiStore)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useUIStore.setState(useUIStore.getInitialState(), true);
+    useTransportStore.setState(useTransportStore.getInitialState(), true);
+  });
+
+  it('defaults autoScrollEnabled to true', () => {
+    expect(useUIStore.getState().autoScrollEnabled).toBe(true);
+  });
+
+  it('defaults userScrolledDuringPlayback to false', () => {
+    expect(useUIStore.getState().userScrolledDuringPlayback).toBe(false);
+  });
+
+  it('setAutoScrollEnabled toggles the flag', () => {
+    useUIStore.getState().setAutoScrollEnabled(false);
+    expect(useUIStore.getState().autoScrollEnabled).toBe(false);
+
+    useUIStore.getState().setAutoScrollEnabled(true);
+    expect(useUIStore.getState().autoScrollEnabled).toBe(true);
+  });
+
+  it('setUserScrolledDuringPlayback toggles the flag', () => {
+    useUIStore.getState().setUserScrolledDuringPlayback(true);
+    expect(useUIStore.getState().userScrolledDuringPlayback).toBe(true);
+
+    useUIStore.getState().setUserScrolledDuringPlayback(false);
+    expect(useUIStore.getState().userScrolledDuringPlayback).toBe(false);
+  });
+
+  it('toggleAutoScroll flips the enabled state', () => {
+    expect(useUIStore.getState().autoScrollEnabled).toBe(true);
+    useUIStore.getState().toggleAutoScroll();
+    expect(useUIStore.getState().autoScrollEnabled).toBe(false);
+    useUIStore.getState().toggleAutoScroll();
+    expect(useUIStore.getState().autoScrollEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds timeline auto-scroll that keeps the playhead visible during playback with smooth scrolling
- Toggle button in toolbar (next to metronome) with `Shift+F` keyboard shortcut
- Manual scroll during playback temporarily disables auto-scroll; re-engages on playback restart or re-enable

## Implementation
- **uiStore**: `autoScrollEnabled` (default: true), `userScrolledDuringPlayback` (temporary override), `toggleAutoScroll()`
- **Timeline.tsx**: RAF-driven scroll loop checks if playhead exits the visible 20%-80% viewport zone, then smoothly scrolls to center it. Detects manual scroll events vs programmatic ones to avoid false triggers
- **Toolbar.tsx**: Auto-scroll toggle button with active state styling, placed in the Cycle/Metronome group
- **shortcutDefaults.ts**: `view.autoScroll` mapped to `Shift+F`
- **useKeyboardShortcuts.ts**: Wired shortcut handler

## Test plan
- [x] Unit tests for `autoScrollEnabled`, `userScrolledDuringPlayback`, and `toggleAutoScroll` state management
- [ ] Manual: Start playback, verify timeline scrolls to follow playhead
- [ ] Manual: During playback, scroll manually — verify auto-scroll pauses
- [ ] Manual: Restart playback — verify auto-scroll re-engages
- [ ] Manual: Click toggle button or press Shift+F to disable — verify no scrolling
- [ ] Manual: Verify smooth scroll behavior (no jumps)

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)