### PR TITLE
perf: narrow clip block subscriptions

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -713,7 +713,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
     window.addEventListener('keydown', onKeyDown);
-  }, [clip, pixelsPerSecond, project, updateClip, getDragMode, track.id, track.trackName, track.trackType, moveClipToTrack, duplicateClipToTrack, addTrack, batchDuplicateClips, batchMoveClips, beginDrag, endDrag, undo, snapClipEdgeToZeroCrossing, sliceClipToRange, splitClipAtZeroCrossing, selectClip]);
+  }, [addTrack, batchDuplicateClips, batchMoveClips, beginDrag, bpm, clip, duplicateClipToTrack, endDrag, getDragMode, moveClipToTrack, pixelsPerSecond, selectClip, sliceClipToRange, snapClipEdgeToZeroCrossing, splitClipAtZeroCrossing, totalDuration, track.id, track.trackName, track.trackType, undo, updateClip]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();


### PR DESCRIPTION
## Summary
- narrow `ClipBlock` subscriptions from the whole project object to the arrangement fields it actually uses
- keep render-time MIDI thumbnail tempo and drag bounds reactive via scalar selectors
- derive selected multi-clip metadata from `project.tracks` instead of subscribing to the full project object

## Why
As a user, I want clip editing and arrangement interactions to stay responsive when unrelated project state changes, so that editing one clip does not fan out unnecessary rerenders across the arrangement.

## Files changed
- `src/components/timeline/ClipBlock.tsx`

## Manual QA
- open a project with multiple clips and confirm clips still render correctly
- drag, resize, and move audio clips
- drag, resize, and move MIDI clips
- open the clip context menu on single and multi-selected clips
- verify mute/color/consolidate actions still show the expected state
- verify MIDI thumbnails still render with the correct timing grid feel

## Validation
- Automated validation: not run
- Manual QA: required before merge
