### PR TITLE
fix: hide default fade handles on zero-fade audio clips

### DIFF
--- a/docs/plans/fix-generated-audio-clip-fade-affordance.md
+++ b/docs/plans/fix-generated-audio-clip-fade-affordance.md
@@ -1,0 +1,32 @@
+# Fix Generated Audio Clip Fade Affordance
+
+## User Stories
+- As a human user, I want a newly generated audio clip to open without visible fade handles at both edges, so that I can immediately resize or stretch the clip without fighting extra controls.
+- As an AI agent, I want zero-fade audio clips to expose only resize affordances by default, so that browser automation and `window.__store` actions do not confuse fade editing with clip-edge resizing.
+
+## Problem
+- Newly ready audio clips render fade-in and fade-out handles on both sides even when `fadeInDuration` and `fadeOutDuration` are unset or zero.
+- This creates a misleading "pre-faded" look and puts fade controls in the same edge region as clip-resize interactions.
+
+## Root Cause
+- [`src/components/timeline/ClipBlock.tsx`](../../src/components/timeline/ClipBlock.tsx) always renders both fade handle sliders for every ready audio clip.
+- The clip creation paths do not assign default fade durations, so the unwanted affordance is a presentation bug rather than persisted clip state.
+
+## Solution
+- Update `ClipBlock` so fade handles render only when that side already has a non-zero fade duration.
+- Keep fade overlays and fade editing behavior intact for clips that actually have fades.
+- Update unit and E2E coverage to assert that zero-fade clips do not expose fade sliders by default, while clips with active fades still do.
+
+## Verification
+- `npx vitest run tests/unit/clipFadeHandles.test.tsx tests/unit/clipResizeAndFadeVisuals.test.tsx`
+- `npm run test:e2e -- tests/e2e/clip-fades.spec.ts`
+- `npx tsc --noEmit`
+- `npm run build`
+- Browser workflow: create a project, generate or seed a ready audio clip, verify no fade handles appear on a zero-fade clip, then seed a fade in store state and verify the handle/overlay appear.
+
+## Files To Touch
+- `docs/plans/fix-generated-audio-clip-fade-affordance.md`
+- `src/components/timeline/ClipBlock.tsx`
+- `tests/unit/clipFadeHandles.test.tsx`
+- `tests/unit/clipResizeAndFadeVisuals.test.tsx`
+- `tests/e2e/clip-fades.spec.ts`

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -117,6 +117,8 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const { fadeInDuration, fadeOutDuration } = getClipFadeBounds(clip);
   const fadeInWidth = Math.min(width, fadeInDuration * pixelsPerSecond);
   const fadeOutWidth = Math.min(width, fadeOutDuration * pixelsPerSecond);
+  const showFadeInHandle = fadeInDuration > 0;
+  const showFadeOutHandle = fadeOutDuration > 0;
   const clipColor = clip.color ?? track.color;
 
   const dragRef = useRef(false);
@@ -642,44 +644,48 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
                 }}
               />
             )}
