### PR TITLE
feat: add focused clip range slicing

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -125,6 +125,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const applyAudioQuantize = useProjectStore((s) => s.applyAudioQuantize);
   const clearAudioQuantize = useProjectStore((s) => s.clearAudioQuantize);
   const exportMidiClip = useProjectStore((s) => s.exportMidiClip);
+  const sliceClipToRange = useProjectStore((s) => s.sliceClipToRange);
   const splitClipAtZeroCrossing = useProjectStore((s) => s.splitClipAtZeroCrossing);
   const batchDuplicateClips = useProjectStore((s) => s.batchDuplicateClips);
   const batchMoveClips = useProjectStore((s) => s.batchMoveClips);
@@ -139,10 +140,12 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [dragGhost, setDragGhost] = useState<DragGhostInfo | null>(null);
   const [scissorLine, setScissorLine] = useState<number | null>(null);
+  const [rangePreview, setRangePreview] = useState<{ left: number; width: number } | null>(null);
   const [hoveredResizeEdge, setHoveredResizeEdge] = useState<'left' | 'right' | null>(null);
   const [hoverSeekX, setHoverSeekX] = useState<number | null>(null);
   const scissorRef = useRef(false);
   const suppressContextMenuRef = useRef(false);
+  const rangePreviewCommittedRef = useRef(false);
 
   // Cleanup cursor on unmount if scissor mode was active
   useEffect(() => {
@@ -278,6 +281,59 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       || mode === 'resize-right'
       || (isHeaderRailTarget && (mode === 'move' || mode === 'slip'));
     const canStartSecondaryGesture = isSecondaryPress && mode === 'move';
+
+    if (!isSecondaryPress && !canStartPrimaryDrag && mode === 'move') {
+      e.stopPropagation();
+      e.preventDefault();
+
+      const clipRect = clipBlockRef.current?.getBoundingClientRect();
+      if (!clipRect) return;
+
+      const startRelX = Math.max(0, Math.min(e.clientX - clipRect.left, clipRect.width));
+      let didDrag = false;
+
+      const updatePreview = (clientX: number) => {
+        const currentRelX = Math.max(0, Math.min(clientX - clipRect.left, clipRect.width));
+        const leftPx = Math.min(startRelX, currentRelX);
+        const widthPx = Math.abs(currentRelX - startRelX);
+        setRangePreview(widthPx > 0 ? { left: leftPx, width: widthPx } : null);
+        return { leftPx, widthPx };
+      };
+
+      const onMouseMove = (ev: MouseEvent) => {
+        const { widthPx } = updatePreview(ev.clientX);
+        if (widthPx >= 3) {
+          didDrag = true;
+        }
+      };
+
+      const onMouseUp = (ev: MouseEvent) => {
+        window.removeEventListener('mousemove', onMouseMove);
+        window.removeEventListener('mouseup', onMouseUp);
+
+        const { leftPx, widthPx } = updatePreview(ev.clientX);
+        setRangePreview(null);
+
+        if (!didDrag || widthPx < 3) {
+          return;
+        }
+
+        rangePreviewCommittedRef.current = true;
+
+        const previewStartTime = clip.startTime + (leftPx / pixelsPerSecond);
+        const previewEndTime = clip.startTime + ((leftPx + widthPx) / pixelsPerSecond);
+
+        void sliceClipToRange(clip.id, previewStartTime, previewEndTime).then((selectedClipId) => {
+          if (!selectedClipId) return;
+          selectClip(selectedClipId, false);
+          useUIStore.getState().selectTrack(track.id, false);
+        });
+      };
+
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mouseup', onMouseUp);
+      return;
+    }
 
     if (!canStartPrimaryDrag && !canStartSecondaryGesture) {
       return;
@@ -615,11 +671,14 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
     window.addEventListener('keydown', onKeyDown);
-  }, [clip, pixelsPerSecond, project, updateClip, getDragMode, track.id, moveClipToTrack, duplicateClipToTrack, batchDuplicateClips, batchMoveClips, selectedClipIds, findClosestLane, beginDrag, endDrag, undo, snapClipEdgeToZeroCrossing, splitClipAtZeroCrossing]);
+  }, [clip, pixelsPerSecond, project, updateClip, getDragMode, track.id, moveClipToTrack, duplicateClipToTrack, batchDuplicateClips, batchMoveClips, selectedClipIds, findClosestLane, beginDrag, endDrag, undo, snapClipEdgeToZeroCrossing, sliceClipToRange, splitClipAtZeroCrossing, selectClip]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    if (dragRef.current) return;
+    if (dragRef.current || rangePreviewCommittedRef.current) {
+      rangePreviewCommittedRef.current = false;
+      return;
+    }
     setCtxMenu(null);
     const isMultiSelect = e.metaKey || e.ctrlKey;
     selectClip(clip.id, isMultiSelect);
