### PR TITLE
feat: enhancement presets + Surprise Me random style (#781)

### DIFF
--- a/src/components/generation/EnhancePanel.tsx
+++ b/src/components/generation/EnhancePanel.tsx
@@ -11,6 +11,7 @@ import { WaveformPreview } from './WaveformPreview';
 import { useEnhancePlayback } from '../../hooks/useEnhancePlayback';
 import { computeWaveformPeaks } from '../../utils/waveformPeaks';
 import type { RepaintMode } from '../../types/api';
+import { ENHANCE_PRESETS, surpriseMe } from '../../constants/enhancePresets';
 
 const ENHANCER_BASE_BOTTOM = 60;
 
@@ -94,6 +95,9 @@ export function EnhancePanel() {
 
   // Mini player selected index
   const [miniPlayerIdx, setMiniPlayerIdx] = useState(0);
+
+  // Quick Styles section
+  const [quickStylesOpen, setQuickStylesOpen] = useState(false);
 
   // Playback
   const playback = useEnhancePlayback();
@@ -572,6 +576,54 @@ export function EnhancePanel() {
                   rows={3}
                   className="w-full bg-[#161618] border border-[#333] rounded-lg px-3 py-2 text-xs text-zinc-100 placeholder-zinc-600 resize-none focus:outline-none focus:border-teal-500/60 font-mono"
                 />
+              </div>
+
+              {/* Quick Styles presets */}
+              <div>
+                <button
+                  data-testid="quick-styles-toggle"
+                  onClick={() => setQuickStylesOpen((v) => !v)}
+                  className="flex items-center gap-1.5 text-[10px] font-medium text-zinc-500 uppercase tracking-wide mb-1 hover:text-zinc-300 transition-colors"
+                >
+                  <svg
+                    className={`w-3 h-3 transition-transform ${quickStylesOpen ? 'rotate-90' : ''}`}
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M9 18l6-6-6-6" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  Quick Styles
+                </button>
+                {quickStylesOpen && (
+                  <div data-testid="quick-styles-grid" className="flex flex-wrap gap-1.5 mb-2">
+                    {ENHANCE_PRESETS.map((preset) => (
+                      <button
+                        key={preset.id}
+                        data-testid={`preset-${preset.id}`}
+                        onClick={() => {
+                          setCaption(preset.caption);
+                          setConsistency(preset.consistency);
+                        }}
+                        className="px-2.5 py-1 rounded-full bg-[#2a2a2e] hover:bg-[#3a3a3e] text-[10px] text-zinc-300 transition-colors whitespace-nowrap border border-[#3a3a3a] hover:border-teal-500/40"
+                      >
+                        {preset.icon} {preset.label}
+                      </button>
+                    ))}
+                    <button
+                      data-testid="preset-surprise-me"
+                      onClick={() => {
+                        const result = surpriseMe();
+                        setCaption(result.caption);
+                        setConsistency(result.consistency);
+                      }}
+                      className="px-2.5 py-1 rounded-full bg-gradient-to-r from-purple-600/30 to-pink-600/30 hover:from-purple-600/50 hover:to-pink-600/50 text-[10px] text-zinc-200 transition-all whitespace-nowrap border border-purple-500/30 hover:border-purple-400/60 font-medium"
+                    >
+                      {'\u{1F3B2}'} Surprise Me
+                    </button>
+                  </div>
+                )}
               </div>
 
               {/* Styles (caption) */}

--- a/src/components/generation/__tests__/EnhancePanel.test.tsx
+++ b/src/components/generation/__tests__/EnhancePanel.test.tsx
@@ -4,6 +4,7 @@ import { EnhancePanel } from '../EnhancePanel';
 import { useProjectStore } from '../../../store/projectStore';
 import { useUIStore } from '../../../store/uiStore';
 import { useGenerationStore } from '../../../store/generationStore';
+import { ENHANCE_PRESETS } from '../../../constants/enhancePresets';
 
 vi.mock('../../../services/generationPipeline', () => ({
   generateCoverClip: vi.fn().mockResolvedValue(undefined),
@@ -250,6 +251,95 @@ describe('EnhancePanel', () => {
     });
     render(<EnhancePanel />);
     expect(screen.getByText('1:05')).toBeInTheDocument();
+  });
+});
+
+describe('EnhancePanel Quick Styles presets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGenerationStore.setState({ isGenerating: false });
+  });
+
+  function renderCoverPanel() {
+    const { track, clip } = setupProjectWithClip();
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: {
+        clipId: clip.id,
+        trackId: track.id,
+        range: null,
+        mode: 'cover',
+      },
+    });
+    return render(<EnhancePanel />);
+  }
+
+  it('shows Quick Styles toggle button in cover mode', () => {
+    renderCoverPanel();
+    expect(screen.getByTestId('quick-styles-toggle')).toBeInTheDocument();
+  });
+
+  it('preset grid is collapsed by default', () => {
+    renderCoverPanel();
+    expect(screen.queryByTestId('quick-styles-grid')).not.toBeInTheDocument();
+  });
+
+  it('expands preset grid when clicking toggle', () => {
+    renderCoverPanel();
+    fireEvent.click(screen.getByTestId('quick-styles-toggle'));
+    expect(screen.getByTestId('quick-styles-grid')).toBeInTheDocument();
+  });
+
+  it('shows all preset buttons plus Surprise Me when expanded', () => {
+    renderCoverPanel();
+    fireEvent.click(screen.getByTestId('quick-styles-toggle'));
+    for (const preset of ENHANCE_PRESETS) {
+      expect(screen.getByTestId(`preset-${preset.id}`)).toBeInTheDocument();
+    }
+    expect(screen.getByTestId('preset-surprise-me')).toBeInTheDocument();
+  });
+
+  it('clicking a preset fills the styles textarea', () => {
+    renderCoverPanel();
+    fireEvent.click(screen.getByTestId('quick-styles-toggle'));
+    const jazzPreset = ENHANCE_PRESETS.find((p) => p.id === 'jazz')!;
+    fireEvent.click(screen.getByTestId('preset-jazz'));
+    const stylesInput = screen.getByTestId('enhance-styles-input') as HTMLTextAreaElement;
+    expect(stylesInput.value).toBe(jazzPreset.caption);
+  });
+
+  it('clicking a preset updates the consistency toggle', () => {
+    renderCoverPanel();
+    fireEvent.click(screen.getByTestId('quick-styles-toggle'));
+    // Click orchestral which has high consistency
+    fireEvent.click(screen.getByTestId('preset-orchestral'));
+    const consistencyToggle = screen.getByTestId('enhance-consistency-toggle');
+    // The "high" button should be active
+    const highButton = consistencyToggle.querySelectorAll('button')[2];
+    expect(highButton.className).toContain('bg-teal-600');
+  });
+
+  it('Surprise Me button fills caption with a random preset', () => {
+    renderCoverPanel();
+    fireEvent.click(screen.getByTestId('quick-styles-toggle'));
+    fireEvent.click(screen.getByTestId('preset-surprise-me'));
+    const stylesInput = screen.getByTestId('enhance-styles-input') as HTMLTextAreaElement;
+    expect(stylesInput.value.length).toBeGreaterThan(0);
+  });
+
+  it('does not show Quick Styles in repaint mode', () => {
+    const { track, clip } = setupProjectWithClip();
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: {
+        clipId: clip.id,
+        trackId: track.id,
+        range: { start: 2, end: 5 },
+        mode: 'repaint',
+      },
+    });
+    render(<EnhancePanel />);
+    expect(screen.queryByTestId('quick-styles-toggle')).not.toBeInTheDocument();
   });
 });
 

