### PR TITLE
feat: VST3 state persistence for project save/load (W13)

### DIFF
--- a/src/services/vst3bridge/VST3StateManager.ts
+++ b/src/services/vst3bridge/VST3StateManager.ts
@@ -1,0 +1,63 @@
+/**
+ * VST3 State Manager — captures and restores VST3 plugin state for project persistence.
+ *
+ * VST3 plugins store their IComponent state as opaque binary data.
+ * This manager coordinates with the VST3BridgeClient to serialize/deserialize
+ * that state as base64 strings stored in the project file.
+ */
+
+/**
+ * Minimal interface for the VST3 bridge client used by the state manager.
+ * The full VST3BridgeClient lives in a separate module; this keeps the
+ * state manager decoupled and easy to test.
+ */
+export interface VST3BridgeClient {
+  /** Fetch the current IComponent state as a base64-encoded string. */
+  getPluginState(instanceId: string): Promise<string>;
+  /** Restore a previously captured IComponent state (base64-encoded). */
+  setPluginState(instanceId: string, base64State: string): Promise<void>;
+}
+
+export class VST3StateManager {
+  /**
+   * Before project save: fetch state from all active VST3 plugins.
+   * Returns a map of instanceId to base64-encoded component state.
+   * Errors for individual plugins are silently skipped (the plugin may
+   * have been removed or the companion disconnected).
+   */
+  static async captureAllStates(
+    bridgeClient: VST3BridgeClient,
+    instances: { trackId: string; instanceId: string }[],
+  ): Promise<Map<string, string>> {
+    const result = new Map<string, string>();
+    const tasks = instances.map(async ({ instanceId }) => {
+      try {
+        const state = await bridgeClient.getPluginState(instanceId);
+        result.set(instanceId, state);
+      } catch {
+        // Plugin unavailable — skip silently
+      }
+    });
+    await Promise.all(tasks);
+    return result;
+  }
+
+  /**
+   * After project load: restore state to all re-instantiated VST3 plugins.
+   * Errors for individual plugins are silently skipped (the plugin may
+   * not be available on this machine).
+   */
+  static async restoreAllStates(
+    bridgeClient: VST3BridgeClient,
+    instances: { instanceId: string; vst3State: string }[],
+  ): Promise<void> {
+    const tasks = instances.map(async ({ instanceId, vst3State }) => {
+      try {
+        await bridgeClient.setPluginState(instanceId, vst3State);
+      } catch {
+        // Plugin unavailable — skip silently
+      }
+    });
+    await Promise.all(tasks);
+  }
+}

--- a/src/services/vst3bridge/__tests__/VST3StateManager.test.ts
+++ b/src/services/vst3bridge/__tests__/VST3StateManager.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { VST3StateManager, type VST3BridgeClient } from '../VST3StateManager';
+
+function makeMockBridge(
+  stateMap: Record<string, string> = {},
+): VST3BridgeClient {
+  return {
+    getPluginState: vi.fn(async (instanceId: string) => {
+      const state = stateMap[instanceId];
+      if (!state) throw new Error(`Plugin ${instanceId} not found`);
+      return state;
+    }),
+    setPluginState: vi.fn(async () => {}),
+  };
+}
+
+describe('VST3StateManager.captureAllStates', () => {
+  it('fetches state from all instances via bridge client', async () => {
+    const bridge = makeMockBridge({
+      'inst-1': 'c3RhdGUx',
+      'inst-2': 'c3RhdGUy',
+    });
+
+    const result = await VST3StateManager.captureAllStates(bridge, [
+      { trackId: 't1', instanceId: 'inst-1' },
+      { trackId: 't2', instanceId: 'inst-2' },
+    ]);
+
+    expect(result.size).toBe(2);
+    expect(result.get('inst-1')).toBe('c3RhdGUx');
+    expect(result.get('inst-2')).toBe('c3RhdGUy');
+    expect(bridge.getPluginState).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips instances that fail (plugin unavailable)', async () => {
+    const bridge = makeMockBridge({ 'inst-1': 'c3RhdGUx' });
+    // inst-2 will throw because it's not in the map
+
+    const result = await VST3StateManager.captureAllStates(bridge, [
+      { trackId: 't1', instanceId: 'inst-1' },
+      { trackId: 't2', instanceId: 'inst-2' },
+    ]);
+
+    expect(result.size).toBe(1);
+    expect(result.get('inst-1')).toBe('c3RhdGUx');
+    expect(result.has('inst-2')).toBe(false);
+  });
+
+  it('returns empty map for empty instances list', async () => {
+    const bridge = makeMockBridge();
+    const result = await VST3StateManager.captureAllStates(bridge, []);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('VST3StateManager.restoreAllStates', () => {
+  it('sets state for all instances via bridge client', async () => {
+    const bridge = makeMockBridge();
+
+    await VST3StateManager.restoreAllStates(bridge, [
+      { instanceId: 'inst-1', vst3State: 'c3RhdGUx' },
+      { instanceId: 'inst-2', vst3State: 'c3RhdGUy' },
+    ]);
+
+    expect(bridge.setPluginState).toHaveBeenCalledTimes(2);
+    expect(bridge.setPluginState).toHaveBeenCalledWith('inst-1', 'c3RhdGUx');
+    expect(bridge.setPluginState).toHaveBeenCalledWith('inst-2', 'c3RhdGUy');
+  });
+
+  it('skips instances that fail without throwing', async () => {
+    const bridge: VST3BridgeClient = {
+      getPluginState: vi.fn(),
+      setPluginState: vi.fn(async (instanceId: string) => {
+        if (instanceId === 'inst-2') throw new Error('Plugin missing');
+      }),
+    };
+
+    // Should not throw
+    await VST3StateManager.restoreAllStates(bridge, [
+      { instanceId: 'inst-1', vst3State: 'c3RhdGUx' },
+      { instanceId: 'inst-2', vst3State: 'c3RhdGUy' },
+    ]);
+
+    expect(bridge.setPluginState).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles empty instances list', async () => {
+    const bridge = makeMockBridge();
+    await VST3StateManager.restoreAllStates(bridge, []);
+    expect(bridge.setPluginState).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/__tests__/vst3StatePersistence.test.ts
+++ b/src/store/__tests__/vst3StatePersistence.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+import type { PluginInstance } from '../../types/plugin';
+
+vi.mock('../../services/projectStorage', () => ({ saveProject: vi.fn() }));
+
+/** Helper: create a minimal VST3 PluginInstance. */
+function makeVST3Plugin(overrides?: Partial<PluginInstance>): PluginInstance {
+  return {
+    id: 'vst3-inst-1',
+    pluginId: 'fabfilter-pro-q3',
+    enabled: true,
+    params: {},
+    manifest: {
+      id: 'fabfilter-pro-q3',
+      name: 'FabFilter Pro-Q 3',
+      pluginType: 'effect',
+      version: '3.0.0',
+      author: 'FabFilter',
+      description: 'Parametric EQ',
+      parameters: [],
+    },
+    isVST3: true,
+    vst3Uid: 'ABCD1234',
+    vst3State: 'c29tZUJhc2U2NA==',
+    ...overrides,
+  };
+}
+
+/** Helper: create a minimal WAP (non-VST3) PluginInstance. */
+function makeWAPPlugin(overrides?: Partial<PluginInstance>): PluginInstance {
+  return {
+    id: 'wap-inst-1',
+    pluginId: 'ace-bitcrusher',
+    enabled: true,
+    params: { bits: 8 },
+    manifest: {
+      id: 'ace-bitcrusher',
+      name: 'Bitcrusher',
+      pluginType: 'effect',
+      version: '1.0.0',
+      author: 'ACE',
+      description: 'Lo-fi effect',
+      parameters: [],
+    },
+    ...overrides,
+  };
+}
+
+describe('VST3 state persistence — PluginInstance type', () => {
+  it('PluginInstance with VST3 fields serializes and deserializes correctly', () => {
+    const instance = makeVST3Plugin();
+    const json = JSON.stringify(instance);
+    const parsed: PluginInstance = JSON.parse(json);
+
+    expect(parsed.isVST3).toBe(true);
+    expect(parsed.vst3Uid).toBe('ABCD1234');
+    expect(parsed.vst3State).toBe('c29tZUJhc2U2NA==');
+    expect(parsed.id).toBe('vst3-inst-1');
+    expect(parsed.pluginId).toBe('fabfilter-pro-q3');
+  });
+
+  it('PluginInstance without VST3 fields serializes without extra keys', () => {
+    const instance = makeWAPPlugin();
+    const json = JSON.stringify(instance);
+    const parsed: PluginInstance = JSON.parse(json);
+
+    expect(parsed.isVST3).toBeUndefined();
+    expect(parsed.vst3Uid).toBeUndefined();
+    expect(parsed.vst3State).toBeUndefined();
+  });
+});
+
+describe('VST3 state persistence — projectStore actions', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject({ name: 'Test', bpm: 120 });
+    useProjectStore.getState().addTrack('pianoRoll');
+  });
+
+  it('updateVST3State updates the vst3State of the correct plugin instance', () => {
+    const trackId = useProjectStore.getState().project!.tracks[0].id;
+    const vst3Plugin = makeVST3Plugin({ id: 'v1' });
+    const wapPlugin = makeWAPPlugin({ id: 'w1' });
+
+    useProjectStore.getState().addPlugin(trackId, vst3Plugin);
+    useProjectStore.getState().addPlugin(trackId, wapPlugin);
+
+    useProjectStore.getState().updateVST3State(trackId, 'v1', 'bmV3U3RhdGU=');
+
+    const track = useProjectStore.getState().project!.tracks.find((t) => t.id === trackId)!;
+    const updated = track.plugins!.find((p) => p.id === 'v1')!;
+    expect(updated.vst3State).toBe('bmV3U3RhdGU=');
+
+    // Other plugin unchanged
+    const other = track.plugins!.find((p) => p.id === 'w1')!;
+    expect(other.vst3State).toBeUndefined();
+  });
+
+  it('updateVST3State is a no-op when project is null', () => {
+    useProjectStore.setState({ project: null });
+    // Should not throw
+    useProjectStore.getState().updateVST3State('t1', 'i1', 'state');
+  });
+
+  it('getAllVST3Instances returns only VST3 plugins across all tracks', () => {
+    const state = useProjectStore.getState();
+    const trackId1 = state.project!.tracks[0].id;
+
+    // Add a second track
+    state.addTrack('stems');
+    const trackId2 = useProjectStore.getState().project!.tracks[1].id;
+
+    // Add plugins
+    useProjectStore.getState().addPlugin(trackId1, makeVST3Plugin({ id: 'v1', vst3Uid: 'UID-A' }));
+    useProjectStore.getState().addPlugin(trackId1, makeWAPPlugin({ id: 'w1' }));
+    useProjectStore.getState().addPlugin(trackId2, makeVST3Plugin({ id: 'v2', vst3Uid: 'UID-B' }));
+
+    const instances = useProjectStore.getState().getAllVST3Instances();
+    expect(instances).toHaveLength(2);
+    expect(instances).toEqual(
+      expect.arrayContaining([
+        { trackId: trackId1, instanceId: 'v1', vst3Uid: 'UID-A' },
+        { trackId: trackId2, instanceId: 'v2', vst3Uid: 'UID-B' },
+      ]),
+    );
+  });
+
+  it('getAllVST3Instances returns empty array when project is null', () => {
+    useProjectStore.setState({ project: null });
+    expect(useProjectStore.getState().getAllVST3Instances()).toEqual([]);
+  });
+
+  it('getAllVST3Instances skips VST3 plugins without vst3Uid', () => {
+    const trackId = useProjectStore.getState().project!.tracks[0].id;
+    useProjectStore.getState().addPlugin(
+      trackId,
+      makeVST3Plugin({ id: 'v-no-uid', vst3Uid: undefined }),
+    );
+
+    const instances = useProjectStore.getState().getAllVST3Instances();
+    expect(instances).toHaveLength(0);
+  });
+});
+
+describe('VST3 state persistence — backward compatibility', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject({ name: 'Legacy', bpm: 120 });
+    useProjectStore.getState().addTrack('pianoRoll');
+  });
+
+  it('loading a project without VST3 fields works (tracks with no plugins)', () => {
+    const project = useProjectStore.getState().project!;
+    // Simulate a legacy project: tracks exist but no plugins array
+    const legacyTrack = { ...project.tracks[0] };
+    delete (legacyTrack as Record<string, unknown>).plugins;
+
+    useProjectStore.setState({
+      project: { ...project, tracks: [legacyTrack] },
+    });
+
+    // getAllVST3Instances should handle missing plugins gracefully
+    const instances = useProjectStore.getState().getAllVST3Instances();
+    expect(instances).toEqual([]);
+  });
+
+  it('loading a project with WAP-only plugins works (no VST3 fields)', () => {
+    const trackId = useProjectStore.getState().project!.tracks[0].id;
+    useProjectStore.getState().addPlugin(trackId, makeWAPPlugin());
+
+    const instances = useProjectStore.getState().getAllVST3Instances();
+    expect(instances).toEqual([]);
+
+    // WAP plugin remains intact
+    const track = useProjectStore.getState().project!.tracks.find((t) => t.id === trackId)!;
+    expect(track.plugins).toHaveLength(1);
+    expect(track.plugins![0].pluginId).toBe('ace-bitcrusher');
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -767,6 +767,12 @@ export interface ProjectState {
   togglePlugin: (trackId: string, pluginInstanceId: string) => void;
   loadPlugin: (trackId: string, pluginId: string) => string | undefined;
 
+  // VST3 state persistence
+  /** Update VST3 state for a plugin instance (called before save). */
+  updateVST3State: (trackId: string, instanceId: string, state: string) => void;
+  /** Get all VST3 plugin instances across all tracks (for batch state save). */
+  getAllVST3Instances: () => { trackId: string; instanceId: string; vst3Uid: string }[];
+
   // MIDI effects
   addMidiEffect: (trackId: string, type: MidiEffectType) => string | undefined;
   removeMidiEffect: (trackId: string, effectId: string) => void;
@@ -6006,6 +6012,43 @@ export const useProjectStore = create<ProjectState>()(
       },
     });
     return id;
+  },
+
+  // ─── VST3 State Persistence ──────────────────────────────────────────────
+
+  updateVST3State: (trackId, instanceId, vst3State) => {
+    const state = get();
+    if (!state.project) return;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) =>
+          track.id === trackId
+            ? {
+                ...track,
+                plugins: (track.plugins ?? []).map((p) =>
+                  p.id === instanceId ? { ...p, vst3State } : p,
+                ),
+              }
+            : track,
+        ),
+      },
+    });
+  },
+
+  getAllVST3Instances: () => {
+    const state = get();
+    if (!state.project) return [];
+    const results: { trackId: string; instanceId: string; vst3Uid: string }[] = [];
+    for (const track of state.project.tracks) {
+      for (const plugin of track.plugins ?? []) {
+        if (plugin.isVST3 && plugin.vst3Uid) {
+          results.push({ trackId: track.id, instanceId: plugin.id, vst3Uid: plugin.vst3Uid });
+        }
+      }
+    }
+    return results;
   },
 
   // ─── MIDI Effects ──────────────────────────────────────────────────────────

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -176,6 +176,12 @@ export interface PluginInstance {
   params: PluginParamValues;
   /** Plugin manifest snapshot for display. */
   manifest: PluginManifest;
+  /** VST3 plugin unique ID — used to re-instantiate the correct plugin on load. */
+  vst3Uid?: string;
+  /** Base64-encoded VST3 IComponent state (opaque binary blob). */
+  vst3State?: string;
+  /** Discriminator flag — true when this instance wraps a native VST3 plugin. */
+  isVST3?: boolean;
 }
 
 // ─── Plugin Factory ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extend `PluginInstance` with `vst3Uid`, `vst3State`, `isVST3` fields
- `updateVST3State` and `getAllVST3Instances` store actions
- `VST3StateManager`: capture/restore all VST3 plugin states via bridge client
- Full backward compatibility — projects without VST3 fields load fine

## Test plan
- [x] PluginInstance with VST3 fields serializes correctly
- [x] updateVST3State updates correct instance
- [x] getAllVST3Instances returns only VST3 plugins
- [x] captureAllStates fetches from bridge
- [x] restoreAllStates sets state for all instances
- [x] Backward compat: projects without VST3 fields load fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #834