### PR TITLE
feat: wire WebSocket handlers to real plugin_host methods

### DIFF
--- a/companion/src/plugin_host.rs
+++ b/companion/src/plugin_host.rs
@@ -9,6 +9,7 @@ use std::sync::Mutex;
 use tracing::{info, warn};
 
 use crate::error::{CompanionError, Result};
+use crate::host_impl::MemoryStream;
 use crate::protocol::{ParamInfo, PresetInfo};
 use crate::vst3_loader::{self, Vst3PluginInstance};
 
@@ -118,6 +119,115 @@ impl PluginHost {
                 "Instance '{instance_id}' not found"
             )))
         }
+    }
+
+    /// Run a closure on a live plugin instance, returning `stub_default` for
+    /// stub instances (registered but no real VST3 loaded).
+    ///
+    /// Returns `Err` if the instance_id is completely unknown.
+    fn with_live_instance<T, F>(&self, instance_id: &str, stub_default: T, f: F) -> Result<T>
+    where
+        F: FnOnce(&Vst3PluginInstance) -> T,
+    {
+        let guard = self.live_instances.lock().unwrap();
+        if let Some(instance) = guard.get(instance_id) {
+            Ok(f(instance))
+        } else if self.instances.lock().unwrap().contains_key(instance_id) {
+            Ok(stub_default)
+        } else {
+            Err(CompanionError::Plugin(format!(
+                "Instance '{instance_id}' not found"
+            )))
+        }
+    }
+
+    /// Set a parameter value on a live plugin instance via IEditController.
+    pub fn set_parameter(&self, instance_id: &str, param_id: u32, value: f64) -> Result<()> {
+        self.with_live_instance(instance_id, (), |instance| {
+            if let Some(ref controller) = instance.controller {
+                unsafe {
+                    use vst3::Steinberg::Vst::IEditControllerTrait;
+                    controller.setParamNormalized(param_id, value);
+                }
+                info!(instance_id, param_id, value, "Set parameter via IEditController");
+            } else {
+                warn!(instance_id, param_id, "No IEditController — parameter set ignored");
+            }
+        })
+    }
+
+    /// Get the current state of a plugin instance via IComponent::getState().
+    ///
+    /// Returns the raw state bytes, or an empty vec for stub instances.
+    pub fn get_state(&self, instance_id: &str) -> Result<Vec<u8>> {
+        self.with_live_instance(instance_id, vec![], |instance| {
+            let stream = MemoryStream::new();
+            let stream_ptr = stream.to_com_ptr::<vst3::Steinberg::IBStream>();
+            match stream_ptr {
+                Some(ptr) => {
+                    unsafe {
+                        use vst3::Steinberg::Vst::IComponentTrait;
+                        instance.component.getState(ptr.as_ptr());
+                    }
+                    let data = stream.into_data();
+                    info!(instance_id, bytes = data.len(), "Got plugin state");
+                    data
+                }
+                None => {
+                    warn!(instance_id, "Failed to create IBStream for getState");
+                    vec![]
+                }
+            }
+        })
+    }
+
+    /// Set the state of a plugin instance via IComponent::setState().
+    pub fn set_state(&self, instance_id: &str, data: &[u8]) -> Result<()> {
+        self.with_live_instance(instance_id, (), |instance| {
+            let stream = MemoryStream::from_data(data.to_vec());
+            let stream_ptr = stream.to_com_ptr::<vst3::Steinberg::IBStream>();
+            match stream_ptr {
+                Some(ptr) => {
+                    unsafe {
+                        use vst3::Steinberg::Vst::IComponentTrait;
+                        instance.component.setState(ptr.as_ptr());
+                    }
+                    info!(instance_id, bytes = data.len(), "Set plugin state");
+                }
+                None => {
+                    warn!(instance_id, "Failed to create IBStream for setState");
+                }
+            }
+        })
+    }
+
+    /// Set processing active/inactive via IAudioProcessor::setProcessing().
+    pub fn set_processing(&self, instance_id: &str, active: bool) -> Result<()> {
+        self.with_live_instance(instance_id, (), |instance| {
+            unsafe {
+                use vst3::Steinberg::Vst::{IAudioProcessorTrait, IComponentTrait};
+                if active {
+                    instance.component.setActive(1);
+                    instance.processor.setProcessing(1);
+                } else {
+                    instance.processor.setProcessing(0);
+                    instance.component.setActive(0);
+                }
+            }
+            info!(instance_id, active, "Set processing state");
+        })
+    }
+
+    /// Get latency from IAudioProcessor::getLatencySamples().
+    pub fn get_latency(&self, instance_id: &str) -> Result<u32> {
+        self.with_live_instance(instance_id, 0, |instance| {
+            let samples = unsafe {
+                use vst3::Steinberg::Vst::IAudioProcessorTrait;
+                instance.processor.getLatencySamples() as u32
+            };
+            info!(instance_id, samples, "Got latency");
+            samples
+        })
     }
 
     /// Check whether an instance exists.

