### PR TITLE
feat: refresh clip surfaces and header move rail

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -92,6 +92,7 @@ function getClipPresentation(clipColor: string, isSelected: boolean): ClipPresen
 export function ClipBlock({ clip, track }: ClipBlockProps) {
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const selectedClipIds = useUIStore((s) => s.selectedClipIds);
+  const selectedTrackIds = useUIStore((s) => s.selectedTrackIds);
   const selectClip = useUIStore((s) => s.selectClip);
   const setEditingClip = useUIStore((s) => s.setEditingClip);
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
@@ -148,8 +149,8 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   useEffect(() => {
     return () => {
       if (scissorRef.current) document.body.style.cursor = '';
-      if (document.body.style.cursor === 'col-resize') document.body.style.cursor = '';
-      if (document.documentElement.style.cursor === 'col-resize') document.documentElement.style.cursor = '';
+      if (/(?:^|-)resize$/.test(document.body.style.cursor)) document.body.style.cursor = '';
+      if (/(?:^|-)resize$/.test(document.documentElement.style.cursor)) document.documentElement.style.cursor = '';
     };
   }, []);
 
@@ -219,7 +220,9 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
   const left = clip.startTime * pixelsPerSecond;
   const width = clip.duration * pixelsPerSecond;
-  const isSelected = selectedClipIds.has(clip.id);
+  const isClipSelected = selectedClipIds.has(clip.id);
+  const isTrackSelected = selectedTrackIds.has(track.id);
+  const isSelected = isClipSelected && isTrackSelected;
   const { fadeInDuration, fadeOutDuration } = getClipFadeBounds(clip);
   const fadeInWidth = Math.min(width, fadeInDuration * pixelsPerSecond);
   const fadeOutWidth = Math.min(width, fadeOutDuration * pixelsPerSecond);
@@ -656,13 +659,13 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
   const closeCtxMenu = useCallback(() => setCtxMenu(null), []);
 
-  const setResizeCursor = useCallback((active: boolean) => {
-    const cursor = active ? 'col-resize' : '';
+  const setResizeCursor = useCallback((cursor: 'w-resize' | 'e-resize' | null) => {
+    const nextCursor = cursor ?? '';
     if (clipBlockRef.current) {
-      clipBlockRef.current.style.cursor = cursor;
+      clipBlockRef.current.style.cursor = nextCursor;
     }
-    document.body.style.cursor = cursor;
-    document.documentElement.style.cursor = cursor;
+    document.body.style.cursor = nextCursor;
+    document.documentElement.style.cursor = nextCursor;
   }, []);
 
   const syncHoverState = useCallback((clientX: number, clientY: number, altKey: boolean, currentTarget: HTMLElement) => {
@@ -671,13 +674,15 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     const relY = clientY - rect.top;
 
     if (relX <= EDGE_HANDLE_PX || relX >= rect.width - EDGE_HANDLE_PX) {
-      setHoveredResizeEdge(relX <= EDGE_HANDLE_PX ? 'left' : 'right');
+      const edge = relX <= EDGE_HANDLE_PX ? 'left' : 'right';
+      const cursor = edge === 'left' ? 'w-resize' : 'e-resize';
+      setHoveredResizeEdge(edge);
       setHoverSeekX(null);
-      setResizeCursor(true);
-      currentTarget.style.cursor = 'col-resize';
+      setResizeCursor(cursor);
+      currentTarget.style.cursor = cursor;
     } else {
       setHoveredResizeEdge(null);
-      setResizeCursor(false);
+      setResizeCursor(null);
       if (relY <= HEADER_RAIL_HEIGHT_PX) {
         setHoverSeekX(null);
         currentTarget.style.cursor = altKey ? 'ew-resize' : 'grab';
@@ -701,17 +706,17 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     setHoveredResizeEdge(null);
     setHoverSeekX(null);
     el.style.cursor = '';
-    setResizeCursor(false);
+    setResizeCursor(null);
   }, [setResizeCursor]);
 
   const handleResizeHandleEnter = useCallback((edge: 'left' | 'right') => () => {
     setHoveredResizeEdge(edge);
-    setResizeCursor(true);
+    setResizeCursor(edge === 'left' ? 'w-resize' : 'e-resize');
   }, [setResizeCursor]);
 
   const handleResizeHandleLeave = useCallback(() => {
     setHoveredResizeEdge(null);
-    setResizeCursor(false);
+    setResizeCursor(null);
   }, [setResizeCursor]);
 
   const updateFadeFromPointer = useCallback((edge: 'in' | 'out', clientX: number) => {
@@ -869,9 +874,9 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         />
 
         <div
-          className="absolute top-0 bottom-0 left-0 w-[16px] cursor-col-resize z-10 group/resize-left"
+          className="absolute top-0 bottom-0 left-0 w-[16px] cursor-w-resize z-10 group/resize-left"
           data-testid="resize-handle-left"
-          style={{ cursor: 'col-resize' }}
+          style={{ cursor: 'w-resize' }}
           onMouseEnter={handleResizeHandleEnter('left')}
           onMouseLeave={handleResizeHandleLeave}
         >
@@ -887,9 +892,9 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           />
         </div>
         <div
-          className="absolute top-0 bottom-0 right-0 w-[16px] cursor-col-resize z-10 group/resize-right"
+          className="absolute top-0 bottom-0 right-0 w-[16px] cursor-e-resize z-10 group/resize-right"
           data-testid="resize-handle-right"
-          style={{ cursor: 'col-resize' }}
+          style={{ cursor: 'e-resize' }}
           onMouseEnter={handleResizeHandleEnter('right')}
           onMouseLeave={handleResizeHandleLeave}
         >

--- a/tests/unit/clipBlockHover.test.tsx
+++ b/tests/unit/clipBlockHover.test.tsx
@@ -128,10 +128,10 @@ describe('ClipBlock hover and active feedback', () => {
 
     fireEvent.mouseEnter(leftHandle);
 
-    expect(leftHandle.style.cursor).toBe('col-resize');
-    expect(clipEl.style.cursor).toBe('col-resize');
-    expect(document.body.style.cursor).toBe('col-resize');
-    expect(document.documentElement.style.cursor).toBe('col-resize');
+    expect(leftHandle.style.cursor).toBe('w-resize');
+    expect(clipEl.style.cursor).toBe('w-resize');
+    expect(document.body.style.cursor).toBe('w-resize');
+    expect(document.documentElement.style.cursor).toBe('w-resize');
     expect(leftIndicator.style.backgroundColor).toContain('255, 255, 255');
     expect(leftHoverZone.style.background).toContain('linear-gradient');
 
@@ -163,9 +163,35 @@ describe('ClipBlock hover and active feedback', () => {
 
     fireEvent.mouseEnter(clipEl, { clientX: 103, clientY: 24 });
 
-    expect(clipEl.style.cursor).toBe('col-resize');
-    expect(document.body.style.cursor).toBe('col-resize');
-    expect(document.documentElement.style.cursor).toBe('col-resize');
+    expect(clipEl.style.cursor).toBe('w-resize');
+    expect(document.body.style.cursor).toBe('w-resize');
+    expect(document.documentElement.style.cursor).toBe('w-resize');
+  });
+
+  it('uses a right-edge resize cursor when hovering the clip end', () => {
+    const clip = makeClip();
+    const track = makeTrack();
+
+    render(<ClipBlock clip={clip} track={track} />);
+
+    const clipEl = screen.getByTestId(`clip-${clip.id}`) as HTMLElement;
+    vi.spyOn(clipEl, 'getBoundingClientRect').mockReturnValue({
+      x: 100,
+      y: 20,
+      width: 160,
+      height: 40,
+      top: 20,
+      right: 260,
+      bottom: 60,
+      left: 100,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.mouseEnter(clipEl, { clientX: 257, clientY: 24 });
+
+    expect(clipEl.style.cursor).toBe('e-resize');
+    expect(document.body.style.cursor).toBe('e-resize');
+    expect(document.documentElement.style.cursor).toBe('e-resize');
   });
 
   it('does not interfere with selection ring when clip is selected', () => {
@@ -174,6 +200,7 @@ describe('ClipBlock hover and active feedback', () => {
 
     // Select the clip
     useUIStore.getState().selectClip(clip.id, false);
+    useUIStore.getState().selectTrack(track.id, false);
 
     render(<ClipBlock clip={clip} track={track} />);
 
@@ -184,6 +211,22 @@ describe('ClipBlock hover and active feedback', () => {
     // And hover/active classes should still be present
     expect(clipEl.className).toMatch(/hover:/);
     expect(clipEl.className).toMatch(/active:/);
+  });
+
+  it('removes the visual selected state when another track becomes selected', () => {
+    const clip = makeClip();
+    const track = makeTrack();
+
+    useUIStore.getState().selectClip(clip.id, false);
+    useUIStore.getState().selectTrack('track-2', false);
+
+    render(<ClipBlock clip={clip} track={track} />);
+
+    const clipEl = screen.getByTestId(`clip-${clip.id}`);
+    const bodySurface = screen.getByTestId('clip-body-surface') as HTMLElement;
+
+    expect(clipEl.className).not.toContain('ring-2');
+    expect(bodySurface.style.background).not.toContain('253, 251, 246');
   });
 
   it('exposes a dedicated header rail move handle with grab affordance', () => {

--- a/tests/unit/clipResizeAndFadeVisuals.test.tsx
+++ b/tests/unit/clipResizeAndFadeVisuals.test.tsx
@@ -43,7 +43,8 @@ describe('Clip resize handle width and fade visuals', () => {
     useProjectStore.setState({ project: null });
     useUIStore.setState({
       pixelsPerSecond: 50,
-      selectedClipIds: new Set(['clip-1']),
+      selectedClipIds: new Set(),
+      selectedTrackIds: new Set(),
       editingClipId: null,
       contextWindow: null,
       selectWindow: null,
@@ -66,15 +67,21 @@ describe('Clip resize handle width and fade visuals', () => {
 
     const readyClip = useProjectStore.getState().project!.tracks[0].clips[0];
     useProjectStore.getState().updateClip(readyClip.id, { id: 'clip-1' });
+    useUIStore.setState({
+      selectedClipIds: new Set(['clip-1']),
+      selectedTrackIds: new Set([track.id]),
+    });
   });
 
   it('resize handle divs are 16px wide', () => {
-    const { container } = renderClip();
-    const handles = container.querySelectorAll('.cursor-col-resize');
-    expect(handles.length).toBeGreaterThanOrEqual(2);
-    // Check the first two (left and right resize handles)
-    expect(handles[0].className).toContain('w-[16px]');
-    expect(handles[1].className).toContain('w-[16px]');
+    renderClip();
+    const leftHandle = screen.getByTestId('resize-handle-left');
+    const rightHandle = screen.getByTestId('resize-handle-right');
+
+    expect(leftHandle.className).toContain('w-[16px]');
+    expect(rightHandle.className).toContain('w-[16px]');
+    expect(leftHandle.className).toContain('cursor-w-resize');
+    expect(rightHandle.className).toContain('cursor-e-resize');
   });
 
   it('renders a dedicated header rail and an ivory selected body surface', () => {
@@ -86,6 +93,17 @@ describe('Clip resize handle width and fade visuals', () => {
     expect(headerRail.getAttribute('aria-label')).toBe('Move clip clip-1');
     expect(bodySurface).toBeTruthy();
     expect(bodySurface.style.background).toContain('253, 251, 246');
+  });
+
+  it('uses the non-selected clip surface when its track is no longer selected', () => {
+    useUIStore.setState({ selectedTrackIds: new Set(['other-track']) });
+
+    const { container } = renderClip();
+    const bodySurface = container.querySelector('[data-testid="clip-body-surface"]') as HTMLElement;
+    const clipEl = container.querySelector('[data-testid="clip-clip-1"]') as HTMLElement;
+
+    expect(bodySurface.style.background).not.toContain('253, 251, 246');
+    expect(clipEl.className).not.toContain('ring-2');
   });
 
   it('does not render fade controls or overlays for zero-fade clips', () => {


### PR DESCRIPTION
## Summary
- refresh selected audio clips to use an ivory body with dark waveform contrast
- add a dedicated clip header rail as the move handle
- extend unit coverage for the new clip surface and header affordance

## Linked Issues
- Closes #683
- Closes #685

## Verification
- `npx vitest run tests/unit/clipBlockHover.test.tsx tests/unit/clipResizeAndFadeVisuals.test.tsx tests/unit/clipResizeModifiers.test.tsx tests/unit/clipScissorMode.test.tsx tests/unit/clipWaveform.test.tsx`
- `npx tsc --noEmit`
- `npm run build`

## Notes
This PR is the first half of the clip selection UX refresh. Range slicing will land in a follow-up PR.