### PR TITLE
feat: VST3 companion app core — Rust WS server (W14)

### DIFF
--- a/companion/Cargo.toml
+++ b/companion/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ace-step-companion"
+version = "0.1.0"
+edition = "2021"
+description = "ACE-Step DAW companion app — hosts VST3 plugins and communicates with the browser DAW over WebSocket"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = "0.24"
+futures-util = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"
+uuid = { version = "1", features = ["v4"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "4", features = ["derive"] }
+walkdir = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/companion/README.md
+++ b/companion/README.md
@@ -1,0 +1,81 @@
+# ACE-Step Companion
+
+Local companion app that hosts VST3 plugins and communicates with the ACE-Step browser DAW over WebSocket.
+
+## Prerequisites
+
+- Rust 1.75+ (install via [rustup](https://rustup.rs/))
+
+## Build
+
+```bash
+cd companion
+cargo build
+```
+
+## Run
+
+```bash
+cargo run
+# or with options:
+cargo run -- --port 9851 --verbose
+```
+
+The server listens on `ws://127.0.0.1:9851` by default.
+
+## Test
+
+```bash
+cargo test
+```
+
+## CLI Options
+
+| Flag        | Default | Description                  |
+|-------------|---------|------------------------------|
+| `--port`    | 9851    | WebSocket server port        |
+| `--verbose` | off     | Enable debug-level logging   |
+
+## Architecture
+
+```
+main.rs              CLI entry point
+ws_server.rs         tokio + tungstenite WebSocket server
+protocol.rs          Serde structs for the JSON protocol
+plugin_scanner.rs    Scans /Library/Audio/Plug-Ins/VST3/ for bundles
+plugin_host.rs       Plugin instance lifecycle (stub)
+audio_thread.rs      Real-time audio processing (stub)
+preset_manager.rs    Preset management (stub)
+error.rs             Error types
+build.rs             C++ bridge build script (stub)
+```
+
+## Protocol
+
+All messages are JSON text frames with a `"type"` discriminant field.
+
+### Browser to Companion
+
+- `hello` — Handshake with sample rate and block size
+- `scan_plugins` — Request a plugin scan
+- `instantiate` — Load a plugin instance
+- `set_param` — Set a parameter value
+- `midi` — Send MIDI events to a plugin
+- `open_editor` / `close_editor` — Plugin GUI
+- `get_state` / `set_state` — Plugin state persistence
+- `load_preset` — Load a factory preset
+- `destroy` — Unload a plugin instance
+- `set_processing` — Enable/disable audio processing
+- `get_latency` — Query plugin latency
+- `route_sidechain` — Connect sidechain routing
+
+### Companion to Browser
+
+- `hello_ack` — Handshake response with capabilities
+- `scan_progress` / `scan_complete` — Plugin scan results
+- `instantiated` — Instance created with parameters and presets
+- `param_changed` — Parameter value notification
+- `editor_opened` / `editor_closed` — GUI state
+- `state_data` — Serialized plugin state
+- `latency_info` — Latency in samples
+- `error` — Error with code and message

--- a/companion/build.rs
+++ b/companion/build.rs
@@ -1,0 +1,9 @@
+/// Build script for ACE-Step Companion.
+///
+/// In the future this will invoke cmake to build the C++ VST3 bridge.
+/// For now it is a no-op stub.
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    // TODO: invoke cmake to compile the C++ VST3 bridge code
+    // e.g. cmake::Config::new("cpp_bridge").build();
+}

--- a/companion/src/audio_thread.rs
+++ b/companion/src/audio_thread.rs
@@ -1,0 +1,17 @@
+//! Placeholder for the real-time audio processing thread.
+//!
+//! Will eventually run a dedicated thread that pulls audio from plugin
+//! instances, mixes, and streams the result back to the browser over
+//! WebSocket binary frames.
+
+use tracing::info;
+
+/// Placeholder audio thread handle.
+pub struct AudioThread;
+
+impl AudioThread {
+    pub fn new() -> Self {
+        info!("AudioThread initialized (stub)");
+        Self
+    }
+}

--- a/companion/src/error.rs
+++ b/companion/src/error.rs
@@ -1,0 +1,59 @@
+use std::fmt;
+
+/// Top-level error type for the companion app.
+#[derive(Debug)]
+pub enum CompanionError {
+    /// WebSocket transport error.
+    WebSocket(tokio_tungstenite::tungstenite::Error),
+    /// JSON serialization / deserialization error.
+    Json(serde_json::Error),
+    /// I/O error (file system, network bind, etc.).
+    Io(std::io::Error),
+    /// Plugin-related error with a human-readable message.
+    Plugin(String),
+    /// A protocol-level error (unknown message type, missing fields, etc.).
+    Protocol(String),
+}
+
+impl fmt::Display for CompanionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WebSocket(e) => write!(f, "WebSocket error: {e}"),
+            Self::Json(e) => write!(f, "JSON error: {e}"),
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Plugin(msg) => write!(f, "Plugin error: {msg}"),
+            Self::Protocol(msg) => write!(f, "Protocol error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for CompanionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::WebSocket(e) => Some(e),
+            Self::Json(e) => Some(e),
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for CompanionError {
+    fn from(e: tokio_tungstenite::tungstenite::Error) -> Self {
+        Self::WebSocket(e)
+    }
+}
+
+impl From<serde_json::Error> for CompanionError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Json(e)
+    }
+}
+
+impl From<std::io::Error> for CompanionError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, CompanionError>;

--- a/companion/src/main.rs
+++ b/companion/src/main.rs
@@ -1,0 +1,43 @@
+mod audio_thread;
+mod error;
+mod plugin_host;
+mod plugin_scanner;
+mod preset_manager;
+mod protocol;
+mod ws_server;
+
+use std::net::SocketAddr;
+
+use clap::Parser;
+use tracing_subscriber::EnvFilter;
+
+/// ACE-Step Companion — local VST3 plugin host for the ACE-Step DAW.
+#[derive(Parser, Debug)]
+#[command(name = "ace-step-companion", version = "0.1.0")]
+struct Cli {
+    /// WebSocket server port.
+    #[arg(long, default_value_t = 9851)]
+    port: u16,
+
+    /// Enable verbose (debug-level) logging.
+    #[arg(long)]
+    verbose: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    // Initialise tracing.
+    let filter = if cli.verbose {
+        EnvFilter::new("debug")
+    } else {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+    };
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+
+    let addr: SocketAddr = ([127, 0, 0, 1], cli.port).into();
+    ws_server::run(addr).await?;
+
+    Ok(())
+}

--- a/companion/src/plugin_host.rs
+++ b/companion/src/plugin_host.rs
@@ -1,0 +1,151 @@
+//! Stub plugin host that manages plugin instance lifecycles.
+//!
+//! This module will eventually bridge to the C++ VST3 SDK. For now it returns
+//! fake metadata and tracks active instance IDs.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use tracing::{info, warn};
+
+use crate::error::{CompanionError, Result};
+use crate::protocol::{ParamInfo, PresetInfo};
+
+/// Metadata returned when a plugin is instantiated.
+#[derive(Debug, Clone)]
+pub struct InstanceInfo {
+    pub instance_id: String,
+    pub plugin_uid: String,
+    pub parameters: Vec<ParamInfo>,
+    pub latency_samples: u32,
+    pub tail_samples: u32,
+    pub presets: Vec<PresetInfo>,
+}
+
+/// Stub plugin host that tracks active instances in memory.
+pub struct PluginHost {
+    instances: Mutex<HashMap<String, InstanceInfo>>,
+}
+
+impl PluginHost {
+    pub fn new() -> Self {
+        Self {
+            instances: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Instantiate a plugin. Returns stub metadata.
+    ///
+    /// In the real implementation this will load the VST3 binary and initialize
+    /// the plugin component.
+    pub fn instantiate(&self, plugin_uid: &str, instance_id: &str) -> Result<InstanceInfo> {
+        let mut guard = self.instances.lock().unwrap();
+
+        if guard.contains_key(instance_id) {
+            return Err(CompanionError::Plugin(format!(
+                "Instance '{instance_id}' already exists"
+            )));
+        }
+
+        let info = InstanceInfo {
+            instance_id: instance_id.to_string(),
+            plugin_uid: plugin_uid.to_string(),
+            parameters: vec![
+                ParamInfo {
+                    id: 0,
+                    name: "Volume".into(),
+                    default_value: 0.8,
+                    min_value: 0.0,
+                    max_value: 1.0,
+                    unit: "dB".into(),
+                },
+                ParamInfo {
+                    id: 1,
+                    name: "Pan".into(),
+                    default_value: 0.5,
+                    min_value: 0.0,
+                    max_value: 1.0,
+                    unit: "".into(),
+                },
+            ],
+            latency_samples: 0,
+            tail_samples: 0,
+            presets: vec![PresetInfo {
+                id: 0,
+                name: "Default".into(),
+            }],
+        };
+
+        info!(
+            instance_id,
+            plugin_uid, "Instantiated stub plugin instance"
+        );
+        guard.insert(instance_id.to_string(), info.clone());
+        Ok(info)
+    }
+
+    /// Destroy a plugin instance, freeing its resources.
+    pub fn destroy(&self, instance_id: &str) -> Result<()> {
+        let mut guard = self.instances.lock().unwrap();
+        if guard.remove(instance_id).is_some() {
+            info!(instance_id, "Destroyed plugin instance");
+            Ok(())
+        } else {
+            warn!(instance_id, "Attempted to destroy unknown instance");
+            Err(CompanionError::Plugin(format!(
+                "Instance '{instance_id}' not found"
+            )))
+        }
+    }
+
+    /// Check whether an instance exists.
+    pub fn has_instance(&self, instance_id: &str) -> bool {
+        self.instances.lock().unwrap().contains_key(instance_id)
+    }
+
+    /// Return the number of active instances.
+    pub fn instance_count(&self) -> usize {
+        self.instances.lock().unwrap().len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_instantiate_and_destroy() {
+        let host = PluginHost::new();
+        assert_eq!(host.instance_count(), 0);
+
+        let info = host.instantiate("uid-1", "inst-1").unwrap();
+        assert_eq!(info.instance_id, "inst-1");
+        assert_eq!(info.plugin_uid, "uid-1");
+        assert!(!info.parameters.is_empty());
+        assert_eq!(host.instance_count(), 1);
+        assert!(host.has_instance("inst-1"));
+
+        host.destroy("inst-1").unwrap();
+        assert_eq!(host.instance_count(), 0);
+        assert!(!host.has_instance("inst-1"));
+    }
+
+    #[test]
+    fn test_duplicate_instance_id_errors() {
+        let host = PluginHost::new();
+        host.instantiate("uid-1", "inst-1").unwrap();
+        let result = host.instantiate("uid-2", "inst-1");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_destroy_unknown_instance_errors() {
+        let host = PluginHost::new();
+        let result = host.destroy("nonexistent");
+        assert!(result.is_err());
+    }
+}

--- a/companion/src/plugin_scanner.rs
+++ b/companion/src/plugin_scanner.rs
@@ -1,0 +1,220 @@
+//! Scans the filesystem for VST3 plugin bundles.
+//!
+//! A `.vst3` bundle is a directory whose name ends in `.vst3`. We look in the
+//! standard macOS locations:
+//!
+//! - `/Library/Audio/Plug-Ins/VST3/`
+//! - `~/Library/Audio/Plug-Ins/VST3/`
+//!
+//! Without the real VST3 SDK we derive plugin metadata from the bundle filename.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tracing::info;
+use uuid::Uuid;
+use walkdir::WalkDir;
+
+use crate::protocol::PluginInfo;
+
+/// In-memory cache of scan results.
+pub struct PluginScanner {
+    cache: Mutex<Option<Vec<PluginInfo>>>,
+}
+
+impl PluginScanner {
+    pub fn new() -> Self {
+        Self {
+            cache: Mutex::new(None),
+        }
+    }
+
+    /// Return the default VST3 search directories for macOS.
+    pub fn default_search_dirs() -> Vec<PathBuf> {
+        let mut dirs = vec![PathBuf::from("/Library/Audio/Plug-Ins/VST3")];
+        if let Some(home) = dirs::home_dir_raw() {
+            dirs.push(home.join("Library/Audio/Plug-Ins/VST3"));
+        }
+        dirs
+    }
+
+    /// Scan the given directories for `.vst3` bundles.
+    ///
+    /// Results are cached; subsequent calls return the cached list. Call
+    /// [`clear_cache`] to force a re-scan.
+    pub fn scan(&self, search_dirs: &[PathBuf]) -> Vec<PluginInfo> {
+        {
+            let guard = self.cache.lock().unwrap();
+            if let Some(ref cached) = *guard {
+                return cached.clone();
+            }
+        }
+
+        let plugins = scan_directories(search_dirs);
+        let mut guard = self.cache.lock().unwrap();
+        *guard = Some(plugins.clone());
+        plugins
+    }
+
+    /// Clear the cached scan results so the next [`scan`] re-reads the filesystem.
+    pub fn clear_cache(&self) {
+        let mut guard = self.cache.lock().unwrap();
+        *guard = None;
+    }
+}
+
+/// Walk `search_dirs` and collect every `.vst3` bundle found at depth 1.
+fn scan_directories(search_dirs: &[PathBuf]) -> Vec<PluginInfo> {
+    let mut plugins = Vec::new();
+
+    for dir in search_dirs {
+        if !dir.exists() {
+            info!("Skipping non-existent directory: {}", dir.display());
+            continue;
+        }
+
+        // Only walk one level deep — VST3 bundles sit directly inside the
+        // search directory (they are themselves directories with a `.vst3`
+        // extension).
+        for entry in WalkDir::new(dir).min_depth(1).max_depth(1) {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            if is_vst3_bundle(entry.path()) {
+                if let Some(info) = plugin_info_from_path(entry.path()) {
+                    info!("Found VST3 plugin: {} at {}", info.name, info.path);
+                    plugins.push(info);
+                }
+            }
+        }
+    }
+
+    plugins
+}
+
+/// Check whether a path looks like a `.vst3` bundle (a directory ending in `.vst3`).
+fn is_vst3_bundle(path: &Path) -> bool {
+    path.is_dir()
+        && path
+            .extension()
+            .map_or(false, |ext| ext.eq_ignore_ascii_case("vst3"))
+}
+
+/// Derive stub [`PluginInfo`] from a `.vst3` bundle path.
+///
+/// The real implementation will use the VST3 SDK to query the plugin. For now
+/// we just extract the name from the filename.
+fn plugin_info_from_path(path: &Path) -> Option<PluginInfo> {
+    let stem = path.file_stem()?.to_string_lossy().to_string();
+    Some(PluginInfo {
+        uid: Uuid::new_v4().to_string(),
+        name: stem,
+        vendor: "Unknown".into(),
+        version: "0.0.0".into(),
+        category: "Unknown".into(),
+        path: path.to_string_lossy().to_string(),
+    })
+}
+
+/// Tiny helper so we don't pull in the `dirs` crate just for home directory.
+mod dirs {
+    use std::path::PathBuf;
+
+    pub fn home_dir_raw() -> Option<PathBuf> {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_vst3_bundle(parent: &Path, name: &str) {
+        let bundle = parent.join(format!("{name}.vst3"));
+        fs::create_dir_all(&bundle).unwrap();
+    }
+
+    #[test]
+    fn test_scan_finds_vst3_bundles() {
+        let tmp = TempDir::new().unwrap();
+        make_vst3_bundle(tmp.path(), "Synth1");
+        make_vst3_bundle(tmp.path(), "Compressor");
+
+        // Also create a non-vst3 directory and a regular file — should be ignored.
+        fs::create_dir_all(tmp.path().join("NotAPlugin")).unwrap();
+        fs::write(tmp.path().join("readme.txt"), "hello").unwrap();
+
+        let scanner = PluginScanner::new();
+        let plugins = scanner.scan(&[tmp.path().to_path_buf()]);
+
+        assert_eq!(plugins.len(), 2);
+        let names: Vec<&str> = plugins.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"Synth1"));
+        assert!(names.contains(&"Compressor"));
+    }
+
+    #[test]
+    fn test_scan_caches_results() {
+        let tmp = TempDir::new().unwrap();
+        make_vst3_bundle(tmp.path(), "CachedPlugin");
+
+        let scanner = PluginScanner::new();
+        let first = scanner.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(first.len(), 1);
+
+        // Add another bundle — should not appear because results are cached.
+        make_vst3_bundle(tmp.path(), "NewPlugin");
+        let second = scanner.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(second.len(), 1);
+
+        // After clearing the cache, the new plugin should appear.
+        scanner.clear_cache();
+        let third = scanner.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(third.len(), 2);
+    }
+
+    #[test]
+    fn test_scan_skips_nonexistent_dirs() {
+        let scanner = PluginScanner::new();
+        let plugins = scanner.scan(&[PathBuf::from("/tmp/definitely_does_not_exist_12345")]);
+        assert!(plugins.is_empty());
+    }
+
+    #[test]
+    fn test_is_vst3_bundle() {
+        let tmp = TempDir::new().unwrap();
+
+        let bundle = tmp.path().join("Test.vst3");
+        fs::create_dir_all(&bundle).unwrap();
+        assert!(is_vst3_bundle(&bundle));
+
+        let not_bundle = tmp.path().join("Test.txt");
+        fs::write(&not_bundle, "hi").unwrap();
+        assert!(!is_vst3_bundle(&not_bundle));
+
+        let not_ext = tmp.path().join("Test.dll");
+        fs::create_dir_all(&not_ext).unwrap();
+        assert!(!is_vst3_bundle(&not_ext));
+    }
+
+    #[test]
+    fn test_plugin_info_from_path() {
+        let tmp = TempDir::new().unwrap();
+        let bundle = tmp.path().join("MySynth.vst3");
+        fs::create_dir_all(&bundle).unwrap();
+
+        let info = plugin_info_from_path(&bundle).unwrap();
+        assert_eq!(info.name, "MySynth");
+        assert_eq!(info.vendor, "Unknown");
+        assert!(!info.uid.is_empty());
+        assert!(info.path.contains("MySynth.vst3"));
+    }
+}

--- a/companion/src/preset_manager.rs
+++ b/companion/src/preset_manager.rs
@@ -1,0 +1,16 @@
+//! Placeholder for preset management.
+//!
+//! Will eventually handle loading/saving VST3 plugin presets and factory
+//! preset enumeration via the VST3 SDK.
+
+use tracing::info;
+
+/// Placeholder preset manager.
+pub struct PresetManager;
+
+impl PresetManager {
+    pub fn new() -> Self {
+        info!("PresetManager initialized (stub)");
+        Self
+    }
+}

--- a/companion/src/protocol.rs
+++ b/companion/src/protocol.rs
@@ -1,0 +1,411 @@
+//! JSON protocol types for communication between the browser DAW and the companion app.
+//!
+//! All messages are JSON text frames with a `"type"` discriminant field using snake_case values.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Messages FROM the browser (incoming)
+// ---------------------------------------------------------------------------
+
+/// A single MIDI event.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MidiEvent {
+    /// MIDI status byte (e.g. 0x90 for note-on).
+    pub status: u8,
+    /// First data byte (e.g. note number).
+    pub data1: u8,
+    /// Second data byte (e.g. velocity).
+    pub data2: u8,
+    /// Offset in samples from the start of the current block.
+    pub sample_offset: u32,
+}
+
+/// Messages sent from the browser to the companion app.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum IncomingMessage {
+    Hello {
+        version: String,
+        sample_rate: u32,
+        block_size: u32,
+    },
+    ScanPlugins,
+    Instantiate {
+        req_id: String,
+        plugin_uid: String,
+        instance_id: String,
+    },
+    SetParam {
+        instance_id: String,
+        param_id: u32,
+        value: f64,
+    },
+    Midi {
+        instance_id: String,
+        events: Vec<MidiEvent>,
+    },
+    OpenEditor {
+        instance_id: String,
+    },
+    CloseEditor {
+        instance_id: String,
+    },
+    GetState {
+        instance_id: String,
+    },
+    SetState {
+        instance_id: String,
+        data: String,
+    },
+    LoadPreset {
+        instance_id: String,
+        preset_id: u32,
+    },
+    Destroy {
+        instance_id: String,
+    },
+    SetProcessing {
+        instance_id: String,
+        active: bool,
+    },
+    GetLatency {
+        instance_id: String,
+    },
+    RouteSidechain {
+        instance_id: String,
+        sidechain_input_bus: u32,
+        source_instance_id: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Messages TO the browser (outgoing)
+// ---------------------------------------------------------------------------
+
+/// Metadata about a discovered VST3 plugin.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PluginInfo {
+    pub uid: String,
+    pub name: String,
+    pub vendor: String,
+    pub version: String,
+    pub category: String,
+    pub path: String,
+}
+
+/// Metadata about a single plugin parameter.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ParamInfo {
+    pub id: u32,
+    pub name: String,
+    pub default_value: f64,
+    pub min_value: f64,
+    pub max_value: f64,
+    pub unit: String,
+}
+
+/// Metadata about a factory preset.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PresetInfo {
+    pub id: u32,
+    pub name: String,
+}
+
+/// Messages sent from the companion app to the browser.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OutgoingMessage {
+    HelloAck {
+        version: String,
+        capabilities: Vec<String>,
+    },
+    ScanProgress {
+        found: u32,
+        current: String,
+    },
+    ScanComplete {
+        plugins: Vec<PluginInfo>,
+    },
+    Instantiated {
+        req_id: String,
+        instance_id: String,
+        parameters: Vec<ParamInfo>,
+        latency_samples: u32,
+        tail_samples: u32,
+        presets: Vec<PresetInfo>,
+    },
+    ParamChanged {
+        instance_id: String,
+        param_id: u32,
+        value: f64,
+    },
+    EditorOpened {
+        instance_id: String,
+        width: u32,
+        height: u32,
+    },
+    EditorClosed {
+        instance_id: String,
+    },
+    StateData {
+        instance_id: String,
+        data: String,
+    },
+    LatencyInfo {
+        instance_id: String,
+        samples: u32,
+    },
+    Error {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        req_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        instance_id: Option<String>,
+        code: String,
+        message: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_incoming_hello_roundtrip() {
+        let msg = IncomingMessage::Hello {
+            version: "1.0".into(),
+            sample_rate: 48000,
+            block_size: 128,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: IncomingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+        // Verify the type discriminant
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(val["type"], "hello");
+    }
+
+    #[test]
+    fn test_incoming_scan_plugins_roundtrip() {
+        let msg = IncomingMessage::ScanPlugins;
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: IncomingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(val["type"], "scan_plugins");
+    }
+
+    #[test]
+    fn test_incoming_instantiate_roundtrip() {
+        let msg = IncomingMessage::Instantiate {
+            req_id: "r1".into(),
+            plugin_uid: "uid-abc".into(),
+            instance_id: "inst-1".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: IncomingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_incoming_set_param_roundtrip() {
+        let msg = IncomingMessage::SetParam {
+            instance_id: "inst-1".into(),
+            param_id: 42,
+            value: 0.75,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: IncomingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_incoming_midi_roundtrip() {
+        let msg = IncomingMessage::Midi {
+            instance_id: "inst-1".into(),
+            events: vec![MidiEvent {
+                status: 0x90,
+                data1: 60,
+                data2: 100,
+                sample_offset: 0,
+            }],
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: IncomingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_incoming_destroy_roundtrip() {
+        let msg = IncomingMessage::Destroy {
+            instance_id: "inst-1".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: IncomingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_incoming_set_processing_roundtrip() {
+        let msg = IncomingMessage::SetProcessing {
+            instance_id: "inst-1".into(),
+            active: true,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: IncomingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_incoming_get_latency_roundtrip() {
+        let msg = IncomingMessage::GetLatency {
+            instance_id: "inst-1".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: IncomingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_incoming_route_sidechain_roundtrip() {
+        let msg = IncomingMessage::RouteSidechain {
+            instance_id: "inst-1".into(),
+            sidechain_input_bus: 1,
+            source_instance_id: "inst-2".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: IncomingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_outgoing_hello_ack_roundtrip() {
+        let msg = OutgoingMessage::HelloAck {
+            version: "0.1.0".into(),
+            capabilities: vec!["scan".into(), "host".into()],
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: OutgoingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(val["type"], "hello_ack");
+    }
+
+    #[test]
+    fn test_outgoing_scan_complete_roundtrip() {
+        let msg = OutgoingMessage::ScanComplete {
+            plugins: vec![PluginInfo {
+                uid: "uid-1".into(),
+                name: "TestSynth".into(),
+                vendor: "TestVendor".into(),
+                version: "1.0.0".into(),
+                category: "Instrument".into(),
+                path: "/Library/Audio/Plug-Ins/VST3/TestSynth.vst3".into(),
+            }],
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: OutgoingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_outgoing_instantiated_roundtrip() {
+        let msg = OutgoingMessage::Instantiated {
+            req_id: "r1".into(),
+            instance_id: "inst-1".into(),
+            parameters: vec![ParamInfo {
+                id: 0,
+                name: "Volume".into(),
+                default_value: 0.8,
+                min_value: 0.0,
+                max_value: 1.0,
+                unit: "dB".into(),
+            }],
+            latency_samples: 0,
+            tail_samples: 0,
+            presets: vec![PresetInfo {
+                id: 0,
+                name: "Default".into(),
+            }],
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: OutgoingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_outgoing_error_roundtrip() {
+        let msg = OutgoingMessage::Error {
+            req_id: Some("r1".into()),
+            instance_id: None,
+            code: "not_found".into(),
+            message: "Plugin not found".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: OutgoingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+        // Verify optional fields are properly skipped
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(val.get("instance_id").is_none());
+    }
+
+    #[test]
+    fn test_outgoing_error_with_all_fields() {
+        let msg = OutgoingMessage::Error {
+            req_id: Some("r1".into()),
+            instance_id: Some("inst-1".into()),
+            code: "host_error".into(),
+            message: "Failed to process".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(val["instance_id"], "inst-1");
+    }
+
+    #[test]
+    fn test_parse_hello_from_raw_json() {
+        let raw = r#"{"type":"hello","version":"1.0","sample_rate":44100,"block_size":256}"#;
+        let msg: IncomingMessage = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            msg,
+            IncomingMessage::Hello {
+                version: "1.0".into(),
+                sample_rate: 44100,
+                block_size: 256,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_scan_plugins_from_raw_json() {
+        let raw = r#"{"type":"scan_plugins"}"#;
+        let msg: IncomingMessage = serde_json::from_str(raw).unwrap();
+        assert_eq!(msg, IncomingMessage::ScanPlugins);
+    }
+
+    #[test]
+    fn test_outgoing_scan_progress_roundtrip() {
+        let msg = OutgoingMessage::ScanProgress {
+            found: 5,
+            current: "/Library/Audio/Plug-Ins/VST3/Diva.vst3".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: OutgoingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_outgoing_latency_info_roundtrip() {
+        let msg = OutgoingMessage::LatencyInfo {
+            instance_id: "inst-1".into(),
+            samples: 512,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: OutgoingMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+}

--- a/companion/src/ws_server.rs
+++ b/companion/src/ws_server.rs
@@ -1,0 +1,424 @@
+//! WebSocket server that accepts a single DAW client connection.
+//!
+//! - Listens on `127.0.0.1:<port>` (default 9851).
+//! - Only one connection is active at a time.
+//! - Text frames are parsed as JSON protocol messages.
+//! - Binary frames are reserved for audio (echoed back as a placeholder).
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{error, info, warn};
+
+use crate::error::Result;
+use crate::plugin_host::PluginHost;
+use crate::plugin_scanner::PluginScanner;
+use crate::protocol::{IncomingMessage, OutgoingMessage};
+
+/// Shared application state accessible from every connection handler.
+pub struct AppState {
+    pub scanner: PluginScanner,
+    pub host: PluginHost,
+}
+
+/// Start the WebSocket server and listen for connections forever.
+pub async fn run(addr: SocketAddr) -> Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    info!("ACE-Step Companion v0.1.0 listening on ws://{addr}");
+
+    let state = Arc::new(AppState {
+        scanner: PluginScanner::new(),
+        host: PluginHost::new(),
+    });
+
+    loop {
+        let (stream, peer) = listener.accept().await?;
+        info!(%peer, "New TCP connection");
+        let state = Arc::clone(&state);
+
+        // Spawn a task per connection but we expect only one DAW client.
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(stream, peer, state).await {
+                error!(%peer, "Connection error: {e}");
+            }
+            info!(%peer, "Connection closed");
+        });
+    }
+}
+
+/// Handle a single WebSocket connection.
+async fn handle_connection(
+    stream: TcpStream,
+    peer: SocketAddr,
+    state: Arc<AppState>,
+) -> Result<()> {
+    let ws_stream = tokio_tungstenite::accept_async(stream).await?;
+    info!(%peer, "WebSocket handshake complete");
+
+    let (mut sink, mut stream) = ws_stream.split();
+
+    while let Some(msg_result) = stream.next().await {
+        let msg = match msg_result {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(%peer, "Read error: {e}");
+                break;
+            }
+        };
+
+        match msg {
+            Message::Text(text) => {
+                info!(%peer, "Received text: {text}");
+                match serde_json::from_str::<IncomingMessage>(&text) {
+                    Ok(incoming) => {
+                        let response = handle_message(incoming, &state);
+                        let json = serde_json::to_string(&response)?;
+                        sink.send(Message::Text(json.into())).await?;
+                    }
+                    Err(e) => {
+                        warn!(%peer, "Failed to parse message: {e}");
+                        let err = OutgoingMessage::Error {
+                            req_id: None,
+                            instance_id: None,
+                            code: "parse_error".into(),
+                            message: format!("Invalid message: {e}"),
+                        };
+                        let json = serde_json::to_string(&err)?;
+                        sink.send(Message::Text(json.into())).await?;
+                    }
+                }
+            }
+            Message::Binary(data) => {
+                // Placeholder: echo binary frames back.
+                info!(%peer, bytes = data.len(), "Received binary frame (echo)");
+                sink.send(Message::Binary(data)).await?;
+            }
+            Message::Ping(payload) => {
+                sink.send(Message::Pong(payload)).await?;
+            }
+            Message::Close(_) => {
+                info!(%peer, "Client sent close frame");
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+/// Dispatch an incoming protocol message and produce a response.
+fn handle_message(msg: IncomingMessage, state: &AppState) -> OutgoingMessage {
+    match msg {
+        IncomingMessage::Hello { version, .. } => {
+            info!(client_version = %version, "Hello from browser");
+            OutgoingMessage::HelloAck {
+                version: "0.1.0".into(),
+                capabilities: vec![
+                    "scan".into(),
+                    "host".into(),
+                    "midi".into(),
+                    "state".into(),
+                ],
+            }
+        }
+
+        IncomingMessage::ScanPlugins => {
+            let dirs = PluginScanner::default_search_dirs();
+            let plugins = state.scanner.scan(&dirs);
+            OutgoingMessage::ScanComplete { plugins }
+        }
+
+        IncomingMessage::Instantiate {
+            req_id,
+            plugin_uid,
+            instance_id,
+        } => match state.host.instantiate(&plugin_uid, &instance_id) {
+            Ok(info) => OutgoingMessage::Instantiated {
+                req_id,
+                instance_id: info.instance_id,
+                parameters: info.parameters,
+                latency_samples: info.latency_samples,
+                tail_samples: info.tail_samples,
+                presets: info.presets,
+            },
+            Err(e) => OutgoingMessage::Error {
+                req_id: Some(req_id),
+                instance_id: Some(instance_id),
+                code: "instantiate_error".into(),
+                message: e.to_string(),
+            },
+        },
+
+        IncomingMessage::Destroy { instance_id } => match state.host.destroy(&instance_id) {
+            Ok(()) => OutgoingMessage::Error {
+                req_id: None,
+                instance_id: Some(instance_id),
+                code: "ok".into(),
+                message: "Instance destroyed".into(),
+            },
+            Err(e) => OutgoingMessage::Error {
+                req_id: None,
+                instance_id: Some(instance_id),
+                code: "destroy_error".into(),
+                message: e.to_string(),
+            },
+        },
+
+        IncomingMessage::SetParam {
+            instance_id,
+            param_id,
+            value,
+        } => {
+            info!(instance_id, param_id, value, "SetParam (stub)");
+            OutgoingMessage::ParamChanged {
+                instance_id,
+                param_id,
+                value,
+            }
+        }
+
+        IncomingMessage::Midi {
+            instance_id,
+            events,
+        } => {
+            info!(instance_id, count = events.len(), "MIDI events (stub)");
+            // No response required for MIDI in the current protocol; send an ack-style message.
+            OutgoingMessage::Error {
+                req_id: None,
+                instance_id: Some(instance_id),
+                code: "ok".into(),
+                message: format!("Received {} MIDI events (stub)", events.len()),
+            }
+        }
+
+        IncomingMessage::OpenEditor { instance_id } => {
+            info!(instance_id, "OpenEditor (stub)");
+            OutgoingMessage::EditorOpened {
+                instance_id,
+                width: 800,
+                height: 600,
+            }
+        }
+
+        IncomingMessage::CloseEditor { instance_id } => {
+            info!(instance_id, "CloseEditor (stub)");
+            OutgoingMessage::EditorClosed { instance_id }
+        }
+
+        IncomingMessage::GetState { instance_id } => {
+            info!(instance_id, "GetState (stub)");
+            OutgoingMessage::StateData {
+                instance_id,
+                data: base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    b"stub-state-data",
+                ),
+            }
+        }
+
+        IncomingMessage::SetState {
+            instance_id,
+            data: _,
+        } => {
+            info!(instance_id, "SetState (stub)");
+            OutgoingMessage::Error {
+                req_id: None,
+                instance_id: Some(instance_id),
+                code: "ok".into(),
+                message: "State set (stub)".into(),
+            }
+        }
+
+        IncomingMessage::LoadPreset {
+            instance_id,
+            preset_id,
+        } => {
+            info!(instance_id, preset_id, "LoadPreset (stub)");
+            OutgoingMessage::Error {
+                req_id: None,
+                instance_id: Some(instance_id),
+                code: "ok".into(),
+                message: format!("Loaded preset {preset_id} (stub)"),
+            }
+        }
+
+        IncomingMessage::SetProcessing {
+            instance_id,
+            active,
+        } => {
+            info!(instance_id, active, "SetProcessing (stub)");
+            OutgoingMessage::Error {
+                req_id: None,
+                instance_id: Some(instance_id),
+                code: "ok".into(),
+                message: format!("Processing set to {active} (stub)"),
+            }
+        }
+
+        IncomingMessage::GetLatency { instance_id } => {
+            info!(instance_id, "GetLatency (stub)");
+            OutgoingMessage::LatencyInfo {
+                instance_id,
+                samples: 0,
+            }
+        }
+
+        IncomingMessage::RouteSidechain {
+            instance_id,
+            sidechain_input_bus,
+            source_instance_id,
+        } => {
+            info!(
+                instance_id,
+                sidechain_input_bus, source_instance_id, "RouteSidechain (stub)"
+            );
+            OutgoingMessage::Error {
+                req_id: None,
+                instance_id: Some(instance_id),
+                code: "ok".into(),
+                message: "Sidechain routed (stub)".into(),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::connect_async;
+
+    #[test]
+    fn test_handle_message_hello() {
+        let state = AppState {
+            scanner: PluginScanner::new(),
+            host: PluginHost::new(),
+        };
+        let resp = handle_message(
+            IncomingMessage::Hello {
+                version: "1.0".into(),
+                sample_rate: 48000,
+                block_size: 128,
+            },
+            &state,
+        );
+        match resp {
+            OutgoingMessage::HelloAck {
+                version,
+                capabilities,
+            } => {
+                assert_eq!(version, "0.1.0");
+                assert!(capabilities.contains(&"scan".to_string()));
+            }
+            other => panic!("Expected HelloAck, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_handle_message_instantiate_and_destroy() {
+        let state = AppState {
+            scanner: PluginScanner::new(),
+            host: PluginHost::new(),
+        };
+
+        let resp = handle_message(
+            IncomingMessage::Instantiate {
+                req_id: "r1".into(),
+                plugin_uid: "uid-1".into(),
+                instance_id: "inst-1".into(),
+            },
+            &state,
+        );
+        match &resp {
+            OutgoingMessage::Instantiated { instance_id, .. } => {
+                assert_eq!(instance_id, "inst-1");
+            }
+            other => panic!("Expected Instantiated, got {other:?}"),
+        }
+
+        let resp = handle_message(
+            IncomingMessage::Destroy {
+                instance_id: "inst-1".into(),
+            },
+            &state,
+        );
+        match &resp {
+            OutgoingMessage::Error { code, .. } => assert_eq!(code, "ok"),
+            other => panic!("Expected ok Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_handle_message_get_latency() {
+        let state = AppState {
+            scanner: PluginScanner::new(),
+            host: PluginHost::new(),
+        };
+        let resp = handle_message(
+            IncomingMessage::GetLatency {
+                instance_id: "inst-1".into(),
+            },
+            &state,
+        );
+        match resp {
+            OutgoingMessage::LatencyInfo { samples, .. } => assert_eq!(samples, 0),
+            other => panic!("Expected LatencyInfo, got {other:?}"),
+        }
+    }
+
+    /// Integration test: start the WS server, connect, send hello, receive hello_ack.
+    #[tokio::test]
+    async fn test_ws_hello_handshake() {
+        // Bind to port 0 to get an ephemeral port.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let state = Arc::new(AppState {
+            scanner: PluginScanner::new(),
+            host: PluginHost::new(),
+        });
+
+        // Spawn the accept loop.
+        let server_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            let (stream, peer) = listener.accept().await.unwrap();
+            handle_connection(stream, peer, server_state)
+                .await
+                .unwrap();
+        });
+
+        // Connect as a client.
+        let url = format!("ws://{addr}");
+        let (ws, _) = connect_async(&url).await.unwrap();
+        let (mut sink, mut stream) = ws.split();
+
+        // Send hello.
+        let hello = serde_json::json!({
+            "type": "hello",
+            "version": "1.0",
+            "sample_rate": 48000,
+            "block_size": 128
+        });
+        sink.send(Message::Text(hello.to_string().into()))
+            .await
+            .unwrap();
+
+        // Receive hello_ack.
+        let response = stream.next().await.unwrap().unwrap();
+        let text = response.into_text().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["type"], "hello_ack");
+        assert_eq!(parsed["version"], "0.1.0");
+
+        // Clean up.
+        sink.send(Message::Close(None)).await.ok();
+    }
+}


### PR DESCRIPTION
## Summary
- Rust companion app in `companion/` directory
- WebSocket server (tokio + tungstenite) on `ws://127.0.0.1:9851`
- Full JSON protocol with serde structs matching browser types
- Plugin scanner for macOS VST3 directories
- Stub plugin host for instance lifecycle
- CLI: `--port`, `--verbose` flags

## Test plan
- [ ] Install Rust toolchain, run `cd companion && cargo test`
- [ ] Run `cargo run` and verify WS server starts
- [ ] Connect via wscat and send hello message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #835