### PR TITLE
fix: tighten mixer FX bypass button density

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -122,7 +122,7 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
                 aria-label={`FX bypass ${track.displayName}`}
                 aria-keyshortcuts="P"
                 title={`Bypass all track effects (P)${effectsBypassed ? ' — active' : ''}`}
-                className={`text-xs font-bold px-2 py-1 rounded transition-colors ${
+                className={`flex h-[18px] min-w-[26px] items-center justify-center rounded-sm px-1.5 text-[9px] font-semibold leading-none transition-colors ${
                   effectsBypassed ? 'bg-orange-500 text-black' : 'bg-[#444] text-zinc-400 hover:bg-[#484848]'
                 }`}
               >

--- a/tests/unit/channelStrip.test.tsx
+++ b/tests/unit/channelStrip.test.tsx
@@ -91,6 +91,16 @@ describe('ChannelStrip — Inserts section', () => {
     fireEvent.click(screen.getByRole('button', { name: /fx bypass drums/i }));
     expect(useProjectStore.getState().project!.tracks[0].effectsBypassed).toBe(true);
   });
+
+  it('keeps the FX bypass button visually compact beside mute and solo', () => {
+    render(<MixerPanel />);
+
+    const fxButton = screen.getByRole('button', { name: /fx bypass drums/i });
+    expect(fxButton).toHaveClass('h-[18px]');
+    expect(fxButton).toHaveClass('min-w-[26px]');
+    expect(fxButton).toHaveClass('rounded-sm');
+    expect(fxButton).toHaveClass('text-[9px]');
+  });
 });
 
 describe('ChannelStrip — Sends section', () => {


### PR DESCRIPTION
## Summary
- tighten the Mixer FX bypass button so it sits on the same compact density scale as the Mixer M/S buttons
- keep the existing FX bypass color semantics and keyboard shortcut behavior intact
- add a small regression assertion covering the compact FX button sizing in the channel strip tests

Follow-up to #691.

## Test plan
- [x] npx vitest run tests/unit/channelStrip.test.tsx tests/unit/mixerPanel.test.tsx
- [x] npx tsc --noEmit
- [x] npm run build
- [x] Manual QA: compare Mixer M/S/FX button density on the latest main baseline
