### PR TITLE
fix: tighten timeline ruler spacing

### DIFF
--- a/src/components/timeline/TimeRuler.tsx
+++ b/src/components/timeline/TimeRuler.tsx
@@ -181,7 +181,7 @@ export function TimeRuler() {
           <div className={`absolute top-0 w-px ${isBar ? 'h-full bg-[#5a5a75]' : 'h-2/3 bg-[color:var(--color-daw-grid-bar)]'}`} />
           {/* Label beside tick */}
           <span
-            className={`absolute bottom-[4px] left-[4px] font-medium whitespace-nowrap ${isBar ? 'text-[10px] text-zinc-400/80' : 'text-[9px] text-zinc-500/60'}`}
+            className={`absolute bottom-px left-[4px] font-medium leading-none whitespace-nowrap ${isBar ? 'text-[10px] text-zinc-400/80' : 'text-[9px] text-zinc-500/60'}`}
           >
             {label}
             {tsLabel && (
@@ -215,7 +215,7 @@ const PlayheadRulerIndicator = memo(function PlayheadRulerIndicator({ pixelsPerS
   const svgH = 12;
   return (
     <div
-      className="absolute bottom-[4px] z-30 pointer-events-none"
+      className="absolute bottom-[-1px] z-30 pointer-events-none"
       style={{ left: x, transform: `translate(-${Math.floor(svgW / 2)}px, 0px)` }}
     >
       <svg


### PR DESCRIPTION
## User Story
As a DAW user, I want the timeline ruler triangle and bar numbers to sit tightly against the guide line, so that the top ruler feels precise instead of slightly floating.

## Problem
The timeline ruler looked like it had extra bottom margin: the inverted triangle tip did not meet the separator line, and the bar numbers sat a bit too high above the lower edge.

## Root Cause
Both the label span and the triangle indicator were offset upward with `bottom: 4px`, and the label also inherited extra line box height.

## Solution
- move ruler labels from `bottom-[4px]` to `bottom-px`
- add `leading-none` so the numeric labels use a tighter text box
- move the triangle indicator from `bottom-[4px]` to `bottom-[-1px]` so the tip visually meets the separator line

## Verification
- `npx tsc --noEmit`
- `npm run build`
- local browser verification via Playwright on `http://127.0.0.1:5200/` after creating a project, adding a track, focusing the timeline, and setting the playhead anchor

## Files Touched
- `src/components/timeline/TimeRuler.tsx`