### PR TITLE
feat: #596 — expose advanced generation parameters in generation side panel

### DIFF
--- a/src/components/generation/GenerationSidePanel.tsx
+++ b/src/components/generation/GenerationSidePanel.tsx
@@ -62,10 +62,18 @@ export function GenerationSidePanel() {
   const cancelVariationSession = useGenerationStore((s) => s.cancelVariationSession);
   const clearVariationSession = useGenerationStore((s) => s.clearVariationSession);
 
+  const setGenerationInferenceSteps = useGenerationStore((s) => s.setGenerationInferenceSteps);
+  const setGenerationGuidanceScale = useGenerationStore((s) => s.setGenerationGuidanceScale);
+  const setGenerationShift = useGenerationStore((s) => s.setGenerationShift);
+  const setGenerationThinking = useGenerationStore((s) => s.setGenerationThinking);
+  const setGenerationSeed = useGenerationStore((s) => s.setGenerationSeed);
+  const setGenerationUseRandomSeed = useGenerationStore((s) => s.setGenerationUseRandomSeed);
+
   const [showHistory, setShowHistory] = useState(false);
   const [presetCategory, setPresetCategory] = useState<PresetCategory | 'All'>('All');
   const [showLyrics, setShowLyrics] = useState(false);
   const [styleTagsInput, setStyleTagsInput] = useState('');
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const stemsTracks = useMemo(
     () => project?.tracks.filter((track) => track.trackType === 'stems') ?? [],
@@ -468,6 +476,53 @@ export function GenerationSidePanel() {
               disabled={isSessionActive}
               aria-label="Generation lyrics"
             />
+          )}
+        </section>
+
+        <section className="space-y-2" data-testid="advanced-params-section">
+          <button onClick={() => setShowAdvanced((v) => !v)} className="text-[11px] font-medium uppercase text-zinc-400 transition-colors hover:text-zinc-300" type="button">
+            Advanced Parameters {showAdvanced ? '[-]' : '[+]'}
+          </button>
+          {showAdvanced && (
+            <div className="space-y-3">
+              <div>
+                <div className="flex items-center justify-between">
+                  <label className="text-[11px] font-medium uppercase text-zinc-400" htmlFor="generation-inference-steps">Inference Steps</label>
+                  <span className="text-xs text-zinc-300">{generationForm.inferenceSteps}</span>
+                </div>
+                <input id="generation-inference-steps" type="range" min={1} max={200} step={1} value={generationForm.inferenceSteps} onChange={(e) => setGenerationInferenceSteps(Number(e.target.value))} className="mt-1 w-full accent-indigo-500" disabled={isSessionActive} aria-label="Inference steps" data-testid="generation-inference-steps" />
+                <div className="flex justify-between text-[10px] text-zinc-600"><span>Fast</span><span>Quality</span></div>
+              </div>
+              <div>
+                <div className="flex items-center justify-between">
+                  <label className="text-[11px] font-medium uppercase text-zinc-400" htmlFor="generation-guidance-scale">Guidance Scale</label>
+                  <span className="text-xs text-zinc-300">{generationForm.guidanceScale.toFixed(1)}</span>
+                </div>
+                <input id="generation-guidance-scale" type="range" min={0} max={20} step={0.1} value={generationForm.guidanceScale} onChange={(e) => setGenerationGuidanceScale(Number(e.target.value))} className="mt-1 w-full accent-indigo-500" disabled={isSessionActive} aria-label="Guidance scale" data-testid="generation-guidance-scale" />
+                <div className="flex justify-between text-[10px] text-zinc-600"><span>Creative</span><span>Faithful</span></div>
+              </div>
+              <div>
+                <div className="flex items-center justify-between">
+                  <label className="text-[11px] font-medium uppercase text-zinc-400" htmlFor="generation-shift">Shift</label>
+                  <span className="text-xs text-zinc-300">{generationForm.shift.toFixed(1)}</span>
+                </div>
+                <input id="generation-shift" type="range" min={0} max={10} step={0.1} value={generationForm.shift} onChange={(e) => setGenerationShift(Number(e.target.value))} className="mt-1 w-full accent-indigo-500" disabled={isSessionActive} aria-label="Shift" data-testid="generation-shift" />
+              </div>
+              <div className="flex items-center gap-2">
+                <input id="generation-thinking" type="checkbox" checked={generationForm.thinking} onChange={(e) => setGenerationThinking(e.target.checked)} className="h-3.5 w-3.5 rounded border-[#444] bg-[#2a2a2a] accent-indigo-500" disabled={isSessionActive} aria-label="Thinking" data-testid="generation-thinking" />
+                <label htmlFor="generation-thinking" className="text-[11px] font-medium uppercase text-zinc-400">Thinking</label>
+              </div>
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <label className="text-[11px] font-medium uppercase text-zinc-400" htmlFor="generation-seed">Seed</label>
+                  <label className="flex items-center gap-1.5 text-[10px] text-zinc-400">
+                    <input type="checkbox" checked={generationForm.useRandomSeed} onChange={(e) => setGenerationUseRandomSeed(e.target.checked)} className="h-3 w-3 rounded border-[#444] bg-[#2a2a2a] accent-indigo-500" disabled={isSessionActive} aria-label="Random seed" data-testid="generation-random-seed" />
+                    Random
+                  </label>
+                </div>
+                <input id="generation-seed" type="text" value={generationForm.seed} onChange={(e) => setGenerationSeed(e.target.value)} placeholder="Enter seed value" className="w-full rounded border border-[#444] bg-[#2a2a2a] px-2 py-1 text-sm focus:border-indigo-500 focus:outline-none disabled:opacity-50" disabled={isSessionActive || generationForm.useRandomSeed} aria-label="Seed" data-testid="generation-seed" />
+              </div>
+            </div>
           )}
         </section>
 

--- a/src/components/generation/__tests__/GenerationSidePanel.advancedParams.test.tsx
+++ b/src/components/generation/__tests__/GenerationSidePanel.advancedParams.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GenerationSidePanel } from '../GenerationSidePanel';
+import { useProjectStore } from '../../../store/projectStore';
+import { useUIStore } from '../../../store/uiStore';
+import { useGenerationStore, createDefaultGenerationFormState } from '../../../store/generationStore';
+import { DEFAULT_GENERATION } from '../../../constants/defaults';
+
+vi.mock('../../../services/generationPipeline', () => ({
+  generateVariationSession: vi.fn().mockResolvedValue(true),
+  generateFromGenerationPanel: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../services/lazyContextAudioExtractor', () => ({
+  extractContextAudioLazy: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+function setupProject() {
+  useProjectStore.setState({ project: null });
+  useProjectStore.getState().createProject();
+  useProjectStore.getState().addTrack('stems');
+  const track = useProjectStore.getState().project!.tracks[0];
+  useUIStore.setState({ showGenerationPanel: true });
+  useGenerationStore.setState({
+    generationForm: {
+      ...createDefaultGenerationFormState(),
+      selectedTrackId: track.id,
+      prompt: 'test prompt',
+    },
+    isGenerating: false,
+    variationSession: null,
+  });
+}
+
+describe('GenerationSidePanel — Advanced Parameters', () => {
+  beforeEach(() => {
+    setupProject();
+  });
+
+  it('renders the Advanced Parameters toggle button', () => {
+    render(<GenerationSidePanel />);
+    expect(screen.getByText(/advanced parameters/i)).toBeInTheDocument();
+  });
+
+  it('advanced section is collapsed by default', () => {
+    render(<GenerationSidePanel />);
+    expect(screen.queryByLabelText('Inference steps')).not.toBeInTheDocument();
+  });
+
+  it('expands advanced section when toggle is clicked', () => {
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    expect(screen.getByLabelText('Inference steps')).toBeInTheDocument();
+    expect(screen.getByLabelText('Guidance scale')).toBeInTheDocument();
+    expect(screen.getByLabelText('Shift')).toBeInTheDocument();
+    expect(screen.getByLabelText('Thinking')).toBeInTheDocument();
+    expect(screen.getByLabelText('Seed')).toBeInTheDocument();
+  });
+
+  it('collapses advanced section when toggle is clicked again', () => {
+    render(<GenerationSidePanel />);
+    const toggle = screen.getByText(/advanced parameters/i);
+    fireEvent.click(toggle);
+    expect(screen.getByLabelText('Inference steps')).toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.queryByLabelText('Inference steps')).not.toBeInTheDocument();
+  });
+
+  it('inference steps slider updates generation form', () => {
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    const slider = screen.getByLabelText('Inference steps');
+    fireEvent.change(slider, { target: { value: '100' } });
+    expect(useGenerationStore.getState().generationForm.inferenceSteps).toBe(100);
+  });
+
+  it('guidance scale slider updates generation form', () => {
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    const slider = screen.getByLabelText('Guidance scale');
+    fireEvent.change(slider, { target: { value: '12.5' } });
+    expect(useGenerationStore.getState().generationForm.guidanceScale).toBe(12.5);
+  });
+
+  it('shift slider updates generation form', () => {
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    const slider = screen.getByLabelText('Shift');
+    fireEvent.change(slider, { target: { value: '5.0' } });
+    expect(useGenerationStore.getState().generationForm.shift).toBe(5.0);
+  });
+
+  it('thinking checkbox updates generation form', () => {
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    const checkbox = screen.getByLabelText('Thinking');
+    fireEvent.click(checkbox);
+    expect(useGenerationStore.getState().generationForm.thinking).toBe(true);
+  });
+
+  it('seed input updates generation form', () => {
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    const seedInput = screen.getByLabelText('Seed');
+    fireEvent.change(seedInput, { target: { value: '42' } });
+    expect(useGenerationStore.getState().generationForm.seed).toBe('42');
+  });
+
+  it('random seed toggle updates generation form', () => {
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    const randomToggle = screen.getByLabelText('Random seed');
+    expect(useGenerationStore.getState().generationForm.useRandomSeed).toBe(true);
+    fireEvent.click(randomToggle);
+    expect(useGenerationStore.getState().generationForm.useRandomSeed).toBe(false);
+  });
+
+  it('seed input is disabled when random seed is enabled', () => {
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    const seedInput = screen.getByLabelText('Seed');
+    expect(seedInput).toBeDisabled();
+  });
+
+  it('seed input is enabled when random seed is disabled', () => {
+    useGenerationStore.setState((s) => ({
+      generationForm: { ...s.generationForm, useRandomSeed: false },
+    }));
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    const seedInput = screen.getByLabelText('Seed');
+    expect(seedInput).not.toBeDisabled();
+  });
+
+  it('displays default values from project generation defaults', () => {
+    render(<GenerationSidePanel />);
+    fireEvent.click(screen.getByText(/advanced parameters/i));
+    const stepsSlider = screen.getByLabelText('Inference steps') as HTMLInputElement;
+    expect(Number(stepsSlider.value)).toBe(DEFAULT_GENERATION.inferenceSteps);
+  });
+});
+
+describe('GenerationStore — advanced param setters', () => {
+  beforeEach(() => {
+    useGenerationStore.setState({
+      generationForm: createDefaultGenerationFormState(),
+    });
+  });
+
+  it('setGenerationInferenceSteps clamps to 1-200', () => {
+    useGenerationStore.getState().setGenerationInferenceSteps(250);
+    expect(useGenerationStore.getState().generationForm.inferenceSteps).toBe(200);
+    useGenerationStore.getState().setGenerationInferenceSteps(0);
+    expect(useGenerationStore.getState().generationForm.inferenceSteps).toBe(1);
+  });
+
+  it('setGenerationGuidanceScale clamps to 0-20', () => {
+    useGenerationStore.getState().setGenerationGuidanceScale(25);
+    expect(useGenerationStore.getState().generationForm.guidanceScale).toBe(20);
+    useGenerationStore.getState().setGenerationGuidanceScale(-1);
+    expect(useGenerationStore.getState().generationForm.guidanceScale).toBe(0);
+  });
+
+  it('setGenerationShift clamps to 0-10', () => {
+    useGenerationStore.getState().setGenerationShift(15);
+    expect(useGenerationStore.getState().generationForm.shift).toBe(10);
+    useGenerationStore.getState().setGenerationShift(-5);
+    expect(useGenerationStore.getState().generationForm.shift).toBe(0);
+  });
+
+  it('setGenerationThinking toggles boolean', () => {
+    useGenerationStore.getState().setGenerationThinking(true);
+    expect(useGenerationStore.getState().generationForm.thinking).toBe(true);
+    useGenerationStore.getState().setGenerationThinking(false);
+    expect(useGenerationStore.getState().generationForm.thinking).toBe(false);
+  });
+
+  it('setGenerationSeed stores string value', () => {
+    useGenerationStore.getState().setGenerationSeed('12345');
+    expect(useGenerationStore.getState().generationForm.seed).toBe('12345');
+  });
+
+  it('setGenerationUseRandomSeed stores boolean value', () => {
+    useGenerationStore.getState().setGenerationUseRandomSeed(false);
+    expect(useGenerationStore.getState().generationForm.useRandomSeed).toBe(false);
+  });
+
+  it('advanced params are included in submitGenerationRequest output', () => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    useProjectStore.getState().addTrack('stems');
+    const track = useProjectStore.getState().project!.tracks[0];
+
+    useGenerationStore.setState({
+      generationForm: {
+        ...createDefaultGenerationFormState(),
+        prompt: 'test prompt',
+        selectedTrackId: track.id,
+        inferenceSteps: 75,
+        guidanceScale: 10.0,
+        shift: 5.0,
+        thinking: true,
+        seed: '42',
+        useRandomSeed: false,
+      },
+    });
+
+    const params = useGenerationStore.getState().submitGenerationRequest({ globalCaption: '' });
+    expect(params).not.toBeNull();
+    expect(params!.inferenceSteps).toBe(75);
+    expect(params!.guidanceScale).toBe(10.0);
+    expect(params!.shift).toBe(5.0);
+    expect(params!.thinking).toBe(true);
+    expect(params!.seed).toBe('42');
+    expect(params!.useRandomSeed).toBe(false);
+  });
+});

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -71,6 +71,16 @@ export interface ClipInternalOptions {
   repaintRange?: { start: number; end: number };
   /** Manual override for the backend guidance scale. */
   guidanceScaleOverride?: number;
+  /** Manual override for inference steps. */
+  inferenceStepsOverride?: number;
+  /** Manual override for shift parameter. */
+  shiftOverride?: number;
+  /** Manual override for thinking mode. */
+  thinkingOverride?: boolean;
+  /** Manual override for seed value. */
+  seedOverride?: number;
+  /** Whether to use a random seed (overrides seedOverride). */
+  useRandomSeedOverride?: boolean;
   /** Optional variation index for progressive multi-variation sessions. */
   variationIndex?: number;
 }
@@ -281,6 +291,12 @@ export async function generateVariationSession(
           globalCaptionOverride: params.globalCaption,
           lyricsOverride: params.lyrics,
           variationIndex: index,
+          guidanceScaleOverride: params.guidanceScale,
+          inferenceStepsOverride: params.inferenceSteps,
+          shiftOverride: params.shift,
+          thinkingOverride: params.thinking,
+          seedOverride: params.seed ? Number(params.seed) : undefined,
+          useRandomSeedOverride: params.useRandomSeed,
         }),
       ),
     );