@@ -634,7 +693,10 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
   const handleDoubleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    if (dragRef.current) return;
+    if (dragRef.current || rangePreviewCommittedRef.current) {
+      rangePreviewCommittedRef.current = false;
+      return;
+    }
     if (isMidiClip) {
       setOpenPianoRoll(track.id, clip.id);
       return;
@@ -1121,6 +1183,20 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           >
             <div className="absolute -top-1 -left-[5px] w-[11px] h-[11px] border-2 border-yellow-400 bg-zinc-900 rounded-full" />
           </div>
+        )}
+
+        {rangePreview && (
+          <div
+            className="absolute bottom-0 pointer-events-none z-20"
+            data-testid="clip-range-preview"
+            style={{
+              top: HEADER_RAIL_HEIGHT_PX,
+              left: rangePreview.left,
+              width: rangePreview.width,
+              background: 'rgba(255, 255, 255, 0.26)',
+              boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.7)',
+            }}
+          />
         )}
       </div>
 

--- a/src/store/__tests__/sliceClipToRange.test.ts
+++ b/src/store/__tests__/sliceClipToRange.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../services/audioFileManager', () => ({
+  loadAudioBlobByKey: vi.fn(),
+  saveAudioBlob: vi.fn(),
+}));
+
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(),
+}));
+
+import { loadAudioBlobByKey } from '../../services/audioFileManager';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+
+function fakeAudioBuffer(samples: Float32Array, sampleRate: number) {
+  return {
+    numberOfChannels: 1,
+    sampleRate,
+    length: samples.length,
+    duration: samples.length / sampleRate,
+    getChannelData: (channel: number) => {
+      if (channel !== 0) throw new Error('only channel 0');
+      return samples;
+    },
+  } as unknown as AudioBuffer;
+}
+
+describe('sliceClipToRange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject({ bpm: 120 });
+  });
+
+  it('isolates a middle audio region into three segments while preserving offsets and peaks', async () => {
+    const track = useProjectStore.getState().addTrack('vocals');
+    const clip = useProjectStore.getState().addClip(track.id, {
+      startTime: 0,
+      duration: 6,
+      prompt: 'vox',
+      lyrics: '',
+      source: 'uploaded',
+    });
+
+    useProjectStore.getState().updateClip(clip.id, {
+      generationStatus: 'ready',
+      isolatedAudioKey: null,
+      waveformPeaks: [0.1, 0.2, 0.3, 0.4],
+      audioDuration: 8,
+      audioOffset: 0,
+      contentOffset: 1,
+    });
+
+    const resultId = await useProjectStore.getState().sliceClipToRange(clip.id, 2, 4);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const selectedClip = clips.find((candidate) => candidate.id === clip.id)!;
+
+    expect(resultId).toBe(clip.id);
+    expect(clips).toHaveLength(3);
+    expect(selectedClip.startTime).toBe(2);
+    expect(selectedClip.duration).toBe(2);
+    expect(selectedClip.audioOffset).toBe(1);
+    expect(selectedClip.contentOffset).toBeUndefined();
+    expect(selectedClip.waveformPeaks).toEqual([0.1, 0.2, 0.3, 0.4]);
+    expect(clips.map((candidate) => [candidate.startTime, candidate.duration])).toEqual([
+      [0, 2],
+      [2, 2],
+      [4, 2],
+    ]);
+  });
+
+  it('returns the original clip id without mutating when the selected range covers the full clip', async () => {
+    const track = useProjectStore.getState().addTrack('vocals');
+    const clip = useProjectStore.getState().addClip(track.id, {
+      startTime: 1,
+      duration: 4,
+      prompt: 'vox',
+      lyrics: '',
+      source: 'uploaded',
+    });
+
+    const resultId = await useProjectStore.getState().sliceClipToRange(clip.id, 0, 8);
+
+    expect(resultId).toBe(clip.id);
+    expect(useProjectStore.getState().project!.tracks[0].clips).toHaveLength(1);
+    expect(useProjectStore.getState().project!.tracks[0].clips[0].startTime).toBe(1);
+  });
+
+  it('snaps both boundaries to nearby zero crossings for audio clips', async () => {
+    const track = useProjectStore.getState().addTrack('vocals');
+    const clip = useProjectStore.getState().addClip(track.id, {
+      startTime: 0,
+      duration: 4,
+      prompt: 'vox',
+      lyrics: '',
+      source: 'uploaded',
+    });
+
+    useProjectStore.getState().updateClip(clip.id, {
+      generationStatus: 'ready',
+      isolatedAudioKey: 'audio-key',
+      audioDuration: 4,
+      audioOffset: 0,
+    });
+
+    const samples = new Float32Array(4000);
+    for (let i = 0; i < 4000; i++) {
+      if (i < 1000) {
+        samples[i] = 0.4;
+      } else if (i < 3000) {
+        samples[i] = -0.4;
+      } else {
+        samples[i] = 0.4;
+      }
+    }
+    samples[999] = 0.02;
+    samples[1000] = -0.03;
+    samples[2999] = -0.02;
+    samples[3000] = 0.03;
+
+    vi.mocked(loadAudioBlobByKey).mockResolvedValue(new Blob(['fake']));
+    vi.mocked(getAudioEngine).mockReturnValue({
+      decodeAudioData: vi.fn().mockResolvedValue(fakeAudioBuffer(samples, 1000)),
+    } as any);
+
+    await useProjectStore.getState().sliceClipToRange(clip.id, 1.003, 2.997);
+    const selectedClip = useProjectStore.getState().project!.tracks[0].clips.find((candidate) => candidate.id === clip.id)!;
+
+    expect(selectedClip.startTime).toBeCloseTo(0.999, 3);
+    expect(selectedClip.duration).toBeCloseTo(2.0, 3);
+  });
+
+  it('grid-snaps MIDI boundaries and trims note content into the isolated segment', async () => {
+    const track = useProjectStore.getState().addTrack('synth', 'pianoRoll');
+    const clip = useProjectStore.getState().addClip(track.id, {
+      startTime: 0,
+      duration: 2,
+      prompt: 'MIDI clip',
+      lyrics: '',
+      midiData: {
+        grid: '1/16',
+        notes: [{
+          id: 'note-1',
+          pitch: 60,
+          startBeat: 0,
+          durationBeats: 4,
+          velocity: 0.8,
+        }],
+      },
+      source: 'uploaded',
+    });
+
+    const resultId = await useProjectStore.getState().sliceClipToRange(clip.id, 0.4, 1.4);
+    const selectedClip = useProjectStore.getState().project!.tracks[0].clips.find((candidate) => candidate.id === clip.id)!;
+    const midiData = selectedClip.midiData!;
+
+    expect(resultId).toBe(clip.id);
+    expect(selectedClip.startTime).toBe(0.5);
+    expect(selectedClip.duration).toBe(1);
+    expect(midiData.notes).toHaveLength(1);
+    expect(midiData.notes[0].startBeat).toBeCloseTo(0, 3);
+    expect(midiData.notes[0].durationBeats).toBeCloseTo(2, 3);
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -97,6 +97,14 @@ import { buildConsolidatedMidiClipData, renderConsolidatedAudioClip, validateCli
 import type { MidiCaptureService } from '../services/midiCaptureService';
 import { snapTimeToZeroCrossing } from '../utils/zeroCrossing';
 import {
+  getClipAudibleEndTime,
+  getClipAudibleStartTime,
+  getClipContentOffset,
+  getClipPlaybackRate,
+  isClipRepitchStretched,
+} from '../utils/clipAudio';
+import { snapToGrid } from '../utils/time';
+import {
   createDefaultPlaybackLatencySettings,
   detectPlaybackLatencySettings,
   normalizePlaybackLatencySettings,
@@ -120,6 +128,116 @@ function getBarDurationSec(bpm: number, timeSig: number): number {
 function sanitizeFileNameSegment(value: string) {
   const trimmed = value.trim().replace(/[\\/:*?"<>|]/g, ' ');
   return trimmed.replace(/\s+/g, ' ').trim() || 'untitled';
+}
+
+const CLIP_RANGE_SLICE_EPSILON = 0.01;
+
+function buildSlicedMidiData(
+  clip: Clip,
+  startTime: number,
+  endTime: number,
+  bpm: number,
+): Clip['midiData'] {
+  if (!clip.midiData) return undefined;
+
+  const secPerBeat = 60 / Math.max(1, bpm);
+  const rangeStartSec = Math.max(0, startTime - clip.startTime);
+  const rangeEndSec = Math.max(rangeStartSec, endTime - clip.startTime);
+
+  return {
+    ...clip.midiData,
+    notes: clip.midiData.notes.flatMap((note) => {
+      const noteStartSec = note.startBeat * secPerBeat;
+      const noteEndSec = (note.startBeat + note.durationBeats) * secPerBeat;
+      const clippedStart = Math.max(noteStartSec, rangeStartSec);
+      const clippedEnd = Math.min(noteEndSec, rangeEndSec);
+
+      if (clippedEnd <= clippedStart) return [];
+
+      return [{
+        ...note,
+        startBeat: (clippedStart - rangeStartSec) / secPerBeat,
+        durationBeats: (clippedEnd - clippedStart) / secPerBeat,
+      }];
+    }),
+  };
+}
+
+function buildClipSegmentFromRange(
+  sourceClip: Clip,
+  startTime: number,
+  endTime: number,
+  bpm: number,
+  id: string,
+): Clip {
+  const relativeStart = Math.max(0, startTime - sourceClip.startTime);
+  const duration = Math.max(0, endTime - startTime);
+  const nextClip: Clip = {
+    ...sourceClip,
+    id,
+    startTime,
+    duration,
+  };
+
+  if (sourceClip.midiData) {
+    nextClip.midiData = buildSlicedMidiData(sourceClip, startTime, endTime, bpm);
+  }
+
+  if (isClipRepitchStretched(sourceClip)) {
+    const playbackRate = getClipPlaybackRate(sourceClip);
+    const sourceOffset = (sourceClip.audioOffset ?? 0) + relativeStart * playbackRate;
+    nextClip.audioOffset = Math.max(0, sourceOffset);
+    nextClip.contentOffset = undefined;
+  } else {
+    const contentOffset = getClipContentOffset(sourceClip);
+    const silenceTrim = Math.min(contentOffset, relativeStart);
+    const audioTrim = Math.max(0, relativeStart - silenceTrim);
+    const nextContentOffset = Math.max(0, contentOffset - silenceTrim);
+    const audioDuration = sourceClip.audioDuration ?? sourceClip.duration;
+
+    nextClip.audioOffset = Math.min(audioDuration, (sourceClip.audioOffset ?? 0) + audioTrim);
+    nextClip.contentOffset = nextContentOffset > 0 ? Math.min(nextContentOffset, duration) : undefined;
+  }
+
+  const clampedFades = clampClipFadeDurations({
+    clipDuration: duration,
+    fadeInDuration: sourceClip.fadeInDuration,
+    fadeOutDuration: sourceClip.fadeOutDuration,
+  });
+  nextClip.fadeInDuration = clampedFades.fadeInDuration;
+  nextClip.fadeOutDuration = clampedFades.fadeOutDuration;
+
+  return nextClip;
+}
+
+function snapClipBoundaryToAudio(
+  clip: Clip,
+  boundaryTime: number,
+  samples: Float32Array,
+  sampleRate: number,
+): number {
+  const audibleStart = getClipAudibleStartTime(clip);
+  const audibleEnd = getClipAudibleEndTime(clip);
+  if (boundaryTime <= audibleStart || boundaryTime >= audibleEnd) {
+    return boundaryTime;
+  }
+
+  const audioOffset = clip.audioOffset ?? 0;
+  const snappedSourceTime = isClipRepitchStretched(clip)
+    ? snapTimeToZeroCrossing(
+        samples,
+        sampleRate,
+        audioOffset + (boundaryTime - clip.startTime) * getClipPlaybackRate(clip),
+      )
+    : snapTimeToZeroCrossing(
+        samples,
+        sampleRate,
+        audioOffset + (boundaryTime - audibleStart),
+      );
+
+  return isClipRepitchStretched(clip)
+    ? clip.startTime + ((snappedSourceTime - audioOffset) / getClipPlaybackRate(clip))
+    : audibleStart + (snappedSourceTime - audioOffset);
 }
 
 function buildConsolidatedPrompt(clips: Clip[], fallback: string) {
@@ -538,6 +656,7 @@ export interface ProjectState {
 
   /** Slip-edit: shift audioOffset by deltaSeconds without changing startTime/duration. */
   slipClip: (clipId: string, deltaSeconds: number) => void;
+  sliceClipToRange: (clipId: string, startTime: number, endTime: number) => Promise<string | null>;
   splitClip: (clipId: string, splitTime: number) => void;
   splitClipAtZeroCrossing: (clipId: string, splitTime: number) => Promise<void>;
   snapClipEdgeToZeroCrossing: (clipId: string, edge: 'left' | 'right') => Promise<void>;
@@ -3121,6 +3240,103 @@ export const useProjectStore = create<ProjectState>()(
     );
     envelope.sort((a, b) => a.time - b.time);
     get().updateClip(clipId, { gainEnvelope: envelope });
+  },
+
+  sliceClipToRange: async (clipId, startTime, endTime) => {
+    const state = get();
+    if (!state.project) return null;
+
+    let sourceClip: Clip | undefined;
+    let trackId: string | undefined;
+    for (const track of state.project.tracks) {
+      const clip = track.clips.find((candidate) => candidate.id === clipId);
+      if (clip) {
+        sourceClip = clip;
+        trackId = track.id;
+        break;
+      }
+    }
+    if (!sourceClip || !trackId) return null;
+
+    const originalStart = sourceClip.startTime;
+    const originalEnd = sourceClip.startTime + sourceClip.duration;
+    let rangeStart = Math.max(originalStart, Math.min(startTime, endTime));
+    let rangeEnd = Math.min(originalEnd, Math.max(startTime, endTime));
+
+    if (sourceClip.midiData) {
+      const bpm = state.project.bpm ?? 120;
+      rangeStart = Math.max(originalStart, snapToGrid(rangeStart, bpm, 1));
+      rangeEnd = Math.min(originalEnd, snapToGrid(rangeEnd, bpm, 1));
+    } else {
+      const audioKey = sourceClip.isolatedAudioKey ?? sourceClip.cumulativeMixKey;
+      if (audioKey) {
+        try {
+          const blob = await loadAudioBlobByKey(audioKey);
+          if (blob) {
+            const engine = audioEngineHooks.getAudioEngine();
+            const buffer = await engine.decodeAudioData(blob);
+            const samples = buffer.getChannelData(0);
+            rangeStart = snapClipBoundaryToAudio(sourceClip, rangeStart, samples, buffer.sampleRate);
+            rangeEnd = snapClipBoundaryToAudio(sourceClip, rangeEnd, samples, buffer.sampleRate);
+          }
+        } catch {
+          // Keep the original boundaries if audio decoding or zero-cross lookup fails.
+        }
+      }
+    }
+
+    rangeStart = Math.max(originalStart, rangeStart);
+    rangeEnd = Math.min(originalEnd, rangeEnd);
+
+    if (rangeEnd - rangeStart <= CLIP_RANGE_SLICE_EPSILON) {
+      return null;
+    }
+
+    const hasLeftRemainder = rangeStart > originalStart + CLIP_RANGE_SLICE_EPSILON;
+    const hasRightRemainder = rangeEnd < originalEnd - CLIP_RANGE_SLICE_EPSILON;
+    if (!hasLeftRemainder && !hasRightRemainder) {
+      return clipId;
+    }
+
+    const bpm = state.project.bpm ?? 120;
+    const selectedClip = buildClipSegmentFromRange(sourceClip, rangeStart, rangeEnd, bpm, clipId);
+    const extraClips: Clip[] = [];
+
+    if (hasLeftRemainder) {
+      extraClips.push(buildClipSegmentFromRange(sourceClip, originalStart, rangeStart, bpm, uuidv4()));
+    }
+    if (hasRightRemainder) {
+      extraClips.push(buildClipSegmentFromRange(sourceClip, rangeEnd, originalEnd, bpm, uuidv4()));
+    }
+
+    _pushHistory(state.project);
+
+    const nextTracks = state.project.tracks.map((track) => {
+      if (track.id !== trackId) return track;
+      return {
+        ...track,
+        clips: [...track.clips.filter((clip) => clip.id !== clipId), selectedClip, ...extraClips]
+          .sort((a, b) => a.startTime - b.startTime),
+      };
+    });
+
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(
+          nextTracks,
+          state.project.measures,
+          state.project.bpm,
+          state.project.timeSignature,
+          state.project.tempoMap,
+          state.project.timeSignatureMap,
+        ),
+        tracks: nextTracks,
+      },
+    });
+
+    return clipId;
   },
 
   splitClip: (clipId, splitTime) => {

--- a/tests/unit/clipRangeSlice.test.tsx
+++ b/tests/unit/clipRangeSlice.test.tsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ClipBlock } from '../../src/components/timeline/ClipBlock';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useUIStore } from '../../src/store/uiStore';
+import type { Track } from '../../src/types/project';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useGeneration', () => ({
+  useGeneration: () => ({
+    generateClip: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/services/generationPipeline', () => ({
+  regenerateClip: vi.fn(),
+}));
+
+describe('ClipBlock range slicing', () => {
+  const mockSliceClipToRange = vi.fn().mockResolvedValue('clip-1');
+
+  function getTrack(): Track {
+    return useProjectStore.getState().project!.tracks[0];
+  }
+
+  function getClip() {
+    return getTrack().clips[0];
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    useProjectStore.setState({ project: null });
+    useUIStore.setState({
+      pixelsPerSecond: 100,
+      selectedClipIds: new Set(),
+      editingClipId: null,
+      contextWindow: null,
+      selectWindow: null,
+    });
+
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('vocals');
+    const clip = useProjectStore.getState().addClip(track.id, {
+      startTime: 1,
+      duration: 4,
+      prompt: 'vox',
+      lyrics: '',
+      source: 'uploaded',
+    });
+    useProjectStore.getState().updateClipStatus(clip.id, 'ready', {
+      isolatedAudioKey: 'audio-1',
+      waveformPeaks: [0.2, 0.6, 0.4, 0.8],
+      audioDuration: 8,
+    });
+
+    const readyClip = useProjectStore.getState().project!.tracks[0].clips[0];
+    useProjectStore.getState().updateClip(readyClip.id, { id: 'clip-1' });
+    useProjectStore.setState({ sliceClipToRange: mockSliceClipToRange });
+  });
+
+  it('shows a body-range preview and commits the slice on mouse-up', async () => {
+    const track = getTrack();
+    const clip = getClip();
+    const { container } = render(
+      <div style={{ position: 'relative', width: 800, height: 80 }}>
+        <ClipBlock clip={clip} track={track} />
+      </div>,
+    );
+
+    const clipEl = container.querySelector('[data-clip-block]') as HTMLDivElement;
+    clipEl.getBoundingClientRect = () => ({
+      x: 100,
+      y: 0,
+      left: 100,
+      top: 0,
+      right: 500,
+      bottom: 48,
+      width: 400,
+      height: 48,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.mouseDown(clipEl, { button: 0, clientX: 180, clientY: 28 });
+    fireEvent.mouseMove(window, { clientX: 280, clientY: 28 });
+
+    expect(screen.getByTestId('clip-range-preview')).toBeInTheDocument();
+
+    fireEvent.mouseUp(window, { clientX: 280, clientY: 28 });
+
+    await waitFor(() => {
+      expect(mockSliceClipToRange).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockSliceClipToRange).toHaveBeenCalledWith('clip-1', 1.8, 2.8);
+    expect(screen.queryByTestId('clip-range-preview')).not.toBeInTheDocument();
+    expect(useUIStore.getState().selectedClipIds.has('clip-1')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `sliceClipToRange` to the project store for focused clip isolation
- wire clip body drag to preview and commit the selected range on mouse-up
- cover audio zero-cross snapping, MIDI grid snapping, and component drag behavior

## Linked Issues
- Closes #684

## Verification
- `npx vitest run src/store/__tests__/sliceClipToRange.test.ts tests/unit/clipRangeSlice.test.tsx tests/unit/clipBlockHover.test.tsx tests/unit/clipResizeAndFadeVisuals.test.tsx tests/unit/clipResizeModifiers.test.tsx tests/unit/clipScissorMode.test.tsx tests/unit/clipWaveform.test.tsx`
- `npx tsc --noEmit`
- `npm run build`
- Headless browser QA against `http://127.0.0.1:4173/` verifying body drag slices the focused clip into 3 segments and header drag still moves the selected segment

## Notes
This PR is stacked on top of #686. Review this diff against `feat/v0.1.1-clip-surface-ux`.