### PR TITLE
fix: drag-drop position offset and ghost preview on empty track rows

### DIFF
--- a/src/components/assets/LoopBrowser.tsx
+++ b/src/components/assets/LoopBrowser.tsx
@@ -12,7 +12,12 @@ import {
 import { loadAudioBlobByKey } from '../../services/audioFileManager';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
 import type { AssetClip } from '../../types/project';
+import { setDragPayload, clearDragPayload } from '../../utils/dragPayload';
 import * as Tone from 'tone';
+
+/** 1x1 transparent GIF used to hide the native drag ghost. */
+const TRANSPARENT_IMG = new Image();
+TRANSPARENT_IMG.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -163,15 +168,26 @@ export function LoopBrowser() {
     }
   }, [isOpen, setPreviewingId]);
 
+  // ── Clear drag payload on dragend ──
+  useEffect(() => {
+    const onDragEnd = () => clearDragPayload();
+    window.addEventListener('dragend', onDragEnd);
+    return () => window.removeEventListener('dragend', onDragEnd);
+  }, []);
+
   // ── Drag handlers ──
   const handlePresetDragStart = useCallback((e: React.DragEvent, def: LoopDefinition) => {
     e.dataTransfer.setData('application/x-loop-id', def.id);
     e.dataTransfer.effectAllowed = 'copy';
+    e.dataTransfer.setDragImage(TRANSPARENT_IMG, 0, 0);
+    setDragPayload({ type: 'loop', duration: getLoopDuration(def), name: def.name });
   }, []);
 
   const handleAssetDragStart = useCallback((e: React.DragEvent, asset: AssetClip) => {
     e.dataTransfer.setData('application/x-asset-id', asset.id);
     e.dataTransfer.effectAllowed = 'copy';
+    e.dataTransfer.setDragImage(TRANSPARENT_IMG, 0, 0);
+    setDragPayload({ type: 'asset', duration: asset.duration, name: asset.prompt || asset.trackDisplayName });
   }, []);
 
   // ── Asset actions ──

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -8,13 +8,15 @@ import { TimeRuler } from './TimeRuler';
 import { TrackLane } from './TrackLane';
 import { Playhead } from './Playhead';
 import { GridOverlay } from './GridOverlay';
-import { snapToGrid } from '../../utils/time';
+import { getBarDuration, snapToGrid } from '../../utils/time';
 import { MultiTrackGenerateModal } from '../generation/MultiTrackGenerateModal';
 import { RegionRegenerateModal } from '../generation/RegionRegenerateModal';
 import { RegionContextMenu } from './RegionContextMenu';
 import { CanvasContextMenu } from './CanvasContextMenu';
 import { InlineSuggestionBadge } from './InlineSuggestionBadge';
 import { useAudioImport } from '../../hooks/useAudioImport';
+import { getDragPayload, clearDragPayload } from '../../utils/dragPayload';
+import { clientXToLaneX } from '../../utils/timelineCoords';
 import { Minimap } from './Minimap';
 import { TempoLane } from './TempoLane';
 import { TimeSignatureLane } from './TimeSignatureLane';
@@ -244,12 +246,10 @@ export function Timeline() {
   const [canvasCtxMenu, setCanvasCtxMenu] = useState<{ x: number; y: number } | null>(null);
   const [ctxDrag, setCtxDrag] = useState<DragRect | null>(null);
   const [selDrag, setSelDrag] = useState<DragRect | null>(null);
-  const [fileDragOver, setFileDragOver] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(0);
   const [dragOverTrackId, setDragOverTrackId] = useState<string | null>(null);
   const [dragOverEmptySlotIndex, setDragOverEmptySlotIndex] = useState<number | null>(null);
   const [dragOverPosition, setDragOverPosition] = useState<'before' | 'after'>('before');
-  const dragCounterRef = useRef(0);
   const draggedTrackIdRef = useRef<string | null>(null);
   const trackListResizeRef = useRef<{ startX: number; startW: number } | null>(null);
   const zoomAnimationFrameRef = useRef<number | null>(null);
@@ -268,27 +268,8 @@ export function Timeline() {
     }
   }, []);
 