--- a/companion/src/ws_server.rs
+++ b/companion/src/ws_server.rs
@@ -180,13 +180,18 @@ fn handle_message(msg: IncomingMessage, state: &AppState) -> OutgoingMessage {
             instance_id,
             param_id,
             value,
-        } => {
-            info!(instance_id, param_id, value, "SetParam (stub)");
-            OutgoingMessage::ParamChanged {
+        } => match state.host.set_parameter(&instance_id, param_id, value) {
+            Ok(()) => OutgoingMessage::ParamChanged {
                 instance_id,
                 param_id,
                 value,
-            }
+            },
+            Err(e) => OutgoingMessage::Error {
+                req_id: None,
+                instance_id: Some(instance_id),
+                code: "set_param_error".into(),
+                message: e.to_string(),
+            },
         }
 
         IncomingMessage::Midi {
@@ -218,26 +223,54 @@ fn handle_message(msg: IncomingMessage, state: &AppState) -> OutgoingMessage {
         }
 
         IncomingMessage::GetState { instance_id } => {
-            info!(instance_id, "GetState (stub)");
-            OutgoingMessage::StateData {
-                instance_id,
-                data: base64::Engine::encode(
-                    &base64::engine::general_purpose::STANDARD,
-                    b"stub-state-data",
-                ),
+            match state.host.get_state(&instance_id) {
+                Ok(bytes) => OutgoingMessage::StateData {
+                    instance_id,
+                    data: base64::Engine::encode(
+                        &base64::engine::general_purpose::STANDARD,
+                        &bytes,
+                    ),
+                },
+                Err(e) => OutgoingMessage::Error {
+                    req_id: None,
+                    instance_id: Some(instance_id),
+                    code: "get_state_error".into(),
+                    message: e.to_string(),
+                },
             }
         }
 
         IncomingMessage::SetState {
             instance_id,
-            data: _,
+            data,
         } => {
-            info!(instance_id, "SetState (stub)");
-            OutgoingMessage::Error {
-                req_id: None,
-                instance_id: Some(instance_id),
-                code: "ok".into(),
-                message: "State set (stub)".into(),
+            let bytes = match base64::Engine::decode(
+                &base64::engine::general_purpose::STANDARD,
+                &data,
+            ) {
+                Ok(b) => b,
+                Err(e) => {
+                    return OutgoingMessage::Error {
+                        req_id: None,
+                        instance_id: Some(instance_id),
+                        code: "set_state_error".into(),
+                        message: format!("Invalid base64 data: {e}"),
+                    };
+                }
+            };
+            match state.host.set_state(&instance_id, &bytes) {
+                Ok(()) => OutgoingMessage::Error {
+                    req_id: None,
+                    instance_id: Some(instance_id),
+                    code: "ok".into(),
+                    message: "State set".into(),
+                },
+                Err(e) => OutgoingMessage::Error {
+                    req_id: None,
+                    instance_id: Some(instance_id),
+                    code: "set_state_error".into(),
+                    message: e.to_string(),
+                },
             }
         }
 
@@ -257,21 +290,33 @@ fn handle_message(msg: IncomingMessage, state: &AppState) -> OutgoingMessage {
         IncomingMessage::SetProcessing {
             instance_id,
             active,
-        } => {
-            info!(instance_id, active, "SetProcessing (stub)");
-            OutgoingMessage::Error {
+        } => match state.host.set_processing(&instance_id, active) {
+            Ok(()) => OutgoingMessage::Error {
                 req_id: None,
                 instance_id: Some(instance_id),
                 code: "ok".into(),
-                message: format!("Processing set to {active} (stub)"),
-            }
+                message: format!("Processing set to {active}"),
+            },
+            Err(e) => OutgoingMessage::Error {
+                req_id: None,
+                instance_id: Some(instance_id),
+                code: "set_processing_error".into(),
+                message: e.to_string(),
+            },
         }
 
         IncomingMessage::GetLatency { instance_id } => {
-            info!(instance_id, "GetLatency (stub)");
-            OutgoingMessage::LatencyInfo {
-                instance_id,
-                samples: 0,
+            match state.host.get_latency(&instance_id) {
+                Ok(samples) => OutgoingMessage::LatencyInfo {
+                    instance_id,
+                    samples,
+                },
+                Err(e) => OutgoingMessage::Error {
+                    req_id: None,
+                    instance_id: Some(instance_id),
+                    code: "get_latency_error".into(),
+                    message: e.to_string(),
+                },
             }
         }
 
@@ -370,6 +415,8 @@ mod tests {
             scanner: PluginScanner::new(),
             host: PluginHost::new(),
         };
+        // Must instantiate first so the instance exists
+        state.host.instantiate("uid-1", "inst-1", None).unwrap();
         let resp = handle_message(
             IncomingMessage::GetLatency {
                 instance_id: "inst-1".into(),


### PR DESCRIPTION
## Summary
- Replace stub/placeholder handlers in `ws_server.rs` with real calls to `PluginHost` methods for SetParam, GetState, SetState, SetProcessing, and GetLatency
- Add `set_parameter()`, `get_state()`, `set_state()`, `set_processing()`, and `get_latency()` methods to `PluginHost`, delegating to real VST3 COM interfaces (IEditController, IComponent, IAudioProcessor)
- Extract `with_live_instance()` helper to eliminate repeated live-instance lookup + stub-fallback boilerplate across all new methods

## Test plan
- [x] All 82 existing unit tests pass (`cargo test`)
- [x] `cargo build` succeeds with no errors
- [ ] Integration test with a real VST3 plugin: instantiate, set param, get/set state, toggle processing, query latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)