### PR TITLE
fix: render playhead anchor on empty arrangement lane clicks

### DIFF
--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useState, useEffect, useMemo } from 'react';
+import { useRef, useCallback, useState, useEffect, useMemo, useLayoutEffect } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useTransportStore } from '../../store/transportStore';
 import { useUIStore } from '../../store/uiStore';
@@ -1227,12 +1227,15 @@ function ArrangementEmptyTrackHeaderRow({
 function EmptyTrackRow({ slotIndex }: { slotIndex: number }) {
   const selectedTrackIds = useUIStore((s) => s.selectedTrackIds);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
+  const setTrackLaneRect = useUIStore((s) => s.setTrackLaneRect);
+  const removeTrackLaneRect = useUIStore((s) => s.removeTrackLaneRect);
   const project = useProjectStore((s) => s.project);
   const addTrack = useProjectStore((s) => s.addTrack);
   const virtualId = getArrangementEmptyTrackId(slotIndex);
   const isSelected = selectedTrackIds.has(virtualId);
   const { importLoopToTrack, importAssetToTrack, importAssetAsQuickSampler, importAudioFileAsNewQuickSampler } = useAudioImport();
 
+  const laneRef = useRef<HTMLDivElement>(null);
   const [dropGhost, setDropGhost] = useState<{ left: number; width: number; name: string } | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const dragCounterRef = useRef(0);
@@ -1240,6 +1243,29 @@ function EmptyTrackRow({ slotIndex }: { slotIndex: number }) {
   const defaultClipDuration = project
     ? getBarDuration(project.bpm, project.timeSignature, project.timeSignatureDenominator ?? 4) * 4
     : 8;
+
+  useLayoutEffect(() => {
+    const el = laneRef.current;
+    if (!el) return;
+
+    const update = () => {
+      const parentEl = el.offsetParent as HTMLElement | null;
+      const parentOffset = parentEl ? parentEl.offsetTop : 0;
+      setTrackLaneRect(virtualId, {
+        top: el.offsetTop + parentOffset,
+        height: el.offsetHeight,
+      });
+    };
+
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+
+    return () => {
+      ro.disconnect();
+      removeTrackLaneRect(virtualId);
+    };
+  }, [removeTrackLaneRect, setTrackLaneRect, virtualId]);
 
   const onDragEnter = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer.types;
@@ -1319,6 +1345,7 @@ function EmptyTrackRow({ slotIndex }: { slotIndex: number }) {
 
   return (
     <div
+      ref={laneRef}
       data-track-id={virtualId}
       data-timeline-lane
       className="relative"

--- a/tests/e2e/empty-track-playhead.spec.ts
+++ b/tests/e2e/empty-track-playhead.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { getArrangementEmptyTrackId } from '../../src/components/arrangement/trackSlotLayout';
+import { loadReturningUserApp } from '../support/e2eStartup';
+import type { E2EBrowserWindow } from '../support/browserStores';
+
+test.describe('Empty arrangement lane playhead anchor', () => {
+  test('clicking an empty lane shows the playhead anchor cursor', async ({ page }) => {
+    const emptyTrackId = getArrangementEmptyTrackId(1);
+
+    await loadReturningUserApp(page);
+    await page.evaluate(() => {
+      const dawWindow = window as E2EBrowserWindow;
+      dawWindow.__uiStore.getState().setShowNewProjectDialog(false);
+      dawWindow.__store.getState().createProject({ name: 'Empty Lane Playhead Regression' });
+      dawWindow.__store.getState().addTrack('drums');
+    });
+
+    const emptyLane = page.getByTestId('empty-row-1');
+    await expect(emptyLane).toBeVisible();
+    await emptyLane.click({ position: { x: 240, y: 20 } });
+
+    await expect.poll(async () => page.evaluate(({ targetEmptyTrackId }) => {
+      const dawWindow = window as E2EBrowserWindow;
+      const ui = dawWindow.__uiStore.getState();
+      const transport = dawWindow.__transportStore.getState();
+      const hasBlinkCursor = Array.from(document.querySelectorAll<HTMLElement>('div'))
+        .some((el) => el.style.animation.includes('playhead-blink-line') && el.style.height.length > 0);
+
+      return (
+        ui.selectedTrackIds.has(targetEmptyTrackId)
+        && ui.trackLaneRects.has(targetEmptyTrackId)
+        && transport.playStartTime > 0
+        && Math.abs(transport.currentTime - transport.playStartTime) < 0.001
+        && hasBlinkCursor
+      );
+    }, { targetEmptyTrackId: emptyTrackId })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- register placeholder arrangement lanes in `uiStore.trackLaneRects` so empty rows can render the playhead anchor cursor
- add a Playwright regression test for click-to-seek on empty arrangement lanes
- Fixes #867

## Root cause
Empty arrangement rows selected a virtual track id, but unlike normal `TrackLane` rows they never reported their geometry to `uiStore.trackLaneRects`. The playhead anchor cursor renders from that cache, so empty rows had no vertical cursor even though the seek action completed.

## Verification
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npx tsc --noEmit`
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npm test`
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npm run build`
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npx playwright test tests/e2e/empty-track-playhead.spec.ts`
