### PR TITLE
perf: cache track lane rects to eliminate Playhead DOM queries at 60fps

### DIFF
--- a/src/components/timeline/Playhead.tsx
+++ b/src/components/timeline/Playhead.tsx
@@ -52,23 +52,16 @@ export function Playhead() {
 
 /** Cursor line positioned over a single selected track row */
 function SelectedTrackCursor({ trackId, x, blink }: { trackId: string; x: number; blink?: boolean }) {
-  // Find the track lane element in the timeline (not the left panel header)
-  const laneEl = document.querySelector(`[data-timeline-lane][data-track-id="${trackId}"]`) as HTMLElement | null;
-  if (!laneEl) return null;
-
-  // laneEl.offsetTop is relative to its offsetParent (trackAreaRef).
-  // We need the total offset relative to the positioned ancestor that
-  // the Playhead is also positioned against (the outer `relative` div).
-  const parentEl = laneEl.offsetParent as HTMLElement | null;
-  const parentOffset = parentEl ? parentEl.offsetTop : 0;
+  const laneRect = useUIStore((s) => s.trackLaneRects.get(trackId));
+  if (!laneRect) return null;
 
   return (
     <div
       className="absolute w-px z-20 pointer-events-none"
       style={{
         left: x,
-        top: laneEl.offsetTop + parentOffset,
-        height: laneEl.offsetHeight,
+        top: laneRect.top,
+        height: laneRect.height,
         animation: blink ? 'playhead-blink-line 1.2s ease-in-out infinite' : undefined,
         backgroundColor: blink ? undefined : '#ffffff',
         boxShadow: '0 0 3px rgba(0, 0, 0, 0.35), 0 0 8px rgba(0, 0, 0, 0.15)',

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState, useRef } from 'react';
+import React, { useCallback, useLayoutEffect, useMemo, useState, useRef } from 'react';
 import type { Track } from '../../types/project';
 import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
@@ -81,6 +81,7 @@ function TrackLaneInner({ track }: TrackLaneProps) {
   const [dropGhost, setDropGhost] = useState<{ left: number; width: number; name: string } | null>(null);
   const dragCounterRef = useRef(0);
 
+  const laneRef = useRef<HTMLDivElement>(null);
   const resizeRef = useRef<{ startY: number; startRowHeight: number; startLaneHeight: number } | null>(null);
   const laneHeight = track.laneHeight ?? 80;
   const rowHeight = getArrangementRowHeight(track);
@@ -339,9 +340,32 @@ function TrackLaneInner({ track }: TrackLaneProps) {
     [automationLanesRaw, track.id],
   );
 
+  // Report lane geometry to uiStore so SelectedTrackCursor can read it
+  // without triggering per-frame DOM queries during playback.
+  useLayoutEffect(() => {
+    const el = laneRef.current;
+    if (!el) return;
+    const update = () => {
+      const parentEl = el.offsetParent as HTMLElement | null;
+      const parentOffset = parentEl ? parentEl.offsetTop : 0;
+      useUIStore.getState().setTrackLaneRect(track.id, {
+        top: el.offsetTop + parentOffset,
+        height: el.offsetHeight,
+      });
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      useUIStore.getState().removeTrackLaneRect(track.id);
+    };
+  }, [track.id]);
+
   return (
     <>
       <div
+        ref={laneRef}
         data-track-id={track.id}
         data-timeline-lane
         data-testid={`track-lane-${track.id}`}

--- a/src/components/timeline/__tests__/PlayheadBlink.test.tsx
+++ b/src/components/timeline/__tests__/PlayheadBlink.test.tsx
@@ -44,4 +44,38 @@ describe('Playhead blink animation', () => {
     const { container } = render(<Playhead />);
     expect(container.firstElementChild).toBeNull();
   });
+
+  it('renders anchor cursor using trackLaneRects cache instead of DOM queries', () => {
+    const rects = new Map([['track-a', { top: 50, height: 80 }]]);
+    useTransportStore.setState({ isPlaying: false, currentTime: 0, playStartTime: 2 });
+    useUIStore.setState({
+      pixelsPerSecond: 100,
+      timelineFocused: true,
+      selectedTrackIds: new Set(['track-a']),
+      trackLaneRects: rects,
+    });
+    const { container } = render(<Playhead />);
+    // First child is transport line, second is the anchor cursor
+    const children = Array.from(container.children);
+    const cursor = children.find(
+      (el) => (el as HTMLElement).style.top === '50px' && (el as HTMLElement).style.height === '80px',
+    ) as HTMLElement | undefined;
+    expect(cursor).toBeTruthy();
+    expect(cursor!.style.left).toBe('200px'); // playStartTime=2 * pps=100
+  });
+
+  it('does not render anchor cursor when trackLaneRects has no entry for the track', () => {
+    useTransportStore.setState({ isPlaying: false, currentTime: 0, playStartTime: 2 });
+    useUIStore.setState({
+      pixelsPerSecond: 100,
+      timelineFocused: true,
+      selectedTrackIds: new Set(['track-missing']),
+      trackLaneRects: new Map(),
+    });
+    const { container } = render(<Playhead />);
+    // Transport line is shown (currentTime=0 vs playStartTime=2), but no cursor for missing track
+    const children = Array.from(container.children);
+    // Should only have the transport line
+    expect(children.length).toBe(1);
+  });
 });

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -216,6 +216,9 @@ export interface UIState {
   inlineSuggestions: InlineSuggestion[];
   suggestionFrequency: 'off' | 'subtle' | 'active';
 
+  // Playhead DOM cache — avoids per-frame layout queries in SelectedTrackCursor
+  trackLaneRects: Map<string, { top: number; height: number }>;
+
   setMainView: (view: 'arrangement' | 'session') => void;
   toggleMainView: () => void;
   setPixelsPerSecond: (pps: number) => void;
@@ -397,6 +400,10 @@ export interface UIState {
   clearInlineSuggestions: () => void;
   setSuggestionFrequency: (v: 'off' | 'subtle' | 'active') => void;
   applyWorkspaceComplexity: (tier: 'simple' | 'standard' | 'advanced') => void;
+
+  // Playhead DOM cache
+  setTrackLaneRect: (trackId: string, rect: { top: number; height: number }) => void;
+  removeTrackLaneRect: (trackId: string) => void;
 }
 
 const MIN_VIRTUAL_KEYBOARD_OCTAVE = 1;
@@ -586,6 +593,8 @@ export const useUIStore = create<UIState>()(
   regionRegenerateTarget: null,
   inlineSuggestions: [],
   suggestionFrequency: 'subtle',
+
+  trackLaneRects: new Map(),
 
   setMainView: (mainView) => set({ mainView, arrangementView: mainView }),
   toggleMainView: () => set((s) => {
@@ -1160,6 +1169,21 @@ export const useUIStore = create<UIState>()(
   clearInlineSuggestions: () => set({ inlineSuggestions: [] }),
   setSuggestionFrequency: (v) => set({ suggestionFrequency: v }),
   applyWorkspaceComplexity: (tier) => set(getComplexityDefaults(tier)),
+
+  setTrackLaneRect: (trackId, rect) =>
+    set((s) => {
+      const prev = s.trackLaneRects.get(trackId);
+      if (prev && prev.top === rect.top && prev.height === rect.height) return s;
+      const next = new Map(s.trackLaneRects);
+      next.set(trackId, rect);
+      return { trackLaneRects: next };
+    }),
+  removeTrackLaneRect: (trackId) =>
+    set((s) => {
+      const next = new Map(s.trackLaneRects);
+      next.delete(trackId);
+      return { trackLaneRects: next };
+    }),
 }),
     {
       name: 'ace-step-daw-ui',

--- a/tests/unit/uiStore.test.ts
+++ b/tests/unit/uiStore.test.ts
@@ -229,4 +229,38 @@ describe('uiStore', () => {
       expect(entry?.searchText).toContain('volume');
     });
   });
+
+  describe('trackLaneRects cache', () => {
+    it('starts with an empty Map', () => {
+      expect(useUIStore.getState().trackLaneRects).toBeInstanceOf(Map);
+      expect(useUIStore.getState().trackLaneRects.size).toBe(0);
+    });
+
+    it('setTrackLaneRect adds an entry', () => {
+      useUIStore.getState().setTrackLaneRect('track-1', { top: 100, height: 80 });
+      const rect = useUIStore.getState().trackLaneRects.get('track-1');
+      expect(rect).toEqual({ top: 100, height: 80 });
+    });
+
+    it('setTrackLaneRect updates an existing entry', () => {
+      useUIStore.getState().setTrackLaneRect('track-1', { top: 100, height: 80 });
+      useUIStore.getState().setTrackLaneRect('track-1', { top: 120, height: 90 });
+      const rect = useUIStore.getState().trackLaneRects.get('track-1');
+      expect(rect).toEqual({ top: 120, height: 90 });
+    });
+
+    it('removeTrackLaneRect removes an entry', () => {
+      useUIStore.getState().setTrackLaneRect('track-1', { top: 100, height: 80 });
+      useUIStore.getState().removeTrackLaneRect('track-1');
+      expect(useUIStore.getState().trackLaneRects.has('track-1')).toBe(false);
+    });
+
+    it('does not affect other entries when setting or removing', () => {
+      useUIStore.getState().setTrackLaneRect('track-1', { top: 100, height: 80 });
+      useUIStore.getState().setTrackLaneRect('track-2', { top: 200, height: 60 });
+      useUIStore.getState().removeTrackLaneRect('track-1');
+      expect(useUIStore.getState().trackLaneRects.has('track-1')).toBe(false);
+      expect(useUIStore.getState().trackLaneRects.get('track-2')).toEqual({ top: 200, height: 60 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add `trackLaneRects` Map cache to uiStore with `setTrackLaneRect`/`removeTrackLaneRect` actions
- Replace `document.querySelector()` + `offsetTop`/`offsetHeight` DOM reads in `SelectedTrackCursor` with cached values from uiStore
- Populate cache from `TrackLane` via `useLayoutEffect` + `ResizeObserver`
- Includes no-op guard in setter to skip Map re-creation when values unchanged

Eliminates layout thrashing during playback (60fps DOM queries → 0).

## Test plan
- [x] 5 new tests in `uiStore.test.ts` for trackLaneRects cache
- [x] 2 new tests in `PlayheadBlink.test.tsx` for SelectedTrackCursor cache reads
- [x] All 2365 tests pass
- [x] TypeScript compiles with 0 errors
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)