### PR TITLE
fix: add responsive layout guards to prevent overlap on narrow viewports (#744)

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -93,7 +93,7 @@ function EditorShell() {
 
   return (
     <div
-      className="flex flex-col h-screen bg-daw-bg text-zinc-300"
+      className="flex flex-col h-screen min-w-[900px] bg-daw-bg text-zinc-300"
       role="application"
       aria-label="ACE-Step DAW"
       tabIndex={-1}

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -97,7 +97,7 @@ export function StatusBar() {
           >
             <div className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-emerald-500' : 'bg-red-500'}`} />
           </div>
-          <span className="truncate text-daw-text-muted" data-testid="status-model-name">{resolvedModelName}</span>
+          <span className="hidden lg:inline truncate text-daw-text-muted" data-testid="status-model-name">{resolvedModelName}</span>
           <span className="flex-1" />
           <div className="hidden items-center gap-1.5 text-[9px] text-daw-text-muted/80 md:flex" data-testid="status-legal-notice">
             <span className="whitespace-nowrap text-daw-text-muted/90" data-testid="status-copyright-notice">{copyrightNotice}</span>
@@ -131,7 +131,7 @@ export function StatusBar() {
               AGPL
             </a>
           </div>
-          <div className="flex items-center gap-1.5 text-daw-text-muted">
+          <div className="hidden md:flex items-center gap-1.5 text-daw-text-muted">
             <button
               type="button"
               onClick={() => setShowKeyboardShortcutsDialog(true)}

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -666,7 +666,9 @@ export function Toolbar() {
       <div className="flex-1" />
 
       {/* Project timing settings */}
-      <ProjectTimingStrip disabled={!project} />
+      <div className="hidden md:flex shrink-0">
+        <ProjectTimingStrip disabled={!project} />
+      </div>
 
       {/* Center: Transport controls */}
       <div className="shrink-0" data-testid="toolbar-group">
@@ -752,7 +754,9 @@ export function Toolbar() {
 
       <div className="flex-1" />
 
-      <HarmonySettingsStrip disabled={!project} />
+      <div className="hidden lg:flex shrink-0">
+        <HarmonySettingsStrip disabled={!project} />
+      </div>
 
       {/* Command Palette + ACE Studio */}
       <div className="flex items-center gap-1 shrink-0">

--- a/src/components/tracks/TrackList.tsx
+++ b/src/components/tracks/TrackList.tsx
@@ -185,7 +185,7 @@ export function TrackList() {
     <div
       id="arrangement-track-list"
       className="flex flex-col bg-[#2a2a2a] border-r border-[#1a1a1a] relative shrink-0"
-      style={{ width: trackListWidth }}
+      style={{ width: trackListWidth, minWidth: isCollapsed ? undefined : 120 }}
       onDragLeave={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget as Node)) {
           setDragOverId(null);


### PR DESCRIPTION
## Summary
- Add `min-w-[900px]` to main layout container to enable horizontal scroll on narrow viewports
- Hide `ProjectTimingStrip` at `<md` breakpoint, `HarmonySettingsStrip` at `<lg`
- Hide model name at `<lg`, keyboard shortcuts/zoom controls at `<md` in StatusBar
- Set `minWidth: 120px` on track list to prevent crushing

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 2311 tests pass
- [ ] Verify layout at 375px, 768px, 1024px, 1280px viewports

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)