### PR TITLE
perf: add CSS containment and compositing hints to timeline components

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -910,6 +910,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           left,
           width: Math.max(width, 4),
           boxShadow: clipPresentation.containerShadow,
+          contain: 'layout style paint',
           ...(isSelected ? { '--tw-ring-color': clipPresentation.selectionRingColor } as React.CSSProperties : {}),
         }}
         data-clip-block
@@ -1349,6 +1350,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
               borderLeft: `2px solid ${clipColor}`,
               boxShadow: `0 4px 20px ${hexToRgba(clipColor, 0.3)}, 0 0 0 1px ${clipPresentation.bodyBorderColor}`,
               transition: 'top 80ms ease-out',
+              willChange: 'transform',
             }}
           >
             <div

--- a/src/components/timeline/Playhead.tsx
+++ b/src/components/timeline/Playhead.tsx
@@ -34,9 +34,10 @@ export function Playhead() {
       {/* Transport line — full-height, visible during playback and at stop position */}
       {showTransportLine && (
         <div
-          className="absolute top-0 w-px z-20 pointer-events-none"
+          className="absolute top-0 left-0 w-px z-20 pointer-events-none"
           style={{
-            left: transportX,
+            transform: `translateX(${transportX}px)`,
+            willChange: 'transform',
             minHeight: '100vh',
             backgroundColor: '#ffffff',
             boxShadow: '0 0 3px rgba(0, 0, 0, 0.35), 0 0 8px rgba(0, 0, 0, 0.15)',

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -998,7 +998,7 @@ export function Timeline() {
             <GridOverlay />
             <Playhead />
 
-            <div ref={trackAreaRef} className="relative">
+            <div ref={trackAreaRef} className="relative" style={{ contain: 'style layout' }}>
 
               {/* Committed context window overlay — Apple Teal (#5AC8FA) */}
               {ctxLeft !== null && ctxWidth !== null && ctxVRange && (

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -344,6 +344,9 @@ export function TrackLane({ track }: TrackLaneProps) {
           height: rowHeight,
           opacity: track.muted ? 0.4 : 1,
           borderColor: ARRANGEMENT_ROW_SEPARATOR_COLOR,
+          contain: 'content',
+          contentVisibility: 'auto',
+          containIntrinsicSize: `auto ${rowHeight}px`,
         }}
         onContextMenu={handleContextMenu}
         onDoubleClick={handleDoubleClick}

--- a/src/components/timeline/__tests__/PlayheadBlink.test.tsx
+++ b/src/components/timeline/__tests__/PlayheadBlink.test.tsx
@@ -17,7 +17,7 @@ describe('Playhead blink animation', () => {
     const line = container.firstElementChild as HTMLElement;
     expect(line).not.toBeNull();
     expect(line.style.backgroundColor).toBe('rgb(255, 255, 255)');
-    expect(line.style.left).toBe('300px');
+    expect(line.style.transform).toBe('translateX(300px)');
     expect(line.style.minHeight).toBe('100vh');
   });
 
@@ -35,7 +35,7 @@ describe('Playhead blink animation', () => {
     const { container } = render(<Playhead />);
     const line = container.firstElementChild as HTMLElement;
     expect(line).not.toBeNull();
-    expect(line.style.left).toBe('500px');
+    expect(line.style.transform).toBe('translateX(500px)');
   });
 
   it('hides transport line when currentTime equals playStartTime', () => {


### PR DESCRIPTION
## Summary
- Add `contain: layout style paint` to ClipBlock container to scope layout/paint
- Add `contain: content`, `content-visibility: auto`, and `contain-intrinsic-size` to TrackLane for off-screen rendering optimization
- Switch Playhead from `left` to `transform: translateX()` with `will-change: transform` for GPU compositing
- Add `contain: style layout` to Timeline track area container
- Add `will-change: transform` to drag ghost overlay

## Test plan
- [x] All 257 test files pass (2358 tests)
- [x] TypeScript compiles with no errors
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)