### PR TITLE
feat: wire VST3 Load button to instantiate plugins

### DIFF
--- a/src/components/plugins/VST3SidePanel.tsx
+++ b/src/components/plugins/VST3SidePanel.tsx
@@ -1,11 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useUIStore } from '../../store/uiStore';
+import { useVST3Store } from '../../store/vst3Store';
+import { useProjectStore } from '../../store/projectStore';
 import { VST3PluginBrowser } from './VST3PluginBrowser';
 import { Z } from '../../utils/zIndex';
 
 export function VST3SidePanel() {
   const show = useUIStore((s) => s.showVST3Panel);
   const setShow = useUIStore((s) => s.setShowVST3Panel);
+  const selectedTrackIds = useUIStore((s) => s.selectedTrackIds);
+  const firstTrackId = useProjectStore((s) => s.project?.tracks[0]?.id ?? '');
+  const loadPlugin = useVST3Store((s) => s.loadPlugin);
 
   // Delay unmount for exit animation
   const [renderPanel, setRenderPanel] = useState(show);
@@ -16,6 +21,17 @@ export function VST3SidePanel() {
       return () => clearTimeout(t);
     }
   }, [show]);
+
+  const handleLoadPlugin = useCallback(
+    (pluginId: string) => {
+      // Use the first selected track, or fall back to the first track in the project
+      const [firstSelected] = selectedTrackIds;
+      const trackId = firstSelected ?? firstTrackId;
+      if (!trackId) return;
+      loadPlugin(pluginId, trackId);
+    },
+    [selectedTrackIds, firstTrackId, loadPlugin],
+  );
 
   if (!renderPanel && !show) return null;
 
@@ -47,7 +63,7 @@ export function VST3SidePanel() {
 
       {/* Plugin Browser */}
       <div className="flex-1 overflow-y-auto">
-        <VST3PluginBrowser />
+        <VST3PluginBrowser onLoadPlugin={handleLoadPlugin} />
       </div>
     </aside>
   );

--- a/src/components/plugins/__tests__/VST3SidePanel.test.tsx
+++ b/src/components/plugins/__tests__/VST3SidePanel.test.tsx
@@ -1,11 +1,27 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { VST3SidePanel } from '../VST3SidePanel';
 import { useUIStore } from '../../../store/uiStore';
