### PR TITLE
fix: stop Strudel audio when editor panel closes (#839)

### DIFF
--- a/src/components/strudel/StrudelEditor.tsx
+++ b/src/components/strudel/StrudelEditor.tsx
@@ -9,7 +9,7 @@ import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
 import { Z } from '../../utils/zIndex';
 import type { StrudelFromMidiOptions } from '../../types/project';
-import { registerStrudelEditorPlaybackStop } from '../../engine/strudelEditorPlayback';
+import { registerStrudelEditorPlaybackStop, registerStrudelEditorAudioContext } from '../../engine/strudelEditorPlayback';
 const DEFAULT_CODE = `s("[bd <hh oh>]*2, [~ cp]*2")`;
 
 // Inject CSS to constrain the autocomplete info panel
@@ -223,6 +223,12 @@ export function StrudelEditor() {
         }
 
         editorRef.current = editor;
+
+        // Register the AudioContext so transport stop can force-kill audio
+        // even after this component unmounts.
+        const ctx = webaudioMod.getAudioContext?.();
+        if (ctx) registerStrudelEditorAudioContext(ctx);
+
         setIsLoading(false);
         setConsoleMessages(['🌀 Strudel ready']);
       } catch (err) {

--- a/src/engine/__tests__/strudelEditorPlayback.test.ts
+++ b/src/engine/__tests__/strudelEditorPlayback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   registerStrudelEditorPlaybackStop,
+  registerStrudelEditorAudioContext,
   stopStrudelEditorPlayback,
 } from '../strudelEditorPlayback';
 
@@ -23,5 +24,41 @@ describe('strudelEditorPlayback', () => {
     stopStrudelEditorPlayback();
 
     expect(stop).not.toHaveBeenCalled();
+  });
+
+  it('suspends AudioContext as fallback when handler is null', async () => {
+    registerStrudelEditorPlaybackStop(null);
+
+    const suspendFn = vi.fn(() => Promise.resolve());
+    const resumeFn = vi.fn();
+    const fakeCtx = { state: 'running', suspend: suspendFn, resume: resumeFn } as unknown as AudioContext;
+    registerStrudelEditorAudioContext(fakeCtx);
+
+    stopStrudelEditorPlayback();
+
+    expect(suspendFn).toHaveBeenCalledTimes(1);
+    // Wait for the suspend promise to resolve so resume is called
+    await vi.waitFor(() => expect(resumeFn).toHaveBeenCalledTimes(1));
+
+    // Cleanup
+    registerStrudelEditorAudioContext(null);
+  });
+
+  it('does not suspend AudioContext when handler is registered', () => {
+    const stop = vi.fn();
+    registerStrudelEditorPlaybackStop(stop);
+
+    const suspendFn = vi.fn(() => Promise.resolve());
+    const fakeCtx = { state: 'running', suspend: suspendFn, resume: vi.fn() } as unknown as AudioContext;
+    registerStrudelEditorAudioContext(fakeCtx);
+
+    stopStrudelEditorPlayback();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(suspendFn).not.toHaveBeenCalled();
+
+    // Cleanup
+    registerStrudelEditorPlaybackStop(null);
+    registerStrudelEditorAudioContext(null);
   });
 });

--- a/src/engine/strudelEditorPlayback.ts
+++ b/src/engine/strudelEditorPlayback.ts
@@ -1,4 +1,5 @@
 let stopHandler: (() => void) | null = null;
+let editorAudioContext: AudioContext | null = null;
 
 /**
  * Register the live Strudel editor playback stop handler so transport controls
@@ -9,8 +10,26 @@ export function registerStrudelEditorPlaybackStop(handler: (() => void) | null):
 }
 
 /**
+ * Register the AudioContext used by the Strudel editor so we can force-stop
+ * audio even after the editor component unmounts.
+ */
+export function registerStrudelEditorAudioContext(ctx: AudioContext | null): void {
+  editorAudioContext = ctx;
+}
+
+/**
  * Stop any active Strudel editor playback.
+ * Falls back to suspending the AudioContext if the handler was cleared
+ * (e.g. editor component already unmounted).
  */
 export function stopStrudelEditorPlayback(): void {
-  stopHandler?.();
+  if (stopHandler) {
+    stopHandler();
+  } else if (editorAudioContext && editorAudioContext.state === 'running') {
+    // Nuclear fallback: suspend the AudioContext to kill all audio nodes.
+    // Resume it immediately so future playback works.
+    editorAudioContext.suspend().then(() => {
+      editorAudioContext?.resume();
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Adds AudioContext suspend/resume fallback to `stopStrudelEditorPlayback()` for when the stop handler has been cleared (editor unmounted)
- Registers the Strudel editor's AudioContext at module level in `strudelEditorPlayback.ts` so it persists beyond component lifecycle
- When the stop handler is null (panel closed), suspends the AudioContext to kill all audio nodes, then immediately resumes for future playback

## Root Cause
When the Strudel editor panel closes, the component unmounts and the stop handler is cleared to null. The underlying WebAudio scheduler continues running with no way to stop it — transport stop, seeking, and all other controls become useless.

## Files Changed
- `src/engine/strudelEditorPlayback.ts` — added `registerStrudelEditorAudioContext()` and AudioContext suspend fallback
- `src/components/strudel/StrudelEditor.tsx` — register AudioContext after editor init
- `src/engine/__tests__/strudelEditorPlayback.test.ts` — tests for AudioContext fallback behavior

## Test Plan
- [ ] Open Strudel panel, play a pattern, close panel → audio stops
- [ ] Open Strudel panel, play, press transport Stop → audio stops
- [ ] Open Strudel panel, play, close panel, reopen, play again → works normally

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)