--- a/src/constants/enhancePresets.ts
+++ b/src/constants/enhancePresets.ts
@@ -1,0 +1,144 @@
+export interface EnhancePreset {
+  id: string;
+  label: string;
+  icon: string;
+  caption: string;
+  consistency: 'low' | 'medium' | 'high';
+  tags: string[];
+}
+
+export const ENHANCE_PRESETS: EnhancePreset[] = [
+  {
+    id: 'jazz',
+    label: 'Jazz',
+    icon: '\u{1F3B7}',
+    caption: 'jazz arrangement, upright bass, brushed drums, warm piano chords, swing feel',
+    consistency: 'medium',
+    tags: ['jazz', 'swing'],
+  },
+  {
+    id: 'lofi',
+    label: 'Lo-Fi',
+    icon: '\u{1F319}',
+    caption: 'lo-fi hip hop, vinyl crackle, mellow Rhodes piano, tape saturation, chill beats',
+    consistency: 'medium',
+    tags: ['lofi', 'chill'],
+  },
+  {
+    id: 'orchestral',
+    label: 'Orchestral',
+    icon: '\u{1F3BB}',
+    caption: 'orchestral arrangement, strings, woodwinds, cinematic, sweeping dynamics',
+    consistency: 'high',
+    tags: ['orchestral', 'cinematic'],
+  },
+  {
+    id: 'acoustic',
+    label: 'Acoustic',
+    icon: '\u{1F3B8}',
+    caption: 'acoustic guitar, fingerpicking, warm vocals, intimate, folk-inspired',
+    consistency: 'medium',
+    tags: ['acoustic', 'folk'],
+  },
+  {
+    id: 'electronic',
+    label: 'Electronic',
+    icon: '\u{1F3B9}',
+    caption: 'electronic synths, arpeggiator, side-chain compression, modern beat',
+    consistency: 'low',
+    tags: ['electronic', 'synth'],
+  },
+  {
+    id: 'cinematic',
+    label: 'Cinematic',
+    icon: '\u{1F3AC}',
+    caption: 'cinematic score, epic brass, tension building, dramatic percussion',
+    consistency: 'high',
+    tags: ['cinematic', 'epic'],
+  },
+  {
+    id: 'rnb',
+    label: 'R&B',
+    icon: '\u{1F3A4}',
+    caption: 'smooth R&B, neo-soul, warm harmonies, groovy bassline, silky vocals',
+    consistency: 'medium',
+    tags: ['rnb', 'soul'],
+  },
+  {
+    id: 'ambient',
+    label: 'Ambient',
+    icon: '\u{1F30A}',
+    caption: 'ambient soundscape, ethereal pads, reverb-drenched textures, atmospheric',
+    consistency: 'low',
+    tags: ['ambient', 'atmospheric'],
+  },
+  {
+    id: 'hiphop',
+    label: 'Hip-Hop',
+    icon: '\u{1F3A7}',
+    caption: 'hip-hop beat, heavy 808 bass, crisp snare, trap hi-hats, dark energy',
+    consistency: 'medium',
+    tags: ['hiphop', 'trap'],
+  },
+  {
+    id: 'reggae',
+    label: 'Reggae',
+    icon: '\u{1F3DD}\u{FE0F}',
+    caption: 'reggae rhythm, offbeat guitar, deep bass, one drop drum pattern, sunny',
+    consistency: 'medium',
+    tags: ['reggae', 'island'],
+  },
+  {
+    id: 'metal',
+    label: 'Metal',
+    icon: '\u{1F918}',
+    caption: 'heavy metal, distorted guitars, double kick drums, aggressive, powerful riffs',
+    consistency: 'medium',
+    tags: ['metal', 'rock'],
+  },
+  {
+    id: 'bossa',
+    label: 'Bossa Nova',
+    icon: '\u{2615}',
+    caption: 'bossa nova, nylon guitar, soft brush percussion, gentle swing, warm',
+    consistency: 'medium',
+    tags: ['bossa', 'latin'],
+  },
+];
+
+/**
+ * Pick a random preset, or combine two presets for a "Surprise Me" result.
+ * Consistency is always 'low' or 'medium' (never 'high') for surprises.
+ * Uses an optional random function for testability.
+ */
+export function surpriseMe(
+  presets: EnhancePreset[] = ENHANCE_PRESETS,
+  randomFn: () => number = Math.random,
+): { caption: string; consistency: 'low' | 'medium' } {
+  if (presets.length === 0) {
+    return { caption: '', consistency: 'medium' };
+  }
+
+  if (presets.length === 1) {
+    const consistency = randomFn() < 0.5 ? 'low' : 'medium';
+    return { caption: presets[0].caption, consistency };
+  }
+
+  const shouldCombine = randomFn() < 0.4;
+  const consistency: 'low' | 'medium' = randomFn() < 0.5 ? 'low' : 'medium';
+
+  if (shouldCombine && presets.length >= 2) {
+    const idxA = Math.floor(randomFn() * presets.length);
+    let idxB = Math.floor(randomFn() * (presets.length - 1));
+    if (idxB >= idxA) idxB += 1;
+    const a = presets[idxA];
+    const b = presets[idxB];
+    return {
+      caption: `${a.caption}, ${b.caption}`,
+      consistency,
+    };
+  }
+
+  const idx = Math.floor(randomFn() * presets.length);
+  return { caption: presets[idx].caption, consistency };
+}

