### PR TITLE
feat: wire MIDI to VST3 plugins via IEventList

### DIFF
--- a/companion/src/audio_thread.rs
+++ b/companion/src/audio_thread.rs
@@ -7,11 +7,12 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use vst3::Steinberg::Vst::{
-    AudioBusBuffers, AudioBusBuffers__type0, IAudioProcessorTrait, IComponentTrait, ProcessData,
-    ProcessSetup, ProcessModes_, SymbolicSampleSizes_,
+    AudioBusBuffers, AudioBusBuffers__type0, IAudioProcessorTrait, IComponentTrait,
+    IEventList, ProcessData, ProcessSetup, ProcessModes_, SymbolicSampleSizes_,
 };
 use vst3::Steinberg::kResultOk;
 
+use crate::host_impl::{midi_to_vst3_event, EventList};
 use crate::vst3_loader::Vst3PluginInstance;
 
 /// A MIDI event to be processed by a VST3 plugin.
@@ -21,6 +22,17 @@ pub struct MidiEvent {
     pub data1: u8,
     pub data2: u8,
     pub sample_offset: u32,
+}
+
+impl From<&crate::protocol::MidiEvent> for MidiEvent {
+    fn from(e: &crate::protocol::MidiEvent) -> Self {
+        Self {
+            status: e.status,
+            data1: e.data1,
+            data2: e.data2,
+            sample_offset: e.sample_offset,
+        }
+    }
 }
 
 /// A queued parameter change.
