### PR TITLE
feat: iterative enhancement workflow — chain results as sources (#779)

### DIFF
--- a/src/components/generation/EnhancePanel.tsx
+++ b/src/components/generation/EnhancePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useGenerationStore } from '../../store/generationStore';
 import { useUIStore, getBottomPanelHeight } from '../../store/uiStore';
@@ -13,6 +13,7 @@ import { useEnhancePlayback } from '../../hooks/useEnhancePlayback';
 import { computeWaveformPeaks } from '../../utils/waveformPeaks';
 import type { RepaintMode } from '../../types/api';
 import { ENHANCE_PRESETS, surpriseMe } from '../../constants/enhancePresets';
+import type { EnhancementNode } from '../../types/enhance';
 
 const ENHANCER_BASE_BOTTOM = 60;
 
@@ -52,6 +53,62 @@ interface ResultEntry {
 }
 
 type ABSide = 'A' | 'B';
+
+/** Recursive version tree node renderer */
+function VersionTreeNodes({
+  nodes,
+  getChildren,
+  activeNodeId,
+  onNodeClick,
+  depth,
+}: {
+  nodes: EnhancementNode[];
+  getChildren: (parentId: string) => EnhancementNode[];
+  activeNodeId: string | null;
+  onNodeClick: (node: EnhancementNode) => void;
+  depth: number;
+}) {
+  return (
+    <>
+      {nodes.map((node, idx) => {
+        const isActive = node.id === activeNodeId;
+        const children = getChildren(node.id);
+        const versionNum = idx + 1 + depth;
+        return (
+          <div key={node.id}>
+            <button
+              data-testid={`version-tree-node-${node.id}`}
+              onClick={() => onNodeClick(node)}
+              className={`w-full text-left py-1.5 rounded-md text-[10px] transition-colors truncate flex items-center gap-1.5 ${
+                isActive
+                  ? 'bg-[#2a2a2e] text-teal-300'
+                  : 'text-zinc-500 hover:bg-[#222226] hover:text-zinc-300'
+              }`}
+              style={{ paddingLeft: `${8 + depth * 10}px` }}
+            >
+              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                isActive ? 'bg-teal-400' : 'bg-zinc-600'
+              }`} />
+              <span className="truncate">
+                v{versionNum} ({node.label})
+                {isActive && ' \u2190'}
+              </span>
+            </button>
+            {children.length > 0 && (
+              <VersionTreeNodes
+                nodes={children}
+                getChildren={getChildren}
+                activeNodeId={activeNodeId}
+                onNodeClick={onNodeClick}
+                depth={depth + 1}
+              />
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}
 
 export function EnhancePanel() {
   const enhancerOpen = useUIStore((s) => s.enhancerOpen);
@@ -104,8 +161,19 @@ export function EnhancePanel() {
   // Playback
   const playback = useEnhancePlayback();
 
-  // Source audio key
-  const sourceAudioKey = clip?.isolatedAudioKey || clip?.cumulativeMixKey || '';
+  // Enhancement session (iterative chaining)
+  const enhancementSession = useUIStore((s) => s.enhancementSession);
+  const startEnhancementSession = useUIStore((s) => s.startEnhancementSession);
+  const addEnhancementNode = useUIStore((s) => s.addEnhancementNode);
+  const setActiveEnhancementNode = useUIStore((s) => s.setActiveEnhancementNode);
+  const rollbackToNode = useUIStore((s) => s.rollbackToNode);
+
+  // Track the overridden source audio key when using a result as new source
+  const [chainedSourceAudioKey, setChainedSourceAudioKey] = useState<string | null>(null);
+
+  // Source audio key — use chained source if iterating, otherwise clip audio
+  const clipAudioKey = clip?.isolatedAudioKey || clip?.cumulativeMixKey || '';
+  const sourceAudioKey = chainedSourceAudioKey || clipAudioKey;
 
   // Initialize form when enhancerTarget changes
   useEffect(() => {
@@ -143,6 +211,13 @@ export function EnhancePanel() {
       setAbSide('A');
       setSelectedResultId(null);
       setMiniPlayerIdx(0);
+      setChainedSourceAudioKey(null);
+
+      // Start an enhancement session for version tracking (only if no session exists for this clip)
+      const currentSession = useUIStore.getState().enhancementSession;
+      if (!currentSession || currentSession.clipId !== enhancerTarget.clipId) {
+        startEnhancementSession(enhancerTarget.clipId);
+      }
     }
   }, [enhancerTarget?.clipId]);
 
@@ -305,6 +380,52 @@ export function EnhancePanel() {
     }
   }, [abSide, results, selectedResultId, sourceAudioKey, playback]);
 
+  // Use result as new source for next enhancement round
+  const handleUseAsSource = useCallback((result: ResultEntry) => {
+    if (!result.audioKey || !enhancerTarget) return;
+
+    // Add an enhancement node to track this in the version tree
+    addEnhancementNode({
+      parentId: enhancementSession?.activeNodeId ?? null,
+      clipId: result.clipId,
+      audioKey: result.audioKey,
+      mode,
+      params: mode === 'cover'
+        ? { caption, lyrics, coverStrength: CONSISTENCY_VALUES[consistency] }
+        : { repaintRange: { start: selStart, end: selEnd }, repaintMode, repaintStrength },
+      label: result.title,
+    });
+
+    // Set this result's audio as the source for the next enhancement
+    setChainedSourceAudioKey(result.audioKey);
+
+    // Create a new session entry for the next round
+    handleNewSession();
+  }, [enhancerTarget, enhancementSession, addEnhancementNode, mode, caption, lyrics, consistency, selStart, selEnd, repaintMode, repaintStrength, handleNewSession]);
+
+  // Handle clicking a version tree node to load it as the current source
+  const handleVersionTreeClick = useCallback((node: EnhancementNode) => {
+    rollbackToNode(node.id);
+    setChainedSourceAudioKey(node.audioKey);
+  }, [rollbackToNode]);
+
+  // Handle clicking "Original" in the version tree — reset to original source
+  const handleVersionTreeOriginal = useCallback(() => {
+    setChainedSourceAudioKey(null);
+    setActiveEnhancementNode(null);
+  }, [setActiveEnhancementNode]);
+
+  // Build the version tree structure for rendering
+  const versionTreeRoots = useMemo(() => {
+    if (!enhancementSession) return [];
+    return enhancementSession.nodes.filter((n) => n.parentId === null);
+  }, [enhancementSession]);
+
+  const getNodeChildren = useCallback((parentId: string): EnhancementNode[] => {
+    if (!enhancementSession) return [];
+    return enhancementSession.nodes.filter((n) => n.parentId === parentId);
+  }, [enhancementSession]);
+
   // Mini player controls
   const miniResult = results[miniPlayerIdx] ?? null;
 
@@ -402,7 +523,7 @@ export function EnhancePanel() {
       className="fixed left-1/2 -translate-x-1/2 w-[820px] max-h-[60vh] bg-[#1e1e22] border border-[#3a3a3a] rounded-xl shadow-2xl flex text-xs text-zinc-200 overflow-hidden transition-[bottom] duration-200 ease-out"
       style={{ zIndex: Z.panel, bottom: `${dynamicBottom}px` }}
     >
-      {/* Left Sidebar — Session History */}
+      {/* Left Sidebar — Version Tree & Session History */}
       <div data-testid="enhance-history" className="w-[150px] min-w-[150px] border-r border-[#3a3a3a] flex flex-col bg-[#1a1a1e]">
         <div className="px-3 pt-3 pb-2">
           <button
@@ -414,6 +535,37 @@ export function EnhancePanel() {
             New Enhance
           </button>
         </div>
+
+        {/* Version Tree */}
+        {enhancementSession && enhancementSession.nodes.length > 0 && (
+          <div data-testid="version-tree" className="px-1.5 pb-2 border-b border-[#3a3a3a] mb-1">
+            <p className="text-[9px] text-zinc-600 uppercase tracking-wide px-2 mb-1">Versions</p>
+            {/* Original source */}
+            <button
+              data-testid="version-tree-original"
+              onClick={handleVersionTreeOriginal}
+              className={`w-full text-left px-2 py-1.5 rounded-md text-[10px] transition-colors truncate flex items-center gap-1.5 ${
+                enhancementSession.activeNodeId === null
+                  ? 'bg-[#2a2a2e] text-teal-300'
+                  : 'text-zinc-500 hover:bg-[#222226] hover:text-zinc-300'
+              }`}
+            >
+              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                enhancementSession.activeNodeId === null ? 'bg-teal-400' : 'bg-zinc-600'
+              }`} />
+              v0 (Original)
+            </button>
+            {/* Tree nodes */}
+            <VersionTreeNodes
+              nodes={versionTreeRoots}
+              getChildren={getNodeChildren}
+              activeNodeId={enhancementSession.activeNodeId}
+              onNodeClick={handleVersionTreeClick}
+              depth={0}
+            />
+          </div>
+        )}
+
         <div className="flex-1 overflow-y-auto px-1.5 pb-2 space-y-0.5">
           {sessions.map((s) => (
             <button
@@ -478,6 +630,9 @@ export function EnhancePanel() {
             <div className="flex items-center justify-between mb-1.5">
               <p className="text-[10px] text-zinc-500 uppercase tracking-wide">
                 Source
+                {chainedSourceAudioKey && (
+                  <span className="ml-1 text-teal-400 normal-case" data-testid="chained-source-indicator">(chained)</span>
+                )}
                 {canAB && (
                   <span className={`ml-1.5 ${abSide === 'A' ? 'text-teal-400 font-bold' : 'text-zinc-600'}`}>A</span>
                 )}
@@ -884,6 +1039,16 @@ export function EnhancePanel() {
                       </p>
                       <p className="text-[10px] text-zinc-600">{r.duration}</p>
                     </div>
+                    {r.audioKey && (
+                      <button
+                        data-testid={`use-as-source-btn-${idx}`}
+                        onClick={(e) => { e.stopPropagation(); handleUseAsSource(r); }}
+                        className="opacity-0 group-hover:opacity-100 px-1.5 py-0.5 rounded text-[9px] font-medium bg-teal-700/50 text-teal-300 hover:bg-teal-600/60 transition-all whitespace-nowrap"
+                        title="Use this result as source for next enhancement"
+                      >
+                        Use as Source
+                      </button>
+                    )}
                     <button
                       className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-zinc-300 transition-opacity"
                       aria-label="More options"

--- a/src/components/generation/__tests__/EnhancePanel.test.tsx
+++ b/src/components/generation/__tests__/EnhancePanel.test.tsx
@@ -401,4 +401,233 @@ describe('uiStore enhancer actions', () => {
     expect(state.enhancerOpen).toBe(true);
     expect(state.enhancerTarget).toBeNull();
   });
+
+  it('closeEnhancer also clears enhancementSession', () => {
+    const project = useProjectStore.getState().project!;
+    const track = project.tracks[0];
+    const clip = track.clips[0];
+    useUIStore.getState().openEnhancer(clip.id, track.id);
+    useUIStore.getState().startEnhancementSession(clip.id);
+    expect(useUIStore.getState().enhancementSession).not.toBeNull();
+    useUIStore.getState().closeEnhancer();
+    expect(useUIStore.getState().enhancementSession).toBeNull();
+  });
+});
+
+describe('uiStore enhancement session actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupProjectWithClip();
+  });
+
+  it('startEnhancementSession creates a new session', () => {
+    useUIStore.getState().startEnhancementSession('clip-1');
+    const session = useUIStore.getState().enhancementSession;
+    expect(session).not.toBeNull();
+    expect(session!.clipId).toBe('clip-1');
+    expect(session!.nodes).toEqual([]);
+    expect(session!.activeNodeId).toBeNull();
+  });
+
+  it('addEnhancementNode adds a node and sets it active', () => {
+    useUIStore.getState().startEnhancementSession('clip-1');
+    const nodeId = useUIStore.getState().addEnhancementNode({
+      parentId: null,
+      clipId: 'clip-1',
+      audioKey: 'audio-key-1',
+      mode: 'cover',
+      params: { caption: 'jazz cover' },
+      label: 'Enhancement 1',
+    });
+    const session = useUIStore.getState().enhancementSession!;
+    expect(session.nodes).toHaveLength(1);
+    expect(session.nodes[0].id).toBe(nodeId);
+    expect(session.nodes[0].parentId).toBeNull();
+    expect(session.nodes[0].audioKey).toBe('audio-key-1');
+    expect(session.nodes[0].label).toBe('Enhancement 1');
+    expect(session.activeNodeId).toBe(nodeId);
+  });
+
+  it('addEnhancementNode chains with parentId', () => {
+    useUIStore.getState().startEnhancementSession('clip-1');
+    const nodeId1 = useUIStore.getState().addEnhancementNode({
+      parentId: null,
+      clipId: 'clip-1',
+      audioKey: 'audio-1',
+      mode: 'cover',
+      params: { caption: 'jazz' },
+      label: 'v1',
+    });
+    const nodeId2 = useUIStore.getState().addEnhancementNode({
+      parentId: nodeId1,
+      clipId: 'clip-1',
+      audioKey: 'audio-2',
+      mode: 'cover',
+      params: { caption: 'add reverb' },
+      label: 'v2',
+    });
+    const session = useUIStore.getState().enhancementSession!;
+    expect(session.nodes).toHaveLength(2);
+    expect(session.nodes[1].parentId).toBe(nodeId1);
+    expect(session.activeNodeId).toBe(nodeId2);
+  });
+
+  it('setActiveEnhancementNode changes the active node', () => {
+    useUIStore.getState().startEnhancementSession('clip-1');
+    const nodeId1 = useUIStore.getState().addEnhancementNode({
+      parentId: null,
+      clipId: 'clip-1',
+      audioKey: 'audio-1',
+      mode: 'cover',
+      params: {},
+      label: 'v1',
+    });
+    useUIStore.getState().addEnhancementNode({
+      parentId: nodeId1,
+      clipId: 'clip-1',
+      audioKey: 'audio-2',
+      mode: 'cover',
+      params: {},
+      label: 'v2',
+    });
+    // Active should be v2
+    expect(useUIStore.getState().enhancementSession!.activeNodeId).not.toBe(nodeId1);
+    // Set back to v1
+    useUIStore.getState().setActiveEnhancementNode(nodeId1);
+    expect(useUIStore.getState().enhancementSession!.activeNodeId).toBe(nodeId1);
+  });
+
+  it('rollbackToNode sets the target node as active', () => {
+    useUIStore.getState().startEnhancementSession('clip-1');
+    const nodeId1 = useUIStore.getState().addEnhancementNode({
+      parentId: null,
+      clipId: 'clip-1',
+      audioKey: 'audio-1',
+      mode: 'cover',
+      params: {},
+      label: 'v1',
+    });
+    useUIStore.getState().addEnhancementNode({
+      parentId: nodeId1,
+      clipId: 'clip-1',
+      audioKey: 'audio-2',
+      mode: 'repaint',
+      params: { repaintRange: { start: 2, end: 5 } },
+      label: 'v2',
+    });
+    useUIStore.getState().rollbackToNode(nodeId1);
+    expect(useUIStore.getState().enhancementSession!.activeNodeId).toBe(nodeId1);
+  });
+
+  it('rollbackToNode does nothing if node not found', () => {
+    useUIStore.getState().startEnhancementSession('clip-1');
+    const nodeId1 = useUIStore.getState().addEnhancementNode({
+      parentId: null,
+      clipId: 'clip-1',
+      audioKey: 'audio-1',
+      mode: 'cover',
+      params: {},
+      label: 'v1',
+    });
+    useUIStore.getState().rollbackToNode('nonexistent');
+    expect(useUIStore.getState().enhancementSession!.activeNodeId).toBe(nodeId1);
+  });
+
+  it('clearEnhancementSession nullifies the session', () => {
+    useUIStore.getState().startEnhancementSession('clip-1');
+    useUIStore.getState().addEnhancementNode({
+      parentId: null,
+      clipId: 'clip-1',
+      audioKey: 'audio-1',
+      mode: 'cover',
+      params: {},
+      label: 'v1',
+    });
+    useUIStore.getState().clearEnhancementSession();
+    expect(useUIStore.getState().enhancementSession).toBeNull();
+  });
+
+  it('addEnhancementNode returns id even without session', () => {
+    // No session started
+    useUIStore.setState({ enhancementSession: null });
+    const id = useUIStore.getState().addEnhancementNode({
+      parentId: null,
+      clipId: 'clip-1',
+      audioKey: 'audio-1',
+      mode: 'cover',
+      params: {},
+      label: 'v1',
+    });
+    expect(typeof id).toBe('string');
+    // Session remains null
+    expect(useUIStore.getState().enhancementSession).toBeNull();
+  });
+});
+
+describe('EnhancePanel version tree UI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGenerationStore.setState({ isGenerating: false });
+  });
+
+  it('does not show version tree when no enhancement nodes exist', () => {
+    const { track, clip } = setupProjectWithClip();
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: { clipId: clip.id, trackId: track.id, range: null, mode: 'cover' },
+      enhancementSession: {
+        id: 'session-1',
+        clipId: clip.id,
+        nodes: [],
+        activeNodeId: null,
+      },
+    });
+    render(<EnhancePanel />);
+    expect(screen.queryByTestId('version-tree')).not.toBeInTheDocument();
+  });
+
+  it('shows version tree when enhancement nodes exist', () => {
+    const { track, clip } = setupProjectWithClip();
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: { clipId: clip.id, trackId: track.id, range: null, mode: 'cover' },
+      enhancementSession: {
+        id: 'session-1',
+        clipId: clip.id,
+        nodes: [
+          {
+            id: 'enh-1',
+            parentId: null,
+            clipId: clip.id,
+            audioKey: 'result-audio-1',
+            mode: 'cover' as const,
+            params: { caption: 'jazz' },
+            createdAt: 1000,
+            label: 'Jazz cover',
+          },
+        ],
+        activeNodeId: 'enh-1',
+      },
+    });
+    render(<EnhancePanel />);
+    expect(screen.getByTestId('version-tree')).toBeInTheDocument();
+    expect(screen.getByTestId('version-tree-original')).toBeInTheDocument();
+    expect(screen.getByText(/v0 \(Original\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Jazz cover/)).toBeInTheDocument();
+  });
+
+  it('shows chained source indicator when chainedSourceAudioKey is set', () => {
+    // This tests the UI indicator — we can't directly set React state,
+    // but we can verify the version tree renders. The chained indicator
+    // is driven by local React state which is set via handleUseAsSource.
+    const { track, clip } = setupProjectWithClip();
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: { clipId: clip.id, trackId: track.id, range: null, mode: 'cover' },
+      enhancementSession: null,
+    });
+    render(<EnhancePanel />);
+    // Without chaining, no indicator should appear
+    expect(screen.queryByTestId('chained-source-indicator')).not.toBeInTheDocument();
+  });
 });

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -11,6 +11,7 @@ import { buildAssistantContext } from '../utils/aiAssistantContext';
 import { getAssistantSuggestions, streamAssistantResponse } from '../services/aiAssistantService';
 import type { ShortcutContext } from '../types/shortcuts';
 import type { ThemeId } from '../themes/themeTokens';