-            <button
-              type="button"
-              role="slider"
-              aria-label={`Fade in handle for clip ${clip.id}`}
-              aria-valuemin={0}
-              aria-valuemax={clip.duration}
-              aria-valuenow={fadeInDuration}
-              className="absolute top-1 bottom-1 z-20 rounded-full border border-white/40 bg-black/55 shadow-[0_0_0_1px_rgba(0,0,0,0.18)] hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-sky-400"
-              style={{
-                left: Math.max(EDGE_HANDLE_PX, fadeInWidth - FADE_HANDLE_HIT_TARGET_PX / 2),
-                width: FADE_HANDLE_HIT_TARGET_PX,
-              }}
-              data-fade-handle="in"
-              onMouseDown={handleFadeMouseDown('in')}
-              onKeyDown={handleFadeKeyDown('in')}
-              onDoubleClick={handleFadeReset('in')}
-            >
-              <span className="pointer-events-none absolute inset-y-1 left-1/2 w-px -translate-x-1/2 bg-white/80" />
-            </button>
-            <button
-              type="button"
-              role="slider"
-              aria-label={`Fade out handle for clip ${clip.id}`}
-              aria-valuemin={0}
-              aria-valuemax={clip.duration}
-              aria-valuenow={fadeOutDuration}
-              className="absolute top-1 bottom-1 z-20 rounded-full border border-white/40 bg-black/55 shadow-[0_0_0_1px_rgba(0,0,0,0.18)] hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-sky-400"
-              style={{
-                left: Math.max(EDGE_HANDLE_PX, width - fadeOutWidth - FADE_HANDLE_HIT_TARGET_PX / 2),
-                width: FADE_HANDLE_HIT_TARGET_PX,
-              }}
-              data-fade-handle="out"
-              onMouseDown={handleFadeMouseDown('out')}
-              onKeyDown={handleFadeKeyDown('out')}
-              onDoubleClick={handleFadeReset('out')}
-            >
-              <span className="pointer-events-none absolute inset-y-1 left-1/2 w-px -translate-x-1/2 bg-white/80" />
-            </button>
+            {showFadeInHandle && (
+              <button
+                type="button"
+                role="slider"
+                aria-label={`Fade in handle for clip ${clip.id}`}
+                aria-valuemin={0}
+                aria-valuemax={clip.duration}
+                aria-valuenow={fadeInDuration}
+                className="absolute top-1 bottom-1 z-20 rounded-full border border-white/40 bg-black/55 shadow-[0_0_0_1px_rgba(0,0,0,0.18)] hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-sky-400"
+                style={{
+                  left: Math.max(EDGE_HANDLE_PX, fadeInWidth - FADE_HANDLE_HIT_TARGET_PX / 2),
+                  width: FADE_HANDLE_HIT_TARGET_PX,
+                }}
+                data-fade-handle="in"
+                onMouseDown={handleFadeMouseDown('in')}
+                onKeyDown={handleFadeKeyDown('in')}
+                onDoubleClick={handleFadeReset('in')}
+              >
+                <span className="pointer-events-none absolute inset-y-1 left-1/2 w-px -translate-x-1/2 bg-white/80" />
+              </button>
+            )}
+            {showFadeOutHandle && (
+              <button
+                type="button"
+                role="slider"
+                aria-label={`Fade out handle for clip ${clip.id}`}
+                aria-valuemin={0}
+                aria-valuemax={clip.duration}
+                aria-valuenow={fadeOutDuration}
+                className="absolute top-1 bottom-1 z-20 rounded-full border border-white/40 bg-black/55 shadow-[0_0_0_1px_rgba(0,0,0,0.18)] hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-sky-400"
+                style={{
+                  left: Math.max(EDGE_HANDLE_PX, width - fadeOutWidth - FADE_HANDLE_HIT_TARGET_PX / 2),
+                  width: FADE_HANDLE_HIT_TARGET_PX,
+                }}
+                data-fade-handle="out"
+                onMouseDown={handleFadeMouseDown('out')}
+                onKeyDown={handleFadeKeyDown('out')}
+                onDoubleClick={handleFadeReset('out')}
+              >
+                <span className="pointer-events-none absolute inset-y-1 left-1/2 w-px -translate-x-1/2 bg-white/80" />
+              </button>
+            )}
           </>
         )}
 

--- a/tests/e2e/clip-fades.spec.ts
+++ b/tests/e2e/clip-fades.spec.ts
@@ -35,7 +35,14 @@ test.describe('Clip fade handles', () => {
   });
 
   test('supports keyboard-adjustable fade handles on audio clips', async ({ page }) => {
-    await page.getByText('Click anywhere to enable audio').click();
+    await expect(page.getByRole('slider', { name: /fade in handle/i })).toHaveCount(0);
+    await expect(page.getByRole('slider', { name: /fade out handle/i })).toHaveCount(0);
+
+    await page.evaluate(() => {
+      const store = (window as any).__store;
+      const clip = store.getState().project.tracks[0].clips[0];
+      store.getState().setClipFade(clip.id, { fadeInDuration: 0.2, fadeOutDuration: 0.4 });
+    });
 
     const fadeInHandle = page.getByRole('slider', { name: /fade in handle/i });
     await expect(fadeInHandle).toBeVisible();
@@ -52,8 +59,8 @@ test.describe('Clip fade handles', () => {
       };
     });
 
-    expect(fadeState.fadeInDuration).toBe(0.6);
-    expect(fadeState.fadeOutDuration).toBe(0);
+    expect(fadeState.fadeInDuration).toBe(0.8);
+    expect(fadeState.fadeOutDuration).toBe(0.4);
 
     const fadeOutHandle = page.getByRole('slider', { name: /fade out handle/i });
     await fadeOutHandle.dblclick();
@@ -63,5 +70,6 @@ test.describe('Clip fade handles', () => {
     });
 
     expect(fadeOutAfterReset).toBe(0);
+    await expect(page.getByRole('slider', { name: /fade out handle/i })).toHaveCount(0);
   });
 });

