### PR TITLE
fix: allow tracks to drop into empty arrangement slots

### DIFF
--- a/docs/plans/fix-track-reorder-empty-slots.md
+++ b/docs/plans/fix-track-reorder-empty-slots.md
@@ -1,0 +1,48 @@
+# Plan: Fix Track Reordering Into Empty Arrangement Slots
+
+## User Stories
+
+- As a human user, I want to drag a track header into an empty arrangement row, so that I can place the track exactly where I want instead of only swapping against another visible track.
+- As an AI agent, I want empty arrangement rows to expose a real drop target and stable ordering API, so that browser automation and `window.__store`-driven workflows can reorder tracks into arbitrary slots without pixel-perfect hacks.
+
+## Problem
+
+Track reordering currently works only when the dragged header is dropped on top of another existing track header. When the user drags a track into an empty row between tracks, nothing happens because that placeholder row is not a valid drop target.
+
+This breaks the arrangement workflow shown in the bug report: the user can see a clear destination lane, but the UI ignores the drop.
+
+## Root Cause
+
+1. `TrackList` wires drag-and-drop handlers only into `TrackHeader` rows. Empty placeholder rows are rendered by `EmptyTrackHeaderRow`, which has no `onDragOver`, `onDrop`, or insertion affordance. As a result, the drag never resolves when the pointer is over an empty slot.
+2. The store exposes `reorderTrack(draggedId, targetId, position)`, which only supports placing a track relative to another track id. There is no store API for dropping into an explicit arrangement slot / order index.
+3. The arrangement UI is already slot-based via `buildArrangementTrackSlots()`, so the visual model supports empty insertion points, but the interaction model does not.
+
+## Solution
+
+1. Add a store action that moves a track to a target arrangement order slot, not just relative to another track.
+2. Teach `TrackList` to treat empty placeholder rows as valid drag targets with visible insertion feedback.
+3. Reuse the arrangement slot index to compute the destination order so dropping into gaps and after the final visible track behaves predictably.
+4. Add regression tests that cover:
+   - dropping onto an empty placeholder row inserts the track into that slot
+   - dropping onto an existing track still works
+   - the rendered order stays aligned with arrangement slots
+
+## Verification
+
+1. Manual user-story test:
+   - Create at least two tracks with an empty gap between their order values.
+   - Drag the upper track into the empty row between them.
+   - Confirm the header and timeline lane move into that position.
+2. Agent workflow test:
+   - Use browser automation to drag a track header over an empty arrangement row.
+   - Verify the rendered order changes and the drop target exposes accessible feedback.
+3. Build checks:
+   - `npx tsc --noEmit`
+   - `npm run build`
+   - targeted unit tests for track list / store reorder logic
+
+## Files to Touch
+
+1. `src/store/projectStore.ts`
+2. `src/components/tracks/TrackList.tsx`
+3. `src/components/tracks/__tests__/...` (new or updated regression tests)

