### PR TITLE
feat: real waveform preview + A/B comparison playback in EnhancePanel (#777)

### DIFF
--- a/src/components/generation/EnhancePanel.tsx
+++ b/src/components/generation/EnhancePanel.tsx
@@ -7,6 +7,9 @@ import { generateRepaintClip } from '../../services/generationPipeline';
 import { modelSupportsTaskType } from '../../services/aceStepApi';
 import { DualRangeSlider } from '../ui/DualRangeSlider';
 import { Z } from '../../utils/zIndex';
+import { WaveformPreview } from './WaveformPreview';
+import { useEnhancePlayback } from '../../hooks/useEnhancePlayback';
+import { computeWaveformPeaks } from '../../utils/waveformPeaks';
 import type { RepaintMode } from '../../types/api';
 
 const ENHANCER_BASE_BOTTOM = 60;
@@ -22,6 +25,12 @@ function fmt(s: number) {
   return `${s.toFixed(2)}s`;
 }
 
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
 interface SessionEntry {
   id: string;
   label: string;
@@ -31,10 +40,15 @@ interface SessionEntry {
 interface ResultEntry {
   id: string;
   clipId: string;
+  audioKey: string;
   title: string;
   duration: string;
+  durationSec: number;
+  peaks: number[];
   timestamp: number;
 }
+
+type ABSide = 'A' | 'B';
 
 export function EnhancePanel() {
   const enhancerOpen = useUIStore((s) => s.enhancerOpen);
@@ -74,6 +88,19 @@ export function EnhancePanel() {
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const sessionCounterRef = useRef(0);
 
+  // A/B comparison
+  const [abSide, setAbSide] = useState<ABSide>('A');
+  const [selectedResultId, setSelectedResultId] = useState<string | null>(null);
+
+  // Mini player selected index
+  const [miniPlayerIdx, setMiniPlayerIdx] = useState(0);
+
+  // Playback
+  const playback = useEnhancePlayback();
+
+  // Source audio key
+  const sourceAudioKey = clip?.isolatedAudioKey || clip?.cumulativeMixKey || '';
+
   // Initialize form when enhancerTarget changes
   useEffect(() => {
     if (enhancerTarget && clip) {
@@ -107,8 +134,18 @@ export function EnhancePanel() {
       }]);
       setActiveSessionId(sessionId);
       setResults([]);
+      setAbSide('A');
+      setSelectedResultId(null);
+      setMiniPlayerIdx(0);
     }
   }, [enhancerTarget?.clipId]);
+
+  // Stop playback when panel closes
+  useEffect(() => {
+    if (!enhancerOpen) {
+      playback.stopPlayback();
+    }
+  }, [enhancerOpen, playback.stopPlayback]);
 
   // Escape to close
   useEffect(() => {
@@ -139,6 +176,8 @@ export function EnhancePanel() {
     setRepaintMode('balanced');
     setRepaintStrength(0.5);
     setResults([]);
+    setSelectedResultId(null);
+    setMiniPlayerIdx(0);
   }, [clip]);
 
   const handleRangeChange = useCallback((s: number, e: number) => {
@@ -154,8 +193,11 @@ export function EnhancePanel() {
     setResults((prev) => [...prev, {
       id: resultId,
       clipId: enhancerTarget.clipId,
+      audioKey: '',
       title: caption || 'Untitled enhancement',
       duration: '--:--',
+      durationSec: 0,
+      peaks: [],
       timestamp: Date.now(),
     }]);
     await generateCoverClip({
@@ -165,6 +207,8 @@ export function EnhancePanel() {
       coverStrength,
       createNew,
     });
+    // After generation, try to load the result audio to get peaks/duration
+    await finalizeResult(resultId, enhancerTarget.clipId);
   }, [enhancerTarget, caption, lyrics, consistency, createNew, isGenerating]);
 
   // Repaint generation
@@ -174,8 +218,11 @@ export function EnhancePanel() {
     setResults((prev) => [...prev, {
       id: resultId,
       clipId: enhancerTarget.clipId,
+      audioKey: '',
       title: prompt || 'Untitled repaint',
       duration: '--:--',
+      durationSec: 0,
+      peaks: [],
       timestamp: Date.now(),
     }]);
     await generateRepaintClip({
@@ -187,9 +234,95 @@ export function EnhancePanel() {
       repaintMode,
       repaintStrength,
     });
+    await finalizeResult(resultId, enhancerTarget.clipId);
   }, [enhancerTarget, selStart, selEnd, prompt, globalCaption, repaintMode, repaintStrength, isGenerating]);
 
+  // After generation, load the new clip's audio to compute peaks and duration
+  const finalizeResult = useCallback(async (resultId: string, originalClipId: string) => {
+    // The generation pipeline creates a new clip or updates the existing one
+    // Re-read the clip from the store to get the new audio key
+    const updatedClip = useProjectStore.getState().getClipById(originalClipId);
+    const audioKey = updatedClip?.isolatedAudioKey || updatedClip?.cumulativeMixKey || '';
+    if (!audioKey) return;
+
+    try {
+      const buffer = await playback.loadBuffer(audioKey);
+      if (!buffer) return;
+      const peaks = computeWaveformPeaks(buffer, 60);
+      const dur = buffer.duration;
+      setResults((prev) => prev.map((r) =>
+        r.id === resultId
+          ? { ...r, audioKey, peaks, duration: formatDuration(dur), durationSec: dur }
+          : r,
+      ));
+      // Auto-select first result
+      setSelectedResultId((prev) => prev ?? resultId);
+      setMiniPlayerIdx((prev) => {
+        if (prev === 0) return Math.max(0, results.length); // point to new entry
+        return prev;
+      });
+    } catch {
+      // Audio decode failed — leave duration as --:--
+    }
+  }, [playback, results.length]);
+
   const handleGenerate = mode === 'cover' ? handleCoverGenerate : handleRepaintGenerate;
+
+  // Source play handler
+  const handleSourcePlay = useCallback(() => {
+    if (!sourceAudioKey) return;
+    playback.togglePlay('source', sourceAudioKey);
+  }, [sourceAudioKey, playback]);
+
+  const handleSourceSeek = useCallback((progress: number) => {
+    if (!sourceAudioKey) return;
+    playback.seek('source', sourceAudioKey, progress);
+  }, [sourceAudioKey, playback]);
+
+  // Result play handler
+  const handleResultPlay = useCallback((resultId: string, audioKey: string) => {
+    if (!audioKey) return;
+    setSelectedResultId(resultId);
+    playback.togglePlay(resultId, audioKey);
+  }, [playback]);
+
+  // A/B toggle
+  const handleABToggle = useCallback(() => {
+    const nextSide: ABSide = abSide === 'A' ? 'B' : 'A';
+    setAbSide(nextSide);
+    const selectedResult = results.find((r) => r.id === selectedResultId);
+
+    if (nextSide === 'A' && sourceAudioKey) {
+      playback.play('source', sourceAudioKey, playback.progress);
+    } else if (nextSide === 'B' && selectedResult?.audioKey) {
+      playback.play(selectedResult.id, selectedResult.audioKey, playback.progress);
+    }
+  }, [abSide, results, selectedResultId, sourceAudioKey, playback]);
+
+  // Mini player controls
+  const miniResult = results[miniPlayerIdx] ?? null;
+
+  const handleMiniPrev = useCallback(() => {
+    setMiniPlayerIdx((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const handleMiniNext = useCallback(() => {
+    setMiniPlayerIdx((prev) => Math.min(results.length - 1, prev + 1));
+  }, [results.length]);
+
+  const handleMiniPlay = useCallback(() => {
+    if (!miniResult?.audioKey) return;
+    setSelectedResultId(miniResult.id);
+    playback.togglePlay(miniResult.id, miniResult.audioKey);
+  }, [miniResult, playback]);
+
+  const handleMiniSeek = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (!miniResult?.audioKey) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const progress = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    setSelectedResultId(miniResult.id);
+    playback.seek(miniResult.id, miniResult.audioKey, progress);
+  }, [miniResult, playback]);
 
   if (!enhancerOpen) return null;
 
@@ -240,11 +373,22 @@ export function EnhancePanel() {
   const totalDur = project?.totalDuration ?? clipEnd;
 
   // Accent colors per mode
-  const accent = mode === 'cover' ? 'teal' : 'rose';
+  const accentColor = mode === 'cover' ? '#14b8a6' : '#f43f5e';
   const accentBg = mode === 'cover' ? 'bg-teal-600' : 'bg-rose-600';
   const accentBgHover = mode === 'cover' ? 'hover:bg-teal-500' : 'hover:bg-rose-500';
-  const accentBadgeBg = mode === 'cover' ? 'bg-teal-700/60' : 'bg-rose-700/60';
-  const accentBadgeText = mode === 'cover' ? 'text-teal-200' : 'text-rose-200';
+
+  // Source waveform peaks
+  const sourcePeaks = clip?.waveformPeaks ?? [];
+  const sourceIsPlaying = playback.playingId === 'source';
+  const sourceProgress = sourceIsPlaying ? playback.progress : 0;
+
+  // A/B: determine which side has a valid result
+  const selectedResult = results.find((r) => r.id === selectedResultId);
+  const canAB = hasAudio && !!selectedResult?.audioKey;
+
+  // Mini player progress
+  const miniIsPlaying = miniResult ? playback.playingId === miniResult.id : false;
+  const miniProgress = miniIsPlaying ? playback.progress : 0;
 
   return (
     <div
@@ -325,16 +469,37 @@ export function EnhancePanel() {
         <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0">
           {/* Source audio preview */}
           <div className="bg-[#161618] rounded-lg px-3 py-3 border border-[#333]">
-            <p className="text-[10px] text-zinc-500 uppercase tracking-wide mb-1.5">Source</p>
+            <div className="flex items-center justify-between mb-1.5">
+              <p className="text-[10px] text-zinc-500 uppercase tracking-wide">
+                Source
+                {canAB && (
+                  <span className={`ml-1.5 ${abSide === 'A' ? 'text-teal-400 font-bold' : 'text-zinc-600'}`}>A</span>
+                )}
+              </p>
+              {clip && (
+                <span className="text-[9px] text-zinc-600 font-mono">
+                  {formatDuration(clip.duration)}
+                </span>
+              )}
+            </div>
             {clip && track ? (
               <>
                 <div className="flex items-center gap-2">
                   <button
                     data-testid="source-play-btn"
-                    className="w-7 h-7 flex items-center justify-center rounded-full bg-[#2a2a2e] text-zinc-400 hover:text-zinc-200 transition-colors"
-                    aria-label="Play source"
+                    onClick={handleSourcePlay}
+                    className={`w-7 h-7 flex items-center justify-center rounded-full transition-colors flex-shrink-0 ${
+                      sourceIsPlaying
+                        ? 'bg-teal-600 text-white'
+                        : 'bg-[#2a2a2e] text-zinc-400 hover:text-zinc-200'
+                    }`}
+                    aria-label={sourceIsPlaying ? 'Stop source' : 'Play source'}
                   >
-                    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                    {sourceIsPlaying ? (
+                      <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16" /><rect x="14" y="4" width="4" height="16" /></svg>
+                    ) : (
+                      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                    )}
                   </button>
                   <div className="flex-1 min-w-0">
                     <p className="text-[11px] font-medium text-zinc-200 truncate">
@@ -343,17 +508,16 @@ export function EnhancePanel() {
                     <p className="text-[10px] text-zinc-500 truncate">{clip.prompt || '(no prompt)'}</p>
                   </div>
                 </div>
-                {/* Waveform placeholder */}
-                <div className="mt-2 h-10 bg-[#1e1e22] rounded flex items-center justify-center">
-                  <div className="flex items-end gap-px h-6">
-                    {Array.from({ length: 40 }).map((_, i) => (
-                      <div
-                        key={i}
-                        className={`w-1 rounded-sm ${mode === 'cover' ? 'bg-teal-600/40' : 'bg-rose-600/40'}`}
-                        style={{ height: `${Math.max(2, Math.sin(i * 0.3) * 16 + Math.random() * 8)}px` }}
-                      />
-                    ))}
-                  </div>
+                {/* Real waveform */}
+                <div className="mt-2">
+                  <WaveformPreview
+                    peaks={sourcePeaks}
+                    color={accentColor}
+                    height={40}
+                    playbackProgress={sourceProgress}
+                    onSeek={hasAudio ? handleSourceSeek : undefined}
+                    data-testid="source-waveform"
+                  />
                 </div>
               </>
             ) : (
@@ -370,6 +534,27 @@ export function EnhancePanel() {
               </p>
             )}
           </div>
+
+          {/* A/B Comparison Toggle */}
+          {canAB && (
+            <div className="flex items-center justify-center" data-testid="ab-toggle-section">
+              <button
+                data-testid="ab-toggle-btn"
+                onClick={handleABToggle}
+                className={`flex items-center gap-2 px-4 py-1.5 rounded-lg text-[11px] font-semibold transition-colors border ${
+                  abSide === 'A'
+                    ? 'border-teal-500/50 bg-teal-900/30 text-teal-300'
+                    : 'border-violet-500/50 bg-violet-900/30 text-violet-300'
+                }`}
+              >
+                <span className={abSide === 'A' ? 'text-teal-300' : 'text-zinc-500'}>A</span>
+                <svg className="w-3.5 h-3.5 text-zinc-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M7 16l5-5-5-5M17 8l-5 5 5 5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <span className={abSide === 'B' ? 'text-violet-300' : 'text-zinc-500'}>B</span>
+              </button>
+            </div>
+          )}
 
           {/* === COVER MODE CONTROLS === */}
           {mode === 'cover' && (
@@ -629,55 +814,128 @@ export function EnhancePanel() {
               </p>
             </div>
           ) : (
-            results.map((r) => (
-              <div
-                key={r.id}
-                className="flex items-center gap-2 px-2 py-2 rounded-md hover:bg-[#222226] transition-colors group"
-              >
-                <button
-                  className="w-6 h-6 flex items-center justify-center rounded-full bg-[#2a2a2e] text-zinc-400 hover:text-zinc-200 transition-colors flex-shrink-0"
-                  aria-label="Play result"
+            results.map((r, idx) => {
+              const isPlaying = playback.playingId === r.id;
+              const isSelected = r.id === selectedResultId;
+              return (
+                <div
+                  key={r.id}
+                  data-testid={`result-item-${idx}`}
+                  onClick={() => { setSelectedResultId(r.id); setMiniPlayerIdx(idx); }}
+                  className={`rounded-md transition-colors group cursor-pointer ${
+                    isSelected ? 'bg-[#2a2a30] ring-1 ring-zinc-600' : 'hover:bg-[#222226]'
+                  }`}
                 >
-                  <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
-                </button>
-                <div className="flex-1 min-w-0">
-                  <p className="text-[11px] text-zinc-300 truncate">{r.title}</p>
-                  <p className="text-[10px] text-zinc-600">{r.duration}</p>
+                  <div className="flex items-center gap-2 px-2 py-2">
+                    <button
+                      data-testid={`result-play-btn-${idx}`}
+                      onClick={(e) => { e.stopPropagation(); handleResultPlay(r.id, r.audioKey); }}
+                      className={`w-6 h-6 flex items-center justify-center rounded-full transition-colors flex-shrink-0 ${
+                        isPlaying
+                          ? 'bg-violet-600 text-white'
+                          : 'bg-[#2a2a2e] text-zinc-400 hover:text-zinc-200'
+                      }`}
+                      aria-label={isPlaying ? 'Stop result' : 'Play result'}
+                    >
+                      {isPlaying ? (
+                        <svg className="w-2.5 h-2.5" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16" /><rect x="14" y="4" width="4" height="16" /></svg>
+                      ) : (
+                        <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                      )}
+                    </button>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[11px] text-zinc-300 truncate">
+                        {r.title}
+                        {canAB && isSelected && (
+                          <span className={`ml-1 ${abSide === 'B' ? 'text-violet-400 font-bold' : 'text-zinc-600'}`}>B</span>
+                        )}
+                      </p>
+                      <p className="text-[10px] text-zinc-600">{r.duration}</p>
+                    </div>
+                    <button
+                      className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-zinc-300 transition-opacity"
+                      aria-label="More options"
+                    >
+                      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                        <circle cx="12" cy="5" r="1.5" />
+                        <circle cx="12" cy="12" r="1.5" />
+                        <circle cx="12" cy="19" r="1.5" />
+                      </svg>
+                    </button>
+                  </div>
+                  {/* Result waveform */}
+                  {r.peaks.length > 0 && (
+                    <div className="px-2 pb-2">
+                      <WaveformPreview
+                        peaks={r.peaks}
+                        color="#8b5cf6"
+                        height={24}
+                        playbackProgress={isPlaying ? playback.progress : 0}
+                        data-testid={`result-waveform-${idx}`}
+                      />
+                    </div>
+                  )}
                 </div>
-                <button
-                  className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-zinc-300 transition-opacity"
-                  aria-label="More options"
-                >
-                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                    <circle cx="12" cy="5" r="1.5" />
-                    <circle cx="12" cy="12" r="1.5" />
-                    <circle cx="12" cy="19" r="1.5" />
-                  </svg>
-                </button>
-              </div>
-            ))
+              );
+            })
           )}
         </div>
 
         {/* Mini player */}
         {results.length > 0 && (
-          <div className="border-t border-[#3a3a3a] px-3 py-2.5">
+          <div className="border-t border-[#3a3a3a] px-3 py-2.5" data-testid="mini-player">
             <div className="flex items-center gap-2">
-              <button className="text-zinc-500 hover:text-zinc-300 transition-colors" aria-label="Previous">
+              <button
+                data-testid="mini-prev-btn"
+                onClick={handleMiniPrev}
+                disabled={miniPlayerIdx <= 0}
+                className={`transition-colors ${miniPlayerIdx <= 0 ? 'text-zinc-700' : 'text-zinc-500 hover:text-zinc-300'}`}
+                aria-label="Previous"
+              >
                 <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" /></svg>
               </button>
-              <button className="text-zinc-300 hover:text-white transition-colors" aria-label="Play">
-                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+              <button
+                data-testid="mini-play-btn"
+                onClick={handleMiniPlay}
+                className={`transition-colors ${miniIsPlaying ? 'text-violet-400' : 'text-zinc-300 hover:text-white'}`}
+                aria-label={miniIsPlaying ? 'Pause' : 'Play'}
+              >
+                {miniIsPlaying ? (
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16" /><rect x="14" y="4" width="4" height="16" /></svg>
+                ) : (
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                )}
               </button>
-              <button className="text-zinc-500 hover:text-zinc-300 transition-colors" aria-label="Next">
+              <button
+                data-testid="mini-next-btn"
+                onClick={handleMiniNext}
+                disabled={miniPlayerIdx >= results.length - 1}
+                className={`transition-colors ${miniPlayerIdx >= results.length - 1 ? 'text-zinc-700' : 'text-zinc-500 hover:text-zinc-300'}`}
+                aria-label="Next"
+              >
                 <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M16 18h2V6h-2zm-2-6L5.5 6v12z" /></svg>
               </button>
-              <div className="flex-1 mx-1.5">
-                <div className="h-1 bg-[#2a2a2e] rounded-full">
-                  <div className="h-1 bg-teal-600 rounded-full w-0" />
+              <div
+                data-testid="mini-progress-bar"
+                className="flex-1 mx-1.5 cursor-pointer"
+                onClick={handleMiniSeek}
+              >
+                <div className="h-1 bg-[#2a2a2e] rounded-full relative">
+                  <div
+                    className="h-1 bg-violet-600 rounded-full transition-[width] duration-75"
+                    style={{ width: `${miniProgress * 100}%` }}
+                  />
                 </div>
               </div>
+              {miniResult && (
+                <span className="text-[9px] text-zinc-600 font-mono whitespace-nowrap">
+                  {miniResult.duration !== '--:--' ? miniResult.duration : ''}
+                </span>
+              )}
             </div>
+            {miniResult && (
+              <p className="text-[9px] text-zinc-500 truncate mt-1">{miniResult.title}</p>
+            )}
           </div>
         )}
       </div>

--- a/src/components/generation/WaveformPreview.tsx
+++ b/src/components/generation/WaveformPreview.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useRef } from 'react';
+import { PEAK_STRIDE } from '../../utils/waveformPeaks';
+
+export interface WaveformPreviewProps {
+  /** Interleaved stereo peaks [Lmax, Lmin, Rmax, Rmin, ...] or simple amplitude array */
+  peaks: number[];
+  /** Fill color for the waveform bars */
+  color: string;
+  /** Container height in px */
+  height: number;
+  /** 0-1 playback progress for the overlay */
+  playbackProgress: number;
+  /** Callback when user clicks to seek (0-1 normalized position) */
+  onSeek?: (progress: number) => void;
+  /** Optional test id */
+  'data-testid'?: string;
+}
+
+/**
+ * Simplified waveform renderer for the Enhance Panel.
+ * Renders stereo waveform peaks with a playback progress overlay.
+ */
+export function WaveformPreview({
+  peaks,
+  color,
+  height,
+  playbackProgress,
+  onSeek,
+  'data-testid': testId,
+}: WaveformPreviewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!onSeek || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const progress = Math.max(0, Math.min(1, x / rect.width));
+      onSeek(progress);
+    },
+    [onSeek],
+  );
+
+  if (!peaks || peaks.length === 0) {
+    return (
+      <div
+        data-testid={testId}
+        className="bg-[#1e1e22] rounded flex items-center justify-center"
+        style={{ height }}
+      >
+        <span className="text-[9px] text-zinc-600">No waveform data</span>
+      </div>
+    );
+  }
+
+  const isStereo = peaks.length >= PEAK_STRIDE && peaks.length % PEAK_STRIDE === 0;
+  const logicalCount = isStereo ? peaks.length / PEAK_STRIDE : peaks.length;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid={testId}
+      className="relative bg-[#1e1e22] rounded overflow-hidden"
+      style={{ height, cursor: onSeek ? 'pointer' : 'default' }}
+      onClick={handleClick}
+    >
+      <svg
+        width="100%"
+        height="100%"
+        viewBox={`0 0 ${logicalCount} 100`}
+        preserveAspectRatio="none"
+        className="absolute inset-0"
+      >
+        {isStereo
+          ? renderStereoPeaks(peaks, logicalCount, color)
+          : renderSimplePeaks(peaks, color)}
+      </svg>
+      {/* Playback progress overlay */}
+      {playbackProgress > 0 && (
+        <div
+          data-testid={testId ? `${testId}-progress` : undefined}
+          className="absolute inset-y-0 left-0 pointer-events-none"
+          style={{
+            width: `${Math.min(100, playbackProgress * 100)}%`,
+            background: `${color}33`,
+          }}
+        />
+      )}
+      {/* Playhead line */}
+      {playbackProgress > 0 && playbackProgress < 1 && (
+        <div
+          className="absolute inset-y-0 w-px pointer-events-none"
+          style={{
+            left: `${playbackProgress * 100}%`,
+            backgroundColor: color,
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function renderStereoPeaks(peaks: number[], logicalCount: number, color: string) {
+  // Build SVG path for combined L+R envelope centered at y=50
+  const upperPoints: string[] = [];
+  const lowerPoints: string[] = [];
+
+  for (let i = 0; i < logicalCount; i++) {
+    const idx = i * PEAK_STRIDE;
+    const lMax = peaks[idx] ?? 0;
+    const lMin = peaks[idx + 1] ?? 0;
+    const rMax = peaks[idx + 2] ?? 0;
+    const rMin = peaks[idx + 3] ?? 0;
+    // Combine channels: take the max of both channels for the envelope
+    const maxVal = Math.max(lMax, rMax);
+    const minVal = Math.min(lMin, rMin);
+    const x = i + 0.5;
+    upperPoints.push(`${x} ${50 - maxVal * 48}`);
+    lowerPoints.push(`${x} ${50 - minVal * 48}`);
+  }
+
+  const path = `M ${upperPoints[0]} L ${upperPoints.join(' L ')} L ${lowerPoints.reverse().join(' L ')} Z`;
+  return <path d={path} fill={color} opacity={0.6} data-testid="waveform-path" />;
+}
+
+function renderSimplePeaks(peaks: number[], color: string) {
+  // Simple amplitude bars centered vertically
+  const count = peaks.length;
+  const upperPoints: string[] = [];
+  const lowerPoints: string[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const val = Math.abs(peaks[i]);
+    const x = i + 0.5;
+    upperPoints.push(`${x} ${50 - val * 48}`);
+    lowerPoints.push(`${x} ${50 + val * 48}`);
+  }
+
+  const path = `M ${upperPoints[0]} L ${upperPoints.join(' L ')} L ${lowerPoints.reverse().join(' L ')} Z`;
+  return <path d={path} fill={color} opacity={0.6} data-testid="waveform-path" />;
+}

--- a/src/components/generation/__tests__/EnhancePanel.test.tsx
+++ b/src/components/generation/__tests__/EnhancePanel.test.tsx
@@ -18,6 +18,21 @@ vi.mock('../../../services/aceStepApi', () => ({
   modelSupportsTaskType: vi.fn(() => true),
 }));
 
+const mockPlayback = {
+  playingId: null as string | null,
+  progress: 0,
+  duration: 0,
+  play: vi.fn(),
+  togglePlay: vi.fn(),
+  seek: vi.fn(),
+  stopPlayback: vi.fn(),
+  loadBuffer: vi.fn(),
+};
+
+vi.mock('../../../hooks/useEnhancePlayback', () => ({
+  useEnhancePlayback: () => mockPlayback,
+}));
+
 function setupProjectWithClip() {
   useProjectStore.setState({ project: null });
   useProjectStore.getState().createProject();
@@ -171,6 +186,70 @@ describe('EnhancePanel', () => {
     render(<EnhancePanel />);
     expect(screen.getByTestId('enhance-results')).toBeInTheDocument();
     expect(screen.getByText('Enhanced results will appear here')).toBeInTheDocument();
+  });
+
+  it('renders real source waveform instead of fake bars', () => {
+    const { track, clip } = setupProjectWithClip();
+    // Give the clip waveform peaks
+    clip.waveformPeaks = new Array(240).fill(0).map((_, i) => Math.sin(i * 0.1) * 0.5);
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: {
+        clipId: clip.id,
+        trackId: track.id,
+        range: null,
+        mode: 'cover',
+      },
+    });
+    render(<EnhancePanel />);
+    expect(screen.getByTestId('source-waveform')).toBeInTheDocument();
+  });
+
+  it('source play button calls togglePlay', () => {
+    const { track, clip } = setupProjectWithClip();
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: {
+        clipId: clip.id,
+        trackId: track.id,
+        range: null,
+        mode: 'cover',
+      },
+    });
+    render(<EnhancePanel />);
+    fireEvent.click(screen.getByTestId('source-play-btn'));
+    expect(mockPlayback.togglePlay).toHaveBeenCalledWith('source', 'some-audio-key');
+  });
+
+  it('does not show A/B toggle when no results exist', () => {
+    const { track, clip } = setupProjectWithClip();
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: {
+        clipId: clip.id,
+        trackId: track.id,
+        range: null,
+        mode: 'cover',
+      },
+    });
+    render(<EnhancePanel />);
+    expect(screen.queryByTestId('ab-toggle-btn')).not.toBeInTheDocument();
+  });
+
+  it('shows source duration', () => {
+    const { track, clip } = setupProjectWithClip();
+    clip.duration = 65; // 1:05
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: {
+        clipId: clip.id,
+        trackId: track.id,
+        range: null,
+        mode: 'cover',
+      },
+    });
+    render(<EnhancePanel />);
+    expect(screen.getByText('1:05')).toBeInTheDocument();
   });
 });
 

--- a/src/components/generation/__tests__/WaveformPreview.test.tsx
+++ b/src/components/generation/__tests__/WaveformPreview.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WaveformPreview } from '../WaveformPreview';
+import { PEAK_STRIDE } from '../../../utils/waveformPeaks';
+
+function makeStereopeaks(count: number): number[] {
+  const peaks: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const val = Math.sin((i / count) * Math.PI);
+    peaks.push(val, -val * 0.8, val * 0.9, -val * 0.7); // Lmax, Lmin, Rmax, Rmin
+  }
+  return peaks;
+}
+
+describe('WaveformPreview', () => {
+  it('renders empty state when peaks array is empty', () => {
+    render(
+      <WaveformPreview
+        peaks={[]}
+        color="#14b8a6"
+        height={40}
+        playbackProgress={0}
+        data-testid="waveform"
+      />,
+    );
+    expect(screen.getByText('No waveform data')).toBeInTheDocument();
+  });
+
+  it('renders SVG waveform path for stereo peaks', () => {
+    const peaks = makeStereopeaks(60);
+    expect(peaks.length).toBe(60 * PEAK_STRIDE);
+
+    render(
+      <WaveformPreview
+        peaks={peaks}
+        color="#14b8a6"
+        height={40}
+        playbackProgress={0}
+        data-testid="waveform"
+      />,
+    );
+    expect(screen.getByTestId('waveform')).toBeInTheDocument();
+    expect(screen.getByTestId('waveform-path')).toBeInTheDocument();
+  });
+
+  it('renders simple amplitude peaks', () => {
+    const peaks = [0.2, 0.5, 0.8, 0.6, 0.3];
+    render(
+      <WaveformPreview
+        peaks={peaks}
+        color="#f43f5e"
+        height={40}
+        playbackProgress={0}
+        data-testid="waveform"
+      />,
+    );
+    expect(screen.getByTestId('waveform-path')).toBeInTheDocument();
+  });
+
+  it('shows progress overlay when playbackProgress > 0', () => {
+    const peaks = makeStereopeaks(60);
+    render(
+      <WaveformPreview
+        peaks={peaks}
+        color="#14b8a6"
+        height={40}
+        playbackProgress={0.5}
+        data-testid="waveform"
+      />,
+    );
+    const progressEl = screen.getByTestId('waveform-progress');
+    expect(progressEl).toBeInTheDocument();
+    expect(progressEl.style.width).toBe('50%');
+  });
+
+  it('does not show progress overlay when playbackProgress is 0', () => {
+    const peaks = makeStereopeaks(60);
+    render(
+      <WaveformPreview
+        peaks={peaks}
+        color="#14b8a6"
+        height={40}
+        playbackProgress={0}
+        data-testid="waveform"
+      />,
+    );
+    expect(screen.queryByTestId('waveform-progress')).not.toBeInTheDocument();
+  });
+
+  it('calls onSeek with normalized position when clicked', () => {
+    const peaks = makeStereopeaks(60);
+    const onSeek = vi.fn();
+    render(
+      <WaveformPreview
+        peaks={peaks}
+        color="#14b8a6"
+        height={40}
+        playbackProgress={0}
+        onSeek={onSeek}
+        data-testid="waveform"
+      />,
+    );
+    const el = screen.getByTestId('waveform');
+    // Mock getBoundingClientRect
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      right: 200,
+      width: 200,
+      top: 0,
+      bottom: 40,
+      height: 40,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    fireEvent.click(el, { clientX: 100, clientY: 20 });
+    expect(onSeek).toHaveBeenCalledWith(0.5);
+  });
+
+  it('clamps seek to 0-1 range', () => {
+    const peaks = makeStereopeaks(60);
+    const onSeek = vi.fn();
+    render(
+      <WaveformPreview
+        peaks={peaks}
+        color="#14b8a6"
+        height={40}
+        playbackProgress={0}
+        onSeek={onSeek}
+        data-testid="waveform"
+      />,
+    );
+    const el = screen.getByTestId('waveform');
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      left: 100,
+      right: 300,
+      width: 200,
+      top: 0,
+      bottom: 40,
+      height: 40,
+      x: 100,
+      y: 0,
+      toJSON: () => {},
+    });
+    // Click before the element
+    fireEvent.click(el, { clientX: 50, clientY: 20 });
+    expect(onSeek).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/hooks/__tests__/useEnhancePlayback.test.ts
+++ b/src/hooks/__tests__/useEnhancePlayback.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useEnhancePlayback } from '../useEnhancePlayback';
+import { useTransportStore } from '../../store/transportStore';
+
+// Mock the audio engine
+const mockCtx = {
+  currentTime: 0,
+  state: 'running' as AudioContextState,
+  resume: vi.fn().mockResolvedValue(undefined),
+  createBufferSource: vi.fn(),
+  destination: {},
+};
+
+const mockBuffer = {
+  duration: 10,
+  length: 441000,
+  sampleRate: 44100,
+  numberOfChannels: 2,
+  getChannelData: vi.fn(() => new Float32Array(441000)),
+};
+
+const mockSourceNode = {
+  buffer: null as unknown,
+  connect: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  disconnect: vi.fn(),
+  onended: null as null | (() => void),
+};
+
+vi.mock('../useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    ctx: mockCtx,
+    decodeAudioData: vi.fn().mockResolvedValue(mockBuffer),
+  }),
+}));
+
+vi.mock('../../services/audioFileManager', () => ({
+  loadAudioBlobByKey: vi.fn().mockResolvedValue(new Blob(['audio'], { type: 'audio/wav' })),
+}));
+
+describe('useEnhancePlayback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCtx.createBufferSource.mockReturnValue({ ...mockSourceNode, onended: null });
+    mockCtx.currentTime = 0;
+    useTransportStore.setState({ isPlaying: false });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes with null playingId and 0 progress', () => {
+    const { result } = renderHook(() => useEnhancePlayback());
+    expect(result.current.playingId).toBeNull();
+    expect(result.current.progress).toBe(0);
+    expect(result.current.duration).toBe(0);
+  });
+
+  it('plays audio and sets playingId', async () => {
+    const { result } = renderHook(() => useEnhancePlayback());
+    await act(async () => {
+      await result.current.play('source', 'audio-key-1');
+    });
+    expect(result.current.playingId).toBe('source');
+    expect(result.current.duration).toBe(10);
+  });
+
+  it('stops playback and resets state', async () => {
+    const { result } = renderHook(() => useEnhancePlayback());
+    await act(async () => {
+      await result.current.play('source', 'audio-key-1');
+    });
+    expect(result.current.playingId).toBe('source');
+
+    act(() => {
+      result.current.stopPlayback();
+    });
+    expect(result.current.playingId).toBeNull();
+    expect(result.current.progress).toBe(0);
+  });
+
+  it('togglePlay stops when same id is already playing', async () => {
+    const { result } = renderHook(() => useEnhancePlayback());
+    await act(async () => {
+      await result.current.play('source', 'audio-key-1');
+    });
+    expect(result.current.playingId).toBe('source');
+
+    await act(async () => {
+      await result.current.togglePlay('source', 'audio-key-1');
+    });
+    expect(result.current.playingId).toBeNull();
+  });
+
+  it('togglePlay plays when different id', async () => {
+    const { result } = renderHook(() => useEnhancePlayback());
+    await act(async () => {
+      await result.current.play('source', 'audio-key-1');
+    });
+
+    await act(async () => {
+      await result.current.togglePlay('result-1', 'audio-key-2');
+    });
+    expect(result.current.playingId).toBe('result-1');
+  });
+
+  it('stops playback when main transport starts', async () => {
+    const { result } = renderHook(() => useEnhancePlayback());
+    await act(async () => {
+      await result.current.play('source', 'audio-key-1');
+    });
+    expect(result.current.playingId).toBe('source');
+
+    act(() => {
+      useTransportStore.setState({ isPlaying: true });
+    });
+    expect(result.current.playingId).toBeNull();
+  });
+
+  it('seek plays from a given position', async () => {
+    const { result } = renderHook(() => useEnhancePlayback());
+    await act(async () => {
+      await result.current.seek('source', 'audio-key-1', 0.5);
+    });
+    expect(result.current.playingId).toBe('source');
+    expect(result.current.progress).toBe(0.5);
+  });
+});