@@ -161,9 +173,9 @@ impl AudioThread {
         let total = (channels * samples) as usize;
 
         // Drain queues
-        let mut _midi_events = Vec::new();
+        let mut midi_events = Vec::new();
         while let Some(event) = self.midi_queue.pop() {
-            _midi_events.push(event);
+            midi_events.push(event);
         }
         let mut _param_changes = Vec::new();
         while let Some(change) = self.param_queue.pop() {
@@ -176,7 +188,7 @@ impl AudioThread {
 
         // Try real VST3 processing
         if let Some(ref plugin) = self.plugin {
-            return self.process_vst3(plugin.clone(), input, channels, samples);
+            return self.process_vst3(plugin.clone(), &midi_events, input, channels, samples);
         }
 
         // Stub fallback
@@ -195,6 +207,7 @@ impl AudioThread {
     fn process_vst3(
         &self,
         plugin: Arc<Vst3PluginInstance>,
+        midi_events: &[MidiEvent],
         input: &[f32],
         channels: u32,
         samples: u32,
@@ -243,6 +256,24 @@ impl AudioThread {
             },
         };
 
+        // Convert MIDI events to VST3 events and pack into IEventList.
+        // Skip allocation when there are no events (common case).
+        let vst3_events: Vec<_> = midi_events
+            .iter()
+            .filter_map(midi_to_vst3_event)
+            .collect();
+
+        let event_list = if !vst3_events.is_empty() {
+            Some(EventList::with_events(vst3_events))
+        } else {
+            None
+        };
+        let input_events_ptr = event_list
+            .as_ref()
+            .and_then(|el| el.to_com_ptr::<IEventList>())
+            .map(|p| p.as_ptr())
+            .unwrap_or(ptr::null_mut());
+
         let mut process_data = ProcessData {
             processMode: ProcessModes_::kRealtime as i32,
             symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
@@ -251,9 +282,9 @@ impl AudioThread {
             numOutputs: 1,
             inputs: if self.is_instrument { ptr::null_mut() } else { &mut input_bus },
             outputs: &mut output_bus,
-            inputParameterChanges: ptr::null_mut(), // TODO: W4 will implement IParameterChanges
+            inputParameterChanges: ptr::null_mut(), // TODO: implement IParameterChanges
             outputParameterChanges: ptr::null_mut(),
-            inputEvents: ptr::null_mut(), // TODO: W4 will implement IEventList for MIDI
+            inputEvents: input_events_ptr,
             outputEvents: ptr::null_mut(),
             processContext: ptr::null_mut(),
         };
@@ -360,6 +391,7 @@ impl AudioFrame {
 /// State of a single running stream.
 struct StreamState {
     stop_flag: Arc<AtomicBool>,
+    midi_queue: Arc<SegQueue<MidiEvent>>,
 }
 
 /// Manages audio processing loops for multiple VST3 plugin instances,
@@ -420,6 +452,7 @@ impl AudioStreamManager {
         if let Some(p) = plugin {
             audio_thread.set_plugin(p);
         }
+        let midi_queue = Arc::clone(&audio_thread.midi_queue);
         audio_thread.start();
 
         std::thread::Builder::new()
@@ -431,7 +464,7 @@ impl AudioStreamManager {
 
         streams.insert(
             instance_id.to_string(),
-            StreamState { stop_flag },
+            StreamState { stop_flag, midi_queue },
         );
 
         true
@@ -442,6 +475,22 @@ impl AudioStreamManager {
         let mut streams = self.streams.lock().unwrap();
         if let Some(state) = streams.remove(instance_id) {
             state.stop_flag.store(true, Ordering::Release);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Send MIDI events to the audio thread for a given instance.
+    ///
+    /// Events are queued and will be picked up on the next `process()` call.
+    /// Returns `false` if no stream exists for the instance.
+    pub fn send_midi(&self, instance_id: &str, events: Vec<MidiEvent>) -> bool {
+        let streams = self.streams.lock().unwrap();
+        if let Some(state) = streams.get(instance_id) {
+            for event in events {
+                state.midi_queue.push(event);
+            }
             true
         } else {
             false
@@ -817,5 +866,30 @@ mod tests {
 
         manager.stop_stream("inst-a");
         manager.stop_stream("inst-b");
+    }
+
+    #[test]
+    fn stream_manager_send_midi_to_active_stream() {
+        let manager = AudioStreamManager::new();
+        manager.start_stream("inst-1", 44100.0, 512, None, true);
+
+        let events = vec![
+            MidiEvent { status: 0x90, data1: 60, data2: 100, sample_offset: 0 },
+            MidiEvent { status: 0x80, data1: 60, data2: 0, sample_offset: 128 },
+        ];
+        let sent = manager.send_midi("inst-1", events);
+        assert!(sent, "send_midi should return true for active stream");
+
+        manager.stop_stream("inst-1");
+    }
+
+    #[test]
+    fn stream_manager_send_midi_to_nonexistent_stream() {
+        let manager = AudioStreamManager::new();
+        let events = vec![
+            MidiEvent { status: 0x90, data1: 60, data2: 100, sample_offset: 0 },
+        ];
+        let sent = manager.send_midi("nonexistent", events);
+        assert!(!sent, "send_midi should return false for nonexistent stream");
     }
 }

--- a/companion/src/host_impl.rs
+++ b/companion/src/host_impl.rs
@@ -17,6 +17,9 @@ use vst3::Steinberg::{
 };
 use vst3::Steinberg::Vst::{
     IComponentHandler, IComponentHandlerTrait, IHostApplication, IHostApplicationTrait,
+    IEventList, IEventListTrait,
+    Event, Event__type0, Event_::EventTypes_,
+    NoteOnEvent, NoteOffEvent,
     String128, ParamID, ParamValue,
 };
 
@@ -305,6 +308,142 @@ impl IBStreamTrait for MemoryStream {
 }
 
 // ---------------------------------------------------------------------------
+// IEventList implementation for MIDI events
+// ---------------------------------------------------------------------------
+
+/// Implements `IEventList` — a simple in-memory list of VST3 events.
+///
+/// Used to pass MIDI note-on/off events into `IAudioProcessor::process()`.
+pub struct EventList {
+    events: RefCell<Vec<Event>>,
+}
+
+impl EventList {
+    /// Create an empty event list.
+    pub fn new() -> ComWrapper<Self> {
+        ComWrapper::new(Self {
+            events: RefCell::new(Vec::new()),
+        })
+    }
+
+    /// Create an event list pre-populated with events.
+    pub fn with_events(events: Vec<Event>) -> ComWrapper<Self> {
+        ComWrapper::new(Self {
+            events: RefCell::new(events),
+        })
+    }
+}
+
+impl Class for EventList {
+    type Interfaces = (IEventList,);
+}
+
+impl IEventListTrait for EventList {
+    unsafe fn getEventCount(&self) -> int32 {
+        self.events.borrow().len() as int32
+    }
+
+    unsafe fn getEvent(&self, index: int32, e: *mut Event) -> tresult {
+        let events = self.events.borrow();
+        if index < 0 || (index as usize) >= events.len() || e.is_null() {
+            return kInvalidArgument;
+        }
+        *e = events[index as usize];
+        kResultOk
+    }
+
+    unsafe fn addEvent(&self, e: *mut Event) -> tresult {
+        if e.is_null() {
+            return kInvalidArgument;
+        }
+        self.events.borrow_mut().push(*e);
+        kResultOk
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MIDI-to-VST3 Event conversion
+// ---------------------------------------------------------------------------
+
+use crate::audio_thread::MidiEvent;
+
+/// Convert a raw MIDI event (status/data1/data2) into a VST3 `Event`.
+///
+/// Supports note-on (0x90) and note-off (0x80) messages.
+/// Returns `None` for unsupported message types.
+pub fn midi_to_vst3_event(midi: &MidiEvent) -> Option<Event> {
+    let message_type = midi.status & 0xF0;
+    let channel = (midi.status & 0x0F) as i16;
+
+    match message_type {
+        0x90 => {
+            // Note-on with velocity 0 is treated as note-off per MIDI spec
+            if midi.data2 == 0 {
+                Some(make_note_off_event(
+                    channel,
+                    midi.data1 as i16,
+                    0.0,
+                    midi.sample_offset as i32,
+                ))
+            } else {
+                Some(make_note_on_event(
+                    channel,
+                    midi.data1 as i16,
+                    midi.data2 as f32 / 127.0,
+                    midi.sample_offset as i32,
+                ))
+            }
+        }
+        0x80 => Some(make_note_off_event(
+            channel,
+            midi.data1 as i16,
+            midi.data2 as f32 / 127.0,
+            midi.sample_offset as i32,
+        )),
+        _ => None, // Unsupported message type
+    }
+}
+
+fn make_note_on_event(channel: i16, pitch: i16, velocity: f32, sample_offset: i32) -> Event {
+    Event {
+        busIndex: 0,
+        sampleOffset: sample_offset,
+        ppqPosition: 0.0,
+        flags: 0,
+        r#type: EventTypes_::kNoteOnEvent as u16,
+        __field0: Event__type0 {
+            noteOn: NoteOnEvent {
+                channel,
+                pitch,
+                tuning: 0.0,
+                velocity,
+                length: 0, // not specified
+                noteId: -1, // unassigned
+            },
+        },
+    }
+}
+
+fn make_note_off_event(channel: i16, pitch: i16, velocity: f32, sample_offset: i32) -> Event {
+    Event {
+        busIndex: 0,
+        sampleOffset: sample_offset,
+        ppqPosition: 0.0,
+        flags: 0,
+        r#type: EventTypes_::kNoteOffEvent as u16,
+        __field0: Event__type0 {
+            noteOff: NoteOffEvent {
+                channel,
+                pitch,
+                velocity,
+                noteId: -1,
+                tuning: 0.0,
+            },
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -442,5 +581,143 @@ mod tests {
             stream.tell(&mut pos);
             assert_eq!(pos, 80);
         }
+    }
+
+    // =========================================================================
+    // EventList tests
+    // =========================================================================
+
+    #[test]
+    fn event_list_empty_has_zero_count() {
+        let list = EventList::new();
+        unsafe {
+            assert_eq!(list.getEventCount(), 0);
+        }
+    }
+
+    #[test]
+    fn event_list_add_and_get_events() {
+        let list = EventList::new();
+        let mut event = make_note_on_event(0, 60, 0.8, 0);
+
+        unsafe {
+            let result = list.addEvent(&mut event);
+            assert_eq!(result, kResultOk);
+            assert_eq!(list.getEventCount(), 1);
+
+            let mut retrieved: Event = std::mem::zeroed();
+            let result = list.getEvent(0, &mut retrieved);
+            assert_eq!(result, kResultOk);
+            assert_eq!(retrieved.r#type, EventTypes_::kNoteOnEvent as u16);
+            assert_eq!(retrieved.__field0.noteOn.pitch, 60);
+        }
+    }
+
+    #[test]
+    fn event_list_get_event_out_of_bounds() {
+        let list = EventList::new();
+        unsafe {
+            let mut event: Event = std::mem::zeroed();
+            let result = list.getEvent(0, &mut event);
+            assert_eq!(result, kInvalidArgument);
+            let result = list.getEvent(-1, &mut event);
+            assert_eq!(result, kInvalidArgument);
+        }
+    }
+
+    #[test]
+    fn event_list_with_events() {
+        let events = vec![
+            make_note_on_event(0, 60, 1.0, 0),
+            make_note_off_event(0, 60, 0.0, 100),
+        ];
+        let list = EventList::with_events(events);
+        unsafe {
+            assert_eq!(list.getEventCount(), 2);
+
+            let mut e: Event = std::mem::zeroed();
+            list.getEvent(0, &mut e);
+            assert_eq!(e.r#type, EventTypes_::kNoteOnEvent as u16);
+
+            list.getEvent(1, &mut e);
+            assert_eq!(e.r#type, EventTypes_::kNoteOffEvent as u16);
+        }
+    }
+
+    // =========================================================================
+    // MIDI-to-VST3 conversion tests
+    // =========================================================================
+
+    #[test]
+    fn midi_note_on_converts_correctly() {
+        let midi = MidiEvent {
+            status: 0x90,
+            data1: 60,
+            data2: 100,
+            sample_offset: 42,
+        };
+        let event = midi_to_vst3_event(&midi).unwrap();
+        assert_eq!(event.r#type, EventTypes_::kNoteOnEvent as u16);
+        assert_eq!(event.sampleOffset, 42);
+        unsafe {
+            assert_eq!(event.__field0.noteOn.channel, 0);
+            assert_eq!(event.__field0.noteOn.pitch, 60);
+            assert!((event.__field0.noteOn.velocity - 100.0 / 127.0).abs() < 0.01);
+        }
+    }
+
+    #[test]
+    fn midi_note_off_converts_correctly() {
+        let midi = MidiEvent {
+            status: 0x80,
+            data1: 64,
+            data2: 0,
+            sample_offset: 10,
+        };
+        let event = midi_to_vst3_event(&midi).unwrap();
+        assert_eq!(event.r#type, EventTypes_::kNoteOffEvent as u16);
+        assert_eq!(event.sampleOffset, 10);
+        unsafe {
+            assert_eq!(event.__field0.noteOff.channel, 0);
+            assert_eq!(event.__field0.noteOff.pitch, 64);
+        }
+    }
+
+    #[test]
+    fn midi_note_on_velocity_zero_is_note_off() {
+        let midi = MidiEvent {
+            status: 0x90,
+            data1: 60,
+            data2: 0,
+            sample_offset: 0,
+        };
+        let event = midi_to_vst3_event(&midi).unwrap();
+        assert_eq!(event.r#type, EventTypes_::kNoteOffEvent as u16);
+    }
+
+    #[test]
+    fn midi_channel_extracted_from_status() {
+        let midi = MidiEvent {
+            status: 0x95, // note-on, channel 5
+            data1: 72,
+            data2: 80,
+            sample_offset: 0,
+        };
+        let event = midi_to_vst3_event(&midi).unwrap();
+        unsafe {
+            assert_eq!(event.__field0.noteOn.channel, 5);
+        }
+    }
+
+    #[test]
+    fn midi_unsupported_type_returns_none() {
+        // Control change (0xB0) is not supported yet
+        let midi = MidiEvent {
+            status: 0xB0,
+            data1: 1,
+            data2: 64,
+            sample_offset: 0,
+        };
+        assert!(midi_to_vst3_event(&midi).is_none());
     }
 }

--- a/companion/src/ws_server.rs
+++ b/companion/src/ws_server.rs
@@ -268,13 +268,23 @@ fn handle_message(msg: IncomingMessage, state: &AppState) -> OutgoingMessage {
             instance_id,
             events,
         } => {
-            info!(instance_id, count = events.len(), "MIDI events (stub)");
-            // No response required for MIDI in the current protocol; send an ack-style message.
+            // Convert protocol MidiEvents to audio_thread MidiEvents
+            let audio_events: Vec<crate::audio_thread::MidiEvent> = events
+                .iter()
+                .map(crate::audio_thread::MidiEvent::from)
+                .collect();
+            let count = audio_events.len();
+            let sent = state.audio_streams.send_midi(&instance_id, audio_events);
+            if sent {
+                info!(instance_id, count, "MIDI events forwarded to audio thread");
+            } else {
+                warn!(instance_id, count, "No active audio stream for MIDI events");
+            }
             OutgoingMessage::Error {
                 req_id: None,
                 instance_id: Some(instance_id),
                 code: "ok".into(),
-                message: format!("Received {} MIDI events (stub)", events.len()),
+                message: format!("Received {count} MIDI events"),
             }
         }
 


### PR DESCRIPTION
## Summary
Complete MIDI pipeline from browser piano roll to VST3 plugin audio output.

- **EventList** (`IEventList` COM class): passes MIDI events to VST3 `IAudioProcessor::process()`
- Convert protocol `MidiEvent` (noteOn/noteOff with note/velocity) to VST3 `NoteOnEvent`/`NoteOffEvent`
- `ws_server`: MIDI handler calls `plugin_host.send_midi()` (replaces stub)
- `audio_thread`: drains MIDI queue, packs into `EventList`, passes via `processData.inputEvents`
- Hot path optimization: skip `EventList` COM allocation when no MIDI events

## Full MIDI Data Flow
```
Piano Roll note → useTransport schedules noteOn/noteOff
  → bridgeClient.sendMidi(instanceId, [{type:"noteOn", note:60, velocity:100}])
    → WebSocket JSON → companion ws_server
      → plugin_host.send_midi(instance_id, events)
        → audio_thread MIDI queue (lock-free SegQueue)
          → process_vst3: drain queue → EventList → processData.inputEvents
            → IAudioProcessor::process() → VST3 plugin generates audio
              → audio output → WebSocket binary frame → browser AudioWorklet → speakers 🔊
```

## Test plan
- [x] 131 Rust tests pass (11 new for EventList + MIDI conversion)
- [x] `cargo build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)