--- a/tests/unit/enhancePresets.test.ts
+++ b/tests/unit/enhancePresets.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ENHANCE_PRESETS,
+  surpriseMe,
+  type EnhancePreset,
+} from '../../src/constants/enhancePresets';
+
+describe('ENHANCE_PRESETS data structure', () => {
+  it('has at least 10 presets', () => {
+    expect(ENHANCE_PRESETS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('every preset has unique id', () => {
+    const ids = ENHANCE_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every preset has required fields', () => {
+    for (const preset of ENHANCE_PRESETS) {
+      expect(preset.id).toBeTruthy();
+      expect(preset.label).toBeTruthy();
+      expect(preset.icon).toBeTruthy();
+      expect(preset.caption).toBeTruthy();
+      expect(['low', 'medium', 'high']).toContain(preset.consistency);
+      expect(preset.tags.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every preset caption is a non-empty string', () => {
+    for (const preset of ENHANCE_PRESETS) {
+      expect(typeof preset.caption).toBe('string');
+      expect(preset.caption.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('every preset has at least one tag', () => {
+    for (const preset of ENHANCE_PRESETS) {
+      expect(preset.tags.length).toBeGreaterThanOrEqual(1);
+      for (const tag of preset.tags) {
+        expect(typeof tag).toBe('string');
+        expect(tag.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('surpriseMe', () => {
+  it('returns a caption and consistency', () => {
+    const result = surpriseMe();
+    expect(typeof result.caption).toBe('string');
+    expect(result.caption.length).toBeGreaterThan(0);
+    expect(['low', 'medium']).toContain(result.consistency);
+  });
+
+  it('never returns high consistency', () => {
+    // Run many times with different random seeds
+    for (let i = 0; i < 50; i++) {
+      const result = surpriseMe(ENHANCE_PRESETS, () => i / 50);
+      expect(result.consistency).not.toBe('high');
+    }
+  });
+
+  it('returns a single preset caption when randomFn < 0.4 is false (no combine)', () => {
+    // randomFn returns 0.5 for shouldCombine check (> 0.4, no combine)
+    // then 0.5 for consistency (medium)
+    // then 0.0 for index (first preset)
+    let callIdx = 0;
+    const values = [0.5, 0.5, 0.0];
+    const result = surpriseMe(ENHANCE_PRESETS, () => values[callIdx++] ?? 0);
+    expect(result.caption).toBe(ENHANCE_PRESETS[0].caption);
+    expect(result.consistency).toBe('medium');
+  });
+
+  it('combines two preset captions when randomFn < 0.4 is true', () => {
+    // randomFn returns 0.1 for shouldCombine check (< 0.4, combine)
+    // then 0.5 for consistency (medium)
+    // then values for idxA and idxB
+    let callIdx = 0;
+    const n = ENHANCE_PRESETS.length;
+    const values = [0.1, 0.5, 0.0, 1 / (n - 1)];
+    const result = surpriseMe(ENHANCE_PRESETS, () => values[callIdx++] ?? 0);
+    expect(result.caption).toContain(ENHANCE_PRESETS[0].caption);
+    expect(result.caption).toContain(', ');
+  });
+
+  it('handles empty presets array', () => {
+    const result = surpriseMe([]);
+    expect(result.caption).toBe('');
+    expect(result.consistency).toBe('medium');
+  });
+
+  it('handles single preset array', () => {
+    const single: EnhancePreset[] = [ENHANCE_PRESETS[0]];
+    const result = surpriseMe(single, () => 0.3);
+    expect(result.caption).toBe(ENHANCE_PRESETS[0].caption);
+  });
+
+  it('returns low consistency when randomFn < 0.5 on consistency roll', () => {
+    // shouldCombine = 0.5 (no combine), consistency = 0.3 (< 0.5 => low), idx = 0
+    let callIdx = 0;
+    const values = [0.5, 0.3, 0.0];
+    const result = surpriseMe(ENHANCE_PRESETS, () => values[callIdx++] ?? 0);
+    expect(result.consistency).toBe('low');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 12 curated genre presets (Jazz, Lo-Fi, Orchestral, Acoustic, Electronic, Cinematic, R&B, Ambient, Hip-Hop, Reggae, Metal, Bossa Nova)
- Add collapsible "Quick Styles" preset grid above Styles textarea in Cover mode
- Add "Surprise Me" button that randomly selects or combines two presets
- Each preset auto-fills caption and sets suggested consistency level
- 17 new tests covering preset data validation and UI behavior

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 2270 tests pass (247 suites)
- [x] `npm run build` — succeeds
- [ ] Verify Quick Styles grid appears in Cover mode
- [ ] Verify Surprise Me fills random caption

Depends on #783. Closes #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)