--- a/src/hooks/useEnhancePlayback.ts
+++ b/src/hooks/useEnhancePlayback.ts
@@ -1,0 +1,173 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { getAudioEngine } from './useAudioEngine';
+import { loadAudioBlobByKey } from '../services/audioFileManager';
+import { useTransportStore } from '../store/transportStore';
+
+export interface EnhancePlaybackState {
+  /** Which item is currently playing ('source' or a result id) */
+  playingId: string | null;
+  /** Current playback progress 0-1 */
+  progress: number;
+  /** Duration in seconds of the currently playing buffer */
+  duration: number;
+}
+
+/**
+ * Hook for one-shot audio playback in the Enhance Panel.
+ * Uses Web Audio API AudioBufferSourceNode — independent of the main transport.
+ */
+export function useEnhancePlayback() {
+  const [state, setState] = useState<EnhancePlaybackState>({
+    playingId: null,
+    progress: 0,
+    duration: 0,
+  });
+
+  const sourceNodeRef = useRef<AudioBufferSourceNode | null>(null);
+  const startTimeRef = useRef(0);
+  const durationRef = useRef(0);
+  const rafRef = useRef<number>(0);
+  const seekOffsetRef = useRef(0);
+  const bufferCacheRef = useRef<Map<string, AudioBuffer>>(new Map());
+
+  const stopPlayback = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = 0;
+    }
+    if (sourceNodeRef.current) {
+      try {
+        sourceNodeRef.current.stop();
+      } catch {
+        // Already stopped
+      }
+      sourceNodeRef.current.disconnect();
+      sourceNodeRef.current = null;
+    }
+    seekOffsetRef.current = 0;
+    setState({ playingId: null, progress: 0, duration: 0 });
+  }, []);
+
+  // Animate progress via requestAnimationFrame
+  const animateProgress = useCallback(() => {
+    const engine = getAudioEngine();
+    const elapsed = engine.ctx.currentTime - startTimeRef.current + seekOffsetRef.current;
+    const dur = durationRef.current;
+    if (dur > 0) {
+      const p = Math.min(1, elapsed / dur);
+      setState((prev) => ({ ...prev, progress: p }));
+      if (p >= 1) {
+        stopPlayback();
+        return;
+      }
+    }
+    rafRef.current = requestAnimationFrame(animateProgress);
+  }, [stopPlayback]);
+
+  /**
+   * Load and decode an audio blob, with caching.
+   */
+  const loadBuffer = useCallback(async (audioKey: string): Promise<AudioBuffer | null> => {
+    const cached = bufferCacheRef.current.get(audioKey);
+    if (cached) return cached;
+
+    const blob = await loadAudioBlobByKey(audioKey);
+    if (!blob) return null;
+
+    const engine = getAudioEngine();
+    const buffer = await engine.decodeAudioData(blob);
+    bufferCacheRef.current.set(audioKey, buffer);
+    return buffer;
+  }, []);
+
+  /**
+   * Play an audio buffer identified by audioKey.
+   * @param id - Identifier for the playing item ('source' or result id)
+   * @param audioKey - IDB key for the audio blob
+   * @param seekProgress - Optional seek position (0-1)
+   */
+  const play = useCallback(
+    async (id: string, audioKey: string, seekProgress = 0) => {
+      // Stop any current playback first
+      stopPlayback();
+
+      const buffer = await loadBuffer(audioKey);
+      if (!buffer) return;
+
+      const engine = getAudioEngine();
+      const ctx = engine.ctx;
+      if (ctx.state === 'suspended') await ctx.resume();
+
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+      source.connect(ctx.destination);
+
+      const offset = seekProgress * buffer.duration;
+      seekOffsetRef.current = offset;
+      durationRef.current = buffer.duration;
+      startTimeRef.current = ctx.currentTime;
+
+      source.start(0, offset);
+      sourceNodeRef.current = source;
+
+      setState({ playingId: id, progress: seekProgress, duration: buffer.duration });
+      rafRef.current = requestAnimationFrame(animateProgress);
+
+      source.onended = () => {
+        if (sourceNodeRef.current === source) {
+          stopPlayback();
+        }
+      };
+    },
+    [stopPlayback, loadBuffer, animateProgress],
+  );
+
+  /**
+   * Toggle playback — play if stopped or different id, stop if same id.
+   */
+  const togglePlay = useCallback(
+    async (id: string, audioKey: string) => {
+      if (state.playingId === id) {
+        stopPlayback();
+      } else {
+        await play(id, audioKey);
+      }
+    },
+    [state.playingId, play, stopPlayback],
+  );
+
+  /**
+   * Seek to a position while playing.
+   */
+  const seek = useCallback(
+    async (id: string, audioKey: string, progress: number) => {
+      await play(id, audioKey, progress);
+    },
+    [play],
+  );
+
+  // Stop playback when the main transport starts playing (avoid audio overlap)
+  useEffect(() => {
+    const unsub = useTransportStore.subscribe((state) => {
+      if (state.isPlaying) stopPlayback();
+    });
+    return unsub;
+  }, [stopPlayback]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      stopPlayback();
+      bufferCacheRef.current.clear();
+    };
+  }, [stopPlayback]);
+
+  return {
+    ...state,
+    play,
+    togglePlay,
+    seek,
+    stopPlayback,
+    loadBuffer,
+  };
+}


