### PR TITLE
fix: remove decorative logo from StatusBar

### DIFF
--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -65,7 +65,6 @@ export function StatusBar() {
         </span>
       )}
       <span className="flex-1" />
-      <img src="/logo.png" alt="" width={12} height={12} className="rounded-sm opacity-30" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Removed the decorative `<img src="/logo.png">` element from `StatusBar.tsx`
- The 12px, 30% opacity logo provided no useful information and was purely visual clutter

Closes #698

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npx vitest run` — 225 test files pass (2086 tests), same as before the change
- [x] `npm run build` — succeeds with 0 errors
- [ ] Visual check: StatusBar no longer shows the faint logo in the bottom-right corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)