--- a/tests/unit/clipFadeHandles.test.tsx
+++ b/tests/unit/clipFadeHandles.test.tsx
@@ -67,15 +67,24 @@ describe('ClipBlock fade handles', () => {
     useProjectStore.getState().updateClip(readyClip.id, { id: 'clip-1' });
   });
 
+  it('hides fade handles for zero-fade audio clips', () => {
+    renderClip();
+
+    expect(screen.queryByLabelText('Fade in handle for clip clip-1')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Fade out handle for clip clip-1')).not.toBeInTheDocument();
+  });
+
   it('adjusts fade in with keyboard input', () => {
+    useProjectStore.getState().setClipFade('clip-1', { fadeInDuration: 0.2 });
     renderClip();
 
     fireEvent.keyDown(screen.getByLabelText('Fade in handle for clip clip-1'), { key: 'ArrowRight' });
 
-    expect(getClip().fadeInDuration).toBe(0.1);
+    expect(getClip().fadeInDuration).toBe(0.3);
   });
 
   it('drags fade out from the clip edge', () => {
+    useProjectStore.getState().setClipFade('clip-1', { fadeOutDuration: 0.8 });
     const { container } = renderClip();
     const clipBlock = container.querySelector('[data-clip-block]') as HTMLDivElement;
     clipBlock.getBoundingClientRect = () => ({

--- a/tests/unit/clipResizeAndFadeVisuals.test.tsx
+++ b/tests/unit/clipResizeAndFadeVisuals.test.tsx
@@ -77,6 +77,15 @@ describe('Clip resize handle width and fade visuals', () => {
     expect(handles[1].className).toContain('w-[10px]');
   });
 
+  it('does not render fade controls or overlays for zero-fade clips', () => {
+    const { container } = renderClip();
+
+    expect(container.querySelector('[data-testid="fade-in-overlay"]')).toBeNull();
+    expect(container.querySelector('[data-testid="fade-out-overlay"]')).toBeNull();
+    expect(screen.queryByLabelText('Fade in handle for clip clip-1')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Fade out handle for clip clip-1')).not.toBeInTheDocument();
+  });
+
   it('fade-in triangle uses correct clip path (upper-left triangle)', () => {
     useProjectStore.getState().setClipFade('clip-1', { fadeInDuration: 1 });
     const { container } = renderClip();


### PR DESCRIPTION
## Summary
- hide fade handles on ready audio clips when the corresponding fade duration is zero
- preserve fade overlays and fade handle editing for clips that already have non-zero fades
- add a hotfix plan doc plus unit/E2E regression coverage for zero-fade and non-zero-fade paths

## Linked Issue
Closes #672

## User Story
- As a human user, I want a newly generated audio clip to open without visible fade handles at both edges, so that I can resize or stretch it without fighting extra controls.
- As an AI agent, I want zero-fade audio clips to expose only resize affordances by default, so that store-driven and browser-driven tests do not confuse fade editing with clip-edge resizing.

## Root Cause
`ClipBlock` rendered both fade handle sliders for every ready audio clip, even when `fadeInDuration` and `fadeOutDuration` were zero. Clip creation paths were not persisting default fades, so the bug lived in the UI affordance layer rather than clip state.

## Testing
- `npx vitest run tests/unit/clipFadeHandles.test.tsx tests/unit/clipResizeAndFadeVisuals.test.tsx`
- `npm run test:e2e -- tests/e2e/clip-fades.spec.ts`
- `npx tsc --noEmit`
- `npm run build`

## Notes
- This is intentionally scoped as a hotfix for the resize-vs-fade interaction conflict on newly ready audio clips.
- I am leaving the branch unmerged for product review and acceptance.