-  const handleDragEnter = useCallback((e: React.DragEvent) => {
-    const types = e.dataTransfer.types;
-    if (types.includes('Files') || types.includes('application/x-loop-id') || types.includes('application/x-asset-id')) {
-      e.preventDefault();
-      dragCounterRef.current++;
-      setFileDragOver(true);
-    }
-  }, []);
-
-  const handleDragLeave = useCallback(() => {
-    dragCounterRef.current--;
-    if (dragCounterRef.current <= 0) {
-      dragCounterRef.current = 0;
-      setFileDragOver(false);
-    }
-  }, []);
-
   const handleDrop = useCallback(async (e: React.DragEvent) => {
     e.preventDefault();
-    dragCounterRef.current = 0;
-    setFileDragOver(false);
 
     // Handle preset loop drop -> create new sample track
     const loopId = e.dataTransfer.getData('application/x-loop-id');
@@ -317,21 +298,6 @@ export function Timeline() {
       }
     }
   }, [addTrack, importMultipleFiles, importLoopToTrack, importAssetToTrack, importAudioFileAsNewQuickSampler, importAssetAsQuickSampler]);
-
-  // Safety net: if a child (e.g. TrackLane) stops propagation on drop,
-  // the Timeline's own handleDrop never fires. Listen globally to clear the overlay.
-  useEffect(() => {
-    const clearOverlay = () => {
-      dragCounterRef.current = 0;
-      setFileDragOver(false);
-    };
-    window.addEventListener('drop', clearOverlay);
-    window.addEventListener('dragend', clearOverlay);
-    return () => {
-      window.removeEventListener('drop', clearOverlay);
-      window.removeEventListener('dragend', clearOverlay);
-    };
-  }, []);
 
   const handleTrackHeaderDragStart = useCallback((trackId: string) => {
     draggedTrackIdRef.current = trackId;
@@ -904,8 +870,6 @@ export function Timeline() {
         onBlur={() => setTimelineFocused(false)}
         onMouseDown={() => setKeyboardContext('timeline')}
         onDragOver={handleDragOver}
-        onDragEnter={handleDragEnter}
-        onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         onContextMenu={(e) => {
           // Only show canvas context menu on empty area
@@ -923,14 +887,6 @@ export function Timeline() {
         }}
         style={{ cursor: 'default' }}
       >
-        {fileDragOver && (
-          <div className="absolute inset-0 z-50 flex items-center justify-center bg-blue-900/30 border-2 border-dashed border-blue-400/60 pointer-events-none">
-            <div className="bg-blue-950/80 border border-blue-500/50 rounded-lg px-6 py-4 text-center">
-              <p className="text-sm font-medium text-blue-200">Drop audio or MIDI files here</p>
-              <p className="text-[10px] text-blue-400 mt-1">WAV, MP3, OGG, FLAC, AAC, MID</p>
-            </div>
-          </div>
-        )}
         <div
           className="relative grid"
           style={{
@@ -1227,8 +1183,96 @@ function ArrangementEmptyTrackHeaderRow({
 
 function EmptyTrackRow({ slotIndex }: { slotIndex: number }) {
   const selectedTrackIds = useUIStore((s) => s.selectedTrackIds);
+  const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
+  const project = useProjectStore((s) => s.project);
+  const addTrack = useProjectStore((s) => s.addTrack);
   const virtualId = getArrangementEmptyTrackId(slotIndex);
   const isSelected = selectedTrackIds.has(virtualId);
+  const { importLoopToTrack, importAssetToTrack, importAssetAsQuickSampler, importAudioFileAsNewQuickSampler } = useAudioImport();
+
+  const [dropGhost, setDropGhost] = useState<{ left: number; width: number; name: string } | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const dragCounterRef = useRef(0);
+
+  const defaultClipDuration = project
+    ? getBarDuration(project.bpm, project.timeSignature, project.timeSignatureDenominator ?? 4) * 4
+    : 8;
+
+  const onDragEnter = useCallback((e: React.DragEvent) => {
+    const types = e.dataTransfer.types;
+    if (types.includes('Files') || types.includes('application/x-loop-id') || types.includes('application/x-asset-id')) {
+      e.preventDefault();
+      dragCounterRef.current++;
+      setIsDragOver(true);
+    }
+  }, []);
+
+  const onDragOver = useCallback((e: React.DragEvent) => {
+    const types = e.dataTransfer.types;
+    if (types.includes('Files') || types.includes('application/x-loop-id') || types.includes('application/x-asset-id')) {
+      e.preventDefault();
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = 'copy';
+
+      const payload = getDragPayload();
+      if (payload && project) {
+        const laneX = clientXToLaneX(e.clientX);
+        const rawTime = laneX / pixelsPerSecond;
+        const snappedTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1, project.tempoMap));
+        const ghostDuration = payload.duration ?? defaultClipDuration;
+        setDropGhost({
+          left: snappedTime * pixelsPerSecond,
+          width: ghostDuration * pixelsPerSecond,
+          name: payload.name ?? 'Audio',
+        });
+      }
+    }
+  }, [project, pixelsPerSecond, defaultClipDuration]);
+
+  const onDragLeave = useCallback(() => {
+    dragCounterRef.current--;
+    if (dragCounterRef.current <= 0) {
+      dragCounterRef.current = 0;
+      setIsDragOver(false);
+      setDropGhost(null);
+    }
+  }, []);
+
+  const onDrop = useCallback(async (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current = 0;
+    setIsDragOver(false);
+    setDropGhost(null);
+    clearDragPayload();
+    if (!project) return;
+
+    const laneX = clientXToLaneX(e.clientX);
+    const rawTime = laneX / pixelsPerSecond;
+    const startTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1, project.tempoMap));
+
+    const loopId = e.dataTransfer.getData('application/x-loop-id');
+    if (loopId) {
+      const newTrack = addTrack('custom', 'sample');
+      await importLoopToTrack(loopId, newTrack.id, startTime);
+      return;
+    }
+
+    const assetId = e.dataTransfer.getData('application/x-asset-id');
+    if (assetId) {
+      await importAssetAsQuickSampler(assetId);
+      return;
+    }
+
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      for (const file of Array.from(files)) {
+        if (file.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|aac|m4a|webm)$/i.test(file.name)) {
+          await importAudioFileAsNewQuickSampler(file);
+        }
+      }
+    }
+  }, [project, pixelsPerSecond, addTrack, importLoopToTrack, importAssetToTrack, importAssetAsQuickSampler, importAudioFileAsNewQuickSampler]);
 
   return (
     <div
@@ -1238,11 +1282,29 @@ function EmptyTrackRow({ slotIndex }: { slotIndex: number }) {
       style={{
         height: PLACEHOLDER_ROW_HEIGHT,
         borderBottom: '1px solid var(--color-daw-arrangement-separator)',
+        backgroundColor: isDragOver ? 'rgba(94, 89, 255, 0.08)' : undefined,
       }}
       data-testid={`empty-row-${slotIndex}`}
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
     >
       {isSelected && (
         <div aria-hidden="true" className="absolute inset-0 pointer-events-none" style={{ backgroundColor: 'rgba(94, 89, 255, 0.24)' }} />
+      )}
+      {dropGhost && (
+        <div
+          className="absolute top-1 bottom-1 rounded-md pointer-events-none z-30 flex items-center overflow-hidden"
+          style={{
+            left: dropGhost.left,
+            width: Math.max(dropGhost.width, 4),
+            backgroundColor: 'rgba(94, 89, 255, 0.30)',
+            border: '1px dashed rgba(94, 89, 255, 0.7)',
+          }}
+        >
+          <span className="text-[10px] text-white/70 px-2 truncate">{dropGhost.name}</span>
+        </div>
       )}
     </div>
   );

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -13,6 +13,8 @@ import { CanvasContextMenu } from './CanvasContextMenu';
 import { CrossfadeOverlay } from './CrossfadeOverlay';
 import { getTimelineVisualDuration } from '../../utils/timelineZoom';
 import { TRACK_TYPE_CATALOG } from '../../constants/tracks';
+import { getDragPayload, clearDragPayload } from '../../utils/dragPayload';
+import { clientXToLaneX } from '../../utils/timelineCoords';
 import {
   ARRANGEMENT_EMPTY_LANE_BG,
   ARRANGEMENT_ROW_BORDER_CLASS,
@@ -68,6 +70,8 @@ export function TrackLane({ track }: TrackLaneProps) {
     importAssetToTrack,
   } = useAudioImport();
   const [fileDragOver, setFileDragOver] = useState(false);
+  const [dropGhost, setDropGhost] = useState<{ left: number; width: number; name: string } | null>(null);
+  const dragCounterRef = useRef(0);
 
   const resizeRef = useRef<{ startY: number; startRowHeight: number; startLaneHeight: number } | null>(null);
   const laneHeight = track.laneHeight ?? 80;
@@ -143,8 +147,7 @@ export function TrackLane({ track }: TrackLaneProps) {
     if (e.target !== e.currentTarget) return;
     e.preventDefault();
     e.stopPropagation();
-    const rect = e.currentTarget.getBoundingClientRect();
-    const laneX = e.clientX - rect.left;
+    const laneX = clientXToLaneX(e.clientX);
     const rawTime = laneX / pixelsPerSecond;
     const startTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1, project.tempoMap));
     const remaining = project.totalDuration - startTime;
@@ -174,9 +177,7 @@ export function TrackLane({ track }: TrackLaneProps) {
     }
     if (isPianoRoll) {
       e.stopPropagation();
-      const rect = e.currentTarget.getBoundingClientRect();
-      const laneX = e.clientX - rect.left;
-      const rawTime = laneX / pixelsPerSecond;
+      const rawTime = clientXToLaneX(e.clientX) / pixelsPerSecond;
       const startTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1, project.tempoMap));
       const clip = addClip(track.id, {
         startTime,
@@ -194,9 +195,7 @@ export function TrackLane({ track }: TrackLaneProps) {
 
     // For stems/sample/audio tracks, double-click on empty space creates a new empty clip
     e.stopPropagation();
-    const rect = e.currentTarget.getBoundingClientRect();
-    const laneX = e.clientX - rect.left;
-    const clickTime = laneX / pixelsPerSecond;
+    const clickTime = clientXToLaneX(e.clientX) / pixelsPerSecond;
     if (hitsClip(clickTime)) return;
     const startTime = Math.max(0, snapToGrid(clickTime, project.bpm, 1, project.tempoMap));
     const clip = addClip(track.id, {
@@ -214,6 +213,20 @@ export function TrackLane({ track }: TrackLaneProps) {
     setAddLayerTarget(null);
   }, []);
 
+  const handleFileDragEnter = useCallback((e: React.DragEvent) => {
+    const types = e.dataTransfer.types;
+    if (
+      types.includes('Files')
+      || types.includes('application/x-loop-id')
+      || types.includes('application/x-asset-id')
+      || types.includes('application/x-generation-history-id')
+    ) {
+      e.preventDefault();
+      dragCounterRef.current++;
+      setFileDragOver(true);
+    }
+  }, []);
+
   const handleFileDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer.types;
     if (
@@ -225,22 +238,42 @@ export function TrackLane({ track }: TrackLaneProps) {
       e.preventDefault();
       e.stopPropagation();
       e.dataTransfer.dropEffect = 'copy';
-      setFileDragOver(true);
+
+      // Compute ghost preview position
+      const payload = getDragPayload();
+      if (payload && project) {
+        const laneX = clientXToLaneX(e.clientX);
+        const rawTime = laneX / pixelsPerSecond;
+        const snappedTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1, project.tempoMap));
+        const ghostDuration = payload.duration ?? defaultClipDuration;
+        setDropGhost({
+          left: snappedTime * pixelsPerSecond,
+          width: ghostDuration * pixelsPerSecond,
+          name: payload.name ?? 'Audio',
+        });
+      }
     }
-  }, []);
+  }, [project, pixelsPerSecond, defaultClipDuration]);
 
   const handleFileDragLeave = useCallback(() => {
-    setFileDragOver(false);
+    dragCounterRef.current--;
+    if (dragCounterRef.current <= 0) {
+      dragCounterRef.current = 0;
+      setFileDragOver(false);
+      setDropGhost(null);
+    }
   }, []);
 
   const handleFileDrop = useCallback(async (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    dragCounterRef.current = 0;
     setFileDragOver(false);
+    setDropGhost(null);
+    clearDragPayload();
     if (!project) return;
 
-    const rect = e.currentTarget.getBoundingClientRect();
-    const laneX = e.clientX - rect.left;
+    const laneX = clientXToLaneX(e.clientX);
     const rawTime = laneX / pixelsPerSecond;
     const startTime = Math.max(0, snapToGrid(rawTime, project.bpm, 1, project.tempoMap));
 
@@ -308,6 +341,7 @@ export function TrackLane({ track }: TrackLaneProps) {
         }}
         onContextMenu={handleContextMenu}
         onDoubleClick={handleDoubleClick}
+        onDragEnter={handleFileDragEnter}
         onDragOver={handleFileDragOver}
         onDragLeave={handleFileDragLeave}
         onDrop={handleFileDrop}
@@ -333,9 +367,18 @@ export function TrackLane({ track }: TrackLaneProps) {
           />
         )}
 
-        {fileDragOver && (
-          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-30 border border-dashed border-blue-400/60 rounded-sm">
-            <span className="text-[10px] text-blue-300 bg-blue-950/80 px-2 py-0.5 rounded">Drop audio or MIDI here {track.trackType !== 'pianoRoll' ? '(Alt = Quick Sampler)' : ''}</span>
+        {/* Drop ghost preview — shows where the clip will land */}
+        {dropGhost && (
+          <div
+            className="absolute top-1 bottom-1 rounded-md pointer-events-none z-30 flex items-center overflow-hidden"
+            style={{
+              left: dropGhost.left,
+              width: Math.max(dropGhost.width, 4),
+              backgroundColor: track.color ? `${track.color}4D` : 'rgba(94, 89, 255, 0.30)',
+              border: `1px dashed ${track.color ?? 'rgba(94, 89, 255, 0.7)'}`,
+            }}
+          >
+            <span className="text-[10px] text-white/70 px-2 truncate">{dropGhost.name}</span>
           </div>
         )}
 

--- a/src/utils/dragPayload.ts
+++ b/src/utils/dragPayload.ts
@@ -1,0 +1,29 @@
+/**
+ * Module-level drag payload for communicating drag metadata between
+ * drag source (LoopBrowser) and drop target (TrackLane).
+ *
+ * We can't use e.dataTransfer.getData() during dragover (browser security),
+ * so we store the payload here when drag starts and read it during dragover.
+ */
+
+export interface DragPayload {
+  type: 'loop' | 'asset' | 'file';
+  /** Duration of the dragged item in seconds (if known). */
+  duration?: number;
+  /** Display name for the ghost preview. */
+  name?: string;
+}
+
+let currentPayload: DragPayload | null = null;
+
+export function setDragPayload(payload: DragPayload): void {
+  currentPayload = payload;
+}
+
+export function getDragPayload(): DragPayload | null {
+  return currentPayload;
+}
+
+export function clearDragPayload(): void {
+  currentPayload = null;
+}

--- a/src/utils/timelineCoords.ts
+++ b/src/utils/timelineCoords.ts
@@ -1,0 +1,15 @@
+import { useUIStore } from '../store/uiStore';
+
+/**
+ * Convert a viewport clientX to a pixel offset within the timeline lane area,
+ * correctly accounting for CSS Grid sticky layout and horizontal scroll.
+ * Uses the scroll container (not the lane element) to avoid getBoundingClientRect
+ * inaccuracies with sticky grid siblings.
+ */
+export function clientXToLaneX(clientX: number): number {
+  const scrollContainer = document.getElementById('arrangement-timeline-scroll');
+  if (!scrollContainer) return 0;
+  const containerRect = scrollContainer.getBoundingClientRect();
+  const trackListW = useUIStore.getState().trackListWidth;
+  return clientX - containerRect.left - trackListW + scrollContainer.scrollLeft;
+}

--- a/tests/unit/trackLaneDoubleClickCreateClip.test.tsx
+++ b/tests/unit/trackLaneDoubleClickCreateClip.test.tsx
@@ -42,22 +42,26 @@ vi.mock('../../src/components/timeline/CrossfadeOverlay', () => ({
   CrossfadeOverlay: () => null,
 }));
 
+function ensureScrollContainer() {
+  let container = document.getElementById('arrangement-timeline-scroll');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'arrangement-timeline-scroll';
+    Object.defineProperty(container, 'scrollLeft', { configurable: true, value: 0 });
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        left: 0, top: 0, width: 1000, height: 500,
+        right: 1000, bottom: 500, x: 0, y: 0, toJSON: () => ({}),
+      }),
+    });
+    document.body.appendChild(container);
+  }
+}
+
 function doubleClickLane(trackId: string, clientX: number) {
+  ensureScrollContainer();
   const lane = screen.getByTestId(`track-lane-${trackId}`);
-  Object.defineProperty(lane, 'getBoundingClientRect', {
-    configurable: true,
-    value: () => ({
-      left: 0,
-      top: 0,
-      width: 1000,
-      height: 64,
-      right: 1000,
-      bottom: 64,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    }),
-  });
   fireEvent.doubleClick(lane, { clientX });
 }
 
@@ -68,6 +72,8 @@ describe('TrackLane double-click clip creation', () => {
     useUIStore.setState(useUIStore.getInitialState(), true);
     useProjectStore.getState().createProject({ name: 'Track Lane Double Click Test', bpm: 120, timeSignature: 4 });
     useUIStore.getState().setPixelsPerSecond(100);
+    // Set trackListWidth to 0 so clientXToLaneX(clientX) == clientX in tests
+    useUIStore.setState({ trackListWidth: 0 });
   });
 
   it('creates and selects an empty audio clip on stems tracks and supports undo', () => {


### PR DESCRIPTION
## Summary
- Fix clip landing position mismatch when dragging loops from Loop Library to timeline (offset worsened with horizontal scroll)
- Add ghost preview with name label to empty track rows, matching the existing TrackLane behavior
- Extract `clientXToLaneX` to shared utility and add `dragPayload` module for cross-component drag metadata

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 2276 tests pass
- [x] `npm run build` — succeeds
- [ ] Manual: drag loop to empty row → ghost preview appears at snapped position
- [ ] Manual: drop on empty row → new track created with clip at correct position
- [ ] Manual: scroll timeline right, drag loop → position still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)