### PR TITLE
fix: use compact Mute/Solo buttons in Mixer to reduce visual redundancy

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -97,12 +97,12 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
             {track.displayName}
           </span>
 
-          <div className="flex gap-2 mt-0.5">
+          <div className="flex gap-1.5 mt-0.5">
             <button
               onClick={() => track.isGroup ? setGroupMuted(track.id, !track.muted) : updateTrack(track.id, { muted: !track.muted })}
               aria-label={`Mute ${track.displayName}`}
-              className={`text-xs font-bold px-2.5 py-1 rounded transition-colors ${
-                track.muted ? 'bg-amber-500 text-black' : 'bg-[#444] text-zinc-400 hover:bg-[#484848]'
+              className={`text-[10px] font-bold w-[18px] h-[18px] flex items-center justify-center rounded-sm transition-colors ${
+                track.muted ? 'bg-amber-500 text-black' : 'bg-[#444] text-zinc-500 hover:bg-[#484848]'
               }`}
             >
               M
@@ -110,8 +110,8 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
             <button
               onClick={() => track.isGroup ? setGroupSoloed(track.id, !track.soloed) : updateTrack(track.id, { soloed: !track.soloed })}
               aria-label={`Solo ${track.displayName}`}
-              className={`text-xs font-bold px-2.5 py-1 rounded transition-colors ${
-                track.soloed ? 'bg-emerald-500 text-black' : 'bg-[#444] text-zinc-400 hover:bg-[#484848]'
+              className={`text-[10px] font-bold w-[18px] h-[18px] flex items-center justify-center rounded-sm transition-colors ${
+                track.soloed ? 'bg-emerald-500 text-black' : 'bg-[#444] text-zinc-500 hover:bg-[#484848]'
               }`}
             >
               S


### PR DESCRIPTION
## Summary
- Reduces M/S button size in Mixer ChannelStrip from `text-xs px-2.5 py-1` to fixed `18x18px` with `text-[10px]` font
- Uses `rounded-sm` instead of `rounded` for tighter appearance
- Same color semantics (amber for mute, emerald for solo) and click handlers preserved
- Creates visual differentiation: TrackHeader has primary M/S controls, Mixer has compact status indicators

Closes #691

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 2086 tests pass (225 suites)
- [x] `npm run build` — succeeds
- [ ] Visual check: M/S buttons in Mixer are visibly smaller than TrackHeader buttons
- [ ] Click M/S in Mixer — track mute/solo state toggles correctly
- [ ] Color states: muted shows amber, soloed shows emerald, default shows dark gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)