### PR TITLE
feat: SPSC ring buffer for VST3 audio (W3)

### DIFF
--- a/src/services/vst3bridge/__tests__/ringBuffer.test.ts
+++ b/src/services/vst3bridge/__tests__/ringBuffer.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import { RingBuffer } from '../ringBuffer';
+
+describe('RingBuffer', () => {
+  it('initial state: availableRead=0, availableWrite=capacity', () => {
+    const rb = RingBuffer.create(1024, 2);
+    expect(rb.availableRead).toBe(0);
+    expect(rb.availableWrite).toBe(1024);
+    expect(rb.capacity).toBe(1024);
+    expect(rb.channelCount).toBe(2);
+  });
+
+  it('write N frames, verify availableRead=N, availableWrite=capacity-N', () => {
+    const rb = RingBuffer.create(1024, 1);
+    const data = new Float32Array(100);
+    for (let i = 0; i < 100; i++) data[i] = i * 0.01;
+
+    const written = rb.write(data, 100);
+    expect(written).toBe(100);
+    expect(rb.availableRead).toBe(100);
+    expect(rb.availableWrite).toBe(1024 - 100);
+  });
+
+  it('write then read N frames, data matches', () => {
+    const rb = RingBuffer.create(1024, 1);
+    const input = new Float32Array(64);
+    for (let i = 0; i < 64; i++) input[i] = i * 0.1;
+
+    rb.write(input, 64);
+
+    const output = new Float32Array(64);
+    const read = rb.read(output, 64);
+    expect(read).toBe(64);
+    expect(output).toEqual(input);
+    expect(rb.availableRead).toBe(0);
+    expect(rb.availableWrite).toBe(1024);
+  });
+
+  it('multi-channel stereo write/read round-trip', () => {
+    const rb = RingBuffer.create(512, 2);
+    const frames = 128;
+    // Interleaved: L0 R0 L1 R1 ...
+    const input = new Float32Array(frames * 2);
+    for (let i = 0; i < frames; i++) {
+      input[i * 2] = i * 0.01;       // left
+      input[i * 2 + 1] = -i * 0.01;  // right
+    }
+
+    const written = rb.write(input, frames);
+    expect(written).toBe(frames);
+    expect(rb.availableRead).toBe(frames);
+
+    const output = new Float32Array(frames * 2);
+    const read = rb.read(output, frames);
+    expect(read).toBe(frames);
+    expect(output).toEqual(input);
+  });
+
+  it('buffer overflow: write more than capacity, only capacity frames stored', () => {
+    const rb = RingBuffer.create(64, 1);
+    const cap = rb.capacity; // 64
+    const input = new Float32Array(cap + 32);
+    for (let i = 0; i < input.length; i++) input[i] = i;
+
+    const written = rb.write(input, cap + 32);
+    // Should only write up to capacity
+    expect(written).toBe(cap);
+    expect(rb.availableRead).toBe(cap);
+    expect(rb.availableWrite).toBe(0);
+  });
+
+  it('buffer underflow: read from empty buffer returns 0', () => {
+    const rb = RingBuffer.create(256, 1);
+    const output = new Float32Array(64);
+    const read = rb.read(output, 64);
+    expect(read).toBe(0);
+  });
+
+  it('wrap-around: fill buffer, read half, write more, verify data integrity', () => {
+    const rb = RingBuffer.create(8, 1);
+    const cap = rb.capacity; // 8
+
+    // Fill completely
+    const fill = new Float32Array(cap);
+    for (let i = 0; i < cap; i++) fill[i] = i + 1;
+    rb.write(fill, cap);
+    expect(rb.availableRead).toBe(cap);
+
+    // Read half
+    const half = new Float32Array(4);
+    rb.read(half, 4);
+    expect(half[0]).toBe(1);
+    expect(half[3]).toBe(4);
+    expect(rb.availableRead).toBe(4);
+    expect(rb.availableWrite).toBe(4);
+
+    // Write 4 more (wraps around)
+    const more = new Float32Array([100, 200, 300, 400]);
+    const written = rb.write(more, 4);
+    expect(written).toBe(4);
+    expect(rb.availableRead).toBe(cap);
+
+    // Read all 8 and verify order
+    const all = new Float32Array(cap);
+    rb.read(all, cap);
+    // Should be: 5,6,7,8 (remaining original) then 100,200,300,400 (newly written)
+    expect(all[0]).toBe(5);
+    expect(all[1]).toBe(6);
+    expect(all[2]).toBe(7);
+    expect(all[3]).toBe(8);
+    expect(all[4]).toBe(100);
+    expect(all[5]).toBe(200);
+    expect(all[6]).toBe(300);
+    expect(all[7]).toBe(400);
+  });
+
+  it('writeDeinterleaved/readDeinterleaved round-trip', () => {
+    const rb = RingBuffer.create(256, 2);
+    const frames = 64;
+    const left = new Float32Array(frames);
+    const right = new Float32Array(frames);
+    for (let i = 0; i < frames; i++) {
+      left[i] = i * 0.01;
+      right[i] = -i * 0.01;
+    }
+
+    const written = rb.writeDeinterleaved([left, right], frames);
+    expect(written).toBe(frames);
+
+    const outLeft = new Float32Array(frames);
+    const outRight = new Float32Array(frames);
+    const read = rb.readDeinterleaved([outLeft, outRight], frames);
+    expect(read).toBe(frames);
+
+    for (let i = 0; i < frames; i++) {
+      expect(outLeft[i]).toBeCloseTo(left[i], 6);
+      expect(outRight[i]).toBeCloseTo(right[i], 6);
+    }
+  });
+
+  it('reset: write data, reset, verify empty', () => {
+    const rb = RingBuffer.create(256, 1);
+    const data = new Float32Array(100);
+    rb.write(data, 100);
+    expect(rb.availableRead).toBe(100);
+
+    rb.reset();
+    expect(rb.availableRead).toBe(0);
+    expect(rb.availableWrite).toBe(256);
+  });
+
+  it('power-of-2 rounding: create with non-power-of-2, verify rounded up', () => {
+    const rb = RingBuffer.create(100, 1);
+    expect(rb.capacity).toBe(128); // next power of 2 above 100
+
+    const rb2 = RingBuffer.create(7, 2);
+    expect(rb2.capacity).toBe(8);
+
+    const rb3 = RingBuffer.create(1, 1);
+    expect(rb3.capacity).toBe(1);
+
+    const rb4 = RingBuffer.create(256, 1);
+    expect(rb4.capacity).toBe(256); // already power of 2
+  });
+
+  it('wrap: reconstruct from SharedArrayBuffer', () => {
+    const rb1 = RingBuffer.create(512, 2);
+    const frames = 64;
+    const input = new Float32Array(frames * 2);
+    for (let i = 0; i < input.length; i++) input[i] = i * 0.001;
+
+    rb1.write(input, frames);
+
+    // Wrap the same SAB (simulating AudioWorklet receiving it)
+    const rb2 = RingBuffer.wrap(rb1.sharedBuffer, 2);
+    expect(rb2.availableRead).toBe(frames);
+    expect(rb2.capacity).toBe(512);
+    expect(rb2.channelCount).toBe(2);
+
+    const output = new Float32Array(frames * 2);
+    const read = rb2.read(output, frames);
+    expect(read).toBe(frames);
+    expect(output).toEqual(input);
+  });
+
+  it('partial read: read fewer frames than available', () => {
+    const rb = RingBuffer.create(256, 1);
+    const input = new Float32Array(100);
+    for (let i = 0; i < 100; i++) input[i] = i;
+    rb.write(input, 100);
+
+    const out = new Float32Array(30);
+    const read = rb.read(out, 30);
+    expect(read).toBe(30);
+    for (let i = 0; i < 30; i++) expect(out[i]).toBe(i);
+    expect(rb.availableRead).toBe(70);
+  });
+
+  it('partial write: write when partially full', () => {
+    const rb = RingBuffer.create(8, 1);
+    const cap = rb.capacity;
+
+    // Fill 6 of 8
+    const data = new Float32Array(6).fill(1);
+    rb.write(data, 6);
+    expect(rb.availableWrite).toBe(cap - 6);
+
+    // Try to write 4 more, only 2 should fit
+    const more = new Float32Array([10, 20, 30, 40]);
+    const written = rb.write(more, 4);
+    expect(written).toBe(2);
+    expect(rb.availableRead).toBe(cap);
+  });
+});

