### PR TITLE
fix: Strudel play/stop broken — init effect dependency cycle destroys editor on evaluate

### DIFF
--- a/src/components/strudel/StrudelEditor.tsx
+++ b/src/components/strudel/StrudelEditor.tsx
@@ -9,7 +9,7 @@ import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
 import { Z } from '../../utils/zIndex';
 import type { StrudelFromMidiOptions } from '../../types/project';
-import { registerStrudelEditorPlaybackStop, registerStrudelEditorAudioContext } from '../../engine/strudelEditorPlayback';
+import { registerStrudelEditorPlaybackStop, registerStrudelEditorAudioContext, resumeStrudelAudio } from '../../engine/strudelEditorPlayback';
 const DEFAULT_CODE = `s("[bd <hh oh>]*2, [~ cp]*2")`;
 
 // Inject CSS to constrain the autocomplete info panel
@@ -175,7 +175,13 @@ export function StrudelEditor() {
         containerRef.current.innerHTML = '';
 
         const store = useProjectStore.getState();
-        let strudelTrack = activeStrudelTrack;
+        // Read the track from the store snapshot — NOT from the reactive
+        // `activeStrudelTrack` memo. Using the memo as a dependency would
+        // cause this entire init effect to re-run (and destroy+recreate
+        // the editor) every time the track's code changes via evaluate().
+        let strudelTrack = openStrudelEditorTrackId
+          ? store.project?.tracks.find((t) => t.id === openStrudelEditorTrackId && t.trackType === 'strudel')
+          : store.project?.tracks.find((t) => t.trackType === 'strudel');
         if (!strudelTrack) {
           strudelTrack = store.addTrack('custom', 'strudel');
           setOpenStrudelEditor(strudelTrack.id);
@@ -244,7 +250,9 @@ export function StrudelEditor() {
       editorRef.current = null;
       if (containerRef.current) containerRef.current.innerHTML = '';
     };
-  }, [activeStrudelTrack, openStrudelEditorTrackId, setOpenStrudelEditor, stopEditorPlayback, strudelPanelOpen]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- activeStrudelTrack intentionally excluded:
+  // the effect reads the track from the store snapshot to avoid re-init on every code change.
+  }, [openStrudelEditorTrackId, setOpenStrudelEditor, stopEditorPlayback, strudelPanelOpen]);
 
   useEffect(() => {
     if (!strudelPanelOpen) {
@@ -263,6 +271,8 @@ export function StrudelEditor() {
       stopEditorPlayback();
       setConsoleMessages((prev) => [...prev.slice(-50), '⏹ stopped']);
     } else {
+      // Resume AudioContexts in background — evaluate() triggers audio init anyway
+      resumeStrudelAudio();
       editorRef.current.evaluate();
       setIsPlaying(true);
     }
@@ -271,6 +281,7 @@ export function StrudelEditor() {
   // Update (re-evaluate while playing)
   const handleUpdate = useCallback(() => {
     if (!editorRef.current) return;
+    resumeStrudelAudio();
     editorRef.current.evaluate();
     if (!isPlaying) setIsPlaying(true);
   }, [isPlaying]);
@@ -283,6 +294,7 @@ export function StrudelEditor() {
     try {
       // Evaluate first to sync code to store
       if (editorRef.current) {
+        resumeStrudelAudio();
         editorRef.current.evaluate();
         setIsPlaying(true);
         await new Promise((r) => setTimeout(r, 300));

--- a/src/engine/__tests__/strudelEditorPlayback.test.ts
+++ b/src/engine/__tests__/strudelEditorPlayback.test.ts
@@ -2,10 +2,22 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   registerStrudelEditorPlaybackStop,
   registerStrudelEditorAudioContext,
+  getStrudelEditorAudioContext,
   stopStrudelEditorPlayback,
+  resumeStrudelAudio,
 } from '../strudelEditorPlayback';
 
+// Mock superdough so the dynamic import in stopStrudelEditorPlayback resolves
+vi.mock('superdough', () => ({
+  getAudioContext: vi.fn(() => null),
+}));
+
 describe('strudelEditorPlayback', () => {
+  afterEach(() => {
+    registerStrudelEditorPlaybackStop(null);
+    registerStrudelEditorAudioContext(null);
+  });
+
   it('calls the registered stop handler', () => {
     const stop = vi.fn();
     registerStrudelEditorPlaybackStop(stop);
@@ -13,10 +25,9 @@ describe('strudelEditorPlayback', () => {
     stopStrudelEditorPlayback();
 
     expect(stop).toHaveBeenCalledTimes(1);
-    registerStrudelEditorPlaybackStop(null);
   });
 
-  it('clears the stop handler when unregistered', () => {
+  it('does not call handler when unregistered', () => {
     const stop = vi.fn();
     registerStrudelEditorPlaybackStop(stop);
     registerStrudelEditorPlaybackStop(null);
@@ -26,36 +37,43 @@ describe('strudelEditorPlayback', () => {
     expect(stop).not.toHaveBeenCalled();
   });
 
-  it('suspends AudioContext as fallback when handler is null', async () => {
-    registerStrudelEditorPlaybackStop(null);
-
-    const suspendFn = vi.fn(() => Promise.resolve());
-    const resumeFn = vi.fn();
-    const fakeCtx = { state: 'running', suspend: suspendFn, resume: resumeFn } as unknown as AudioContext;
-    registerStrudelEditorAudioContext(fakeCtx);
-
-    stopStrudelEditorPlayback();
-
-    expect(suspendFn).toHaveBeenCalledTimes(1);
-    await vi.waitFor(() => expect(resumeFn).toHaveBeenCalledTimes(1));
-
-    registerStrudelEditorAudioContext(null);
-  });
-
-  it('does not suspend AudioContext when handler is registered', () => {
-    const stop = vi.fn();
-    registerStrudelEditorPlaybackStop(stop);
-
+  it('suspends registered AudioContext on stop', () => {
     const suspendFn = vi.fn(() => Promise.resolve());
     const fakeCtx = { state: 'running', suspend: suspendFn, resume: vi.fn() } as unknown as AudioContext;
     registerStrudelEditorAudioContext(fakeCtx);
 
     stopStrudelEditorPlayback();
 
-    expect(stop).toHaveBeenCalledTimes(1);
-    expect(suspendFn).not.toHaveBeenCalled();
+    expect(suspendFn).toHaveBeenCalledTimes(1);
+  });
 
-    registerStrudelEditorPlaybackStop(null);
+  it('does not suspend if AudioContext is already suspended', () => {
+    const suspendFn = vi.fn(() => Promise.resolve());
+    const fakeCtx = { state: 'suspended', suspend: suspendFn, resume: vi.fn() } as unknown as AudioContext;
+    registerStrudelEditorAudioContext(fakeCtx);
+
+    stopStrudelEditorPlayback();
+
+    expect(suspendFn).not.toHaveBeenCalled();
+  });
+
+  it('getStrudelEditorAudioContext returns the registered context', () => {
+    const fakeCtx = { state: 'running' } as unknown as AudioContext;
+    registerStrudelEditorAudioContext(fakeCtx);
+
+    expect(getStrudelEditorAudioContext()).toBe(fakeCtx);
+
     registerStrudelEditorAudioContext(null);
+    expect(getStrudelEditorAudioContext()).toBeNull();
+  });
+
+  it('resumeStrudelAudio resumes suspended context', async () => {
+    const resumeFn = vi.fn(() => Promise.resolve());
+    const fakeCtx = { state: 'suspended', resume: resumeFn } as unknown as AudioContext;
+    registerStrudelEditorAudioContext(fakeCtx);
+
+    await resumeStrudelAudio();
+
+    expect(resumeFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/engine/strudelEditorPlayback.ts
+++ b/src/engine/strudelEditorPlayback.ts
@@ -18,18 +18,55 @@ export function registerStrudelEditorAudioContext(ctx: AudioContext | null): voi
 }
 
 /**
+ * Get the registered Strudel editor AudioContext.
+ */
+export function getStrudelEditorAudioContext(): AudioContext | null {
+  return editorAudioContext;
+}
+
+/**
+ * Resume all Strudel-related AudioContexts that may have been suspended by stop.
+ * Call this before evaluate/play to ensure audio can flow again.
+ */
+export async function resumeStrudelAudio(): Promise<void> {
+  if (editorAudioContext?.state === 'suspended') {
+    await editorAudioContext.resume();
+  }
+  // Also resume superdough's internal context if different
+  try {
+    const sd = await import('superdough');
+    const superdoughCtx = sd.getAudioContext?.();
+    if (superdoughCtx && superdoughCtx !== editorAudioContext && superdoughCtx.state === 'suspended') {
+      await superdoughCtx.resume();
+    }
+  } catch {
+    // superdough not available
+  }
+}
+
+/**
  * Stop any active Strudel editor playback.
- * Falls back to suspending the AudioContext if the handler was cleared
- * (e.g. editor component already unmounted).
+ *
+ * Calls the stop handler if registered, then suspends the AudioContext to
+ * silence superdough audio nodes. Also dynamically imports superdough to
+ * suspend its internal AudioContext (which may differ from the registered one).
+ *
+ * The AudioContext is NOT resumed here — it will be resumed on next play.
  */
 export function stopStrudelEditorPlayback(): void {
   if (stopHandler) {
     stopHandler();
-  } else if (editorAudioContext && editorAudioContext.state === 'running') {
-    // Nuclear fallback: suspend the AudioContext to kill all audio nodes.
-    // Resume it immediately so future playback works.
-    editorAudioContext.suspend().then(() => {
-      editorAudioContext?.resume();
-    });
   }
+  // Suspend the registered Strudel AudioContext
+  if (editorAudioContext && editorAudioContext.state === 'running') {
+    editorAudioContext.suspend();
+  }
+  // Also suspend superdough's internal AudioContext — it may be a different
+  // instance than the one registered if timing/init order differed.
+  import('superdough').then((sd) => {
+    const superdoughCtx = sd.getAudioContext?.();
+    if (superdoughCtx && superdoughCtx !== editorAudioContext && superdoughCtx.state === 'running') {
+      superdoughCtx.suspend();
+    }
+  }).catch(() => {});
 }


### PR DESCRIPTION
## Summary

- **Root cause**: The StrudelMirror init `useEffect` included `activeStrudelTrack` in its dependency array. Every `evaluate()` call updates the track's `strudelCode` via `onUpdateState`, which mutates the project state, triggers a new `activeStrudelTrack` reference, and **re-runs the init effect** — destroying and recreating the editor immediately after play starts.
- **Result**: `cyclist.stop()` fires during cleanup → `onUpdateState({ started: false })` → `isPlaying` stays false → play button never becomes stop → user cannot stop audio.
- **Fix**: Remove `activeStrudelTrack` from the init effect deps. Read the track from the store snapshot inside the effect instead of reactively. This prevents the evaluate→update→reinit cycle.
- Also includes AudioContext suspend/resume for robust stop after panel close, and superdough dual-context handling.

## Files Changed

- `src/components/strudel/StrudelEditor.tsx` — remove `activeStrudelTrack` from init effect deps, read track from store snapshot, add `resumeStrudelAudio()` calls
- `src/engine/strudelEditorPlayback.ts` — add `getStrudelEditorAudioContext`, `resumeStrudelAudio`, dual-context suspend in stop
- `src/engine/__tests__/strudelEditorPlayback.test.ts` — tests for suspend/resume/getter

## Test Plan

- [ ] Open Strudel panel → click Play → button changes to Stop, spiral spins
- [ ] Click Stop → audio stops, button returns to Play
- [ ] Close panel while playing → audio stops
- [ ] Reopen panel → click Play → works again
- [ ] Transport stop also stops Strudel audio

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)