### PR TITLE
feat: Active Plugins section with parameter controls

### DIFF
--- a/src/components/plugins/ActivePlugins.tsx
+++ b/src/components/plugins/ActivePlugins.tsx
@@ -1,0 +1,88 @@
+import { useMemo, useState } from 'react';
+import { useVST3Store } from '../../store/vst3Store';
+import { useProjectStore } from '../../store/projectStore';
+import { VST3PluginPanel } from './VST3PluginPanel';
+
+const EMPTY_TRACKS: never[] = [];
+
+export function ActivePlugins() {
+  const instances = useVST3Store((s) => s.instances);
+  const tracks = useProjectStore((s) => s.project?.tracks) ?? EMPTY_TRACKS;
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const instanceList = useMemo(() => Object.values(instances), [instances]);
+
+  const trackNameMap = useMemo(
+    () => new Map(tracks.map((t) => [t.id, t.displayName])),
+    [tracks],
+  );
+
+  return (
+    <div className="flex flex-col" data-testid="active-plugins-section">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-[#333]">
+        <span className="text-xs font-semibold text-zinc-200">Active Plugins</span>
+        <span className="text-[10px] text-zinc-500">{instanceList.length}</span>
+      </div>
+
+      {instanceList.length === 0 ? (
+        <div
+          className="px-3 py-4 text-center text-[11px] text-zinc-500"
+          data-testid="active-plugins-empty"
+        >
+          No plugins loaded. Browse and load a plugin above.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1 p-2">
+          {instanceList.map((inst) => (
+            <div key={inst.instanceId}>
+              <button
+                type="button"
+                onClick={() =>
+                  setExpandedId(expandedId === inst.instanceId ? null : inst.instanceId)
+                }
+                className={`w-full flex items-center gap-2 rounded px-2 py-1.5 text-left transition-colors ${
+                  expandedId === inst.instanceId
+                    ? 'bg-violet-500/10 border border-violet-500/20'
+                    : 'hover:bg-white/5 border border-transparent'
+                } ${!inst.enabled ? 'opacity-50' : ''}`}
+                data-testid={`active-instance-${inst.instanceId}`}
+              >
+                {/* Enable indicator dot */}
+                <span
+                  className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                    inst.enabled ? 'bg-green-400' : 'bg-zinc-600'
+                  }`}
+                />
+                <span className="flex-1 truncate text-[11px] font-medium text-zinc-200">
+                  {inst.pluginName}
+                </span>
+                <span className="truncate text-[10px] text-zinc-500 max-w-[80px]">
+                  {trackNameMap.get(inst.trackId) ?? inst.trackId}
+                </span>
+                {/* Chevron */}
+                <svg
+                  className={`h-3 w-3 text-zinc-500 transition-transform ${
+                    expandedId === inst.instanceId ? 'rotate-90' : ''
+                  }`}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
+
+              {/* Expanded panel */}
+              {expandedId === inst.instanceId && (
+                <div className="mt-1">
+                  <VST3PluginPanel instanceId={inst.instanceId} />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/plugins/VST3SidePanel.tsx
+++ b/src/components/plugins/VST3SidePanel.tsx
@@ -3,6 +3,7 @@ import { useUIStore } from '../../store/uiStore';
 import { useVST3Store } from '../../store/vst3Store';
 import { useProjectStore } from '../../store/projectStore';
 import { VST3PluginBrowser } from './VST3PluginBrowser';
+import { ActivePlugins } from './ActivePlugins';
 import { Z } from '../../utils/zIndex';
 
 export function VST3SidePanel() {
@@ -61,9 +62,10 @@ export function VST3SidePanel() {
         </button>
       </div>
 
-      {/* Plugin Browser */}
+      {/* Plugin Browser + Active Plugins */}
       <div className="flex-1 overflow-y-auto">
         <VST3PluginBrowser onLoadPlugin={handleLoadPlugin} />
+        <ActivePlugins />
       </div>
     </aside>
   );

--- a/src/components/plugins/__tests__/ActivePlugins.test.tsx
+++ b/src/components/plugins/__tests__/ActivePlugins.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VST3SidePanel } from '../VST3SidePanel';
+import { useUIStore } from '../../../store/uiStore';
+import { useVST3Store } from '../../../store/vst3Store';
+import { useProjectStore } from '../../../store/projectStore';
+import type { VST3ActiveInstance } from '../../../types/vst3';
+
+const INSTANCE_A: VST3ActiveInstance = {
+  instanceId: 'inst-a',
+  pluginId: 'com.acme.synth',
+  pluginName: 'AcmeSynth',
+  vendor: 'Acme',
+  trackId: 'track-1',
+  enabled: true,
+  online: true,
+  parameters: [
+    { id: 0, name: 'Volume', value: 0.8, minValue: 0, maxValue: 1, defaultValue: 0.5, enumValues: [], unit: 'dB' },
+    { id: 1, name: 'Pan', value: 0.5, minValue: 0, maxValue: 1, defaultValue: 0.5, enumValues: [], unit: '' },
+  ],
+  presets: ['Init'],
+  activePreset: null,
+};
+
+const INSTANCE_B: VST3ActiveInstance = {
+  instanceId: 'inst-b',
+  pluginId: 'com.acme.reverb',
+  pluginName: 'AcmeVerb',
+  vendor: 'Acme',
+  trackId: 'track-2',
+  enabled: false,
+  online: true,
+  parameters: [],
+  presets: [],
+  activePreset: null,
+};
+
+function setupWithInstances(instances: Record<string, VST3ActiveInstance> = {}) {
+  useUIStore.setState({ showVST3Panel: true, selectedTrackIds: new Set() });
+  useVST3Store.setState({
+    connectionStatus: 'connected',
+    plugins: [],
+    instances,
+  });
+  useProjectStore.setState({
+    project: {
+      id: 'proj-1',
+      name: 'Test',
+      bpm: 120,
+      tracks: [
+        { id: 'track-1', displayName: 'Lead Synth', type: 'stems', clips: [], color: '#fff', mute: false, solo: false, volume: 0.8, pan: 0 },
+        { id: 'track-2', displayName: 'FX Bus', type: 'stems', clips: [], color: '#0ff', mute: false, solo: false, volume: 0.8, pan: 0 },
+      ],
+    } as any,
+  });
+}
+
+describe('Active Plugins section in VST3SidePanel', () => {
+  beforeEach(() => {
+    setupWithInstances();
+  });
+
+  it('shows "Active Plugins" heading', () => {
+    setupWithInstances({ 'inst-a': INSTANCE_A });
+    render(<VST3SidePanel />);
+    expect(screen.getByText('Active Plugins')).toBeInTheDocument();
+  });
+
+  it('renders loaded plugin instances', () => {
+    setupWithInstances({ 'inst-a': INSTANCE_A, 'inst-b': INSTANCE_B });
+    render(<VST3SidePanel />);
+    expect(screen.getByText('AcmeSynth')).toBeInTheDocument();
+    expect(screen.getByText('AcmeVerb')).toBeInTheDocument();
+  });
+
+  it('shows track name for each instance', () => {
+    setupWithInstances({ 'inst-a': INSTANCE_A });
+    render(<VST3SidePanel />);
+    expect(screen.getByText('Lead Synth')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no plugins are loaded', () => {
+    setupWithInstances({});
+    render(<VST3SidePanel />);
+    expect(screen.getByTestId('active-plugins-empty')).toBeInTheDocument();
+  });
+
+  it('clicking instance expands to show parameters', () => {
+    setupWithInstances({ 'inst-a': INSTANCE_A });
+    render(<VST3SidePanel />);
+
+    // Click the instance row to expand
+    fireEvent.click(screen.getByTestId('active-instance-inst-a'));
+
+    // Should show the plugin panel with parameter sliders
+    expect(screen.getByTestId('plugin-panel')).toBeInTheDocument();
+    expect(screen.getAllByTestId('param-slider')).toHaveLength(2);
+  });
+
+  it('toggle button bypasses/enables instance', () => {
+    setupWithInstances({ 'inst-a': INSTANCE_A });
+    render(<VST3SidePanel />);
+
+    // Expand first
+    fireEvent.click(screen.getByTestId('active-instance-inst-a'));
+
+    fireEvent.click(screen.getByTestId('toggle-enable-btn'));
+    expect(useVST3Store.getState().instances['inst-a'].enabled).toBe(false);
+  });
+
+  it('remove button removes instance from store', () => {
+    setupWithInstances({ 'inst-a': INSTANCE_A });
+    render(<VST3SidePanel />);
+
+    // Expand first
+    fireEvent.click(screen.getByTestId('active-instance-inst-a'));
+
+    fireEvent.click(screen.getByTestId('remove-plugin-btn'));
+    expect(useVST3Store.getState().instances['inst-a']).toBeUndefined();
+  });
+
+  it('parameter slider change updates the store after debounce', () => {
+    vi.useFakeTimers();
+    setupWithInstances({ 'inst-a': INSTANCE_A });
+    render(<VST3SidePanel />);
+
+    // Expand
+    fireEvent.click(screen.getByTestId('active-instance-inst-a'));
+
+    const sliders = screen.getAllByTestId('param-slider');
+    fireEvent.change(sliders[0], { target: { value: '0.9' } });
+
+    // Advance past the 50ms debounce in ParameterControl
+    vi.advanceTimersByTime(100);
+
+    expect(useVST3Store.getState().instances['inst-a'].parameters[0].value).toBe(0.9);
+    vi.useRealTimers();
+  });
+});
+
+describe('setParameter bridge forwarding', () => {
+  it('updates store when setParameter is called', () => {
+    useVST3Store.setState({
+      instances: { 'inst-a': INSTANCE_A },
+    });
+
+    useVST3Store.getState().setParameter('inst-a', 0, 0.75);
+
+    expect(useVST3Store.getState().instances['inst-a'].parameters[0].value).toBe(0.75);
+  });
+});

--- a/src/store/vst3Store.ts
+++ b/src/store/vst3Store.ts
@@ -166,6 +166,13 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
 
   setParameter: (instanceId: string, paramId: number, value: number) => {
     get()._updateParameter(instanceId, paramId, value);
+    // Fire-and-forget: forward to bridge companion
+    try {
+      const client = _getBridgeClient();
+      client.setParam(instanceId, paramId, value);
+    } catch {
+      // Bridge not connected — ignore silently
+    }
   },
 
   selectPreset: (instanceId: string, preset: string) => {


### PR DESCRIPTION
## Summary
- **ActivePlugins component** — shows loaded VST3 plugin instances below the browser in the side panel
- Each instance displays: plugin name, track name, enable/bypass toggle, remove button
- Click instance to expand and show **parameter sliders**
- Parameter changes call `vst3Store.setParameter` (fire-and-forget forwarding to companion bridge)
- Memoized instance list to prevent unnecessary re-renders

## Test plan
- [x] Unit tests for ActivePlugins rendering, toggle, remove, parameter change
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — all pass
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)