### PR TITLE
fix: align waveform thumbnail with timeline grid

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -551,7 +551,6 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           left,
           width: Math.max(width, 4),
           background: `linear-gradient(180deg, ${hexToRgba(clipColor, 0.45)} 0%, ${hexToRgba(clipColor, 0.28)} 100%)`,
-          borderLeft: `3px solid ${clipColor}`,
           boxShadow: isSelected ? '0 0 10px rgba(0, 122, 255, 0.45), inset 0 0 0 1px rgba(0, 122, 255, 0.3)' : 'none',
           ...(isSelected ? { '--tw-ring-color': 'rgba(0, 122, 255, 0.85)' } as React.CSSProperties : {}),
         }}
@@ -570,6 +569,12 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         <div className="absolute top-0 bottom-0 right-0 w-[10px] cursor-col-resize z-10 group/resize-right" data-testid="resize-handle-right">
           <div className="absolute top-0 bottom-0 right-0 w-[2px] bg-white/0 group-hover/resize-right:bg-white/20 transition-colors duration-100" data-testid="resize-indicator-right" />
         </div>
+
+        {/* Color strip — overlay instead of borderLeft to avoid shifting waveform content */}
+        <div
+          className="absolute top-0 bottom-0 left-0 w-[3px] rounded-l-md z-[5] pointer-events-none"
+          style={{ backgroundColor: clipColor }}
+        />
 
         <ClipWaveform
           peaks={peaks}

--- a/src/components/timeline/ClipWaveform.tsx
+++ b/src/components/timeline/ClipWaveform.tsx
@@ -19,7 +19,7 @@ export function ClipWaveform({
   color,
   opacityClassName = 'opacity-60',
 }: ClipWaveformProps) {
-  const contentWidth = Math.max(width - 3, 0);
+  const contentWidth = Math.max(width, 0);
   const peakSlice = getVisiblePeakSlice(peaks, audioDuration, audioOffset, clipDuration);
 
   if (!peaks || peakSlice.numBars === 0 || contentWidth <= 0) {

--- a/tests/unit/clipBlockHover.test.tsx
+++ b/tests/unit/clipBlockHover.test.tsx
@@ -140,7 +140,10 @@ describe('ClipBlock hover and active feedback', () => {
     render(<ClipBlock clip={clip} track={track} />);
 
     const clipEl = screen.getByTestId(`clip-${clip.id}`);
-    expect(clipEl.style.borderLeft).toContain('rgb(34, 197, 94)');
+    // Color strip is now a child overlay div (not borderLeft) for waveform alignment
+    const stripEl = clipEl.querySelector('.w-\\[3px\\]') as HTMLElement;
+    expect(stripEl).toBeTruthy();
+    expect(stripEl!.style.backgroundColor).toContain('rgb(34, 197, 94)');
     expect(clipEl.style.background).toContain('34, 197, 94');
   });
 
@@ -151,7 +154,10 @@ describe('ClipBlock hover and active feedback', () => {
     render(<ClipBlock clip={clip} track={track} />);
 
     const clipEl = screen.getByTestId(`clip-${clip.id}`);
-    expect(clipEl.style.borderLeft).toContain('rgb(68, 136, 255)');
+    // Color strip is now a child overlay div (not borderLeft) for waveform alignment
+    const stripEl = clipEl.querySelector('.w-\\[3px\\]') as HTMLElement;
+    expect(stripEl).toBeTruthy();
+    expect(stripEl!.style.backgroundColor).toContain('rgb(68, 136, 255)');
     expect(clipEl.style.background).toContain('68, 136, 255');
   });
 });


### PR DESCRIPTION
## Summary
- Replace CSS `borderLeft` on clip blocks with an overlay strip div, so the 3px border no longer consumes content area width
- Remove the `width - 3` compensation in `ClipWaveform`, allowing the waveform SVG to fill the full clip width
- Waveform thumbnails now scale at exactly `pixelsPerSecond`, matching the timeline grid — cross-track alignment ("对轨") is reliable

## Root Cause
The clip's `borderLeft: 3px solid` used `border-box` sizing, shrinking the content area by 3px. The waveform SVG was rendered in `width - 3` pixels but represented `clipDuration` seconds, creating:
1. A 3px rightward offset (waveform started late)
2. Cumulative horizontal drift over long clips (compressed scale)

## Test plan
- [x] All 2060 unit tests pass
- [x] Build succeeds with 0 errors
- [ ] Visual verification: load a project with clips, confirm waveform bars align with beat grid markers
- [ ] Cross-track alignment: compare waveform positions across Drums and Bass tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)