### PR TITLE
feat: VST3 bridge protocol types (W1)

### DIFF
--- a/src/services/vst3bridge/VST3BridgeProtocol.ts
+++ b/src/services/vst3bridge/VST3BridgeProtocol.ts
@@ -1,0 +1,426 @@
+/**
+ * VST3 Bridge Protocol — WebSocket message types between browser and companion app.
+ *
+ * Defines every message in the protocol, data models for plugins/parameters/presets,
+ * binary audio frame helpers, and type guards for runtime validation.
+ */
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Default WebSocket port for the VST3 companion app. */
+export const VST3_BRIDGE_PORT = 9851;
+
+/** Protocol version string used in the handshake. */
+export const VST3_BRIDGE_VERSION = '1.0';
+
+/** Size in bytes of the binary audio frame header. */
+export const AUDIO_HEADER_SIZE = 16;
+
+// ─── Data Models ────────────────────────────────────────────────────────────
+
+/** Metadata for a scanned VST3 plugin. */
+export interface VST3PluginInfo {
+  /** Unique plugin identifier from the VST3 binary. */
+  uid: string;
+  /** Human-readable plugin name. */
+  name: string;
+  /** Plugin vendor / manufacturer. */
+  vendor: string;
+  /** Top-level category. */
+  category: 'instrument' | 'effect';
+  /** Finer-grained subcategory (e.g. "Reverb", "Synth"). */
+  subcategory: string;
+  /** Number of audio input channels. */
+  inputChannels: number;
+  /** Number of audio output channels. */
+  outputChannels: number;
+  /** Whether the plugin provides a custom GUI editor. */
+  hasEditor: boolean;
+  /** Whether the plugin supports multiple output busses. */
+  supportsMultiOutput: boolean;
+  /** Descriptions of available output busses. */
+  outputBusses: { name: string; channels: number }[];
+}
+
+/** Descriptor for a single automatable VST3 parameter. */
+export interface VST3ParamInfo {
+  /** Parameter ID as reported by the plugin. */
+  id: number;
+  /** Human-readable parameter name. */
+  name: string;
+  /** Minimum value. */
+  min: number;
+  /** Maximum value. */
+  max: number;
+  /** Default value. */
+  default: number;
+  /** Number of discrete steps (0 = continuous). */
+  stepCount: number;
+  /** Unit label (e.g. "dB", "Hz", "%"). */
+  unitName: string;
+}
+
+/** Descriptor for a factory preset. */
+export interface VST3PresetInfo {
+  /** Preset ID / index. */
+  id: number;
+  /** Human-readable preset name. */
+  name: string;
+}
+
+/** A single MIDI event sent to a plugin instance. */
+export interface VST3MidiEvent {
+  /** MIDI event type. */
+  type: 'noteOn' | 'noteOff' | 'cc' | 'pitchBend';
+  /** MIDI note number (noteOn / noteOff). */
+  note?: number;
+  /** Velocity value (noteOn / noteOff). */
+  velocity?: number;
+  /** Control-change number (cc). */
+  cc?: number;
+  /** Generic value (cc value or pitch-bend amount). */
+  value?: number;
+  /** Sample offset within the current processing block. */
+  sampleOffset: number;
+}
+
+// ─── Browser → Companion Messages ───────────────────────────────────────────
+
+/** Handshake initiation from browser. */
+export interface HelloMessage {
+  type: 'hello';
+  version: string;
+  sampleRate: number;
+  blockSize: number;
+}
+
+/** Request a full plugin scan. */
+export interface ScanPluginsMessage {
+  type: 'scan_plugins';
+}
+
+/** Request to instantiate a plugin. */
+export interface InstantiateMessage {
+  type: 'instantiate';
+  reqId: string;
+  pluginUid: string;
+  instanceId: string;
+}
+
+/** Set a parameter value on a plugin instance. */
+export interface SetParamMessage {
+  type: 'set_param';
+  instanceId: string;
+  paramId: number;
+  value: number;
+}
+
+/** Send MIDI events to a plugin instance. */
+export interface MidiMessage {
+  type: 'midi';
+  instanceId: string;
+  events: VST3MidiEvent[];
+}
+
+/** Request opening the plugin's native GUI editor. */
+export interface OpenEditorMessage {
+  type: 'open_editor';
+  instanceId: string;
+}
+
+/** Request closing the plugin's native GUI editor. */
+export interface CloseEditorMessage {
+  type: 'close_editor';
+  instanceId: string;
+}
+
+/** Request the full serialized state of a plugin instance. */
+export interface GetStateMessage {
+  type: 'get_state';
+  instanceId: string;
+}
+
+/** Restore serialized state to a plugin instance. */
+export interface SetStateMessage {
+  type: 'set_state';
+  instanceId: string;
+  /** Base64-encoded plugin state blob. */
+  data: string;
+}
+
+/** Load a factory preset by ID. */
+export interface LoadPresetMessage {
+  type: 'load_preset';
+  instanceId: string;
+  presetId: number;
+}
+
+/** Destroy a plugin instance and free resources. */
+export interface DestroyMessage {
+  type: 'destroy';
+  instanceId: string;
+}
+
+/** Enable or disable audio processing on a plugin instance. */
+export interface SetProcessingMessage {
+  type: 'set_processing';
+  instanceId: string;
+  active: boolean;
+}
+
+/** Query the current processing latency of a plugin instance. */
+export interface GetLatencyMessage {
+  type: 'get_latency';
+  instanceId: string;
+}
+
+/** Configure sidechain routing for a plugin instance. */
+export interface RouteSidechainMessage {
+  type: 'route_sidechain';
+  instanceId: string;
+  sidechainInputBus: number;
+  sourceInstanceId: string;
+}
+
+// ─── Companion → Browser Messages ───────────────────────────────────────────
+
+/** Handshake acknowledgement from companion. */
+export interface HelloAckMessage {
+  type: 'hello_ack';
+  version: string;
+  capabilities: string[];
+}
+
+/** Progress update during plugin scanning. */
+export interface ScanProgressMessage {
+  type: 'scan_progress';
+  found: number;
+  current: string;
+}
+
+/** Scan complete with full plugin list. */
+export interface ScanCompleteMessage {
+  type: 'scan_complete';
+  plugins: VST3PluginInfo[];
+}
+
+/** Plugin instance created successfully. */
+export interface InstantiatedMessage {
+  type: 'instantiated';
+  reqId: string;
+  instanceId: string;
+  parameters: VST3ParamInfo[];
+  latencySamples: number;
+  tailSamples: number;
+  presets: VST3PresetInfo[];
+}
+
+/** A parameter value was changed (e.g. from the plugin GUI). */
+export interface ParamChangedMessage {
+  type: 'param_changed';
+  instanceId: string;
+  paramId: number;
+  value: number;
+}
+
+/** Plugin editor window opened. */
+export interface EditorOpenedMessage {
+  type: 'editor_opened';
+  instanceId: string;
+  width: number;
+  height: number;
+}
+
+/** Plugin editor window closed. */
+export interface EditorClosedMessage {
+  type: 'editor_closed';
+  instanceId: string;
+}
+
+/** Serialized plugin state (base64). */
+export interface StateDataMessage {
+  type: 'state_data';
+  instanceId: string;
+  /** Base64-encoded plugin state blob. */
+  data: string;
+}
+
+/** Latency information for a plugin instance. */
+export interface LatencyInfoMessage {
+  type: 'latency_info';
+  instanceId: string;
+  samples: number;
+}
+
+/** Error response from the companion. */
+export interface ErrorMessage {
+  type: 'error';
+  reqId?: string;
+  instanceId?: string;
+  code: string;
+  message: string;
+}
+
+// ─── Union Type ─────────────────────────────────────────────────────────────
+
+/** Union of all possible VST3 Bridge protocol messages. */
+export type VST3BridgeMessage =
+  | HelloMessage
+  | HelloAckMessage
+  | ScanPluginsMessage
+  | ScanProgressMessage
+  | ScanCompleteMessage
+  | InstantiateMessage
+  | InstantiatedMessage
+  | SetParamMessage
+  | ParamChangedMessage
+  | MidiMessage
+  | OpenEditorMessage
+  | EditorOpenedMessage
+  | CloseEditorMessage
+  | EditorClosedMessage
+  | GetStateMessage
+  | StateDataMessage
+  | SetStateMessage
+  | LoadPresetMessage
+  | DestroyMessage
+  | SetProcessingMessage
+  | GetLatencyMessage
+  | LatencyInfoMessage
+  | RouteSidechainMessage
+  | ErrorMessage;
+
+// ─── Valid Message Types ────────────────────────────────────────────────────
+
+/** Set of all valid message type strings for runtime validation. */
+const VALID_MESSAGE_TYPES = new Set<string>([
+  'hello',
+  'hello_ack',
+  'scan_plugins',
+  'scan_progress',
+  'scan_complete',
+  'instantiate',
+  'instantiated',
+  'set_param',
+  'param_changed',
+  'midi',
+  'open_editor',
+  'editor_opened',
+  'close_editor',
+  'editor_closed',
+  'get_state',
+  'state_data',
+  'set_state',
+  'load_preset',
+  'destroy',
+  'set_processing',
+  'get_latency',
+  'latency_info',
+  'route_sidechain',
+  'error',
+]);
+
+// ─── Type Guard ─────────────────────────────────────────────────────────────
+
+/**
+ * Runtime type guard that checks whether an unknown value is a valid VST3BridgeMessage.
+ * Validates that the value is a non-null object with a recognised `type` field.
+ */
+export function isVST3BridgeMessage(msg: unknown): msg is VST3BridgeMessage {
+  if (msg === null || msg === undefined || typeof msg !== 'object') {
+    return false;
+  }
+  const obj = msg as Record<string, unknown>;
+  return typeof obj.type === 'string' && VALID_MESSAGE_TYPES.has(obj.type);
+}
+
+// ─── FNV-1a Hash ────────────────────────────────────────────────────────────
+
+/**
+ * Compute a 32-bit FNV-1a hash of a string.
+ * Used to convert instance UUID strings into compact uint32 identifiers
+ * for the binary audio frame header.
+ */
+export function fnv1aHash(str: string): number {
+  let hash = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    // FNV prime multiply — use Math.imul for correct 32-bit multiply
+    hash = Math.imul(hash, 0x01000193);
+  }
+  // Return as unsigned 32-bit integer
+  return hash >>> 0;
+}
+
+// ─── Binary Audio Frame Helpers ─────────────────────────────────────────────
+
+/**
+ * Encode audio samples into a binary frame with a 16-byte header.
+ *
+ * Header layout (16 bytes, little-endian):
+ *   [0..3]   uint32  instanceIdHash  (FNV-1a of the instance UUID)
+ *   [4..7]   uint32  sequenceNumber
+ *   [8..11]  uint32  numChannels
+ *   [12..15] uint32  numSamples (per channel)
+ *
+ * Body: float32[] interleaved audio (channel-first: all samples of ch0, then ch1, ...).
+ *
+ * @param instanceIdHash - FNV-1a hash of the instance UUID.
+ * @param seq - Monotonically increasing sequence number.
+ * @param channels - Number of audio channels.
+ * @param samples - Array of Float32Arrays, one per channel.
+ * @returns An ArrayBuffer containing the complete frame.
+ */
+export function encodeAudioFrame(
+  instanceIdHash: number,
+  seq: number,
+  channels: number,
+  samples: Float32Array[],
+): ArrayBuffer {
+  const numSamples = samples.length > 0 ? samples[0].length : 0;
+  const bodyBytes = channels * numSamples * 4; // float32 = 4 bytes
+  const buffer = new ArrayBuffer(AUDIO_HEADER_SIZE + bodyBytes);
+  const view = new DataView(buffer);
+
+  // Write header (little-endian)
+  view.setUint32(0, instanceIdHash, true);
+  view.setUint32(4, seq, true);
+  view.setUint32(8, channels, true);
+  view.setUint32(12, numSamples, true);
+
+  // Write interleaved body (channel-first layout)
+  const body = new Float32Array(buffer, AUDIO_HEADER_SIZE);
+  for (let ch = 0; ch < channels; ch++) {
+    body.set(samples[ch], ch * numSamples);
+  }
+
+  return buffer;
+}
+
+/**
+ * Decode a binary audio frame into its header fields and per-channel sample arrays.
+ *
+ * @param buffer - The raw ArrayBuffer received over WebSocket.
+ * @returns Parsed header fields and an array of Float32Arrays (one per channel).
+ */
+export function decodeAudioFrame(buffer: ArrayBuffer): {
+  instanceIdHash: number;
+  seq: number;
+  channels: number;
+  samples: Float32Array[];
+} {
+  const view = new DataView(buffer);
+
+  const instanceIdHash = view.getUint32(0, true);
+  const seq = view.getUint32(4, true);
+  const channels = view.getUint32(8, true);
+  const numSamples = view.getUint32(12, true);
+
+  const body = new Float32Array(buffer, AUDIO_HEADER_SIZE);
+  const samplesOut: Float32Array[] = [];
+  for (let ch = 0; ch < channels; ch++) {
+    samplesOut.push(body.slice(ch * numSamples, (ch + 1) * numSamples));
+  }
+
+  return { instanceIdHash, seq, channels, samples: samplesOut };
+}

