### PR TITLE
fix: align default track height with ACE Studio

### DIFF
--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -69,7 +69,7 @@ export function TrackLane({ track }: TrackLaneProps) {
   const [fileDragOver, setFileDragOver] = useState(false);
 
   const resizeRef = useRef<{ startY: number; startRowHeight: number; startLaneHeight: number } | null>(null);
-  const laneHeight = track.laneHeight ?? 64;
+  const laneHeight = track.laneHeight ?? 80;
   const rowHeight = getArrangementRowHeight(track);
 
   const onResizeMouseDown = useCallback((e: React.MouseEvent) => {

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -126,7 +126,7 @@ export function TrackHeader({
     setEditValue(track.displayName);
   }, [track.displayName]);
 
-  const laneHeight = track.laneHeight ?? 64;
+  const laneHeight = track.laneHeight ?? 80;
   const rowHeight = getArrangementRowHeight(track);
   const resizeRef = useRef<{ startY: number; startH: number } | null>(null);
   const isCompact = laneHeight < 52;

--- a/src/constants/trackHeight.ts
+++ b/src/constants/trackHeight.ts
@@ -11,8 +11,8 @@ export const TRACK_HEIGHT_PRESETS: Record<string, number> = {
 
 /** Default lane heights per track type (used for 'auto' preset). */
 const AUTO_DEFAULTS: Record<TrackType, number> = {
-  stems: 64,
-  sample: 64,
+  stems: 80,
+  sample: 80,
   sequencer: 80,
   pianoRoll: 88,
   drumMachine: 80,
@@ -23,6 +23,6 @@ export function getTrackHeightForPreset(
   preset: TrackHeightPreset,
   trackType: TrackType,
 ): number {
-  if (preset === 'auto') return AUTO_DEFAULTS[trackType] ?? 64;
+  if (preset === 'auto') return AUTO_DEFAULTS[trackType] ?? 80;
   return TRACK_HEIGHT_PRESETS[preset];
 }

--- a/src/store/__tests__/trackHeightPresets.test.ts
+++ b/src/store/__tests__/trackHeightPresets.test.ts
@@ -37,8 +37,8 @@ describe('track height presets', () => {
     });
 
     it('returns track-type default for auto preset', () => {
-      expect(getTrackHeightForPreset('auto', 'stems')).toBe(64);
-      expect(getTrackHeightForPreset('auto', 'sample')).toBe(64);
+      expect(getTrackHeightForPreset('auto', 'stems')).toBe(80);
+      expect(getTrackHeightForPreset('auto', 'sample')).toBe(80);
       expect(getTrackHeightForPreset('auto', 'sequencer')).toBe(80);
       expect(getTrackHeightForPreset('auto', 'pianoRoll')).toBe(88);
     });
@@ -87,7 +87,7 @@ describe('track height presets', () => {
       useProjectStore.getState().addTrack('stems', 'pianoRoll');
       useProjectStore.getState().setAllTracksHeightPreset('auto');
       const tracks = useProjectStore.getState().project!.tracks;
-      expect(tracks[0].laneHeight).toBe(64);
+      expect(tracks[0].laneHeight).toBe(80);
       expect(tracks[1].laneHeight).toBe(80);
       expect(tracks[2].laneHeight).toBe(88);
     });

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -509,7 +509,7 @@ export interface Track {
   // Track Inspector
   /** Default prompt for clips on this track; falls back to track display name if empty. */
   localCaption?: string;
-  /** Per-track lane height in pixels (default 64, min 40, max 200). */
+  /** Per-track lane height in pixels (default 80, min 40, max 200). */
   laneHeight?: number;
   /** Sends to return tracks (mixer bus routing). */
   sends?: Send[];

--- a/tests/unit/trackHeightPresets.test.ts
+++ b/tests/unit/trackHeightPresets.test.ts
@@ -67,8 +67,8 @@ describe('Track Height Presets (#210)', () => {
     });
 
     it('returns type-specific default for auto preset', () => {
-      expect(getTrackHeightForPreset('auto', 'stems')).toBe(64);
-      expect(getTrackHeightForPreset('auto', 'sample')).toBe(64);
+      expect(getTrackHeightForPreset('auto', 'stems')).toBe(80);
+      expect(getTrackHeightForPreset('auto', 'sample')).toBe(80);
       expect(getTrackHeightForPreset('auto', 'sequencer')).toBe(80);
       expect(getTrackHeightForPreset('auto', 'pianoRoll')).toBe(88);
     });
@@ -148,7 +148,7 @@ describe('Track Height Presets (#210)', () => {
       useProjectStore.getState().setAllTracksHeightPreset('auto');
 
       const tracks = useProjectStore.getState().project!.tracks;
-      expect(tracks[0].laneHeight).toBe(64);  // stems auto
+      expect(tracks[0].laneHeight).toBe(80);  // stems auto
       expect(tracks[1].laneHeight).toBe(88);  // pianoRoll auto
     });
   });


### PR DESCRIPTION
## Summary
- Updated default lane height for `stems` and `sample` tracks from 64px to 80px to match ACE Studio's reference design
- Updated fallback defaults in `TrackHeader`, `TrackLane`, and `trackHeight.ts` constants
- Updated all related test assertions

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — all 2129 tests pass
- [x] `npm run build` — succeeds
- [x] Visual verification against ACE Studio confirmed by user

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)