+import { useVST3Store } from '../../../store/vst3Store';
+import { useProjectStore } from '../../../store/projectStore';
 
 describe('VST3SidePanel', () => {
   beforeEach(() => {
-    useUIStore.setState({ showVST3Panel: false });
+    useUIStore.setState({ showVST3Panel: false, selectedTrackIds: new Set() });
+    useVST3Store.setState({
+      connectionStatus: 'connected',
+      plugins: [
+        {
+          id: 'com.xfer.serum',
+          name: 'Serum',
+          vendor: 'Xfer Records',
+          version: '1.0.0',
+          category: 'instrument',
+          subcategory: 'Synthesizer',
+        },
+      ],
+      instances: {},
+    });
   });
 
   it('is not rendered when showVST3Panel is false', () => {
@@ -31,5 +47,56 @@ describe('VST3SidePanel', () => {
     useUIStore.setState({ showVST3Panel: true });
     render(<VST3SidePanel />);
     expect(screen.getByTestId('vst3-side-panel')).toBeInTheDocument();
+  });
+
+  it('calls loadPlugin with first track when Load button is clicked', () => {
+    useUIStore.setState({ showVST3Panel: true });
+    useProjectStore.setState({
+      project: {
+        id: 'proj-1',
+        name: 'Test',
+        bpm: 120,
+        tracks: [{ id: 'track-1', name: 'Track 1', type: 'stems', clips: [], color: '#fff', mute: false, solo: false, volume: 0.8, pan: 0 }],
+      } as any,
+    });
+
+    const loadPluginSpy = vi.spyOn(useVST3Store.getState(), 'loadPlugin');
+
+    render(<VST3SidePanel />);
+
+    const loadButtons = screen.getAllByTestId('plugin-load-btn');
+    expect(loadButtons.length).toBeGreaterThan(0);
+    fireEvent.click(loadButtons[0]);
+
+    expect(loadPluginSpy).toHaveBeenCalledWith('com.xfer.serum', 'track-1');
+    loadPluginSpy.mockRestore();
+  });
+
+  it('uses selected track when available', () => {
+    useUIStore.setState({
+      showVST3Panel: true,
+      selectedTrackIds: new Set(['track-selected']),
+    });
+    useProjectStore.setState({
+      project: {
+        id: 'proj-1',
+        name: 'Test',
+        bpm: 120,
+        tracks: [
+          { id: 'track-1', name: 'Track 1', type: 'stems', clips: [], color: '#fff', mute: false, solo: false, volume: 0.8, pan: 0 },
+          { id: 'track-selected', name: 'Selected', type: 'stems', clips: [], color: '#fff', mute: false, solo: false, volume: 0.8, pan: 0 },
+        ],
+      } as any,
+    });
+
+    const loadPluginSpy = vi.spyOn(useVST3Store.getState(), 'loadPlugin');
+
+    render(<VST3SidePanel />);
+
+    const loadButtons = screen.getAllByTestId('plugin-load-btn');
+    fireEvent.click(loadButtons[0]);
+
+    expect(loadPluginSpy).toHaveBeenCalledWith('com.xfer.serum', 'track-selected');
+    loadPluginSpy.mockRestore();
   });
 });

--- a/src/store/__tests__/vst3Store.test.ts
+++ b/src/store/__tests__/vst3Store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { useVST3Store } from '../vst3Store';
 import type { VST3ActiveInstance, VST3PluginInfo } from '../../types/vst3';
@@ -204,6 +204,90 @@ describe('vst3Store', () => {
       const { instances } = useVST3Store.getState();
       expect(instances['i1'].online).toBe(false);
       expect(instances['i2'].online).toBe(false);
+    });
+  });
+
+  describe('loadPlugin', () => {
+    const pluginInfo = mockPlugin({ id: 'com.xfer.serum', name: 'Serum', vendor: 'Xfer Records' });
+
+    beforeEach(() => {
+      useVST3Store.setState({ plugins: [pluginInfo], connectionStatus: 'connected' });
+    });
+
+    it('creates an instance in the store on success', async () => {
+      const { _getBridgeClient } = await import('../../hooks/useVST3Connection');
+      const client = _getBridgeClient();
+
+      // Intercept on/off to capture event listeners registered by loadPlugin
+      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+      client.on = vi.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+        if (!listeners[event]) listeners[event] = [];
+        listeners[event].push(handler);
+      });
+      client.off = vi.fn();
+
+      // Mock createInstance to simulate the companion responding with instanceCreated
+      const mockCreateInstance = vi.fn().mockImplementation((_pluginUid: string, instanceId: string) => {
+        queueMicrotask(() => {
+          for (const fn of listeners['instanceCreated'] ?? []) {
+            fn(instanceId, []);
+          }
+        });
+        return Promise.resolve();
+      });
+      client.createInstance = mockCreateInstance;
+
+      await useVST3Store.getState().loadPlugin('com.xfer.serum', 'track-1');
+
+      // Should have called createInstance with the pluginId and a generated instanceId
+      expect(mockCreateInstance).toHaveBeenCalledWith('com.xfer.serum', expect.any(String));
+
+      // Should have created an instance in the store
+      const { instances } = useVST3Store.getState();
+      const instanceIds = Object.keys(instances);
+      expect(instanceIds).toHaveLength(1);
+
+      const instance = instances[instanceIds[0]];
+      expect(instance.pluginId).toBe('com.xfer.serum');
+      expect(instance.pluginName).toBe('Serum');
+      expect(instance.vendor).toBe('Xfer Records');
+      expect(instance.trackId).toBe('track-1');
+      expect(instance.enabled).toBe(true);
+      expect(instance.online).toBe(true);
+    });
+
+    it('does not create an instance when bridge call fails', async () => {
+      const { _getBridgeClient } = await import('../../hooks/useVST3Connection');
+      const client = _getBridgeClient();
+
+      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+      client.on = vi.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+        if (!listeners[event]) listeners[event] = [];
+        listeners[event].push(handler);
+      });
+      client.off = vi.fn();
+
+      client.createInstance = vi.fn().mockImplementation(() => {
+        // Trigger the error listener
+        queueMicrotask(() => {
+          for (const fn of listeners['error'] ?? []) {
+            fn('Connection lost');
+          }
+        });
+        return Promise.resolve();
+      });
+
+      await useVST3Store.getState().loadPlugin('com.xfer.serum', 'track-1');
+
+      const { instances } = useVST3Store.getState();
+      expect(Object.keys(instances)).toHaveLength(0);
+    });
+
+    it('does not create instance for unknown plugin', async () => {
+      await useVST3Store.getState().loadPlugin('unknown-plugin', 'track-1');
+
+      const { instances } = useVST3Store.getState();
+      expect(Object.keys(instances)).toHaveLength(0);
     });
   });
 });