--- a/src/services/vst3bridge/ringBuffer.ts
+++ b/src/services/vst3bridge/ringBuffer.ts
@@ -1,0 +1,203 @@
+/**
+ * Lock-free Single-Producer Single-Consumer (SPSC) ring buffer for real-time
+ * audio streaming between the main thread and AudioWorklet.
+ *
+ * SharedArrayBuffer layout:
+ *   [0..3]  Int32 — write head (atomic, monotonically increasing)
+ *   [4..7]  Int32 — read head (atomic, monotonically increasing)
+ *   [8..]   Float32 — interleaved audio data ring
+ *
+ * Audio is stored interleaved: ch0_s0, ch1_s0, ch0_s1, ch1_s1, ...
+ *
+ * Heads are NOT masked on store — they grow monotonically. Masking is applied
+ * only when indexing into the data array. This lets us distinguish "full"
+ * (wr - rd === capacity) from "empty" (wr === rd) without wasting a slot.
+ */
+
+/** Index of the write-head Int32 in the header. */
+const WRITE_HEAD_INDEX = 0;
+/** Index of the read-head Int32 in the header. */
+const READ_HEAD_INDEX = 1;
+/** Byte size of the header (2 x Int32). */
+const HEADER_BYTES = 8;
+
+/**
+ * Round up to the next power of 2. Returns n if already a power of 2.
+ */
+function nextPowerOf2(n: number): number {
+  if (n <= 1) return 1;
+  return 1 << (32 - Math.clz32(n - 1));
+}
+
+export class RingBuffer {
+  /** Atomic read/write head views (indices 0 = writeHead, 1 = readHead). */
+  private readonly _heads: Int32Array;
+  /** Float32 view over the audio data portion of the SAB. */
+  private readonly _data: Float32Array;
+  /** The underlying SharedArrayBuffer. */
+  private readonly _sab: SharedArrayBuffer;
+  /** Capacity in frames (always a power of 2). */
+  private readonly _capacity: number;
+  /** Number of audio channels. */
+  private readonly _channels: number;
+  /** Bitmask for efficient modulo: capacity - 1. */
+  private readonly _mask: number;
+
+  private constructor(sab: SharedArrayBuffer, capacity: number, channels: number) {
+    this._sab = sab;
+    this._capacity = capacity;
+    this._channels = channels;
+    this._mask = capacity - 1;
+    this._heads = new Int32Array(sab, 0, 2);
+    this._data = new Float32Array(sab, HEADER_BYTES);
+  }
+
+  /**
+   * Create a new ring buffer with the given capacity in frames (per channel).
+   * Capacity is rounded up to the next power of 2.
+   */
+  static create(capacityFrames: number, channels: number): RingBuffer {
+    const capacity = nextPowerOf2(capacityFrames);
+    const byteLength = HEADER_BYTES + capacity * channels * Float32Array.BYTES_PER_ELEMENT;
+    const sab = new SharedArrayBuffer(byteLength);
+    return new RingBuffer(sab, capacity, channels);
+  }
+
+  /**
+   * Wrap an existing SharedArrayBuffer (for use in AudioWorklet).
+   * The SAB must have been created by `RingBuffer.create`.
+   */
+  static wrap(sab: SharedArrayBuffer, channels: number): RingBuffer {
+    const dataBytes = sab.byteLength - HEADER_BYTES;
+    const totalSamples = dataBytes / Float32Array.BYTES_PER_ELEMENT;
+    const capacity = totalSamples / channels;
+    return new RingBuffer(sab, capacity, channels);
+  }
+
+  /** The underlying SharedArrayBuffer (pass to AudioWorklet via port.postMessage). */
+  get sharedBuffer(): SharedArrayBuffer {
+    return this._sab;
+  }
+
+  /** Total capacity in frames. */
+  get capacity(): number {
+    return this._capacity;
+  }
+
+  /** Number of channels. */
+  get channelCount(): number {
+    return this._channels;
+  }
+
+  /** Number of frames available to read. */
+  get availableRead(): number {
+    const wr = Atomics.load(this._heads, WRITE_HEAD_INDEX);
+    const rd = Atomics.load(this._heads, READ_HEAD_INDEX);
+    return wr - rd;
+  }
+
+  /** Number of frames available to write. */
+  get availableWrite(): number {
+    return this._capacity - this.availableRead;
+  }
+
+  /**
+   * Write interleaved audio frames.
+   * @returns Number of frames actually written (may be less than requested if buffer is full).
+   */
+  write(data: Float32Array, frames: number): number {
+    const toWrite = Math.min(frames, this.availableWrite);
+    if (toWrite === 0) return 0;
+
+    const wr = Atomics.load(this._heads, WRITE_HEAD_INDEX);
+    const ch = this._channels;
+    const mask = this._mask;
+
+    for (let i = 0; i < toWrite; i++) {
+      const ringIdx = ((wr + i) & mask) * ch;
+      const srcIdx = i * ch;
+      for (let c = 0; c < ch; c++) {
+        this._data[ringIdx + c] = data[srcIdx + c];
+      }
+    }
+
+    Atomics.store(this._heads, WRITE_HEAD_INDEX, wr + toWrite);
+    return toWrite;
+  }
+
+  /**
+   * Read interleaved audio frames into buffer.
+   * @returns Number of frames actually read (may be less than requested if buffer is empty).
+   */
+  read(output: Float32Array, frames: number): number {
+    const toRead = Math.min(frames, this.availableRead);
+    if (toRead === 0) return 0;
+
+    const rd = Atomics.load(this._heads, READ_HEAD_INDEX);
+    const ch = this._channels;
+    const mask = this._mask;
+
+    for (let i = 0; i < toRead; i++) {
+      const ringIdx = ((rd + i) & mask) * ch;
+      const dstIdx = i * ch;
+      for (let c = 0; c < ch; c++) {
+        output[dstIdx + c] = this._data[ringIdx + c];
+      }
+    }
+
+    Atomics.store(this._heads, READ_HEAD_INDEX, rd + toRead);
+    return toRead;
+  }
+
+  /**
+   * Write from separate per-channel arrays (deinterleaved).
+   * @returns Number of frames actually written.
+   */
+  writeDeinterleaved(channels: Float32Array[], frames: number): number {
+    const toWrite = Math.min(frames, this.availableWrite);
+    if (toWrite === 0) return 0;
+
+    const wr = Atomics.load(this._heads, WRITE_HEAD_INDEX);
+    const ch = this._channels;
+    const mask = this._mask;
+
+    for (let i = 0; i < toWrite; i++) {
+      const ringIdx = ((wr + i) & mask) * ch;
+      for (let c = 0; c < ch; c++) {
+        this._data[ringIdx + c] = channels[c][i];
+      }
+    }
+
+    Atomics.store(this._heads, WRITE_HEAD_INDEX, wr + toWrite);
+    return toWrite;
+  }
+
+  /**
+   * Read into separate per-channel arrays (deinterleaved).
+   * @returns Number of frames actually read.
+   */
+  readDeinterleaved(channels: Float32Array[], frames: number): number {
+    const toRead = Math.min(frames, this.availableRead);
+    if (toRead === 0) return 0;
+
+    const rd = Atomics.load(this._heads, READ_HEAD_INDEX);
+    const ch = this._channels;
+    const mask = this._mask;
+
+    for (let i = 0; i < toRead; i++) {
+      const ringIdx = ((rd + i) & mask) * ch;
+      for (let c = 0; c < ch; c++) {
+        channels[c][i] = this._data[ringIdx + c];
+      }
+    }
+
+    Atomics.store(this._heads, READ_HEAD_INDEX, rd + toRead);
+    return toRead;
+  }
+
+  /** Reset read and write heads to 0. */
+  reset(): void {
+    Atomics.store(this._heads, WRITE_HEAD_INDEX, 0);
+    Atomics.store(this._heads, READ_HEAD_INDEX, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- Lock-free SPSC ring buffer over SharedArrayBuffer
- Atomic read/write heads, power-of-2 capacity, bitwise wrapping
- Interleaved and deinterleaved multi-channel read/write
- Designed for AudioWorklet ↔ main thread real-time audio streaming

## Test plan
- [x] Write/read round-trip (mono + stereo)
- [x] Buffer overflow and underflow handling
- [x] Wrap-around data integrity
- [x] Power-of-2 capacity rounding
- [x] SharedArrayBuffer reconstruction via wrap()

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #824