### PR TITLE
perf: memoize ClipBlock, optimize selectors, and RAF-throttle drag

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useState, useEffect } from 'react';
+import React, { useRef, useCallback, useState, useEffect, useMemo } from 'react';
 import type { Clip, Track } from '../../types/project';
 import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
@@ -92,9 +92,9 @@ function getClipPresentation(clipColor: string, isSelected: boolean): ClipPresen
   };
 }
 
-export function ClipBlock({ clip, track }: ClipBlockProps) {
+function ClipBlockInner({ clip, track }: ClipBlockProps) {
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
-  const selectedClipIds = useUIStore((s) => s.selectedClipIds);
+  const isClipSelected = useUIStore((s) => s.selectedClipIds.has(clip.id));
   const selectClip = useUIStore((s) => s.selectClip);
   const setEditingClip = useUIStore((s) => s.setEditingClip);
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
@@ -107,14 +107,15 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const setAudioToMidiModal = useUIStore((s) => s.setAudioToMidiModal);
 
   const generatingProgress = useGenerationStore((s) => {
-    const job = [...s.jobs].reverse().find(
-      (j) => j.clipId === clip.id && (j.status === 'generating' || j.status === 'queued' || j.status === 'processing'),
-    );
-    if (!job) return null;
-    if (job.progressPercent != null) {
-      return `${job.stage ?? job.progress} ${Math.round(job.progressPercent)}%`;
+    for (let i = s.jobs.length - 1; i >= 0; i--) {
+      const j = s.jobs[i];
+      if (j.clipId === clip.id && (j.status === 'generating' || j.status === 'queued' || j.status === 'processing')) {
+        return j.progressPercent != null
+          ? `${j.stage ?? j.progress} ${Math.round(j.progressPercent)}%`
+          : j.stage ?? j.progress;
+      }
     }
-    return job.stage ?? job.progress;
+    return null;
   });
   const updateClip = useProjectStore((s) => s.updateClip);
   const setClipFade = useProjectStore((s) => s.setClipFade);
@@ -225,7 +226,6 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
   const left = clip.startTime * pixelsPerSecond;
   const width = clip.duration * pixelsPerSecond;
-  const isClipSelected = selectedClipIds.has(clip.id);
   const isSelected = isClipSelected;
   const { fadeInDuration, fadeOutDuration } = getClipFadeBounds(clip);
   const fadeInWidth = Math.min(width, fadeInDuration * pixelsPerSecond);
@@ -233,7 +233,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const showFadeInHandle = fadeInDuration > 0;
   const showFadeOutHandle = fadeOutDuration > 0;
   const clipColor = clip.color ?? track.color;
-  const clipPresentation = getClipPresentation(clipColor, isSelected);
+  const clipPresentation = useMemo(() => getClipPresentation(clipColor, isSelected), [clipColor, isSelected]);
 
   const dragRef = useRef(false);
 
@@ -259,21 +259,6 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const endDrag = useProjectStore((s) => s.endDrag);
   const undo = useProjectStore((s) => s.undo);
   const clipBlockRef = useRef<HTMLDivElement>(null);
-
-  const findClosestLane = useCallback((clientY: number): { trackId: string; rect: DOMRect } | null => {
-    const lanes = document.querySelectorAll<HTMLElement>('[data-timeline-lane][data-track-id]');
-    let best: { trackId: string; rect: DOMRect; dist: number } | null = null;
-    for (const lane of lanes) {
-      const trackId = lane.dataset.trackId!;
-      const r = lane.getBoundingClientRect();
-      const centerY = r.top + r.height / 2;
-      const dist = Math.abs(clientY - centerY);
-      if (!best || dist < best.dist) {
-        best = { trackId, rect: r, dist };
-      }
-    }
-    return best ? { trackId: best.trackId, rect: best.rect } : null;
-  }, []);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     // Skip scissor tool on fade handles
@@ -371,7 +356,8 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     scissorRef.current = false;
     let isShiftCopy = e.shiftKey;
 
-    const isMultiSelected = selectedClipIds.size > 1 && selectedClipIds.has(clip.id);
+    const currentSelectedClipIds = useUIStore.getState().selectedClipIds;
+    const isMultiSelected = currentSelectedClipIds.size > 1 && currentSelectedClipIds.has(clip.id);
     let lastBatchOffset = 0;
 
     const clipW = clip.duration * pixelsPerSecond;
@@ -381,6 +367,28 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     const supportsScissor = clip.generationStatus === 'ready' || Boolean(clip.midiData);
     const canStartLongPressScissor = supportsScissor && isSecondaryPress && mode === 'move';
     let secondaryMoved = false;
+    let pendingGhost: DragGhostInfo | null = null;
+    let ghostRafId = 0;
+
+    // Cache lane rects at drag start to avoid repeated DOM queries during drag
+    const laneElements = document.querySelectorAll<HTMLElement>('[data-timeline-lane][data-track-id]');
+    const cachedLaneRects = new Map<string, DOMRect>();
+    laneElements.forEach(el => {
+      const trackId = el.getAttribute('data-track-id');
+      if (trackId) cachedLaneRects.set(trackId, el.getBoundingClientRect());
+    });
+    const findClosestLaneCached = (clientY: number): { trackId: string; rect: DOMRect } | null => {
+      let best: { trackId: string; rect: DOMRect; dist: number } | null = null;
+      for (const [tid, r] of cachedLaneRects) {
+        const centerY = r.top + r.height / 2;
+        const dist = Math.abs(clientY - centerY);
+        if (!best || dist < best.dist) {
+          best = { trackId: tid, rect: r, dist };
+        }
+      }
+      return best ? { trackId: best.trackId, rect: best.rect } : null;
+    };
+    const sourceLane = findClosestLaneCached(startY);
 
     // --- Long-press scissor detection (secondary press only) ---
     let longPressTimer: ReturnType<typeof setTimeout> | null = null;
@@ -439,7 +447,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
         document.body.style.cursor = isShiftCopy ? 'copy' : 'grabbing';
         if (isShiftCopy) {
           if (isMultiSelected && lastBatchOffset !== 0) {
-            batchMoveClips([...selectedClipIds], -lastBatchOffset);
+            batchMoveClips([...currentSelectedClipIds], -lastBatchOffset);
             lastBatchOffset = 0;
           } else {
             updateClip(clip.id, { startTime: origStart });
@@ -455,7 +463,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           if (isMultiSelected) {
             const delta = timeOffset - lastBatchOffset;
             if (delta !== 0) {
-              batchMoveClips([...selectedClipIds], delta);
+              batchMoveClips([...currentSelectedClipIds], delta);
               lastBatchOffset = timeOffset;
             }
           } else {
@@ -463,12 +471,12 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
           }
         }
 
-        const closest = findClosestLane(ev.clientY);
+        const closest = findClosestLaneCached(ev.clientY);
         if (closest) {
           const ghostLeftVp = ev.clientX - clickOffsetPx;
-          const sourceLane = findClosestLane(startY);
+          // sourceLane is pre-computed at drag start
           const isCrossingTrack = closest.trackId !== track.id;
-          setDragGhost({
+          pendingGhost = {
             x: ghostLeftVp,
             y: closest.rect.top + 4,
             width: clipW,
@@ -481,7 +489,13 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
               ? { top: sourceLane.rect.top, height: sourceLane.rect.height }
               : null,
             isShiftCopy,
-          });
+          };
+          if (!ghostRafId) {
+            ghostRafId = requestAnimationFrame(() => {
+              if (pendingGhost) setDragGhost(pendingGhost);
+              ghostRafId = 0;
+            });
+          }
         }
       } else if (mode === 'resize-left') {
         let newStart = ev.altKey ? origStart + deltaSec : snapToGrid(origStart + deltaSec, bpm, 1);
@@ -558,6 +572,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
       window.removeEventListener('keydown', onKeyDown);
+      cancelAnimationFrame(ghostRafId);
       if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
       // Cancel scissor mode
       if (scissorRef.current) {
@@ -571,7 +586,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       if (dragRef.current) {
         // Restore original state for multi-select batch moves
         if (isMultiSelected && lastBatchOffset !== 0) {
-          batchMoveClips([...selectedClipIds], -lastBatchOffset);
+          batchMoveClips([...currentSelectedClipIds], -lastBatchOffset);
         } else if (mode === 'move') {
           updateClip(clip.id, { startTime: origStart });
         } else if (mode === 'resize-left') {
@@ -603,6 +618,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
       window.removeEventListener('keydown', onKeyDown);
+      cancelAnimationFrame(ghostRafId);
       if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
 
       // Execute scissor split
@@ -652,7 +668,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
       }
 
       if (mode === 'move' && dragRef.current) {
-        const closest = findClosestLane(ev.clientY);
+        const closest = findClosestLaneCached(ev.clientY);
         const deltaSec = (ev.clientX - startX) / pixelsPerSecond;
         const isFineMove = ev.metaKey || ev.ctrlKey;
         const dropStart = Math.max(0, isFineMove
@@ -671,14 +687,14 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
 
         if (ev.shiftKey && closest && resolvedTargetId) {
           if (isMultiSelected && lastBatchOffset !== 0) {
-            batchMoveClips([...selectedClipIds], -lastBatchOffset);
+            batchMoveClips([...currentSelectedClipIds], -lastBatchOffset);
             lastBatchOffset = 0;
           } else {
             updateClip(clip.id, { startTime: origStart });
           }
           const timeOffset = dropStart - origStart;
           if (isMultiSelected) {
-            batchDuplicateClips([...selectedClipIds], timeOffset);
+            batchDuplicateClips([...currentSelectedClipIds], timeOffset);
           } else {
             duplicateClipToTrack(clip.id, resolvedTargetId, dropStart);
           }
@@ -691,7 +707,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
     window.addEventListener('keydown', onKeyDown);
-  }, [clip, pixelsPerSecond, project, updateClip, getDragMode, track.id, track.trackName, track.trackType, moveClipToTrack, duplicateClipToTrack, addTrack, batchDuplicateClips, batchMoveClips, selectedClipIds, findClosestLane, beginDrag, endDrag, undo, snapClipEdgeToZeroCrossing, sliceClipToRange, splitClipAtZeroCrossing, selectClip]);
+  }, [clip, pixelsPerSecond, project, updateClip, getDragMode, track.id, track.trackName, track.trackType, moveClipToTrack, duplicateClipToTrack, addTrack, batchDuplicateClips, batchMoveClips, beginDrag, endDrag, undo, snapClipEdgeToZeroCrossing, sliceClipToRange, splitClipAtZeroCrossing, selectClip]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -890,7 +906,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
   const audioDuration = clip.audioDuration ?? clip.duration;
   const audioOffset = clip.audioOffset ?? 0;
   const contentOffset = getClipContentOffset(clip);
-  const selectedActionClipIds = selectedClipIds.has(clip.id) ? [...selectedClipIds] : [clip.id];
+  const selectedActionClipIds = isClipSelected ? [...useUIStore.getState().selectedClipIds] : [clip.id];
   const selectedActionClips = selectedActionClipIds
     .map((clipId) => project?.tracks.flatMap((candidate) => candidate.clips).find((candidate) => candidate.id === clipId))
     .filter((candidate): candidate is Clip => Boolean(candidate));
@@ -1425,3 +1441,7 @@ export function ClipBlock({ clip, track }: ClipBlockProps) {
     </>
   );
 }
+
+export const ClipBlock = React.memo(ClipBlockInner, (prev, next) => {
+  return prev.clip === next.clip && prev.track === next.track;
+});


### PR DESCRIPTION
## Summary
- **React.memo**: Wrap ClipBlock — prevents all clips re-rendering on any state change
- **Boolean selector**: Replace `selectedClipIds` Set subscription with `selectedClipIds.has(clip.id)` — only re-render when THIS clip's selection changes
- **Imperative store access**: Use `getState()` in drag handlers for full selectedClipIds set
- **useMemo**: Memoize `getClipPresentation` computation
- **Generation selector**: Backward for-loop instead of `[...jobs].reverse().find()` (avoids array allocation)
- **RAF throttle**: `setDragGhost` fires at most once per animation frame during drag
- **Lane rect cache**: Snapshot all lane `getBoundingClientRect()` at drag start, reuse during drag instead of querying DOM 60x/sec
- **Hoist sourceLane**: Compute once at drag start instead of every mousemove

## Test plan
- [x] All 2358 tests pass (257 test files)
- [x] TypeScript compiles with 0 errors
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)