--- a/src/services/vst3bridge/__tests__/VST3BridgeProtocol.test.ts
+++ b/src/services/vst3bridge/__tests__/VST3BridgeProtocol.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for VST3 Bridge Protocol types, type guards, and helpers.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  fnv1aHash,
+  encodeAudioFrame,
+  decodeAudioFrame,
+  isVST3BridgeMessage,
+  VST3_BRIDGE_PORT,
+  VST3_BRIDGE_VERSION,
+  AUDIO_HEADER_SIZE,
+  type VST3BridgeMessage,
+  type HelloMessage,
+  type HelloAckMessage,
+  type ScanPluginsMessage,
+  type ScanProgressMessage,
+  type ScanCompleteMessage,
+  type InstantiateMessage,
+  type InstantiatedMessage,
+  type SetParamMessage,
+  type ParamChangedMessage,
+  type MidiMessage,
+  type OpenEditorMessage,
+  type EditorOpenedMessage,
+  type CloseEditorMessage,
+  type EditorClosedMessage,
+  type GetStateMessage,
+  type StateDataMessage,
+  type SetStateMessage,
+  type LoadPresetMessage,
+  type DestroyMessage,
+  type SetProcessingMessage,
+  type GetLatencyMessage,
+  type LatencyInfoMessage,
+  type RouteSidechainMessage,
+  type ErrorMessage,
+  type VST3PluginInfo,
+  type VST3ParamInfo,
+  type VST3PresetInfo,
+  type VST3MidiEvent,
+} from '../VST3BridgeProtocol';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+describe('VST3 Bridge Protocol constants', () => {
+  it('exports expected port', () => {
+    expect(VST3_BRIDGE_PORT).toBe(9851);
+  });
+
+  it('exports expected version', () => {
+    expect(VST3_BRIDGE_VERSION).toBe('1.0');
+  });
+
+  it('exports expected audio header size', () => {
+    expect(AUDIO_HEADER_SIZE).toBe(16);
+  });
+});
+
+// ─── fnv1aHash ──────────────────────────────────────────────────────────────
+
+describe('fnv1aHash', () => {
+  it('produces consistent results for the same input', () => {
+    const hash1 = fnv1aHash('test-instance-id');
+    const hash2 = fnv1aHash('test-instance-id');
+    expect(hash1).toBe(hash2);
+  });
+
+  it('produces different results for different inputs', () => {
+    const hash1 = fnv1aHash('instance-a');
+    const hash2 = fnv1aHash('instance-b');
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('returns a 32-bit unsigned integer', () => {
+    const hash = fnv1aHash('some-string');
+    expect(hash).toBeGreaterThanOrEqual(0);
+    expect(hash).toBeLessThanOrEqual(0xffffffff);
+    expect(Number.isInteger(hash)).toBe(true);
+  });
+
+  it('handles empty string', () => {
+    const hash = fnv1aHash('');
+    expect(Number.isInteger(hash)).toBe(true);
+    expect(hash).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ─── Audio Frame Encoding / Decoding ────────────────────────────────────────
+
+describe('encodeAudioFrame / decodeAudioFrame', () => {
+  it('round-trips a mono frame', () => {
+    const samples = [new Float32Array([0.1, 0.2, 0.3, 0.4])];
+    const buffer = encodeAudioFrame(42, 1, 1, samples);
+    const result = decodeAudioFrame(buffer);
+
+    expect(result.instanceIdHash).toBe(42);
+    expect(result.seq).toBe(1);
+    expect(result.channels).toBe(1);
+    expect(result.samples).toHaveLength(1);
+    expect(result.samples[0].length).toBe(4);
+    expect(result.samples[0][0]).toBeCloseTo(0.1, 5);
+    expect(result.samples[0][3]).toBeCloseTo(0.4, 5);
+  });
+
+  it('round-trips a stereo frame', () => {
+    const left = new Float32Array([1.0, -1.0, 0.5, -0.5]);
+    const right = new Float32Array([0.0, 0.25, -0.25, 0.75]);
+    const buffer = encodeAudioFrame(100, 7, 2, [left, right]);
+    const result = decodeAudioFrame(buffer);
+
+    expect(result.instanceIdHash).toBe(100);
+    expect(result.seq).toBe(7);
+    expect(result.channels).toBe(2);
+    expect(result.samples).toHaveLength(2);
+    expect(result.samples[0][0]).toBeCloseTo(1.0, 5);
+    expect(result.samples[0][1]).toBeCloseTo(-1.0, 5);
+    expect(result.samples[1][0]).toBeCloseTo(0.0, 5);
+    expect(result.samples[1][3]).toBeCloseTo(0.75, 5);
+  });
+
+  it('produces a buffer of expected size', () => {
+    const samples = [new Float32Array(128), new Float32Array(128)];
+    const buffer = encodeAudioFrame(1, 0, 2, samples);
+    // 16 byte header + 2 channels * 128 samples * 4 bytes
+    expect(buffer.byteLength).toBe(16 + 2 * 128 * 4);
+  });
+});
+
+// ─── Type Guards ────────────────────────────────────────────────────────────
+
+describe('isVST3BridgeMessage', () => {
+  it('returns true for a valid hello message', () => {
+    const msg: HelloMessage = {
+      type: 'hello',
+      version: '1.0',
+      sampleRate: 44100,
+      blockSize: 512,
+    };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for a valid hello_ack message', () => {
+    const msg: HelloAckMessage = {
+      type: 'hello_ack',
+      version: '1.0',
+      capabilities: ['scan', 'process'],
+    };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for a valid scan_plugins message', () => {
+    const msg: ScanPluginsMessage = { type: 'scan_plugins' };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for a valid scan_progress message', () => {
+    const msg: ScanProgressMessage = {
+      type: 'scan_progress',
+      found: 5,
+      current: 'Serum.vst3',
+    };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for a valid instantiate message', () => {
+    const msg: InstantiateMessage = {
+      type: 'instantiate',
+      reqId: 'req-1',
+      pluginUid: 'uid-abc',
+      instanceId: 'inst-1',
+    };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for a valid error message', () => {
+    const msg: ErrorMessage = {
+      type: 'error',
+      code: 'PLUGIN_NOT_FOUND',
+      message: 'Plugin not found',
+    };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for a valid midi message', () => {
+    const msg: MidiMessage = {
+      type: 'midi',
+      instanceId: 'inst-1',
+      events: [{ type: 'noteOn', note: 60, velocity: 100, sampleOffset: 0 }],
+    };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for set_param message', () => {
+    const msg: SetParamMessage = {
+      type: 'set_param',
+      instanceId: 'inst-1',
+      paramId: 0,
+      value: 0.5,
+    };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for destroy message', () => {
+    const msg: DestroyMessage = { type: 'destroy', instanceId: 'inst-1' };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for set_processing message', () => {
+    const msg: SetProcessingMessage = {
+      type: 'set_processing',
+      instanceId: 'inst-1',
+      active: true,
+    };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns true for route_sidechain message', () => {
+    const msg: RouteSidechainMessage = {
+      type: 'route_sidechain',
+      instanceId: 'inst-1',
+      sidechainInputBus: 1,
+      sourceInstanceId: 'inst-2',
+    };
+    expect(isVST3BridgeMessage(msg)).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isVST3BridgeMessage(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isVST3BridgeMessage(undefined)).toBe(false);
+  });
+
+  it('returns false for a string', () => {
+    expect(isVST3BridgeMessage('hello')).toBe(false);
+  });
+
+  it('returns false for an object without type', () => {
+    expect(isVST3BridgeMessage({ version: '1.0' })).toBe(false);
+  });
+
+  it('returns false for an object with unknown type', () => {
+    expect(isVST3BridgeMessage({ type: 'unknown_message' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Define all TypeScript types for the VST3 bridge WebSocket protocol
- Control messages (JSON): scanning, instantiation, params, MIDI, GUI, presets, lifecycle
- Binary audio frame encoding/decoding with FNV-1a instance ID hashing
- Type guards and constants

## Test plan
- [x] Unit tests for fnv1aHash consistency
- [x] Unit tests for encodeAudioFrame/decodeAudioFrame round-trip
- [x] Unit tests for type guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #822