### PR TITLE
fix: make right-side panels mutually exclusive — unified sidebar behavior

### DIFF
--- a/src/store/__tests__/uiStore.rightPanelExclusion.test.ts
+++ b/src/store/__tests__/uiStore.rightPanelExclusion.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useUIStore } from '../uiStore';
+
+/**
+ * Right-side panels are mutually exclusive: opening one closes all others.
+ * Panels: showMixer, loopBrowserOpen, showGenerationPanel,
+ *         showGenerationHistoryPanel, showModelLibrary, showAIAssistant
+ */
+
+const RIGHT_PANEL_KEYS = [
+  'showMixer',
+  'loopBrowserOpen',
+  'showGenerationPanel',
+  'showGenerationHistoryPanel',
+  'showModelLibrary',
+  'showAIAssistant',
+] as const;
+
+type RightPanelKey = (typeof RIGHT_PANEL_KEYS)[number];
+
+function getRightPanelStates() {
+  const state = useUIStore.getState();
+  return Object.fromEntries(RIGHT_PANEL_KEYS.map((k) => [k, state[k]])) as Record<
+    RightPanelKey,
+    boolean
+  >;
+}
+
+function allPanelsClosed() {
+  return Object.values(getRightPanelStates()).every((v) => !v);
+}
+
+function onlyOpen(key: RightPanelKey) {
+  const states = getRightPanelStates();
+  return states[key] === true && Object.entries(states).every(([k, v]) => k === key || !v);
+}
+
+describe('right-side panel mutual exclusion', () => {
+  beforeEach(() => {
+    // Reset all right-panel booleans to false
+    useUIStore.setState({
+      showMixer: false,
+      loopBrowserOpen: false,
+      showGenerationPanel: false,
+      showGenerationHistoryPanel: false,
+      showModelLibrary: false,
+      showAIAssistant: false,
+    });
+  });
+
+  it('starts with all right panels closed', () => {
+    expect(allPanelsClosed()).toBe(true);
+  });
+
+  // --- toggleLoopBrowser ---
+  it('toggleLoopBrowser opens loop browser and closes others', () => {
+    useUIStore.setState({ showMixer: true });
+    useUIStore.getState().toggleLoopBrowser();
+    expect(onlyOpen('loopBrowserOpen')).toBe(true);
+  });
+
+  it('toggleLoopBrowser off does not open another panel', () => {
+    useUIStore.setState({ loopBrowserOpen: true });
+    useUIStore.getState().toggleLoopBrowser();
+    expect(allPanelsClosed()).toBe(true);
+  });
+
+  // --- toggleModelLibrary ---
+  it('toggleModelLibrary opens model library and closes others', () => {
+    useUIStore.setState({ showGenerationPanel: true });
+    useUIStore.getState().toggleModelLibrary();
+    expect(onlyOpen('showModelLibrary')).toBe(true);
+  });
+
+  it('toggleModelLibrary off does not open another panel', () => {
+    useUIStore.setState({ showModelLibrary: true });
+    useUIStore.getState().toggleModelLibrary();
+    expect(allPanelsClosed()).toBe(true);
+  });
+
+  // --- toggleGenerationPanel ---
+  it('toggleGenerationPanel opens generation panel and closes others', () => {
+    useUIStore.setState({ showMixer: true, loopBrowserOpen: true });
+    useUIStore.getState().toggleGenerationPanel();
+    expect(onlyOpen('showGenerationPanel')).toBe(true);
+  });
+
+  it('toggleGenerationPanel off does not open another panel', () => {
+    useUIStore.setState({ showGenerationPanel: true });
+    useUIStore.getState().toggleGenerationPanel();
+    expect(allPanelsClosed()).toBe(true);
+  });
+
+  // --- toggleGenerationHistoryPanel ---
+  it('toggleGenerationHistoryPanel opens history and closes others', () => {
+    useUIStore.setState({ showAIAssistant: true });
+    useUIStore.getState().toggleGenerationHistoryPanel();
+    expect(onlyOpen('showGenerationHistoryPanel')).toBe(true);
+  });
+
+  it('toggleGenerationHistoryPanel off does not open another panel', () => {
+    useUIStore.setState({ showGenerationHistoryPanel: true });
+    useUIStore.getState().toggleGenerationHistoryPanel();
+    expect(allPanelsClosed()).toBe(true);
+  });
+
+  // --- toggleAIAssistant ---
+  it('toggleAIAssistant opens AI assistant and closes others', () => {
+    useUIStore.setState({ showMixer: true, showModelLibrary: true });
+    useUIStore.getState().toggleAIAssistant();
+    expect(onlyOpen('showAIAssistant')).toBe(true);
+  });
+
+  it('toggleAIAssistant off does not open another panel', () => {
+    useUIStore.setState({ showAIAssistant: true });
+    useUIStore.getState().toggleAIAssistant();
+    expect(allPanelsClosed()).toBe(true);
+  });
+
+  // --- setShowMixer (used by Toolbar as toggle) ---
+  it('setShowMixer(true) opens mixer and closes others', () => {
+    useUIStore.setState({ loopBrowserOpen: true, showGenerationPanel: true });
+    useUIStore.getState().setShowMixer(true);
+    expect(onlyOpen('showMixer')).toBe(true);
+  });
+
+  it('setShowMixer(false) closes mixer without opening others', () => {
+    useUIStore.setState({ showMixer: true });
+    useUIStore.getState().setShowMixer(false);
+    expect(allPanelsClosed()).toBe(true);
+  });
+
+  // --- setShowGenerationPanel ---
+  it('setShowGenerationPanel(true) opens generation panel and closes others', () => {
+    useUIStore.setState({ showMixer: true });
+    useUIStore.getState().setShowGenerationPanel(true);
+    expect(onlyOpen('showGenerationPanel')).toBe(true);
+  });
+
+  // --- setShowGenerationHistoryPanel ---
+  it('setShowGenerationHistoryPanel(true) opens history and closes others', () => {
+    useUIStore.setState({ showAIAssistant: true });
+    useUIStore.getState().setShowGenerationHistoryPanel(true);
+    expect(onlyOpen('showGenerationHistoryPanel')).toBe(true);
+  });
+
+  // --- setShowModelLibrary ---
+  it('setShowModelLibrary(true) opens model library and closes others', () => {
+    useUIStore.setState({ showMixer: true });
+    useUIStore.getState().setShowModelLibrary(true);
+    expect(onlyOpen('showModelLibrary')).toBe(true);
+  });
+
+  // --- setShowAIAssistant ---
+  it('setShowAIAssistant(true) opens AI assistant and closes others', () => {
+    useUIStore.setState({ showGenerationPanel: true });
+    useUIStore.getState().setShowAIAssistant(true);
+    expect(onlyOpen('showAIAssistant')).toBe(true);
+  });
+
+  // --- Idempotent: toggling an already-open panel just closes it ---
+  it('toggling the already-open panel closes it', () => {
+    useUIStore.getState().toggleGenerationPanel();
+    expect(onlyOpen('showGenerationPanel')).toBe(true);
+    useUIStore.getState().toggleGenerationPanel();
+    expect(allPanelsClosed()).toBe(true);
+  });
+});

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -420,6 +420,16 @@ function getComplexityDefaults(tier: 'simple' | 'standard' | 'advanced') {
   }
 }
 
+/** State slice that closes every right-side panel. Spread this when opening one. */
+const ALL_RIGHT_PANELS_CLOSED = {
+  showMixer: false,
+  loopBrowserOpen: false,
+  showGenerationPanel: false,
+  showGenerationHistoryPanel: false,
+  showModelLibrary: false,
+  showAIAssistant: false,
+} as const;
+
 export const useUIStore = create<UIState>()(
   persist(
     (set, get) => ({
@@ -682,7 +692,7 @@ export const useUIStore = create<UIState>()(
       historyFocusClipId: resolvedClipId ?? null,
     };
   }),
-  setShowMixer: (v) => set({ showMixer: v }),
+  setShowMixer: (v) => set(v ? { ...ALL_RIGHT_PANELS_CLOSED, showMixer: true } : { showMixer: false }),
   setMixerHeight: (v) => set({ mixerHeight: Math.min(500, Math.max(160, v)) }),
   setShowAssetsPanel: (v) => set({ showAssetsPanel: v }),
   setAssetsPanelWidth: (v) => set({ assetsPanelWidth: Math.min(500, Math.max(160, v)) }),
@@ -823,7 +833,7 @@ export const useUIStore = create<UIState>()(
   setUserScrolledDuringPlayback: (scrolled) => set({ userScrolledDuringPlayback: scrolled }),
   toggleAutoScroll: () => set((s) => ({ autoScrollEnabled: !s.autoScrollEnabled })),
 
-  toggleLoopBrowser: () => set((s) => ({ loopBrowserOpen: !s.loopBrowserOpen })),
+  toggleLoopBrowser: () => set((s) => s.loopBrowserOpen ? { loopBrowserOpen: false } : { ...ALL_RIGHT_PANELS_CLOSED, loopBrowserOpen: true }),
   setLoopBrowserCategory: (v) => set({ loopBrowserCategory: v }),
   setLoopBrowserSearch: (v) => set({ loopBrowserSearch: v }),
   setPreviewingLoopId: (id) => set({ previewingLoopId: id }),
@@ -851,13 +861,13 @@ export const useUIStore = create<UIState>()(
 
   setAddLayerOpen: (v) => set({ addLayerOpen: v }),
 
-  toggleModelLibrary: () => set((s) => ({ showModelLibrary: !s.showModelLibrary })),
-  setShowModelLibrary: (v) => set({ showModelLibrary: v }),
+  toggleModelLibrary: () => set((s) => s.showModelLibrary ? { showModelLibrary: false } : { ...ALL_RIGHT_PANELS_CLOSED, showModelLibrary: true }),
+  setShowModelLibrary: (v) => set(v ? { ...ALL_RIGHT_PANELS_CLOSED, showModelLibrary: true } : { showModelLibrary: false }),
 
-  toggleGenerationPanel: () => set((s) => ({ showGenerationPanel: !s.showGenerationPanel })),
-  setShowGenerationPanel: (v) => set({ showGenerationPanel: v }),
-  toggleGenerationHistoryPanel: () => set((s) => ({ showGenerationHistoryPanel: !s.showGenerationHistoryPanel })),
-  setShowGenerationHistoryPanel: (v) => set({ showGenerationHistoryPanel: v }),
+  toggleGenerationPanel: () => set((s) => s.showGenerationPanel ? { showGenerationPanel: false } : { ...ALL_RIGHT_PANELS_CLOSED, showGenerationPanel: true }),
+  setShowGenerationPanel: (v) => set(v ? { ...ALL_RIGHT_PANELS_CLOSED, showGenerationPanel: true } : { showGenerationPanel: false }),
+  toggleGenerationHistoryPanel: () => set((s) => s.showGenerationHistoryPanel ? { showGenerationHistoryPanel: false } : { ...ALL_RIGHT_PANELS_CLOSED, showGenerationHistoryPanel: true }),
+  setShowGenerationHistoryPanel: (v) => set(v ? { ...ALL_RIGHT_PANELS_CLOSED, showGenerationHistoryPanel: true } : { showGenerationHistoryPanel: false }),
 
   setShowCommandPalette: (v) => set({ showCommandPalette: v }),
   toggleCommandPalette: () => set((s) => ({ showCommandPalette: !s.showCommandPalette })),
@@ -866,6 +876,7 @@ export const useUIStore = create<UIState>()(
     const nextShow = !state.showAIAssistant;
     return nextShow
       ? {
+          ...ALL_RIGHT_PANELS_CLOSED,
           showAIAssistant: true,
           aiAssistantSuggestions: getAssistantSuggestions(getAssistantContext(state)),
           aiAssistantError: null,
@@ -875,6 +886,7 @@ export const useUIStore = create<UIState>()(
   setShowAIAssistant: (v) => set((state) => (
     v
       ? {
+          ...ALL_RIGHT_PANELS_CLOSED,
           showAIAssistant: true,
           aiAssistantSuggestions: getAssistantSuggestions(getAssistantContext(state)),
           aiAssistantError: null,

--- a/tests/unit/uiStore.test.ts
+++ b/tests/unit/uiStore.test.ts
@@ -60,24 +60,26 @@ describe('uiStore', () => {
   });
 
   describe('panel toggles', () => {
-    it('updates mixer, loop browser, and library panel visibility', () => {
+    it('updates mixer, loop browser, and library panel visibility (mutually exclusive)', () => {
+      // Opening mixer
       useUIStore.getState().setShowMixer(true);
+      expect(useUIStore.getState().showMixer).toBe(true);
+
+      // Opening loop browser closes mixer (mutual exclusion)
       useUIStore.getState().toggleLoopBrowser();
+      expect(useUIStore.getState().loopBrowserOpen).toBe(true);
+      expect(useUIStore.getState().showMixer).toBe(false);
+
+      // showLibrary is not a right-side panel, so it stays independent
       useUIStore.getState().setShowLibrary(true);
+      expect(useUIStore.getState().showLibrary).toBe(true);
 
-      let state = useUIStore.getState();
-      expect(state.showMixer).toBe(true);
-      expect(state.loopBrowserOpen).toBe(true);
-      expect(state.showLibrary).toBe(true);
-
-      useUIStore.getState().setShowMixer(false);
+      // Closing loop browser
       useUIStore.getState().toggleLoopBrowser();
-      useUIStore.getState().setShowLibrary(false);
+      expect(useUIStore.getState().loopBrowserOpen).toBe(false);
 
-      state = useUIStore.getState();
-      expect(state.showMixer).toBe(false);
-      expect(state.loopBrowserOpen).toBe(false);
-      expect(state.showLibrary).toBe(false);
+      useUIStore.getState().setShowLibrary(false);
+      expect(useUIStore.getState().showLibrary).toBe(false);
     });
 
     it('toggles the primary arrangement/session view', () => {


### PR DESCRIPTION
## Summary

Closes #696

- When opening any right-side panel (Mixer, Loop Browser, Generation Panel, Generation History, Model Library, AI Assistant), all other right-side panels are automatically closed
- Store-level change only — no UI component modifications needed
- Added `ALL_RIGHT_PANELS_CLOSED` constant spread into each toggle/set action when turning a panel ON
- Toggling a panel OFF simply closes it without opening another

## Test plan

- [x] New test file `src/store/__tests__/uiStore.rightPanelExclusion.test.ts` with 18 tests covering all toggle and set functions
- [x] Updated existing `tests/unit/uiStore.test.ts` to reflect mutual exclusion behavior
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 2104 passed, 0 failed
- [x] `npm run build` — succeeds
- [ ] Manual: open Mixer via X key, then press Loop Browser button — Mixer closes, Loop Browser opens
- [ ] Manual: open AI Assistant, then open Generation Panel — AI Assistant closes
- [ ] Manual: close a panel — no other panel opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)