+import type { EnhancementNode, EnhancementSession } from '../types/enhance';
 import { CHORD_SHAPES } from '../utils/chords';
 import {
   TRACK_LIST_COLLAPSED_WIDTH,
@@ -164,6 +165,9 @@ export interface UIState {
     range: { start: number; end: number } | null;
     mode: 'cover' | 'repaint';
   } | null;
+
+  // Iterative Enhancement Session (version tree / chaining)
+  enhancementSession: EnhancementSession | null;
 
   // Vocal2BGM / Audio Analysis
   vocal2bgmClipId: string | null;
@@ -326,6 +330,13 @@ export interface UIState {
   openEnhancer: (clipId: string, trackId: string, range?: { start: number; end: number } | null) => void;
   openEnhancerFromSelection: () => void;
   closeEnhancer: () => void;
+
+  // Iterative Enhancement Session
+  startEnhancementSession: (clipId: string) => void;
+  addEnhancementNode: (node: Omit<EnhancementNode, 'id' | 'createdAt'>) => string;
+  setActiveEnhancementNode: (nodeId: string | null) => void;
+  rollbackToNode: (nodeId: string) => void;
+  clearEnhancementSession: () => void;
 
   // Vocal2BGM / Audio Analysis
   setVocal2BGMModal: (clipId: string | null) => void;
@@ -538,6 +549,8 @@ export const useUIStore = create<UIState>()(
 
   enhancerOpen: false,
   enhancerTarget: null,
+
+  enhancementSession: null,
 
   vocal2bgmClipId: null,
   analysisClipId: null,
@@ -954,7 +967,55 @@ export const useUIStore = create<UIState>()(
     // No clip found in selection — open with guidance
     set({ enhancerOpen: true, enhancerTarget: null });
   },
-  closeEnhancer: () => set({ enhancerOpen: false, enhancerTarget: null }),
+  closeEnhancer: () => set({ enhancerOpen: false, enhancerTarget: null, enhancementSession: null }),
+
+  startEnhancementSession: (clipId) => {
+    const session: EnhancementSession = {
+      id: `enhance-session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      clipId,
+      nodes: [],
+      activeNodeId: null,
+    };
+    set({ enhancementSession: session });
+  },
+
+  addEnhancementNode: (nodeData) => {
+    const id = `enh-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const node: EnhancementNode = {
+      ...nodeData,
+      id,
+      createdAt: Date.now(),
+    };
+    const session = get().enhancementSession;
+    if (!session) return id;
+    set({
+      enhancementSession: {
+        ...session,
+        nodes: [...session.nodes, node],
+        activeNodeId: id,
+      },
+    });
+    return id;
+  },
+
+  setActiveEnhancementNode: (nodeId) => {
+    const session = get().enhancementSession;
+    if (!session) return;
+    if (nodeId !== null && !session.nodes.some((n) => n.id === nodeId)) return;
+    set({
+      enhancementSession: {
+        ...session,
+        activeNodeId: nodeId,
+      },
+    });
+  },
+
+  rollbackToNode: (nodeId) => {
+    // Alias for setActiveEnhancementNode — semantically loads an earlier version as active
+    get().setActiveEnhancementNode(nodeId);
+  },
+
+  clearEnhancementSession: () => set({ enhancementSession: null }),
 
   setVocal2BGMModal: (clipId) => set({ vocal2bgmClipId: clipId }),
   setAnalysisPanel: (clipId) => set({ analysisClipId: clipId }),

--- a/src/types/__tests__/enhance.test.ts
+++ b/src/types/__tests__/enhance.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import type { EnhancementNode, EnhancementSession } from '../enhance';
+
+describe('Enhancement types', () => {
+  it('EnhancementNode conforms to expected shape', () => {
+    const node: EnhancementNode = {
+      id: 'enh-1',
+      parentId: null,
+      clipId: 'clip-1',
+      audioKey: 'audio-key-1',
+      mode: 'cover',
+      params: {
+        caption: 'jazz cover',
+        lyrics: 'some lyrics',
+        coverStrength: 0.5,
+      },
+      createdAt: Date.now(),
+      label: 'Enhancement 1',
+    };
+    expect(node.id).toBe('enh-1');
+    expect(node.parentId).toBeNull();
+    expect(node.mode).toBe('cover');
+    expect(node.params.caption).toBe('jazz cover');
+  });
+
+  it('EnhancementNode supports repaint mode with range params', () => {
+    const node: EnhancementNode = {
+      id: 'enh-2',
+      parentId: 'enh-1',
+      clipId: 'clip-1',
+      audioKey: 'audio-key-2',
+      mode: 'repaint',
+      params: {
+        repaintRange: { start: 2, end: 5 },
+        repaintMode: 'balanced',
+        repaintStrength: 0.7,
+      },
+      createdAt: Date.now(),
+      label: 'Repaint bars 5-8',
+    };
+    expect(node.parentId).toBe('enh-1');
+    expect(node.mode).toBe('repaint');
+    expect(node.params.repaintRange).toEqual({ start: 2, end: 5 });
+  });
+
+  it('EnhancementSession has flat node list with tree via parentId', () => {
+    const nodes: EnhancementNode[] = [
+      {
+        id: 'enh-1',
+        parentId: null,
+        clipId: 'clip-1',
+        audioKey: 'audio-1',
+        mode: 'cover',
+        params: { caption: 'jazz' },
+        createdAt: 1000,
+        label: 'v1',
+      },
+      {
+        id: 'enh-2',
+        parentId: 'enh-1',
+        clipId: 'clip-1',
+        audioKey: 'audio-2',
+        mode: 'cover',
+        params: { caption: 'add reverb' },
+        createdAt: 2000,
+        label: 'v2',
+      },
+      {
+        id: 'enh-3',
+        parentId: 'enh-1',
+        clipId: 'clip-1',
+        audioKey: 'audio-3',
+        mode: 'repaint',
+        params: { repaintRange: { start: 5, end: 8 } },
+        createdAt: 3000,
+        label: 'v3',
+      },
+    ];
+
+    const session: EnhancementSession = {
+      id: 'session-1',
+      clipId: 'clip-1',
+      nodes,
+      activeNodeId: 'enh-2',
+    };
+
+    expect(session.nodes).toHaveLength(3);
+    expect(session.activeNodeId).toBe('enh-2');
+
+    // Tree structure: enh-1 is root, enh-2 and enh-3 are children of enh-1
+    const roots = session.nodes.filter((n) => n.parentId === null);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].id).toBe('enh-1');
+
+    const childrenOfRoot = session.nodes.filter((n) => n.parentId === 'enh-1');
+    expect(childrenOfRoot).toHaveLength(2);
+  });
+});

--- a/src/types/enhance.ts
+++ b/src/types/enhance.ts
@@ -1,0 +1,30 @@
+/**
+ * Types for the iterative enhancement workflow.
+ * Supports chaining enhancement results as new sources,
+ * building a version tree of enhancements.
+ */
+
+export interface EnhancementNode {
+  id: string;
+  parentId: string | null;    // null = original source
+  clipId: string;
+  audioKey: string;           // IndexedDB key for this version's audio
+  mode: 'cover' | 'repaint';
+  params: {
+    caption?: string;
+    lyrics?: string;
+    coverStrength?: number;
+    repaintRange?: { start: number; end: number };
+    repaintMode?: string;
+    repaintStrength?: number;
+  };
+  createdAt: number;
+  label: string;              // "Enhancement 1", user-editable
+}
+
+export interface EnhancementSession {
+  id: string;
+  clipId: string;             // original source clip
+  nodes: EnhancementNode[];   // flat list, tree via parentId
+  activeNodeId: string | null; // currently selected version
+}


### PR DESCRIPTION
## Summary
- Add `EnhancementNode` and `EnhancementSession` types for tracking version chains
- Add store actions: `startEnhancementSession`, `addEnhancementNode`, `setActiveEnhancementNode`, `rollbackToNode`
- Add "Use as Source" button on each result to chain enhancements iteratively
- Add version tree sidebar with visual tree rendering (indented nodes, active highlight)
- Click any previous version to rollback and use it as source
- Session is in-memory only, cleared when panel closes

## Changes
- `src/types/enhance.ts` (NEW) — type definitions
- `src/types/__tests__/enhance.test.ts` (NEW) — type validation tests
- `src/store/uiStore.ts` — enhancement session state + actions
- `src/components/generation/EnhancePanel.tsx` — UI for version tree + "Use as Source"
- `src/components/generation/__tests__/EnhancePanel.test.tsx` — comprehensive tests

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — all tests pass
- [x] `npm run build` — succeeds
- [ ] Verify "Use as Source" button appears on results
- [ ] Verify version tree shows enhancement chain

Depends on #783. Closes #779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)