### PR TITLE
feat: VST3 preset manager (W11)

### DIFF
--- a/src/services/vst3bridge/VST3PresetManager.ts
+++ b/src/services/vst3bridge/VST3PresetManager.ts
@@ -1,0 +1,159 @@
+import { get, set } from 'idb-keyval';
+import { v4 as uuidv4 } from 'uuid';
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface VST3Preset {
+  id: string;
+  name: string;
+  pluginUid: string;
+  isFactory: boolean;
+  stateData?: string;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+/** Minimal bridge surface consumed by the preset manager. */
+export interface BridgeClientLike {
+  getState(instanceId: string): Promise<string>;
+  setState(instanceId: string, data: string): Promise<void>;
+  request<T>(msg: object): Promise<T>;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function idbKey(pluginUid: string): string {
+  return `vst3-presets-${pluginUid}`;
+}
+
+function uuid(): string {
+  return uuidv4();
+}
+
+/* ------------------------------------------------------------------ */
+/*  Manager                                                            */
+/* ------------------------------------------------------------------ */
+
+export class VST3PresetManager {
+  /** In-memory cache keyed by pluginUid. */
+  private cache = new Map<string, VST3Preset[]>();
+
+  constructor(private bridge: BridgeClientLike) {}
+
+  /* ---------- factory presets ---------- */
+
+  async getFactoryPresets(instanceId: string): Promise<VST3Preset[]> {
+    const res = await this.bridge.request<{
+      presets: { id: number; name: string }[];
+    }>({ type: 'get_factory_presets', instanceId });
+
+    return res.presets.map((p) => ({
+      id: String(p.id),
+      name: p.name,
+      pluginUid: '',
+      isFactory: true,
+    }));
+  }
+
+  async loadFactoryPreset(instanceId: string, presetId: number): Promise<void> {
+    await this.bridge.request({ type: 'load_preset', instanceId, presetId });
+  }
+
+  /* ---------- user presets ---------- */
+
+  async saveUserPreset(
+    instanceId: string,
+    pluginUid: string,
+    name: string,
+  ): Promise<VST3Preset> {
+    const stateData = await this.bridge.getState(instanceId);
+    const now = Date.now();
+    const preset: VST3Preset = {
+      id: uuid(),
+      name,
+      pluginUid,
+      isFactory: false,
+      stateData,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const list = this.getPresetsForPlugin(pluginUid);
+    list.push(preset);
+    this.cache.set(pluginUid, list);
+    await this.persist(pluginUid);
+    return preset;
+  }
+
+  async loadUserPreset(instanceId: string, preset: VST3Preset): Promise<void> {
+    if (!preset.stateData) return;
+    await this.bridge.setState(instanceId, preset.stateData);
+  }
+
+  getUserPresets(pluginUid: string): VST3Preset[] {
+    return this.getPresetsForPlugin(pluginUid);
+  }
+
+  deleteUserPreset(presetId: string): void {
+    for (const [uid, list] of this.cache.entries()) {
+      const idx = list.findIndex((p) => p.id === presetId);
+      if (idx !== -1) {
+        list.splice(idx, 1);
+        this.persist(uid);
+        return;
+      }
+    }
+  }
+
+  renameUserPreset(presetId: string, newName: string): void {
+    for (const [uid, list] of this.cache.entries()) {
+      const preset = list.find((p) => p.id === presetId);
+      if (preset) {
+        preset.name = newName;
+        preset.updatedAt = Date.now();
+        this.persist(uid);
+        return;
+      }
+    }
+  }
+
+  /* ---------- import / export ---------- */
+
+  async exportPreset(instanceId: string): Promise<{ name: string; data: string }> {
+    const [data, info] = await Promise.all([
+      this.bridge.getState(instanceId),
+      this.bridge.request<{ name: string }>({ type: 'get_preset_info', instanceId }),
+    ]);
+    return { name: info.name, data };
+  }
+
+  async importPreset(instanceId: string, data: string): Promise<void> {
+    await this.bridge.setState(instanceId, data);
+  }
+
+  /* ---------- internal ---------- */
+
+  private getPresetsForPlugin(pluginUid: string): VST3Preset[] {
+    if (!this.cache.has(pluginUid)) {
+      this.cache.set(pluginUid, []);
+    }
+    return this.cache.get(pluginUid)!;
+  }
+
+  private async persist(pluginUid: string): Promise<void> {
+    const list = this.cache.get(pluginUid) ?? [];
+    await set(idbKey(pluginUid), list);
+  }
+
+  /** Hydrate in-memory cache from IndexedDB. Call once on startup. */
+  async loadFromStorage(pluginUid: string): Promise<void> {
+    const stored = await get<VST3Preset[]>(idbKey(pluginUid));
+    if (stored) {
+      this.cache.set(pluginUid, stored);
+    }
+  }
+}

--- a/src/services/vst3bridge/__tests__/VST3PresetManager.test.ts
+++ b/src/services/vst3bridge/__tests__/VST3PresetManager.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VST3PresetManager } from '../VST3PresetManager';
+import type { VST3Preset } from '../VST3PresetManager';
+
+// Mock idb-keyval
+const mockStore = new Map<string, unknown>();
+vi.mock('idb-keyval', () => ({
+  get: vi.fn((key: string) => Promise.resolve(mockStore.get(key))),
+  set: vi.fn((key: string, value: unknown) => {
+    mockStore.set(key, value);
+    return Promise.resolve();
+  }),
+}));
+
+function createMockBridge() {
+  return {
+    getState: vi.fn<(id: string) => Promise<string>>().mockResolvedValue('base64statedata=='),
+    setState: vi.fn<(id: string, data: string) => Promise<void>>().mockResolvedValue(undefined),
+    request: vi.fn().mockResolvedValue({}),
+  };
+}
+
+describe('VST3PresetManager', () => {
+  let manager: VST3PresetManager;
+  let bridge: ReturnType<typeof createMockBridge>;
+
+  beforeEach(() => {
+    mockStore.clear();
+    bridge = createMockBridge();
+    manager = new VST3PresetManager(bridge);
+    vi.clearAllMocks();
+  });
+
+  describe('getFactoryPresets', () => {
+    it('returns presets from bridge', async () => {
+      bridge.request.mockResolvedValue({
+        presets: [
+          { id: 0, name: 'Init' },
+          { id: 1, name: 'Warm Pad' },
+        ],
+      });
+
+      const presets = await manager.getFactoryPresets('inst-1');
+
+      expect(bridge.request).toHaveBeenCalledWith({
+        type: 'get_factory_presets',
+        instanceId: 'inst-1',
+      });
+      expect(presets).toHaveLength(2);
+      expect(presets[0]).toMatchObject({
+        id: '0',
+        name: 'Init',
+        isFactory: true,
+      });
+      expect(presets[1]).toMatchObject({
+        id: '1',
+        name: 'Warm Pad',
+        isFactory: true,
+      });
+    });
+  });
+
+  describe('loadFactoryPreset', () => {
+    it('sends correct message to bridge', async () => {
+      bridge.request.mockResolvedValue({});
+
+      await manager.loadFactoryPreset('inst-1', 3);
+
+      expect(bridge.request).toHaveBeenCalledWith({
+        type: 'load_preset',
+        instanceId: 'inst-1',
+        presetId: 3,
+      });
+    });
+  });
+
+  describe('saveUserPreset', () => {
+    it('gets state from bridge and stores in IndexedDB', async () => {
+      const preset = await manager.saveUserPreset('inst-1', 'com.plugin.synth', 'My Patch');
+
+      expect(bridge.getState).toHaveBeenCalledWith('inst-1');
+      expect(preset.name).toBe('My Patch');
+      expect(preset.pluginUid).toBe('com.plugin.synth');
+      expect(preset.isFactory).toBe(false);
+      expect(preset.stateData).toBe('base64statedata==');
+      expect(preset.id).toBeTruthy();
+      expect(preset.createdAt).toBeTypeOf('number');
+      expect(preset.updatedAt).toBeTypeOf('number');
+
+      // Verify stored in IndexedDB under the plugin key
+      const stored = mockStore.get('vst3-presets-com.plugin.synth') as VST3Preset[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].name).toBe('My Patch');
+    });
+  });
+
+  describe('loadUserPreset', () => {
+    it('sets state via bridge', async () => {
+      const preset: VST3Preset = {
+        id: 'preset-123',
+        name: 'Saved Patch',
+        pluginUid: 'com.plugin.synth',
+        isFactory: false,
+        stateData: 'savedstatedata==',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      await manager.loadUserPreset('inst-1', preset);
+
+      expect(bridge.setState).toHaveBeenCalledWith('inst-1', 'savedstatedata==');
+    });
+  });
+
+  describe('getUserPresets', () => {
+    it('returns stored presets for a plugin', async () => {
+      // Save two presets first
+      await manager.saveUserPreset('inst-1', 'com.plugin.synth', 'Patch A');
+      await manager.saveUserPreset('inst-1', 'com.plugin.synth', 'Patch B');
+
+      const presets = manager.getUserPresets('com.plugin.synth');
+
+      expect(presets).toHaveLength(2);
+      expect(presets[0].name).toBe('Patch A');
+      expect(presets[1].name).toBe('Patch B');
+    });
+
+    it('returns empty array when no presets exist', () => {
+      const presets = manager.getUserPresets('com.unknown.plugin');
+      expect(presets).toEqual([]);
+    });
+  });
+
+  describe('deleteUserPreset', () => {
+    it('removes preset from store', async () => {
+      const preset = await manager.saveUserPreset('inst-1', 'com.plugin.synth', 'To Delete');
+      expect(manager.getUserPresets('com.plugin.synth')).toHaveLength(1);
+
+      manager.deleteUserPreset(preset.id);
+
+      expect(manager.getUserPresets('com.plugin.synth')).toHaveLength(0);
+    });
+  });
+
+  describe('renameUserPreset', () => {
+    it('updates preset name', async () => {
+      const preset = await manager.saveUserPreset('inst-1', 'com.plugin.synth', 'Old Name');
+
+      manager.renameUserPreset(preset.id, 'New Name');
+
+      const presets = manager.getUserPresets('com.plugin.synth');
+      expect(presets[0].name).toBe('New Name');
+      expect(presets[0].updatedAt).toBeGreaterThanOrEqual(preset.updatedAt!);
+    });
+  });
+
+  describe('exportPreset', () => {
+    it('returns state data from bridge', async () => {
+      bridge.getState.mockResolvedValue('exportedstate==');
+      bridge.request.mockResolvedValue({ name: 'Current Preset' });
+
+      const result = await manager.exportPreset('inst-1');
+
+      expect(bridge.getState).toHaveBeenCalledWith('inst-1');
+      expect(result.data).toBe('exportedstate==');
+      expect(result.name).toBe('Current Preset');
+    });
+  });
+
+  describe('importPreset', () => {
+    it('sets state via bridge', async () => {
+      await manager.importPreset('inst-1', 'importedstate==');
+
+      expect(bridge.setState).toHaveBeenCalledWith('inst-1', 'importedstate==');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Save/load user presets via IndexedDB (idb-keyval)
- Factory preset browsing from companion
- State chunk import/export (base64)
- Rename/delete user presets

## Test plan
- [x] Factory preset retrieval from bridge
- [x] User preset save/load round-trip
- [x] Preset delete and rename
- [x] Export returns state data
- [x] Import sets state via bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #832