### PR TITLE
feat: add issue-first workflow convention for Claude Code sessions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,39 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Description
+
+<!-- A clear, concise description of the bug -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What should happen -->
+
+## Actual Behavior
+
+<!-- What actually happens -->
+
+## Environment
+
+- Browser:
+- OS:
+- Node version:
+
+## Screenshots / Logs
+
+<!-- If applicable -->
+
+## Acceptance Criteria
+
+- [ ] Bug is reproducible with steps above
+- [ ] Regression test added that fails without the fix
+- [ ] Fix passes all quality gates

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Propose a new feature or enhancement
+labels: enhancement
+---
+
+## Description
+
+<!-- What feature do you want? Why? -->
+
+## Proposed Solution
+
+<!-- How should this work? -->
+
+## Alternatives Considered
+
+<!-- Any other approaches? -->
+
+## Acceptance Criteria
+
+- [ ] <!-- Specific, testable criterion -->
+- [ ] Unit tests cover the new behavior
+- [ ] UI changes verified visually with preview tools

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+Closes #<!-- issue number -->
+
+## Changes
+
+- <!-- List key changes -->
+
+## Test Plan
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm test` passes
+- [ ] `npm run build` succeeds
+- [ ] UI changes verified visually (if applicable)
+
+## Screenshots
+
+<!-- Before/after screenshots for UI changes -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,39 @@ When using Claude Code on this project, install these skills for better UX outpu
 - Never merge a PR before CI passes — check CI status first, fix if red
 - If CI fails: understand root cause → add fix commit → wait for green → then merge
 
+## Issue-First Workflow (mandatory for all interactive sessions)
+
+> When the user describes a problem, bug, or feature request in conversation, the agent MUST follow this workflow. Do NOT skip straight to coding.
+
+### The Rule
+
+**Every code change starts as a GitHub issue.** No exceptions for interactive Claude Code sessions.
+
+### Workflow
+
+1. **User describes a problem** (in any language)
+2. **Agent creates a GitHub issue** via `gh issue create`
+   - Title and body MUST be in **English** regardless of conversation language
+   - Use appropriate label: `bug`, `enhancement`, `docs`, `refactor`
+   - Include acceptance criteria as a checklist
+3. **Agent creates a branch** named `feat/issue-NUMBER` or `fix/issue-NUMBER`
+4. **Agent implements the fix/feature** following TDD and quality gates
+5. **Agent creates a PR** that includes `Closes #NUMBER` in the body
+6. **Agent reports the issue URL and PR URL** back to the user
+
+### Issue Quality Standards
+
+- **Title**: Concise, starts with `feat:`, `fix:`, `docs:`, `refactor:`, or `chore:`
+- **Body**: Problem description, proposed solution, acceptance criteria
+- **Labels**: At least one of `bug`, `enhancement`, `docs`, `refactor`
+- **Language**: Always English — this is a public repo
+
+### When to Skip
+
+- Pure questions / explanations (no code change needed)
+- Trivial typo fixes (< 3 lines changed, single file)
+- Work already tracked by an existing issue (reference it instead)
+
 ## gstack
 
 Use the `/browse` skill from gstack for **all web browsing**. Never use `mcp__Claude_in_Chrome__*` tools.


### PR DESCRIPTION
## Summary

When a user describes a problem in conversation, the agent now must create a GitHub issue first (in English), then create a PR that closes it. This eliminates the need for the user to explicitly ask for this workflow each time.

Closes #868

## Changes

- **CLAUDE.md**: Added "Issue-First Workflow" section with mandatory rules for interactive sessions
- **`.github/ISSUE_TEMPLATE/bug.md`**: Structured bug report template
- **`.github/ISSUE_TEMPLATE/feature.md`**: Feature request template with acceptance criteria
- **`.github/PULL_REQUEST_TEMPLATE.md`**: PR template with issue reference and test plan checklist

## Test Plan

- [ ] CLAUDE.md is valid markdown and renders correctly
- [ ] Issue templates appear when creating new issues on GitHub
- [ ] PR template pre-fills when creating new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)