### PR DESCRIPTION
## Summary

Adds real audio waveform rendering, functional playback, and A/B source/result comparison to the unified Enhance Panel.

## Changes

### New Files
- **`WaveformPreview.tsx`** (141 lines) — Reusable waveform renderer with playback progress overlay and click-to-seek
- **`useEnhancePlayback.ts`** (173 lines) — Custom hook for one-shot AudioBufferSourceNode playback, isolated from main timeline transport
- **`WaveformPreview.test.tsx`** (149 lines) — Component tests
- **`useEnhancePlayback.test.ts`** (131 lines) — Hook tests

### Modified
- **`EnhancePanel.tsx`** (+360/-51) — Major upgrade:
  - Source section: real waveform from `clip.waveformPeaks`, functional Play button
  - Results: real waveforms computed from generated audio, real duration display
  - **A/B toggle**: swap between source and selected result at same playback position
  - Mini player: prev/next/play/seek all wired up with progress bar
  - Auto-stop preview when panel closes or main transport starts
- **`EnhancePanel.test.tsx`** (+79 lines) — Additional tests for new functionality

## Technical Details
- Playback uses standalone `AudioBufferSourceNode` (no interference with main timeline)
- `requestAnimationFrame` for smooth progress tracking
- Auto-cleanup: stops audio on panel close, transport start, or component unmount
- Peaks computed via existing `computeWaveformPeaks(buffer, 60)`

## Testing
- ✅ `npx tsc --noEmit` — zero errors
- ✅ `npm run test` — **246 passed** (+2 new suites), **2250 tests** (+18 new), 0 failures

## Net Impact
- **+982 lines** (new components + hooks + tests)

Depends on #782. Closes #777.