--- a/src/store/vst3Store.ts
+++ b/src/store/vst3Store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { v4 as uuidv4 } from 'uuid';
 import type {
   VST3ConnectionStatus,
   VST3PluginInfo,
@@ -6,6 +7,8 @@ import type {
   VST3ScanProgress,
   VST3Parameter,
 } from '../types/vst3';
+import { toastSuccess, toastError } from '../hooks/useToast';
+import { _getBridgeClient } from '../hooks/useVST3Connection';
 
 export interface VST3Store {
   /* ── Connection ──────────────────────────────────────── */
@@ -26,7 +29,7 @@ export interface VST3Store {
   disconnect: () => void;
   scanPlugins: () => void;
 
-  loadPlugin: (pluginId: string, trackId: string) => void;
+  loadPlugin: (pluginId: string, trackId: string) => Promise<void>;
   removeInstance: (instanceId: string) => void;
   toggleInstance: (instanceId: string) => void;
   openEditor: (instanceId: string) => void;
@@ -78,8 +81,67 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
   },
 
   // ── Plugin lifecycle ────────────────────────────────────
-  loadPlugin: (_pluginId: string, _trackId: string) => {
-    // Bridge will call _upsertInstance once loaded
+  loadPlugin: async (pluginId: string, trackId: string) => {
+    const { plugins } = get();
+    const pluginInfo = plugins.find((p) => p.id === pluginId);
+    if (!pluginInfo) {
+      toastError(`Plugin "${pluginId}" not found in catalogue`);
+      return;
+    }
+
+    const instanceId = `vst3-${uuidv4()}`;
+
+    try {
+      const client = _getBridgeClient();
+
+      // Listen for the instanceCreated event from the bridge
+      const instancePromise = new Promise<VST3Parameter[]>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          client.off('instanceCreated', onCreated);
+          client.off('error', onError);
+          reject(new Error('Plugin instantiation timed out'));
+        }, 10_000);
+
+        const onCreated = (createdId: string, params: VST3Parameter[]) => {
+          if (createdId === instanceId) {
+            clearTimeout(timeout);
+            client.off('instanceCreated', onCreated);
+            client.off('error', onError);
+            resolve(params);
+          }
+        };
+
+        const onError = (errorMsg: string) => {
+          clearTimeout(timeout);
+          client.off('instanceCreated', onCreated);
+          client.off('error', onError);
+          reject(new Error(errorMsg));
+        };
+
+        client.on('instanceCreated', onCreated);
+        client.on('error', onError);
+      });
+
+      await client.createInstance(pluginId, instanceId);
+      const parameters = await instancePromise;
+
+      get()._upsertInstance({
+        instanceId,
+        pluginId,
+        pluginName: pluginInfo.name,
+        vendor: pluginInfo.vendor,
+        trackId,
+        enabled: true,
+        online: true,
+        parameters,
+        presets: [],
+        activePreset: null,
+      });
+
+      toastSuccess(`Loaded ${pluginInfo.name}`);
+    } catch (err) {
+      toastError(`Failed to load ${pluginInfo.name}: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
   },
 
   removeInstance: (instanceId: string) => {


### PR DESCRIPTION
## Summary
- Wire the **Load** button in `VST3PluginBrowser` to actually instantiate a plugin on the selected (or first) track
- Implement `loadPlugin` in `vst3Store` — sends `createInstance` to the bridge client, listens for `instanceCreated` event, upserts the instance into the store
- Show toast notifications on success/failure
- `VST3SidePanel` now resolves the target track from `selectedTrackIds` (falling back to the first project track)

## Test plan
- [x] `vst3Store.loadPlugin` creates instance in store on successful bridge response
- [x] `vst3Store.loadPlugin` does not create instance when bridge errors
- [x] `vst3Store.loadPlugin` does nothing for unknown plugin IDs
- [x] `VST3SidePanel` passes `onLoadPlugin` callback that calls `loadPlugin` with correct track
- [x] `VST3SidePanel` uses selected track when available
- [x] All 2645 unit tests pass, `tsc --noEmit` clean, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)