### PR TITLE
feat: center generation dock on workspace and refine status bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "ace-step-daw",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@breezystack/lamejs": "^1.2.7",
         "@codemirror/commands": "^6.10.3",

--- a/src/components/generation/GenerationSidePanel.tsx
+++ b/src/components/generation/GenerationSidePanel.tsx
@@ -38,6 +38,7 @@ const VARIATION_STATUS_COLORS: Record<VariationStatus, string> = {
 };
 
 export function GenerationSidePanel() {
+  const mainView = useUIStore((s) => s.mainView);
   const show = useUIStore((s) => s.showGenerationPanel);
   const setShow = useUIStore((s) => s.setShowGenerationPanel);
   const openGenerationPanelView = useUIStore((s) => s.openGenerationPanelView);
@@ -54,6 +55,7 @@ export function GenerationSidePanel() {
   const selectClip = useUIStore((s) => s.selectClip);
   const showSmartControls = useUIStore((s) => s.showSmartControls);
   const activeBottomPanel = useUIStore((s) => s.activeBottomPanel);
+  const trackListWidth = useUIStore((s) => s.trackListWidth);
   const project = useProjectStore((s) => s.project);
 
   const generationForm = useGenerationStore((s) => s.generationForm);
@@ -230,13 +232,21 @@ export function GenerationSidePanel() {
     return () => window.clearTimeout(timeout);
   }, [show]);
 
+  const workspaceLeftInset = mainView === 'arrangement' && Number.isFinite(trackListWidth)
+    ? trackListWidth
+    : 0;
+  const dockLeft = workspaceLeftInset > 0
+    ? `calc(50% + ${workspaceLeftInset / 2}px)`
+    : '50%';
+
   if (!project) return null;
 
   return (
     <>
       <div
-        className="fixed left-1/2 -translate-x-1/2 transition-all duration-300 ease-in-out"
+        className="fixed -translate-x-1/2 transition-all duration-300 ease-in-out"
         style={{
+          left: dockLeft,
           zIndex: Z.toast,
           bottom: showSmartControls ? 208 : 68,
           opacity: activeBottomPanel ? 0 : 1,

--- a/src/components/generation/__tests__/GenerationSidePanel.settings.test.tsx
+++ b/src/components/generation/__tests__/GenerationSidePanel.settings.test.tsx
@@ -75,4 +75,12 @@ describe('GenerationSidePanel settings entrypoints', () => {
 
     expect(useUIStore.getState().loopBrowserOpen).toBe(true);
   });
+
+  it('centers the dock against the arrangement workspace instead of the full viewport', () => {
+    useUIStore.setState({ mainView: 'arrangement', trackListWidth: 240 });
+
+    render(<GenerationSidePanel />);
+
+    expect(screen.getByTestId('generation-dock').style.left).toBe('calc(50% + 120px)');
+  });
 });

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -9,7 +9,7 @@ import { TIMELINE_ZOOM_LEVELS } from '../../utils/timelineZoom';
 const HEALTH_POLL_INTERVAL_MS = 10_000;
 const DEFAULT_SOURCE_CODE_URL = 'https://github.com/ace-step/ACE-Step-DAW';
 const CURRENT_YEAR = new Date().getFullYear();
-const DEFAULT_COPYRIGHT_NOTICE = `Copyright (c) ${CURRENT_YEAR} ACE Studio`;
+const DEFAULT_COPYRIGHT_NOTICE = `ACE Studio © ${CURRENT_YEAR}`;
 
 let lastKnownBackendConnection = false;
 
@@ -99,17 +99,20 @@ export function StatusBar() {
           </div>
           <span className="truncate text-daw-text-muted" data-testid="status-model-name">{resolvedModelName}</span>
           <span className="flex-1" />
-          <div className="flex items-center gap-1.5 text-[9px] text-daw-text-muted/85" data-testid="status-legal-notice">
-            <span className="truncate" data-testid="status-copyright-notice">{copyrightNotice}</span>
-            <span aria-hidden="true">•</span>
-            <span data-testid="status-no-warranty">No warranty</span>
-            <span aria-hidden="true">•</span>
-            <span className="hidden md:inline">Share and modify under AGPL-3.0-or-later</span>
+          <div className="hidden items-center gap-1.5 text-[9px] text-daw-text-muted/80 md:flex" data-testid="status-legal-notice">
+            <span className="whitespace-nowrap text-daw-text-muted/90" data-testid="status-copyright-notice">{copyrightNotice}</span>
+            <span
+              className="inline-flex items-center rounded-full border border-white/8 px-1.5 py-[1px] text-[8px] uppercase tracking-[0.16em] text-daw-text-muted/75"
+              data-testid="status-no-warranty"
+              title="No warranty. Share and modify under AGPL-3.0-or-later."
+            >
+              No warranty
+            </span>
             <a
               href={sourceCodeUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded px-1 py-0.5 text-daw-accent transition-colors hover:bg-daw-hover-subtle hover:text-white"
+              className="rounded-full border border-white/8 px-2 py-0.5 text-daw-accent transition-colors hover:border-white/14 hover:bg-daw-hover-subtle hover:text-white"
               data-testid="status-source-link"
               aria-label="View corresponding source code"
               title="View corresponding source code"
@@ -120,12 +123,12 @@ export function StatusBar() {
               href={licenseUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded px-1 py-0.5 text-daw-accent transition-colors hover:bg-daw-hover-subtle hover:text-white"
+              className="rounded-full border border-white/8 px-2 py-0.5 text-daw-accent transition-colors hover:border-white/14 hover:bg-daw-hover-subtle hover:text-white"
               data-testid="status-license-link"
               aria-label="View AGPL license"
-              title="View AGPL license"
+              title="View AGPL-3.0-or-later license"
             >
-              License
+              AGPL
             </a>
           </div>
           <div className="flex items-center gap-1.5 text-daw-text-muted">

--- a/tests/unit/StatusBar.test.tsx
+++ b/tests/unit/StatusBar.test.tsx
@@ -92,7 +92,7 @@ describe('StatusBar', () => {
     it('renders a copyright notice instead of the old marketing link', () => {
       healthCheckMock.mockResolvedValue(false);
       render(<StatusBar />);
-      expect(screen.getByTestId('status-copyright-notice')).toHaveTextContent(`Copyright (c) ${CURRENT_YEAR} ACE Studio`);
+      expect(screen.getByTestId('status-copyright-notice')).toHaveTextContent(`ACE Studio © ${CURRENT_YEAR}`);
       expect(screen.queryByRole('link', { name: /ACE Studio/ })).not.toBeInTheDocument();
     });
   });

--- a/tests/unit/statusBarControls.test.tsx
+++ b/tests/unit/statusBarControls.test.tsx
@@ -89,8 +89,10 @@ describe('StatusBar controls', () => {
   it('shows the AGPL source and license notice links', () => {
     render(<StatusBar />);
 
+    expect(screen.getByTestId('status-copyright-notice')).toHaveTextContent(`ACE Studio © ${new Date().getFullYear()}`);
     expect(screen.getByTestId('status-legal-notice')).toHaveTextContent('No warranty');
     expect(screen.getByTestId('status-source-link')).toHaveAttribute('href', 'https://github.com/ace-step/ACE-Step-DAW');
     expect(screen.getByTestId('status-license-link')).toHaveAttribute('href', 'https://github.com/ace-step/ACE-Step-DAW/blob/main/LICENSE');
+    expect(screen.getByTestId('status-license-link')).toHaveTextContent('AGPL');
   });
 });


### PR DESCRIPTION
## Summary
- Center the generation dock against the arrangement workspace (offset by track list width) instead of the full viewport
- Redesign status bar legal notice with pill badge styling and progressive disclosure (full AGPL text in tooltip)
- Shorten copyright to `ACE Studio © 2026` and license link to `AGPL`

## Test plan
- [x] Unit tests pass (2310 passing)
- [x] Type check passes
- [ ] Verify generation dock centering visually in arrangement view
- [ ] Verify status bar legal notice renders correctly on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)