### PR TITLE
perf: skip computeTotalDuration during drag operations

### DIFF
--- a/src/store/__tests__/dragPerformance.test.ts
+++ b/src/store/__tests__/dragPerformance.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('drag performance optimizations', () => {
+  let trackId: string;
+  let clipId: string;
+
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('vocals');
+    trackId = track.id;
+    useProjectStore.getState().addClip(trackId, {
+      startTime: 0,
+      duration: 10,
+      prompt: 'test clip',
+      lyrics: '',
+    });
+    clipId = useProjectStore.getState().project!.tracks[0].clips[0].id;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function getProject() {
+    return useProjectStore.getState().project!;
+  }
+
+  describe('updateClip during drag skips computeTotalDuration', () => {
+    it('does not change totalDuration during drag', () => {
+      const store = useProjectStore.getState();
+      const durationBefore = getProject().totalDuration;
+
+      store.beginDrag();
+      // Move clip far out — would normally change totalDuration
+      store.updateClip(clipId, { startTime: 1000 });
+      const durationDuring = getProject().totalDuration;
+
+      expect(durationDuring).toBe(durationBefore);
+
+      store.endDrag();
+      // After endDrag, totalDuration should be recomputed
+      const durationAfter = getProject().totalDuration;
+      expect(durationAfter).toBeGreaterThan(durationBefore);
+    });
+
+    it('does not update updatedAt during drag', () => {
+      let time = 1000;
+      vi.spyOn(Date, 'now').mockImplementation(() => time);
+
+      const store = useProjectStore.getState();
+      // Set a known baseline
+      useProjectStore.setState({ project: { ...getProject(), updatedAt: 1000 } });
+      const updatedAtBefore = getProject().updatedAt;
+
+      store.beginDrag();
+      time = 2000;
+      store.updateClip(clipId, { startTime: 500 });
+      const updatedAtDuring = getProject().updatedAt;
+      expect(updatedAtDuring).toBe(updatedAtBefore);
+
+      time = 3000;
+      store.endDrag();
+      const updatedAtAfter = getProject().updatedAt;
+      expect(updatedAtAfter).toBe(3000);
+      expect(updatedAtAfter).toBeGreaterThan(updatedAtBefore);
+    });
+  });
+
+  describe('batchMoveClips during drag skips computeTotalDuration', () => {
+    it('does not change totalDuration during drag', () => {
+      const store = useProjectStore.getState();
+      const durationBefore = getProject().totalDuration;
+
+      store.beginDrag();
+      store.batchMoveClips([clipId], 1000);
+      const durationDuring = getProject().totalDuration;
+
+      expect(durationDuring).toBe(durationBefore);
+
+      store.endDrag();
+      const durationAfter = getProject().totalDuration;
+      expect(durationAfter).toBeGreaterThan(durationBefore);
+    });
+
+    it('does not update updatedAt during drag', () => {
+      let time = 1000;
+      vi.spyOn(Date, 'now').mockImplementation(() => time);
+
+      const store = useProjectStore.getState();
+      useProjectStore.setState({ project: { ...getProject(), updatedAt: 1000 } });
+      const updatedAtBefore = getProject().updatedAt;
+
+      store.beginDrag();
+      time = 2000;
+      store.batchMoveClips([clipId], 500);
+      const updatedAtDuring = getProject().updatedAt;
+      expect(updatedAtDuring).toBe(updatedAtBefore);
+
+      time = 3000;
+      store.endDrag();
+      const updatedAtAfter = getProject().updatedAt;
+      expect(updatedAtAfter).toBe(3000);
+      expect(updatedAtAfter).toBeGreaterThan(updatedAtBefore);
+    });
+  });
+
+  describe('endDrag recomputes totalDuration', () => {
+    it('recomputes totalDuration and updatedAt after drag ends', () => {
+      let time = 1000;
+      vi.spyOn(Date, 'now').mockImplementation(() => time);
+
+      const store = useProjectStore.getState();
+      useProjectStore.setState({ project: { ...getProject(), updatedAt: 1000 } });
+      const durationBefore = getProject().totalDuration;
+
+      store.beginDrag();
+      time = 2000;
+      store.updateClip(clipId, { startTime: 2000 });
+      // During drag: stale values
+      expect(getProject().totalDuration).toBe(durationBefore);
+
+      time = 3000;
+      store.endDrag();
+      // After drag: fresh values
+      expect(getProject().totalDuration).toBeGreaterThan(durationBefore);
+      expect(getProject().updatedAt).toBe(3000);
+    });
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1836,6 +1836,21 @@ export const useProjectStore = create<ProjectState>()(
 
   endDrag: () => {
     _endDrag();
+    // Recompute totalDuration and updatedAt once after drag ends
+    const state = get();
+    if (state.project) {
+      set({
+        project: {
+          ...state.project,
+          updatedAt: Date.now(),
+          totalDuration: computeTotalDuration(
+            state.project.tracks, state.project.measures, state.project.bpm,
+            state.project.timeSignature, state.project.timeSignatureDenominator,
+            state.project.tempoMap, state.project.timeSignatureMap
+          ),
+        },
+      });
+    }
   },
 
   createProject: (params) => {
@@ -2986,14 +3001,12 @@ export const useProjectStore = create<ProjectState>()(
         c.id === clipId ? { ...c, ...updates } : c,
       ),
     }));
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.timeSignatureDenominator, state.project.tempoMap, state.project.timeSignatureMap),
-        tracks: newTracks,
-      },
-    });
+    const updated = { ...state.project, tracks: newTracks };
+    if (!_isDragging) {
+      updated.updatedAt = Date.now();
+      updated.totalDuration = computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.timeSignatureDenominator, state.project.tempoMap, state.project.timeSignatureMap);
+    }
+    set({ project: updated });
   },
 
   updateClipColor: (clipId, color) => {
@@ -3970,14 +3983,12 @@ export const useProjectStore = create<ProjectState>()(
           : c,
       ),
     }));
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.timeSignatureDenominator, state.project.tempoMap, state.project.timeSignatureMap),
-        tracks: newTracks,
-      },
-    });
+    const updated = { ...state.project, tracks: newTracks };
+    if (!_isDragging) {
+      updated.updatedAt = Date.now();
+      updated.totalDuration = computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.timeSignatureDenominator, state.project.tempoMap, state.project.timeSignatureMap);
+    }
+    set({ project: updated });
   },
 
   createSessionScene: (name) => {


### PR DESCRIPTION
## Summary
- Skip expensive `computeTotalDuration()` during drag operations in `updateClip` and `batchMoveClips` — reuse existing value instead of recalculating 60x/sec
- Skip `updatedAt: Date.now()` during drag to avoid creating new timestamps every frame
- Recompute `totalDuration` and `updatedAt` once in `endDrag` to ensure correctness after drag completes

## Test plan
- [x] New test file: `src/store/__tests__/dragPerformance.test.ts` (5 tests)
- [x] All 2363 tests pass
- [x] TypeScript compiles with 0 errors
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)