### PR TITLE
feat: plugin delay compensation — PDC (W10)

### DIFF
--- a/src/engine/PluginEngine.ts
+++ b/src/engine/PluginEngine.ts
@@ -182,6 +182,21 @@ export class PluginEngine {
   }
 
   /**
+   * Get total latency of plugin chain for a track (in samples).
+   * Sums latencySamples from all plugins in the chain.
+   * WAP plugins without latencySamples are assumed to have 0 latency.
+   */
+  getChainLatency(trackId: string): number {
+    const chain = this.chains.get(trackId);
+    if (!chain) return 0;
+    let total = 0;
+    for (const node of chain) {
+      total += node.plugin.latencySamples ?? 0;
+    }
+    return total;
+  }
+
+  /**
    * Dispose the plugin chain for a track.
    */
   disposeChain(trackId: string): void {

--- a/src/engine/TrackNode.ts
+++ b/src/engine/TrackNode.ts
@@ -40,6 +40,7 @@ export class TrackNode {
   private _effectsInput: AudioNode | null = null;
   private _effectsOutput: AudioNode | null = null;
   private _clipped = false;
+  private latencyCompNode: DelayNode | null = null;
 
   private static readonly CLIP_THRESHOLD = 0.995;
 
@@ -353,6 +354,43 @@ export class TrackNode {
   }
 
   // -----------------------------------------------------------------------
+  // Latency Compensation (PDC)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Set latency compensation delay in samples.
+   * 0 (or negative) = bypass/remove delay.
+   * Inserts a DelayNode between compressor and volumeGain.
+   */
+  setLatencyCompensation(samples: number, sampleRate: number): void {
+    if (samples <= 0) {
+      // Bypass: remove delay node if present
+      if (this.latencyCompNode) {
+        this.compressor.disconnect(this.latencyCompNode);
+        this.latencyCompNode.disconnect(this.volumeGain);
+        this.compressor.connect(this.volumeGain);
+        this.latencyCompNode = null;
+      }
+      return;
+    }
+
+    const delaySec = samples / sampleRate;
+
+    if (this.latencyCompNode) {
+      // Update existing delay value
+      this.latencyCompNode.delayTime.value = delaySec;
+    } else {
+      // Create and insert delay node between compressor and volumeGain
+      this.latencyCompNode = this.ctx.createDelay(1.0); // max 1 second
+      this.latencyCompNode.delayTime.value = delaySec;
+
+      this.compressor.disconnect(this.volumeGain);
+      this.compressor.connect(this.latencyCompNode);
+      this.latencyCompNode.connect(this.volumeGain);
+    }
+  }
+
+  // -----------------------------------------------------------------------
 
   /**
    * Re-route the final output (analyserNode) to a new destination node.
@@ -374,6 +412,10 @@ export class TrackNode {
     this.wetGain.disconnect();
     this.sumGain.disconnect();
     this.compressor.disconnect();
+    if (this.latencyCompNode) {
+      this.latencyCompNode.disconnect();
+      this.latencyCompNode = null;
+    }
     this.volumeGain.disconnect();
     this.analyserNode.disconnect();
     this.splitter.disconnect();

--- a/src/services/vst3bridge/VST3LatencyCompensation.ts
+++ b/src/services/vst3bridge/VST3LatencyCompensation.ts
@@ -1,0 +1,68 @@
+/**
+ * Plugin Delay Compensation (PDC) for VST3 plugins.
+ *
+ * VST3 plugins introduce processing latency that must be compensated
+ * so all tracks stay in sync during playback. This class calculates
+ * the required delay for each track based on plugin chain latencies.
+ */
+export class VST3LatencyCompensation {
+  /**
+   * Calculate required delay compensation for each track.
+   *
+   * The track with the highest total plugin latency gets 0 delay;
+   * all other tracks get compensating delay equal to
+   * (maxLatency - trackLatency).
+   *
+   * @param tracks - Array of tracks with their plugin latency values (in samples).
+   * @param _sampleRate - The audio context sample rate (reserved for future use).
+   * @returns A map of trackId to delaySamples.
+   */
+  static calculateCompensation(
+    tracks: { id: string; pluginLatencies: number[] }[],
+    _sampleRate: number,
+  ): Map<string, number> {
+    const result = new Map<string, number>();
+    if (tracks.length === 0) return result;
+
+    // Sum latency per track
+    const trackLatencies = tracks.map((t) => ({
+      id: t.id,
+      total: VST3LatencyCompensation.getChainLatency(t.pluginLatencies),
+    }));
+
+    // Find the maximum latency across all tracks
+    const maxLatency = Math.max(...trackLatencies.map((t) => t.total));
+
+    // Each track's compensation = maxLatency - its own latency
+    for (const t of trackLatencies) {
+      result.set(t.id, maxLatency - t.total);
+    }
+
+    return result;
+  }
+
+  /**
+   * Get total latency for a single plugin chain (in samples).
+   *
+   * @param pluginLatencies - Array of latency values (samples) for each plugin in the chain.
+   * @returns The sum of all plugin latencies.
+   */
+  static getChainLatency(pluginLatencies: number[]): number {
+    let total = 0;
+    for (const latency of pluginLatencies) {
+      total += latency;
+    }
+    return total;
+  }
+
+  /**
+   * Convert a sample count to milliseconds.
+   *
+   * @param samples - Number of samples.
+   * @param sampleRate - Audio context sample rate (e.g. 44100, 48000).
+   * @returns Duration in milliseconds.
+   */
+  static samplesToMs(samples: number, sampleRate: number): number {
+    return (samples / sampleRate) * 1000;
+  }
+}

--- a/src/services/vst3bridge/__tests__/PluginEngineLatency.test.ts
+++ b/src/services/vst3bridge/__tests__/PluginEngineLatency.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PluginEngine } from '../../../engine/PluginEngine';
+import type { WAPPlugin, PluginAudioNode } from '../../../types/plugin';
+
+/** Create a minimal mock WAPPlugin with optional latencySamples. */
+function createMockPlugin(latencySamples?: number): WAPPlugin {
+  const gain = { connect: () => {}, disconnect: () => {} } as unknown as AudioNode;
+  return {
+    name: 'test-plugin',
+    pluginType: 'effect',
+    version: '1.0.0',
+    author: 'test',
+    description: 'test',
+    latencySamples,
+    createAudioNode: () => ({
+      inputNode: gain,
+      outputNode: gain,
+    }),
+    getParameterDescriptors: () => [],
+    setParameter: () => {},
+    getParameter: () => undefined,
+    getParameters: () => ({}),
+    dispose: () => {},
+  } as WAPPlugin;
+}
+
+describe('PluginEngine.getChainLatency', () => {
+  let engine: PluginEngine;
+  const ctx = {
+    createGain: () => ({ connect: () => {}, disconnect: () => {}, gain: { value: 1 } }),
+  } as unknown as AudioContext;
+
+  beforeEach(() => {
+    engine = new PluginEngine();
+  });
+
+  it('returns 0 for a track with no plugins', () => {
+    expect(engine.getChainLatency('no-such-track')).toBe(0);
+  });
+
+  it('returns 0 for WAP plugins (no latencySamples)', () => {
+    const plugin = createMockPlugin();
+    engine.addPlugin('track-1', 'inst-1', plugin, ctx);
+    expect(engine.getChainLatency('track-1')).toBe(0);
+  });
+
+  it('returns latencySamples for a VST3 plugin', () => {
+    const plugin = createMockPlugin(256);
+    engine.addPlugin('track-1', 'inst-1', plugin, ctx);
+    expect(engine.getChainLatency('track-1')).toBe(256);
+  });
+
+  it('sums latencies across multiple plugins in a chain', () => {
+    const p1 = createMockPlugin(128);
+    const p2 = createMockPlugin(256);
+    const p3 = createMockPlugin(); // WAP, 0 latency
+    engine.addPlugin('track-1', 'inst-1', p1, ctx);
+    engine.addPlugin('track-1', 'inst-2', p2, ctx);
+    engine.addPlugin('track-1', 'inst-3', p3, ctx);
+    expect(engine.getChainLatency('track-1')).toBe(384);
+  });
+});

--- a/src/services/vst3bridge/__tests__/VST3LatencyCompensation.test.ts
+++ b/src/services/vst3bridge/__tests__/VST3LatencyCompensation.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { VST3LatencyCompensation } from '../VST3LatencyCompensation';
+
+describe('VST3LatencyCompensation', () => {
+  const sampleRate = 44100;
+
+  describe('calculateCompensation', () => {
+    it('returns 0 compensation for a single track with no plugins', () => {
+      const tracks = [{ id: 'track-1', pluginLatencies: [] }];
+      const result = VST3LatencyCompensation.calculateCompensation(tracks, sampleRate);
+      expect(result.get('track-1')).toBe(0);
+    });
+
+    it('returns correct compensation for two tracks where one has latency', () => {
+      const tracks = [
+        { id: 'track-1', pluginLatencies: [256] },
+        { id: 'track-2', pluginLatencies: [] },
+      ];
+      const result = VST3LatencyCompensation.calculateCompensation(tracks, sampleRate);
+      // track-1 has max latency (256) → 0 compensation
+      expect(result.get('track-1')).toBe(0);
+      // track-2 has 0 latency → needs 256 delay
+      expect(result.get('track-2')).toBe(256);
+    });
+
+    it('returns correct compensation for three tracks with varying latencies', () => {
+      const tracks = [
+        { id: 'track-1', pluginLatencies: [128, 128] }, // 256 total
+        { id: 'track-2', pluginLatencies: [512] },       // 512 total (max)
+        { id: 'track-3', pluginLatencies: [64] },         // 64 total
+      ];
+      const result = VST3LatencyCompensation.calculateCompensation(tracks, sampleRate);
+      expect(result.get('track-1')).toBe(256); // 512 - 256
+      expect(result.get('track-2')).toBe(0);   // max → 0
+      expect(result.get('track-3')).toBe(448); // 512 - 64
+    });
+
+    it('returns 0 compensation for all tracks when they have the same latency', () => {
+      const tracks = [
+        { id: 'track-1', pluginLatencies: [256] },
+        { id: 'track-2', pluginLatencies: [128, 128] },
+        { id: 'track-3', pluginLatencies: [256] },
+      ];
+      const result = VST3LatencyCompensation.calculateCompensation(tracks, sampleRate);
+      expect(result.get('track-1')).toBe(0);
+      expect(result.get('track-2')).toBe(0);
+      expect(result.get('track-3')).toBe(0);
+    });
+
+    it('returns empty map for empty track list', () => {
+      const result = VST3LatencyCompensation.calculateCompensation([], sampleRate);
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('getChainLatency', () => {
+    it('returns 0 for empty plugin list', () => {
+      expect(VST3LatencyCompensation.getChainLatency([])).toBe(0);
+    });
+
+    it('sums latencies of all plugins in a chain', () => {
+      expect(VST3LatencyCompensation.getChainLatency([128, 256, 64])).toBe(448);
+    });
+
+    it('handles single plugin', () => {
+      expect(VST3LatencyCompensation.getChainLatency([512])).toBe(512);
+    });
+  });
+
+  describe('samplesToMs', () => {
+    it('converts samples to milliseconds correctly at 44100 Hz', () => {
+      // 44100 samples = 1000ms
+      expect(VST3LatencyCompensation.samplesToMs(44100, 44100)).toBeCloseTo(1000);
+    });
+
+    it('converts samples to milliseconds correctly at 48000 Hz', () => {
+      // 48000 samples = 1000ms
+      expect(VST3LatencyCompensation.samplesToMs(48000, 48000)).toBeCloseTo(1000);
+    });
+
+    it('handles 0 samples', () => {
+      expect(VST3LatencyCompensation.samplesToMs(0, 44100)).toBe(0);
+    });
+
+    it('converts 256 samples at 44100 Hz', () => {
+      const expected = (256 / 44100) * 1000;
+      expect(VST3LatencyCompensation.samplesToMs(256, 44100)).toBeCloseTo(expected);
+    });
+  });
+});

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -75,6 +75,12 @@ export interface WAPPlugin {
   readonly description: string;
 
   /**
+   * Processing latency in samples (VST3 plugins).
+   * WAP plugins that don't report latency default to 0.
+   */
+  readonly latencySamples?: number;
+
+  /**
    * Create the audio processing nodes.
    * Called once when the plugin is loaded onto a track.
    * @param ctx - The AudioContext to create nodes in.


### PR DESCRIPTION
## Summary
- `VST3LatencyCompensation.ts`: Calculate per-track delay compensation
- `TrackNode.ts`: Add DelayNode + `setLatencyCompensation(samples)` method
- `PluginEngine.ts`: Add `getChainLatency(trackId)` summing VST3 plugin latencies
- `plugin.ts`: Add `latencySamples` to PluginInstance type

## Test plan
- [x] Single track no plugins → 0 compensation
- [x] Two tracks, one with latency → correct compensation
- [x] Three tracks varying latencies → all compensated
- [x] All tracks same latency → all get 0
- [x] samplesToMs conversion
- [x] PluginEngine.getChainLatency aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #831