### PR TITLE
fix: prevent primary long-press clip splitting

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -90,6 +90,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const [dragGhost, setDragGhost] = useState<DragGhostInfo | null>(null);
   const [scissorLine, setScissorLine] = useState<number | null>(null);
   const scissorRef = useRef(false);
+  const suppressContextMenuRef = useRef(false);
 
   // Cleanup cursor on unmount if scissor mode was active
   useEffect(() => {
@@ -153,11 +154,15 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   }, []);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    if (e.button !== 0) return;
     // Skip scissor tool on fade handles
     if ((e.target as HTMLElement).closest('[data-fade-handle]')) return;
+    const isSecondaryPress = e.button === 2 || (e.button === 0 && e.ctrlKey);
+    if (e.button !== 0 && !isSecondaryPress) return;
+
     e.stopPropagation();
-    e.preventDefault();
+    if (e.button === 0) {
+      e.preventDefault();
+    }
 
     const mode = getDragMode(e);
     const startX = e.clientX;
@@ -179,13 +184,18 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     const clipH = clipBlockRef.current?.offsetHeight ?? 48;
     const clipRect = clipBlockRef.current?.getBoundingClientRect();
     const clickOffsetPx = clipRect ? startX - clipRect.left : 0;
+    const supportsScissor = clip.generationStatus === 'ready' || Boolean(clip.midiData);
+    const canStartLongPressScissor = supportsScissor && isSecondaryPress && mode === 'move';
+    let secondaryMoved = false;
 
-    // --- Long-press scissor detection (only for move mode) ---
+    // --- Long-press scissor detection (secondary press only) ---
     let longPressTimer: ReturnType<typeof setTimeout> | null = null;
-    if (mode === 'move' && (clip.generationStatus === 'ready' || Boolean(clip.midiData))) {
+    if (mode === 'move' && canStartLongPressScissor) {
+      e.preventDefault();
       longPressTimer = setTimeout(() => {
         longPressTimer = null;
         scissorRef.current = true;
+        suppressContextMenuRef.current = true;
         // Calculate initial scissor line position
         if (clipRect) {
           const relX = startX - clipRect.left;
@@ -213,6 +223,15 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       }
       const dx = ev.clientX - startX;
       const dy = ev.clientY - startY;
+      if (isSecondaryPress && (Math.abs(dx) >= 3 || Math.abs(dy) >= 3)) {
+        secondaryMoved = true;
+      }
+      if (isSecondaryPress && !scissorRef.current) {
+        if (Math.abs(dx) >= 3 || Math.abs(dy) >= 3) {
+          if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+        }
+        return;
+      }
       if (Math.abs(dx) < 3 && Math.abs(dy) < 3 && !dragRef.current) return;
       // Cancel long-press timer once real drag starts
       if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
@@ -359,6 +378,14 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         return;
       }
 
+      if (isSecondaryPress) {
+        if (!secondaryMoved && !suppressContextMenuRef.current) {
+          setCtxMenu({ x: ev.clientX, y: ev.clientY });
+        }
+        suppressContextMenuRef.current = false;
+        return;
+      }
+
       setDragGhost(null);
       endDrag();
 
@@ -416,6 +443,12 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   }, [isMidiClip, setOpenPianoRoll, track.id, clip.id]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    if (suppressContextMenuRef.current) {
+      suppressContextMenuRef.current = false;
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
     e.preventDefault();
     e.stopPropagation();
     setCtxMenu({ x: e.clientX, y: e.clientY });

--- a/tests/unit/clipScissorMode.test.tsx
+++ b/tests/unit/clipScissorMode.test.tsx
@@ -146,7 +146,7 @@ describe('ClipBlock scissor mode', () => {
     expect(document.body.style.cursor).toBe('');
   });
 
-  it('executes split on mouseup after long-press (happy path)', () => {
+  it('does not execute split on mouseup after primary-button long press', () => {
     const clip = makeClip({ startTime: 2.0, duration: 4.0 });
     const track = makeTrack({ clips: [clip] });
 
@@ -176,11 +176,37 @@ describe('ClipBlock scissor mode', () => {
       window.dispatchEvent(new MouseEvent('mouseup', { clientX: 350, clientY: 24 }));
     });
 
-    // Should have called splitClipAtZeroCrossing with clip-1 and a time around 3.5s (snapped to grid)
+    expect(mockSplitClipAtZeroCrossing).not.toHaveBeenCalled();
+  });
+
+  it('executes split on mouseup after secondary-button long press', () => {
+    const clip = makeClip({ startTime: 2.0, duration: 4.0 });
+    const track = makeTrack({ clips: [clip] });
+
+    useUIStore.setState({ pixelsPerSecond: 100 });
+
+    const { container } = render(<ClipBlock clip={clip} track={track} />);
+    const clipEl = container.querySelector('[data-clip-block]') as HTMLElement;
+    if (!clipEl) return;
+
+    vi.spyOn(clipEl, 'getBoundingClientRect').mockReturnValue({
+      left: 200, right: 600, top: 0, bottom: 48, width: 400, height: 48,
+      x: 200, y: 0, toJSON: () => {},
+    });
+
+    act(() => {
+      clipEl.dispatchEvent(new MouseEvent('mousedown', { clientX: 350, clientY: 24, button: 2, bubbles: true }));
+    });
+
+    act(() => { vi.advanceTimersByTime(400); });
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mouseup', { clientX: 350, clientY: 24, button: 2 }));
+    });
+
     expect(mockSplitClipAtZeroCrossing).toHaveBeenCalledOnce();
     expect(mockSplitClipAtZeroCrossing).toHaveBeenCalledWith('clip-1', expect.any(Number));
     const splitTime = mockSplitClipAtZeroCrossing.mock.calls[0][1];
-    // Should be within clip bounds (2.0 to 6.0) and roughly near 3.5s
     expect(splitTime).toBeGreaterThan(2.01);
     expect(splitTime).toBeLessThan(5.99);
   });


### PR DESCRIPTION
## Summary
Fixes #661.

This change removes the accidental clip split path triggered by a primary-button long press on the timeline.

## User Story
As a human user on macOS, I want a normal primary-button click-and-hold on a clip to remain a selection/drag gesture, so that I do not accidentally split clips while pausing on the timeline.

As a human user on macOS, I want split/scissor mode to require an explicit secondary-button long press gesture, so that destructive edits only happen when I intentionally invoke them.

## Root Cause
`src/components/timeline/ClipBlock.tsx` started the scissor long-press timer for ordinary primary-button move interactions on ready and MIDI clips. That caused a default drag/hold gesture to share the same activation path as split mode.

## What Changed
- Restricted long-press scissor activation to secondary-button presses.
- Preserved primary-button drag behavior for normal clip interactions.
- Suppressed the context menu only after a secondary long press actually enters scissor mode.
- Added regression coverage for primary long press no-op and secondary long press split behavior.

## Verification
- `npx vitest run tests/unit/clipScissorMode.test.tsx`
- `npx tsc --noEmit`
- `npm run build`
- Browser smoke check against local dev server: primary-button long press leaves the clip count unchanged.

## Risk / Follow-up
- Headless browser right-button long-press did not reliably reproduce the split path, so the explicit right-button split behavior is covered by unit tests in this PR.
- I treated the requested macOS gesture rule as: primary-button long press should never split, secondary-button long press is the explicit split gesture. If you want trackpad-specific double-tap/double-click semantics beyond secondary click, we should specify and test that separately.