@@ -479,14 +495,22 @@ async function generateClipInternal(
       bpm: resolvedBpm,
       key_scale: resolvedKey,
       time_signature: resolvedTimeSig,
-      inference_steps: project.generationDefaults.inferenceSteps,
+      inference_steps: options.inferenceStepsOverride ?? project.generationDefaults.inferenceSteps,
       guidance_scale: options.guidanceScaleOverride ?? project.generationDefaults.guidanceScale,
-      shift: project.generationDefaults.shift,
+      shift: options.shiftOverride ?? project.generationDefaults.shift,
       batch_size: 1,
       audio_format: 'wav',
-      thinking: project.generationDefaults.thinking,
+      thinking: options.thinkingOverride ?? project.generationDefaults.thinking,
       model: project.generationDefaults.model,
     } as LegoTaskParams;
+
+    // Per-generation seed override from advanced params
+    if (options.useRandomSeedOverride === false && options.seedOverride !== undefined) {
+      params.seed = options.seedOverride;
+      params.use_random_seed = false;
+    } else if (options.useRandomSeedOverride === true) {
+      params.use_random_seed = true;
+    }
 
     // Shared seed: override backend randomness so all batch tracks are correlated
     if (options.sharedSeed !== undefined) {

--- a/src/store/generationStore.ts
+++ b/src/store/generationStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-import { DEFAULT_BPM, DEFAULT_DURATION, DEFAULT_KEY_SCALE, MAX_BPM, MAX_DURATION, MIN_BPM, MIN_DURATION } from '../constants/defaults';
+import { DEFAULT_BPM, DEFAULT_DURATION, DEFAULT_KEY_SCALE, DEFAULT_GENERATION, MAX_BPM, MAX_DURATION, MIN_BPM, MIN_DURATION } from '../constants/defaults';
 import type { GenerationPreset } from '../constants/generationPresets';
 import { useProjectStore } from './projectStore';
 import {
@@ -194,6 +194,11 @@ export interface VariationSessionParams {
   lyrics?: string;
   globalCaption?: string;
   presetId?: string;
+  inferenceSteps?: number;
+  shift?: number;
+  thinking?: boolean;
+  seed?: string;
+  useRandomSeed?: boolean;
 }
 
 export interface VariationSession {
@@ -237,6 +242,12 @@ export interface GenerationFormState {
   lyrics: string;
   presetId: string | null;
   requestError: string | null;
+  inferenceSteps: number;
+  guidanceScale: number;
+  shift: number;
+  thinking: boolean;
+  seed: string;
+  useRandomSeed: boolean;
 }
 
 export interface GenerationValidationInput {
@@ -262,6 +273,18 @@ function clampTemperature(value: number) {
 
 function clampVariationCount(value: number) {
   return Math.max(1, Math.min(4, Math.round(value)));
+}
+
+function clampInferenceSteps(value: number) {
+  return Math.max(1, Math.min(200, Math.round(value)));
+}
+
+function clampGuidanceScale(value: number) {
+  return Math.max(0, Math.min(20, Number(value.toFixed(1))));
+}
+
+function clampShift(value: number) {
+  return Math.max(0, Math.min(10, Number(value.toFixed(1))));
 }
 
 function sanitizeStyleTag(tag: string) {
@@ -290,12 +313,17 @@ function normalizeVariationSessionParams(
     variationCount: clampVariationCount(params.variationCount),
     bpm: clampBpm(params.bpm),
     duration: clampLengthSeconds(params.duration),
-    guidanceScale: clampTemperature(params.guidanceScale),
+    guidanceScale: params.guidanceScale != null ? clampGuidanceScale(params.guidanceScale) : clampTemperature(params.temperature ?? 0.7),
     temperature: clampTemperature(params.temperature ?? params.guidanceScale),
     styleTags: normalizeStyleTags(params.styleTags ?? []),
     lyrics: params.lyrics?.trim() || undefined,
     globalCaption: params.globalCaption?.trim() || undefined,
     presetId: params.presetId ?? fallbackPresetId ?? undefined,
+    inferenceSteps: params.inferenceSteps != null ? clampInferenceSteps(params.inferenceSteps) : undefined,
+    shift: params.shift != null ? clampShift(params.shift) : undefined,
+    thinking: params.thinking,
+    seed: params.seed,
+    useRandomSeed: params.useRandomSeed,
   };
 }
 
@@ -312,6 +340,12 @@ export function createDefaultGenerationFormState(): GenerationFormState {
     lyrics: '',
     presetId: null,
     requestError: null,
+    inferenceSteps: DEFAULT_GENERATION.inferenceSteps,
+    guidanceScale: DEFAULT_GENERATION.guidanceScale,
+    shift: DEFAULT_GENERATION.shift,
+    thinking: DEFAULT_GENERATION.thinking,
+    seed: '',
+    useRandomSeed: true,
   };
 }
 
@@ -364,6 +398,12 @@ export interface GenerationState {
   setGenerationVariationCount: (variationCount: number) => void;
   setGenerationTargetTrack: (trackId: string) => void;
   setGenerationLyrics: (lyrics: string) => void;
+  setGenerationInferenceSteps: (steps: number) => void;
+  setGenerationGuidanceScale: (scale: number) => void;
+  setGenerationShift: (shift: number) => void;
+  setGenerationThinking: (thinking: boolean) => void;
+  setGenerationSeed: (seed: string) => void;
+  setGenerationUseRandomSeed: (useRandom: boolean) => void;
   setGenerationRequestError: (message: string | null) => void;
   applyGenerationPreset: (preset: GenerationPreset) => void;
   getPromptAutocompleteSuggestions: (prompt?: string, caretIndex?: number, limit?: number) => PromptAutocompleteSuggestion[];
@@ -559,11 +599,31 @@ export const useGenerationStore = create<GenerationState>()(
       })),
 
       setGenerationLyrics: (lyrics) => set((s) => ({
-        generationForm: {
-          ...s.generationForm,
-          lyrics,
-          requestError: null,
-        },
+        generationForm: { ...s.generationForm, lyrics, requestError: null },
+      })),
+
+      setGenerationInferenceSteps: (steps) => set((s) => ({
+        generationForm: { ...s.generationForm, inferenceSteps: clampInferenceSteps(steps), requestError: null },
+      })),
+
+      setGenerationGuidanceScale: (scale) => set((s) => ({
+        generationForm: { ...s.generationForm, guidanceScale: clampGuidanceScale(scale), requestError: null },
+      })),
+
+      setGenerationShift: (shift) => set((s) => ({
+        generationForm: { ...s.generationForm, shift: clampShift(shift), requestError: null },
+      })),
+
+      setGenerationThinking: (thinking) => set((s) => ({
+        generationForm: { ...s.generationForm, thinking, requestError: null },
+      })),
+
+      setGenerationSeed: (seed) => set((s) => ({
+        generationForm: { ...s.generationForm, seed, requestError: null },
+      })),
+
+      setGenerationUseRandomSeed: (useRandom) => set((s) => ({
+        generationForm: { ...s.generationForm, useRandomSeed: useRandom, requestError: null },
       })),
 
       setGenerationRequestError: (message) => set((s) => ({
@@ -631,12 +691,17 @@ export const useGenerationStore = create<GenerationState>()(
           bpm: generationForm.bpm,
           keyScale: generationForm.keyScale,
           duration: generationForm.lengthSeconds,
-          guidanceScale: generationForm.temperature,
+          guidanceScale: generationForm.guidanceScale,
           temperature: generationForm.temperature,
           styleTags: generationForm.styleTags,
           lyrics: generationForm.lyrics.trim() || undefined,
           globalCaption: context?.globalCaption?.trim() || undefined,
           presetId: generationForm.presetId ?? undefined,
+          inferenceSteps: generationForm.inferenceSteps,
+          shift: generationForm.shift,
+          thinking: generationForm.thinking,
+          seed: generationForm.useRandomSeed ? undefined : generationForm.seed || undefined,
+          useRandomSeed: generationForm.useRandomSeed,
         }, generationForm.presetId);
 
         set({

--- a/tests/unit/generationPanel.test.tsx
+++ b/tests/unit/generationPanel.test.tsx
@@ -63,7 +63,7 @@ describe('GenerationSidePanel', () => {
       bpm: 88,
       keyScale: 'D minor',
       duration: 45,
-      guidanceScale: 0.9,
+      guidanceScale: 7.0,
       temperature: 0.9,
       styleTags: ['Lo-Fi'],
       variationCount: 3,


### PR DESCRIPTION
## Summary

Closes #596

- Adds a collapsible **Advanced Parameters** section to `GenerationSidePanel` (collapsed by default) with controls for: Inference Steps (1–200), Guidance Scale (0–20), Shift (0–10), Thinking toggle, and Seed input with Random toggle
- Wires all advanced params through the full pipeline: `GenerationFormState` → `VariationSessionParams` → `ClipInternalOptions` → `LegoTaskParams` as **per-generation overrides** that fall back to project-level `generationDefaults`
- Adds 20 unit tests covering UI toggle behavior, slider interactions, store clamping, and end-to-end parameter flow through `submitGenerationRequest`

## Changed files

- `src/store/generationStore.ts` — Extended form state with 6 new fields + clamping + setters; updated `submitGenerationRequest` to pass advanced params
- `src/services/generationPipeline.ts` — Extended `ClipInternalOptions` with override fields; wired overrides into `LegoTaskParams` construction
- `src/components/generation/GenerationSidePanel.tsx` — Added collapsible Advanced Parameters UI section
- `src/components/generation/__tests__/GenerationSidePanel.advancedParams.test.tsx` — 20 new tests
- `tests/unit/generationPanel.test.tsx` — Updated existing test expectation for `guidanceScale`

## Test plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — all 1905 tests pass (198 test files)
- [x] `npm run build` — succeeds with 0 errors
- [ ] Manual: open GenerationSidePanel, expand Advanced Parameters, verify sliders/toggles update store
- [ ] Manual: generate with custom advanced params, verify API payload includes overrides


🤖 Generated with [Claude Code](https://claude.com/claude-code)