### PR TITLE
fix: remove auto-save indicator from LCD display

### DIFF
--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -35,10 +35,7 @@ function LCDDisplay() {
       <span className={`text-[13px] font-mono tabular-nums tracking-wider ${barsBeatsColor}`}>{displayBarsBeats}</span>
       <span className="text-[11px] font-mono tabular-nums text-zinc-400">{formatTime(currentTime)}</span>
       {project && !countInActive && (
-        <>
-          <span className="text-[11px] font-mono tabular-nums text-zinc-400">{project.bpm} bpm</span>
-          <span className="text-[10px] text-emerald-600/60" title="Project auto-saved to browser storage">●</span>
-        </>
+        <span className="text-[11px] font-mono tabular-nums text-zinc-400">{project.bpm} bpm</span>
       )}
       {countInActive && (
         <span className="text-[11px] font-mono text-red-400 animate-pulse">REC</span>


### PR DESCRIPTION
## Summary
- Remove the auto-save indicator dot (`●`) from the toolbar LCD display — it provided near-zero value and cluttered the display
- Remove the unnecessary React Fragment wrapper since only the BPM span remains

Closes #695

## Test plan
- [ ] Verify the LCD display shows bars/beats, time, and BPM without the green dot
- [ ] Verify count-in mode still shows the REC indicator correctly
- [ ] Verify session recording indicator still appears
- [ ] Verify loop cycle badge still renders during loop recording
- [ ] `npx tsc --noEmit` passes with 0 errors
- [ ] `npm test` passes (2086/2086 tests)
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)