--- a/src/components/tracks/TrackList.tsx
+++ b/src/components/tracks/TrackList.tsx
@@ -18,6 +18,7 @@ import {
 export function TrackList() {
   const project = useProjectStore((s) => s.project);
   const reorderTrack = useProjectStore((s) => s.reorderTrack);
+  const moveTrackToOrder = useProjectStore((s) => s.moveTrackToOrder);
   const getVisibleTracks = useProjectStore((s) => s.getVisibleTracks);
   const trackListWidth = useUIStore((s) => s.trackListWidth);
   const trackListDisplayMode = useUIStore((s) => s.trackListDisplayMode);
@@ -35,6 +36,7 @@ export function TrackList() {
 
   const draggedIdRef = useRef<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
+  const [dragOverEmptySlotIndex, setDragOverEmptySlotIndex] = useState<number | null>(null);
   const [dragOverPosition, setDragOverPosition] = useState<'before' | 'after'>('before');
 
   const handleDragStart = useCallback((id: string) => {
@@ -47,21 +49,55 @@ export function TrackList() {
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
     const midY = rect.top + rect.height / 2;
     setDragOverId(id);
+    setDragOverEmptySlotIndex(null);
     setDragOverPosition(e.clientY < midY ? 'before' : 'after');
   }, []);
+
+  const handleEmptyRowDragOver = useCallback((e: React.DragEvent, slotIndex: number) => {
+    e.preventDefault();
+    if (!draggedIdRef.current || !project) return;
+    const draggedTrack = project.tracks.find((track) => track.id === draggedIdRef.current);
+    if (draggedTrack?.isGroup) return;
+    setDragOverId(null);
+    setDragOverEmptySlotIndex(slotIndex);
+  }, [project]);
 
   const handleDrop = useCallback((e: React.DragEvent, targetId: string) => {
     e.preventDefault();
     const draggedId = draggedIdRef.current;
     if (!draggedId || draggedId === targetId) {
       setDragOverId(null);
+      setDragOverEmptySlotIndex(null);
       draggedIdRef.current = null;
       return;
     }
     reorderTrack(draggedId, targetId, dragOverPosition);
     setDragOverId(null);
+    setDragOverEmptySlotIndex(null);
     draggedIdRef.current = null;
   }, [reorderTrack, dragOverPosition]);
+
+  const handleEmptyRowDrop = useCallback((e: React.DragEvent, slotIndex: number) => {
+    e.preventDefault();
+    const draggedId = draggedIdRef.current;
+    if (!draggedId || !project) {
+      setDragOverId(null);
+      setDragOverEmptySlotIndex(null);
+      draggedIdRef.current = null;
+      return;
+    }
+    const draggedTrack = project.tracks.find((track) => track.id === draggedId);
+    if (draggedTrack?.isGroup) {
+      setDragOverId(null);
+      setDragOverEmptySlotIndex(null);
+      draggedIdRef.current = null;
+      return;
+    }
+    moveTrackToOrder(draggedId, slotIndex + 1);
+    setDragOverId(null);
+    setDragOverEmptySlotIndex(null);
+    draggedIdRef.current = null;
+  }, [moveTrackToOrder, project]);
 
   const resizeDragRef = useRef<{ startX: number; startW: number } | null>(null);
 
@@ -86,6 +122,19 @@ export function TrackList() {
 
   const visibleTracks = useMemo(() => getVisibleTracks(), [getVisibleTracks, project]);
   const rows = useMemo(() => buildArrangementTrackSlots(visibleTracks, PLACEHOLDER_ROW_COUNT), [visibleTracks]);
+  const blockedEmptySlotOrders = useMemo(() => {
+    const collapsedGroupIds = new Set(
+      project.tracks
+        .filter((track) => track.isGroup && track.collapsed)
+        .map((track) => track.id),
+    );
+
+    return new Set(
+      project.tracks
+        .filter((track) => track.parentTrackId && collapsedGroupIds.has(track.parentTrackId))
+        .map((track) => track.order),
+    );
+  }, [project]);
   const showsArrangementMarkers = (project.markers?.length ?? 0) > 0;
 
   return (
@@ -96,6 +145,7 @@ export function TrackList() {
       onDragLeave={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget as Node)) {
           setDragOverId(null);
+          setDragOverEmptySlotIndex(null);
         }
       }}
     >
@@ -141,6 +191,10 @@ export function TrackList() {
             key={getArrangementEmptyTrackId(row.slotIndex)}
             slotIndex={row.slotIndex}
             isCollapsed={isCollapsed}
+            isDropDisabled={blockedEmptySlotOrders.has(row.slotIndex + 1)}
+            isDragOver={dragOverEmptySlotIndex === row.slotIndex}
+            onDragOver={handleEmptyRowDragOver}
+            onDrop={handleEmptyRowDrop}
           />
         )))}
       </div>
@@ -158,7 +212,21 @@ export function TrackList() {
 const PLACEHOLDER_ROW_HEIGHT = 64;
 const PLACEHOLDER_ROW_COUNT = DEFAULT_ARRANGEMENT_PLACEHOLDER_ROW_COUNT;
 
-function EmptyTrackHeaderRow({ slotIndex, isCollapsed }: { slotIndex: number; isCollapsed: boolean }) {
+function EmptyTrackHeaderRow({
+  slotIndex,
+  isCollapsed,
+  isDropDisabled,
+  isDragOver,
+  onDragOver,
+  onDrop,
+}: {
+  slotIndex: number;
+  isCollapsed: boolean;
+  isDropDisabled: boolean;
+  isDragOver: boolean;
+  onDragOver: (e: React.DragEvent, slotIndex: number) => void;
+  onDrop: (e: React.DragEvent, slotIndex: number) => void;
+}) {
   const setShowInstrumentPicker = useUIStore((s) => s.setShowInstrumentPicker);
   const selectedTrackIds = useUIStore((s) => s.selectedTrackIds);
   const virtualId = getArrangementEmptyTrackId(slotIndex);
@@ -170,8 +238,14 @@ function EmptyTrackHeaderRow({ slotIndex, isCollapsed }: { slotIndex: number; is
       style={{
         height: PLACEHOLDER_ROW_HEIGHT,
         borderColor: 'var(--color-daw-arrangement-separator)',
+        backgroundColor: isDragOver ? 'rgba(94, 89, 255, 0.12)' : undefined,
+        boxShadow: isDragOver ? 'inset 0 0 0 1px rgba(94, 89, 255, 0.45)' : undefined,
       }}
       onClick={() => setShowInstrumentPicker(true)}
+      onDragOver={isDropDisabled ? undefined : (e) => onDragOver(e, slotIndex)}
+      onDrop={isDropDisabled ? undefined : (e) => onDrop(e, slotIndex)}
+      aria-label={`Empty track slot ${slotIndex + 1}`}
+      data-drop-disabled={isDropDisabled ? 'true' : 'false'}
       data-testid={`empty-header-row-${slotIndex}`}
     >
       {isSelected && (

--- a/src/components/tracks/__tests__/TrackList.test.tsx
+++ b/src/components/tracks/__tests__/TrackList.test.tsx
@@ -1,0 +1,103 @@
+import type { DragEvent } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { TrackList } from '../TrackList';
+import { useProjectStore } from '../../../store/projectStore';
+import { useUIStore } from '../../../store/uiStore';
+
+vi.mock('../../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../TrackListDisplayToggle', () => ({
+  TrackListDisplayToggle: () => <div data-testid="track-list-display-toggle" />,
+}));
+
+vi.mock('../TrackHeader', () => ({
+  TrackHeader: ({
+    track,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    isDragOver,
+    dragOverPosition,
+  }: {
+    track: { id: string; displayName: string };
+    onDragStart: (id: string) => void;
+    onDragOver: (e: DragEvent, id: string) => void;
+    onDrop: (e: DragEvent, id: string) => void;
+    isDragOver: boolean;
+    dragOverPosition: 'before' | 'after' | null;
+  }) => (
+    <div
+      role="button"
+      tabIndex={0}
+      draggable
+      data-testid={`track-header-${track.id}`}
+      data-drag-over={isDragOver ? 'true' : 'false'}
+      data-drag-position={dragOverPosition ?? 'none'}
+      onDragStart={() => onDragStart(track.id)}
+      onDragOver={(event) => onDragOver(event, track.id)}
+      onDrop={(event) => onDrop(event, track.id)}
+    >
+      {track.displayName}
+    </div>
+  ),
+}));
+
+describe('TrackList drag-and-drop', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    useUIStore.setState({
+      trackListWidth: 320,
+      trackListDisplayMode: 'expanded',
+      showTempoLane: false,
+      scrollY: 0,
+      selectedTrackIds: new Set(),
+    });
+  });
+
+  it('allows dropping a track into an empty arrangement row', async () => {
+    const store = useProjectStore.getState();
+    const drums = store.addTrack('drums', 'stems', { order: 1 });
+    const bass = store.addTrack('bass', 'stems', { order: 4 });
+
+    render(<TrackList />);
+
+    fireEvent.dragStart(screen.getByTestId(`track-header-${drums.id}`));
+    fireEvent.dragOver(screen.getByTestId('empty-header-row-1'));
+    fireEvent.drop(screen.getByTestId('empty-header-row-1'));
+
+    await waitFor(() => {
+      const project = useProjectStore.getState().project!;
+      expect(project.tracks.find((track) => track.id === drums.id)?.order).toBe(2);
+      expect(project.tracks.find((track) => track.id === bass.id)?.order).toBe(4);
+    });
+  });
+
+  it('disables empty-slot drops that are occupied by children of a collapsed group', async () => {
+    const store = useProjectStore.getState();
+    const group = store.createGroupTrack('Drum Bus');
+    const child = store.addTrack('drums', 'stems', { order: 2 });
+    const bass = store.addTrack('bass', 'stems', { order: 4 });
+
+    store.moveTrackToGroup(child.id, group.id);
+    store.toggleGroupCollapse(group.id);
+
+    render(<TrackList />);
+
+    const blockedSlot = screen.getByTestId('empty-header-row-1');
+    expect(blockedSlot.getAttribute('data-drop-disabled')).toBe('true');
+
+    fireEvent.dragStart(screen.getByTestId(`track-header-${bass.id}`));
+    fireEvent.dragOver(blockedSlot);
+    fireEvent.drop(blockedSlot);
+
+    await waitFor(() => {
+      const project = useProjectStore.getState().project!;
+      expect(project.tracks.find((track) => track.id === bass.id)?.order).toBe(4);
+      expect(project.tracks.find((track) => track.id === child.id)?.order).toBe(2);
+    });
+  });
+});

--- a/src/store/__tests__/moveTrackToOrder.test.ts
+++ b/src/store/__tests__/moveTrackToOrder.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('projectStore.moveTrackToOrder', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+  });
+
+  it('moves a track into an empty arrangement slot without collapsing unrelated gaps', () => {
+    const store = useProjectStore.getState();
+    const drums = store.addTrack('drums', 'stems', { order: 1 });
+    const bass = store.addTrack('bass', 'stems', { order: 4 });
+
+    store.moveTrackToOrder(drums.id, 3);
+
+    const project = useProjectStore.getState().project!;
+    expect(project.tracks.find((track) => track.id === drums.id)?.order).toBe(3);
+    expect(project.tracks.find((track) => track.id === bass.id)?.order).toBe(4);
+  });
+
+  it('claims the requested slot and shifts occupied tracks down when needed', () => {
+    const store = useProjectStore.getState();
+    const drums = store.addTrack('drums', 'stems', { order: 1 });
+    const bass = store.addTrack('bass', 'stems', { order: 3 });
+    const keys = store.addTrack('keyboard', 'pianoRoll', { order: 5 });
+
+    store.moveTrackToOrder(drums.id, 3);
+
+    const project = useProjectStore.getState().project!;
+    expect(project.tracks.find((track) => track.id === drums.id)?.order).toBe(3);
+    expect(project.tracks.find((track) => track.id === bass.id)?.order).toBe(4);
+    expect(project.tracks.find((track) => track.id === keys.id)?.order).toBe(5);
+  });
+
+  it('preserves existing track-to-track reorder behavior', () => {
+    const store = useProjectStore.getState();
+    const drums = store.addTrack('drums', 'stems', { order: 1 });
+    const bass = store.addTrack('bass', 'stems', { order: 2 });
+
+    store.reorderTrack(bass.id, drums.id, 'before');
+
+    const project = useProjectStore.getState().project!;
+    expect(project.tracks.find((track) => track.id === bass.id)?.order).toBe(1);
+    expect(project.tracks.find((track) => track.id === drums.id)?.order).toBe(2);
+  });
+
+  it('keeps unaffected duplicate-order tracks in their current relative order', () => {
+    const store = useProjectStore.getState();
+    const drums = store.addTrack('drums', 'stems', { order: 1 });
+    const bass = store.addTrack('bass', 'stems', { order: 3 });
+    const keys = store.addTrack('keyboard', 'pianoRoll', { order: 3 });
+
+    store.moveTrackToOrder(drums.id, 5);
+
+    const orderedTrackIds = [...useProjectStore.getState().project!.tracks]
+      .sort((a, b) => a.order - b.order)
+      .map((track) => track.id);
+
+    expect(orderedTrackIds).toEqual([bass.id, keys.id, drums.id]);
+  });
+
+  it('rejects moves into orders occupied by hidden children of collapsed groups', () => {
+    const store = useProjectStore.getState();
+    const group = store.createGroupTrack('Drum Bus');
+    const child = store.addTrack('drums', 'stems', { order: 2 });
+    const bass = store.addTrack('bass', 'stems', { order: 4 });
+
+    store.moveTrackToGroup(child.id, group.id);
+    store.toggleGroupCollapse(group.id);
+    store.moveTrackToOrder(bass.id, 2);
+
+    const project = useProjectStore.getState().project!;
+    expect(project.tracks.find((track) => track.id === bass.id)?.order).toBe(4);
+    expect(project.tracks.find((track) => track.id === child.id)?.order).toBe(2);
+  });
+
+  it('rejects empty-slot moves for group tracks so children stay attached', () => {
+    const store = useProjectStore.getState();
+    const group = store.createGroupTrack('Drum Bus');
+    const child = store.addTrack('drums', 'stems', { order: 2 });
+
+    store.moveTrackToGroup(child.id, group.id);
+    store.moveTrackToOrder(group.id, 4);
+
+    const project = useProjectStore.getState().project!;
+    expect(project.tracks.find((track) => track.id === group.id)?.order).toBe(1);
+    expect(project.tracks.find((track) => track.id === child.id)?.order).toBe(2);
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -495,6 +495,7 @@ export interface ProjectState {
   setTrackHeightPreset: (trackId: string, preset: TrackHeightPreset) => void;
   setAllTracksHeightPreset: (preset: TrackHeightPreset) => void;
   reorderTrack: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
+  moveTrackToOrder: (trackId: string, targetOrder: number) => void;
 
   addClip: (trackId: string, clip: Omit<Clip, 'id' | 'trackId' | 'generationStatus' | 'generationJobId' | 'cumulativeMixKey' | 'isolatedAudioKey' | 'waveformPeaks'>) => Clip;
   ensureMidiClip: (trackId: string, startTime?: number, duration?: number) => Clip;
@@ -1410,6 +1411,47 @@ function createTrackFromTemplate(
 
   Object.assign(track, syncSamplerState(track, {}));
   return track;
+}
+
+function buildTrackOrderMapForMove(
+  tracks: Track[],
+  movedTrackId: string,
+  requestedOrder: number,
+): Map<string, number> {
+  const normalizedOrder = Math.max(1, Math.floor(requestedOrder));
+  const originalSortedTrackIds = [...tracks]
+    .sort((a, b) => a.order - b.order)
+    .map((track) => track.id);
+  const originalIndexByTrackId = new Map(originalSortedTrackIds.map((trackId, index) => [trackId, index]));
+  const items = tracks.map((track) => ({
+    track,
+    requestedOrder: track.id === movedTrackId
+      ? normalizedOrder
+      : Math.max(1, Math.floor(track.order) || 1),
+    isMovedTrack: track.id === movedTrackId,
+    originalIndex: originalIndexByTrackId.get(track.id) ?? Number.MAX_SAFE_INTEGER,
+  }));
+
+  items.sort((a, b) => {
+    if (a.requestedOrder !== b.requestedOrder) {
+      return a.requestedOrder - b.requestedOrder;
+    }
+    if (a.isMovedTrack !== b.isMovedTrack) {
+      return a.isMovedTrack ? -1 : 1;
+    }
+    return a.originalIndex - b.originalIndex;
+  });
+
+  const orderMap = new Map<string, number>();
+  let nextAvailableOrder = 1;
+
+  for (const item of items) {
+    const resolvedOrder = Math.max(item.requestedOrder, nextAvailableOrder);
+    orderMap.set(item.track.id, resolvedOrder);
+    nextAvailableOrder = resolvedOrder + 1;
+  }
+
+  return orderMap;
 }
 
 function createTrackPresetSnapshot(track: Track, name: string): TrackPreset {
@@ -2613,6 +2655,49 @@ export const useProjectStore = create<ProjectState>()(
       ...t,
       order: idToNewOrder.get(t.id) ?? t.order,
     }));
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: updatedTracks,
+      },
+    });
+  },
+
+  moveTrackToOrder: (trackId, targetOrder) => {
+    const state = get();
+    if (!state.project) return;
+
+    const track = state.project.tracks.find((candidate) => candidate.id === trackId);
+    if (!track) return;
+    if (track.isGroup) return;
+
+    const normalizedOrder = Math.max(1, Math.floor(targetOrder));
+    if (track.order === normalizedOrder) return;
+
+    const collapsedGroupIds = new Set(
+      state.project.tracks
+        .filter((candidate) => candidate.isGroup && candidate.collapsed)
+        .map((candidate) => candidate.id),
+    );
+    const blockedOrders = new Set(
+      state.project.tracks
+        .filter((candidate) => (
+          candidate.id !== trackId
+          && candidate.parentTrackId
+          && collapsedGroupIds.has(candidate.parentTrackId)
+        ))
+        .map((candidate) => candidate.order),
+    );
+    if (blockedOrders.has(normalizedOrder)) return;
+
+    _pushHistory(state.project);
+    const orderMap = buildTrackOrderMapForMove(state.project.tracks, trackId, normalizedOrder);
+    const updatedTracks = state.project.tracks.map((candidate) => ({
+      ...candidate,
+      order: orderMap.get(candidate.id) ?? candidate.order,
+    }));
+
     set({
       project: {
         ...state.project,


### PR DESCRIPTION
## Summary
- fix track-list drag and drop so ordinary tracks can be dropped into visible empty arrangement slots
- add store-side order movement guards so collapsed-group child slots and group headers cannot be reordered through this path
- add plan/test coverage for sparse orders, duplicate-order stability, and collapsed-group protection

## Problem
Closes #655.

Users could only reorder tracks by dropping onto another visible track header. Dragging into a visible empty row did nothing because empty arrangement slots were not valid drop targets.

## Root Cause
- `TrackList` only wired drag handlers into `TrackHeader` rows.
- `projectStore` only exposed `reorderTrack(draggedId, targetId, position)` and had no API for moving to a specific arrangement slot.
- Collapsed groups hide children from `getVisibleTracks()`, so empty-slot handling also needed guards to avoid writing into hidden child orders.

## Verification
- `npx tsc --noEmit`
- `npm run build`
- `npx vitest run --environment=node src/store/__tests__/moveTrackToOrder.test.ts src/components/arrangement/__tests__/trackSlotLayout.test.ts`
- browser QA via Playwright:
  - dragging `Drums` into `empty-header-row-1` moved it to order 2 while preserving `Bass` at order 4
  - dragging `Bass` onto a blocked empty slot under a collapsed group kept `Bass` at order 4 and the hidden child at order 2
- `/codex review` run on the uncommitted diff; follow-up fixes addressed its findings around collapsed groups, duplicate-order stability, store API parity, and grouped-track behavior

## Notes
- `npm test` is currently failing in the repo baseline because Vitest workers hit a `jsdom` / `html-encoding-sniffer` `ERR_REQUIRE_ESM` startup error across many unrelated files. This change does not modify that existing test environment issue.
