### PR TITLE
feat: simplify right-click menu — single Enhance entry (#780)

### DIFF
--- a/src/components/timeline/AIToolsSubmenu.tsx
+++ b/src/components/timeline/AIToolsSubmenu.tsx
@@ -8,7 +8,6 @@ import {
 
 export interface ClipAIContext {
   onRegenerate?: () => void;
-  onEnhance?: () => void;
   onSeparateStems?: () => void;
   onGenerateAccompaniment?: () => void;
   onAnalyze?: () => void;
@@ -181,9 +180,6 @@ export function AIToolsSubmenu({
                       onClick={clipContext.onRegenerate}
                       disabled={!clipContext.hasPrompt}
                     />
-                  )}
-                  {clipContext.onEnhance && (
-                    <ContextMenuItem label="Enhance..." onClick={clipContext.onEnhance} color="#6ee7b7" />
                   )}
                   {clipContext.onSeparateStems && (
                     <ContextMenuItem label="Separate Stems..." onClick={clipContext.onSeparateStems} color="#7dd3fc" />

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -1209,20 +1209,21 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         const isVocalTrack = track.trackName === 'vocals' || track.trackName === 'backing_vocals';
         const hasWarpMarkers = !!(clip.warpMarkers && clip.warpMarkers.length > 0);
 
+        const handleEnhance = (!isMidiClip && isReady) ? () => {
+          closeCtxMenu();
+          let range: { start: number; end: number } | null = null;
+          if (selectWindow) {
+            const rs = Math.max(selectWindow.startTime, clip.startTime);
+            const re = Math.min(selectWindow.endTime, clip.startTime + clip.duration);
+            if (re > rs) range = { start: rs, end: re };
+          }
+          openEnhancer(clip.id, track.id, range);
+        } : undefined;
+
         const clipAIContext = (!isMidiClip && isReady) ? {
           onRegenerate: () => { closeCtxMenu(); regenerateClip(clip.id); },
           hasPrompt: !!clip.prompt,
           isReady,
-          onEnhance: () => {
-            closeCtxMenu();
-            let range: { start: number; end: number } | null = null;
-            if (selectWindow) {
-              const rs = Math.max(selectWindow.startTime, clip.startTime);
-              const re = Math.min(selectWindow.endTime, clip.startTime + clip.duration);
-              if (re > rs) range = { start: rs, end: re };
-            }
-            openEnhancer(clip.id, track.id, range);
-          },
           ...(hasAudio ? { onSeparateStems: () => { closeCtxMenu(); setStemSeparationModal(clip.id); } } : {}),
           ...(isVocalTrack ? { onGenerateAccompaniment: () => { closeCtxMenu(); setVocal2BGMModal(clip.id); } } : {}),
           onAnalyze: () => { closeCtxMenu(); setAnalysisPanel(clip.id); },
@@ -1243,6 +1244,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
             x={ctxMenu.x}
             y={ctxMenu.y}
             onClose={closeCtxMenu}
+            onEnhance={handleEnhance}
             onInspireMe={() => { closeCtxMenu(); useUIStore.getState().setShowGenerationPanel(true); }}
             onAddLayer={() => { closeCtxMenu(); useUIStore.getState().setAddLayerOpen(true); }}
             onMusicEnhancer={() => { closeCtxMenu(); openEnhancer(clip.id, track.id); }}

--- a/src/components/timeline/ClipContextMenu.tsx
+++ b/src/components/timeline/ClipContextMenu.tsx
@@ -7,6 +7,9 @@ interface ClipContextMenuProps {
   y: number;
   onClose: () => void;
 
+  /* Enhance (top-level) */
+  onEnhance?: () => void;
+
   /* AI Tools */
   onInspireMe: () => void;
   onAddLayer: () => void;
@@ -43,6 +46,7 @@ export function ClipContextMenu({
   x,
   y,
   onClose,
+  onEnhance,
   onInspireMe,
   onAddLayer,
   onMusicEnhancer,
@@ -69,6 +73,11 @@ export function ClipContextMenu({
 
   return (
     <ContextMenuWrapper x={x} y={y} onClose={onClose} minWidth={190}>
+      {/* Top-level Enhance entry */}
+      {onEnhance && (
+        <ContextMenuItem label="Enhance..." onClick={onEnhance} color="#6ee7b7" shortcut="⇧E" />
+      )}
+
       {/* AI Tools submenu */}
       <AIToolsSubmenu
         onInspireMe={onInspireMe}

--- a/src/components/timeline/SelectionFloatingToolbar.tsx
+++ b/src/components/timeline/SelectionFloatingToolbar.tsx
@@ -52,10 +52,10 @@ export function SelectionFloatingToolbar({ selLeft, selWidth, selBottom }: Selec
         transform: 'translateX(-50%)',
       }}
     >
-      {/* Music Enhancer */}
+      {/* Enhance */}
       <button
         type="button"
-        aria-label="Music Enhancer"
+        aria-label="Enhance"
         className="flex items-center justify-center w-8 h-8 rounded-full text-zinc-400 hover:text-white hover:bg-white/10 transition-colors"
         onClick={handleMusicEnhancer}
       >

--- a/src/components/timeline/__tests__/SelectionFloatingToolbar.test.tsx
+++ b/src/components/timeline/__tests__/SelectionFloatingToolbar.test.tsx
@@ -53,7 +53,7 @@ describe('SelectionFloatingToolbar', () => {
     render(
       <SelectionFloatingToolbar selLeft={200} selWidth={400} selBottom={100} />,
     );
-    expect(screen.getByRole('button', { name: /music enhancer/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /enhance/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /add layer/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /midi/i })).toBeInTheDocument();
   });

--- a/src/components/timeline/__tests__/simplifyEnhanceMenu.test.tsx
+++ b/src/components/timeline/__tests__/simplifyEnhanceMenu.test.tsx
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ClipContextMenu } from '../ClipContextMenu';
+import { AIToolsSubmenu, type ClipAIContext } from '../AIToolsSubmenu';
+import { SHORTCUT_ACTIONS } from '../../../constants/shortcutDefaults';
+import { buildCommandPaletteCommands, type CommandPaletteContext } from '../../../services/commandPalette';
+
+// ── shortcutDefaults ──────────────────────────────────────────
+describe('shortcutDefaults — clips.enhance', () => {
+  it('registers Shift+E for clips.enhance', () => {
+    const action = SHORTCUT_ACTIONS.find((a) => a.id === 'clips.enhance');
+    expect(action).toBeDefined();
+    expect(action!.defaultCombo).toEqual({ code: 'KeyE', shift: true });
+    expect(action!.category).toBe('clips');
+  });
+
+  it('does not conflict with clips.edit (plain E)', () => {
+    const editAction = SHORTCUT_ACTIONS.find((a) => a.id === 'clips.edit');
+    expect(editAction).toBeDefined();
+    expect(editAction!.defaultCombo.shift).toBeFalsy();
+  });
+});
+
+// ── ClipContextMenu ────────────────────────────────────────────
+describe('ClipContextMenu — top-level Enhance entry', () => {
+  const noop = () => {};
+
+  it('renders Enhance... entry when onEnhance is provided', () => {
+    render(
+      <ClipContextMenu
+        x={100}
+        y={100}
+        onClose={noop}
+        onEnhance={noop}
+        onInspireMe={noop}
+        onAddLayer={noop}
+        onMusicEnhancer={noop}
+        onEdit={noop}
+        onDuplicate={noop}
+        onSplitAtPlayhead={noop}
+        onConsolidate={noop}
+        onDelete={noop}
+        onSelectAll={noop}
+        onLoopSelection={noop}
+        onToggleMute={noop}
+        isMuted={false}
+        onAssignColor={noop}
+        onResetColor={noop}
+        hasCustomColor={false}
+        canConsolidate={false}
+        isMidiClip={false}
+      />,
+    );
+    expect(screen.getByText('Enhance...')).toBeDefined();
+  });
+
+  it('does not render Enhance... when onEnhance is undefined', () => {
+    render(
+      <ClipContextMenu
+        x={100}
+        y={100}
+        onClose={noop}
+        onInspireMe={noop}
+        onAddLayer={noop}
+        onMusicEnhancer={noop}
+        onEdit={noop}
+        onDuplicate={noop}
+        onSplitAtPlayhead={noop}
+        onConsolidate={noop}
+        onDelete={noop}
+        onSelectAll={noop}
+        onLoopSelection={noop}
+        onToggleMute={noop}
+        isMuted={false}
+        onAssignColor={noop}
+        onResetColor={noop}
+        hasCustomColor={false}
+        canConsolidate={false}
+        isMidiClip={false}
+      />,
+    );
+    expect(screen.queryByText('Enhance...')).toBeNull();
+  });
+});
+
+// ── AIToolsSubmenu ──────────────────────────────────────────────
+describe('AIToolsSubmenu — no longer contains Enhance', () => {
+  it('ClipAIContext interface does not include onEnhance', () => {
+    // Verify at the type level: a clipContext with no onEnhance should compile
+    const ctx: ClipAIContext = {
+      onRegenerate: () => {},
+      hasPrompt: true,
+      isReady: true,
+    };
+    expect(ctx).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((ctx as any).onEnhance).toBeUndefined();
+  });
+});
+
+// ── commandPalette ──────────────────────────────────────────────
+describe('commandPalette — Enhance Selected Clip command', () => {
+  function makeContext(overrides: Partial<CommandPaletteContext> = {}): CommandPaletteContext {
+    return {
+      project: {
+        id: 'p1',
+        name: 'Test',
+        bpm: 120,
+        timeSignature: { numerator: 4, denominator: 4 },
+        totalDuration: 60,
+        tracks: [
+          {
+            id: 't1',
+            displayName: 'Track 1',
+            trackName: 'vocals' as any,
+            trackType: 'stems' as any,
+            color: '#fff',
+            volume: 1,
+            pan: 0,
+            muted: false,
+            soloed: false,
+            order: 0,
+            clips: [
+              {
+                id: 'c1',
+                trackId: 't1',
+                startTime: 0,
+                duration: 10,
+                generationStatus: 'ready' as any,
+                prompt: 'test',
+              } as any,
+            ],
+            effects: [],
+          } as any,
+        ],
+        sampleRate: 44100,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      } as any,
+      selectedClipIds: ['c1'],
+      currentTime: 5,
+      isPlaying: false,
+      showMixer: false,
+      showLibrary: false,
+      showSmartControls: false,
+      showAIAssistant: false,
+      loopBrowserOpen: false,
+      showTempoLane: false,
+      loopEnabled: false,
+      metronomeEnabled: false,
+      expandedTrackId: null,
+      openPianoRollTrackId: null,
+      openSequencerTrackId: null,
+      openDrumMachineTrackId: null,
+      actions: {
+        play: vi.fn(),
+        pause: vi.fn(),
+        stop: vi.fn(),
+        toggleLoop: vi.fn(),
+        toggleMetronome: vi.fn(),
+        setShowNewProjectDialog: vi.fn(),
+        setShowProjectListDialog: vi.fn(),
+        openGenerationSettings: vi.fn(),
+        setShowExportDialog: vi.fn(),
+        setShowKeyboardShortcutsDialog: vi.fn(),
+        setShowLibrary: vi.fn(),
+        setShowMixer: vi.fn(),
+        setShowSmartControls: vi.fn(),
+        toggleLoopBrowser: vi.fn(),
+        toggleTempoLane: vi.fn(),
+        toggleAIAssistant: vi.fn(),
+        zoomTimelineToSelection: vi.fn(),
+        zoomTimelineToProject: vi.fn(),
+        setBatchGenerateMode: vi.fn(),
+        addTrack: vi.fn() as any,
+        addTrackEffect: vi.fn() as any,
+        updateProject: vi.fn(),
+        updateTrack: vi.fn(),
+        updateTrackMixer: vi.fn(),
+        updateTrackEffect: vi.fn(),
+        duplicateClip: vi.fn(),
+        splitClip: vi.fn(),
+        splitClipAtZeroCrossing: vi.fn() as any,
+        removeClip: vi.fn(),
+        setEditingClip: vi.fn(),
+        deselectAll: vi.fn(),
+        openEnhancer: vi.fn(),
+      },
+      ...overrides,
+    };
+  }
+
+  it('includes Enhance Selected Clip command when a ready clip is selected', () => {
+    const ctx = makeContext();
+    const commands = buildCommandPaletteCommands(ctx);
+    const enhanceCmd = commands.find((c) => c.id === 'clip:enhance-selected');
+    expect(enhanceCmd).toBeDefined();
+    expect(enhanceCmd!.title).toBe('Enhance Selected Clip');
+    expect(enhanceCmd!.shortcut).toEqual(['Shift', 'E']);
+  });
+
+  it('does not include enhance command when no clip is selected', () => {
+    const ctx = makeContext({ selectedClipIds: [] });
+    const commands = buildCommandPaletteCommands(ctx);
+    const enhanceCmd = commands.find((c) => c.id === 'clip:enhance-selected');
+    expect(enhanceCmd).toBeUndefined();
+  });
+
+  it('calls openEnhancer with clipId and trackId when executed', () => {
+    const ctx = makeContext();
+    const commands = buildCommandPaletteCommands(ctx);
+    const enhanceCmd = commands.find((c) => c.id === 'clip:enhance-selected');
+    enhanceCmd!.execute();
+    expect(ctx.actions.openEnhancer).toHaveBeenCalledWith('c1', 't1');
+  });
+});

--- a/src/constants/shortcutDefaults.ts
+++ b/src/constants/shortcutDefaults.ts
@@ -21,6 +21,7 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   { id: 'clips.edit',            category: 'clips',     label: 'Edit Selected Clip',          defaultCombo: { code: 'KeyE' }, contexts: ['timeline'] },
   { id: 'clips.generate',        category: 'clips',     label: 'Generate Selected Clip',      defaultCombo: { code: 'Enter', mod: true }, contexts: ['timeline'] },
   { id: 'clips.toggleMute',      category: 'clips',     label: 'Toggle Clip Mute',            defaultCombo: { code: 'Digit0' }, contexts: ['timeline'] },
+  { id: 'clips.enhance',         category: 'clips',     label: 'Enhance Selected Clip',       defaultCombo: { code: 'KeyE', shift: true }, contexts: ['timeline'] },
 
   { id: 'tracks.mute',           category: 'tracks',    label: 'Toggle Focused Track Mute',   defaultCombo: { code: 'KeyM' }, contexts: ['timeline', 'mixer', 'pianoRoll'] },
   { id: 'tracks.solo',           category: 'tracks',    label: 'Toggle Focused Track Solo',   defaultCombo: { code: 'KeyS', shift: true }, contexts: ['timeline', 'mixer', 'pianoRoll'] },

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -461,6 +461,32 @@ export function useKeyboardShortcuts() {
         }
       }
 
+      if (matches('clips.enhance')) {
+        const selected = [...ui.selectedClipIds];
+        if (selected.length === 1) {
+          event.preventDefault();
+          const clipId = selected[0];
+          const projectData = project.project;
+          if (projectData) {
+            const clipTrack = projectData.tracks.find((t) => t.clips.some((c) => c.id === clipId));
+            if (clipTrack) {
+              const clip = clipTrack.clips.find((c) => c.id === clipId);
+              if (clip && clip.generationStatus === 'ready') {
+                const sw = ui.selectWindow;
+                let range: { start: number; end: number } | null = null;
+                if (sw) {
+                  const rs = Math.max(sw.startTime, clip.startTime);
+                  const re = Math.min(sw.endTime, clip.startTime + clip.duration);
+                  if (re > rs) range = { start: rs, end: re };
+                }
+                ui.openEnhancer(clipId, clipTrack.id, range);
+              }
+            }
+          }
+        }
+        return;
+      }
+
       if (matches('clips.edit')) {
         const selected = [...ui.selectedClipIds];
         if (selected.length === 1) {

--- a/src/services/commandPalette.ts
+++ b/src/services/commandPalette.ts
@@ -81,6 +81,7 @@ export interface CommandPaletteContext {
     removeClip: (clipId: string) => void;
     setEditingClip: (clipId: string | null) => void;
     deselectAll: () => void;
+    openEnhancer: (clipId: string, trackId: string, range?: { start: number; end: number } | null) => void;
   };
 }
 
@@ -698,6 +699,26 @@ export function buildCommandPaletteCommands(context: CommandPaletteContext): Com
         'Selected clip action',
       ),
     );
+
+    // Find the clip and its track for enhance command
+    const selectedClip = context.project?.tracks
+      .flatMap((t) => t.clips.map((c) => ({ clip: c, trackId: t.id })))
+      .find((item) => item.clip.id === selectedClipId);
+    if (selectedClip && selectedClip.clip.generationStatus === 'ready') {
+      commands.push(
+        createTrackCommand(
+          'clip:enhance-selected',
+          'Enhance Selected Clip',
+          'Clips',
+          'action',
+          ['clip', 'enhance', 'selected', 'cover', 'repaint', 'ai'],
+          ['enhance clip', 'enhance selected', 'open enhancer'],
+          () => context.actions.openEnhancer(selectedClipId, selectedClip.trackId),
+          ['Shift', 'E'],
+          'Selected clip action',
+        ),
+      );
+    }
   }
 
   if (context.selectedClipIds.length > 0) {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1220,6 +1220,7 @@ function buildCommandPaletteContext(state: UIState) {
       removeClip: projectStore.removeClip,
       setEditingClip: state.setEditingClip,
       deselectAll: state.deselectAll,
+      openEnhancer: state.openEnhancer,
     },
   };
 }

--- a/tests/unit/clipContextMenuSplit.test.tsx
+++ b/tests/unit/clipContextMenuSplit.test.tsx
@@ -118,7 +118,6 @@ describe('ClipContextMenu AI Tools submenu', () => {
     renderMenu({
       clipAIContext: {
         onRegenerate: vi.fn(),
-        onEnhance: vi.fn(),
         onAnalyze: vi.fn(),
         hasPrompt: true,
         isReady: true,
@@ -128,7 +127,6 @@ describe('ClipContextMenu AI Tools submenu', () => {
     fireEvent.mouseEnter(trigger);
     act(() => { vi.advanceTimersByTime(100); });
     expect(screen.getByText('Regenerate')).toBeTruthy();
-    expect(screen.getByText('Enhance...')).toBeTruthy();
     expect(screen.getByText('Analyze Audio...')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Promote "Enhance..." to top-level clip context menu with sparkle color and `Shift+E` hint
- Remove "Enhance..." from AI Tools submenu (keep Regenerate, Stems, Analyze, etc.)
- Add `Shift+E` keyboard shortcut for enhancing selected clip
- Register "Enhance Selected Clip" in command palette
- Smart mode inference: if selectWindow overlaps clip → Repaint mode, otherwise Cover mode
- Rename "Music Enhancer" toolbar button to "Enhance"

## Changes (11 files)
- `ClipContextMenu.tsx` — top-level `onEnhance` prop
- `AIToolsSubmenu.tsx` — remove Enhance from submenu
- `ClipBlock.tsx` — extract enhance handler
- `SelectionFloatingToolbar.tsx` — rename button
- `useKeyboardShortcuts.ts` — add Shift+E handler
- `commandPalette.ts` — register command
- `shortcutDefaults.ts` — add shortcut definition
- `uiStore.ts` — wire openEnhancer to command palette
- 3 test files updated/added

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 2258 tests pass
- [x] `npm run build` — succeeds
- [ ] Verify "Enhance..." appears at top level in clip right-click menu
- [ ] Verify Shift+E opens Enhance panel for selected clip

Depends on #783. Closes #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)