### PR TITLE
feat: drag & drop VST3 plugins from browser onto tracks

### DIFF
--- a/src/components/plugins/VST3PluginBrowser.tsx
+++ b/src/components/plugins/VST3PluginBrowser.tsx
@@ -220,13 +220,32 @@ function PluginRow({
   plugin: VST3PluginInfo;
   onLoad: (id: string) => void;
 }) {
+  const [dragging, setDragging] = useState(false);
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent) => {
+      e.dataTransfer.setData('application/x-vst3-plugin', plugin.id);
+      e.dataTransfer.effectAllowed = 'copy';
+      setDragging(true);
+    },
+    [plugin.id],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDragging(false);
+  }, []);
+
   return (
     <div
       className="flex items-center gap-2 rounded-md px-2 py-1 text-xs text-zinc-300 hover:bg-white/5 cursor-pointer"
+      draggable
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
       onDoubleClick={() => onLoad(plugin.id)}
       data-testid="plugin-row"
       data-plugin-id={plugin.id}
       title={`${plugin.name} by ${plugin.vendor}`}
+      style={{ opacity: dragging ? 0.5 : 1 }}
     >
       <span className="flex-1 truncate">{plugin.name}</span>
       <span className="shrink-0 text-[10px] text-zinc-500 max-w-[80px] truncate">{plugin.vendor}</span>

--- a/src/components/plugins/__tests__/VST3PluginBrowser.test.tsx
+++ b/src/components/plugins/__tests__/VST3PluginBrowser.test.tsx
@@ -92,4 +92,44 @@ describe('VST3PluginBrowser', () => {
     render(<VST3PluginBrowser />);
     expect(screen.getByTestId('scan-progress')).toBeInTheDocument();
   });
+
+  describe('drag and drop', () => {
+    it('plugin rows are draggable', () => {
+      render(<VST3PluginBrowser />);
+      const rows = screen.getAllByTestId('plugin-row');
+      expect(rows[0]).toHaveAttribute('draggable', 'true');
+    });
+
+    it('dragStart sets application/x-vst3-plugin data with plugin id', () => {
+      render(<VST3PluginBrowser />);
+      const rows = screen.getAllByTestId('plugin-row');
+      // First row is BassLine (p3) after alphabetical sort
+      const dataTransfer = {
+        setData: vi.fn(),
+        effectAllowed: '',
+      };
+      fireEvent.dragStart(rows[0], { dataTransfer });
+      expect(dataTransfer.setData).toHaveBeenCalledWith('application/x-vst3-plugin', 'p3');
+      expect(dataTransfer.effectAllowed).toBe('copy');
+    });
+
+    it('plugin row reduces opacity during drag', () => {
+      render(<VST3PluginBrowser />);
+      const rows = screen.getAllByTestId('plugin-row');
+      fireEvent.dragStart(rows[0], {
+        dataTransfer: { setData: vi.fn(), effectAllowed: '' },
+      });
+      expect(rows[0]).toHaveStyle({ opacity: '0.5' });
+    });
+
+    it('plugin row restores opacity on drag end', () => {
+      render(<VST3PluginBrowser />);
+      const rows = screen.getAllByTestId('plugin-row');
+      fireEvent.dragStart(rows[0], {
+        dataTransfer: { setData: vi.fn(), effectAllowed: '' },
+      });
+      fireEvent.dragEnd(rows[0]);
+      expect(rows[0]).toHaveStyle({ opacity: '1' });
+    });
+  });
 });

--- a/src/components/timeline/TrackLane.tsx
+++ b/src/components/timeline/TrackLane.tsx
@@ -3,6 +3,7 @@ import type { Track } from '../../types/project';
 import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
 import { useGenerationStore } from '../../store/generationStore';
+import { useVST3Store } from '../../store/vst3Store';
 import { ClipBlock } from './ClipBlock';
 import { TakeLaneStrip } from './TakeLaneStrip';
 import { AutomationLaneView } from './AutomationLaneView';
@@ -59,6 +60,7 @@ function TrackLaneInner({ track }: TrackLaneProps) {
   const convertMidiFileToStrudel = useProjectStore((s) => s.convertMidiFileToStrudel);
   const applyStrudelCodeToTrack = useProjectStore((s) => s.applyStrudelCodeToTrack);
   const placeGenerationHistoryOnTrack = useGenerationStore((s) => s.placeGenerationHistoryOnTrack);
+  const loadVST3Plugin = useVST3Store((s) => s.loadPlugin);
 
   const [ctxMenu, setCtxMenu] = useState<{
     x: number; y: number; startTime: number; duration: number;
@@ -229,6 +231,7 @@ function TrackLaneInner({ track }: TrackLaneProps) {
       || types.includes('application/x-loop-id')
       || types.includes('application/x-asset-id')
       || types.includes('application/x-generation-history-id')
+      || types.includes('application/x-vst3-plugin')
     ) {
       e.preventDefault();
       dragCounterRef.current++;
@@ -243,6 +246,7 @@ function TrackLaneInner({ track }: TrackLaneProps) {
       || types.includes('application/x-loop-id')
       || types.includes('application/x-asset-id')
       || types.includes('application/x-generation-history-id')
+      || types.includes('application/x-vst3-plugin')
     ) {
       e.preventDefault();
       e.stopPropagation();
@@ -285,6 +289,13 @@ function TrackLaneInner({ track }: TrackLaneProps) {
     const laneX = clientXToLaneX(e.clientX);
     const rawTime = laneX / pixelsPerSecond;
     const startTime = Math.max(0, snapToGrid(rawTime, bpm, 1, tempoMap));
+
+    // Handle VST3 plugin drop — loads a plugin instance onto this track
+    const vst3PluginId = e.dataTransfer.getData('application/x-vst3-plugin');
+    if (vst3PluginId) {
+      void loadVST3Plugin(vst3PluginId, track.id);
+      return;
+    }
 
     const historyId = e.dataTransfer.getData('application/x-generation-history-id');
     if (historyId) {
@@ -331,7 +342,7 @@ function TrackLaneInner({ track }: TrackLaneProps) {
         setOpenStrudelEditor,
       });
     }
-  }, [applyStrudelCodeToTrack, convertMidiFileToStrudel, placeGenerationHistoryOnTrack, hasProject, bpm, tempoMap, pixelsPerSecond, track.id, track.trackType, importAssetAsQuickSampler, importAssetToTrack, importAudioFileAsSampler, importAudioFileAsNewQuickSampler, importAudioToTrack, importMidiFile, importLoopToTrack, setOpenStrudelEditor]);
+  }, [applyStrudelCodeToTrack, convertMidiFileToStrudel, loadVST3Plugin, placeGenerationHistoryOnTrack, hasProject, bpm, tempoMap, pixelsPerSecond, track.id, track.trackType, importAssetAsQuickSampler, importAssetToTrack, importAudioFileAsSampler, importAudioFileAsNewQuickSampler, importAudioToTrack, importMidiFile, importLoopToTrack, setOpenStrudelEditor]);
 
   const hasClips = track.clips.length > 0;
   const shouldHighlightEmptyLane = !hasClips && !isSequencer && !isDrumMachine && !isPianoRoll && !isStrudel;

--- a/src/components/timeline/__tests__/TrackLaneVST3Drop.test.tsx
+++ b/src/components/timeline/__tests__/TrackLaneVST3Drop.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Mock heavy child components to avoid pulling in complex dependencies
+vi.mock('../ClipBlock', () => ({ ClipBlock: () => <div data-testid="clip-block" /> }));
+vi.mock('../TakeLaneStrip', () => ({ TakeLaneStrip: () => null }));
+vi.mock('../AutomationLaneView', () => ({ AutomationLaneView: () => null }));
+vi.mock('../../generation/AddLayerModal', () => ({ AddLayerModal: () => null }));
+vi.mock('../CanvasContextMenu', () => ({ CanvasContextMenu: () => null }));
+vi.mock('../CrossfadeOverlay', () => ({ CrossfadeOverlay: () => null }));
+vi.mock('../../../hooks/useAudioImport', () => ({
+  useAudioImport: () => ({
+    importAssetAsQuickSampler: vi.fn(),
+    importAudioFileAsSampler: vi.fn(),
+    importAudioFileAsNewQuickSampler: vi.fn(),
+    importAudioToTrack: vi.fn(),
+    importMidiFile: vi.fn(),
+    importLoopToTrack: vi.fn(),
+    importAssetToTrack: vi.fn(),
+  }),
+}));
+vi.mock('../../../services/projectStorage', () => ({ saveProject: vi.fn() }));
+
+import { TrackLane } from '../TrackLane';
+import { useProjectStore } from '../../../store/projectStore';
+import { useVST3Store } from '../../../store/vst3Store';
+import type { Track } from '../../../types/project';
+
+const TRACK: Track = {
+  id: 'track-1',
+  displayName: 'Test Track',
+  trackName: 'custom',
+  trackType: 'stems',
+  color: '#5e59ff',
+  volume: 0.8,
+  pan: 0,
+  muted: false,
+  soloed: false,
+  clips: [],
+};
+
+describe('TrackLane VST3 plugin drop', () => {
+  beforeEach(() => {
+    useProjectStore.setState({
+      project: {
+        id: 'proj-1',
+        name: 'Test Project',
+        bpm: 120,
+        timeSignature: 4,
+        timeSignatureDenominator: 4,
+        totalDuration: 120,
+        tracks: [TRACK],
+        automationLanes: [],
+      } as any,
+    });
+
+    useVST3Store.setState({
+      connectionStatus: 'connected',
+      plugins: [
+        { id: 'plug-1', name: 'TestSynth', vendor: 'TestVendor', version: '1.0', subcategory: 'Synth', category: 'instrument' as const },
+      ],
+      scanning: false,
+      scanProgress: null,
+    });
+  });
+
+  it('accepts VST3 plugin drag over', () => {
+    render(<TrackLane track={TRACK} />);
+    const lane = screen.getByTestId(`track-lane-${TRACK.id}`);
+
+    const dataTransfer = {
+      types: ['application/x-vst3-plugin'],
+      getData: vi.fn(() => 'plug-1'),
+      dropEffect: '',
+    };
+
+    fireEvent.dragEnter(lane, { dataTransfer });
+    fireEvent.dragOver(lane, { dataTransfer });
+
+    // dragOver should set dropEffect to 'copy'
+    expect(dataTransfer.dropEffect).toBe('copy');
+  });
+
+  it('shows highlight on VST3 plugin drag over', () => {
+    render(<TrackLane track={TRACK} />);
+    const lane = screen.getByTestId(`track-lane-${TRACK.id}`);
+
+    const dataTransfer = {
+      types: ['application/x-vst3-plugin'],
+      getData: vi.fn(() => 'plug-1'),
+      dropEffect: '',
+    };
+
+    fireEvent.dragEnter(lane, { dataTransfer });
+
+    // Should have the blue highlight class for plugin drop
+    expect(lane.className).toContain('bg-blue-900/20');
+  });
+
+  it('calls loadPlugin on drop with correct pluginId and trackId', async () => {
+    const loadPluginSpy = vi.fn().mockResolvedValue(undefined);
+    useVST3Store.setState({ loadPlugin: loadPluginSpy });
+
+    render(<TrackLane track={TRACK} />);
+    const lane = screen.getByTestId(`track-lane-${TRACK.id}`);
+
+    const dataTransfer = {
+      types: ['application/x-vst3-plugin'],
+      getData: vi.fn((type: string) => (type === 'application/x-vst3-plugin' ? 'plug-1' : '')),
+      files: { length: 0 },
+      dropEffect: '',
+    };
+
+    fireEvent.dragEnter(lane, { dataTransfer });
+    fireEvent.drop(lane, { dataTransfer });
+
+    expect(loadPluginSpy).toHaveBeenCalledWith('plug-1', 'track-1');
+  });
+});


### PR DESCRIPTION
## Summary
- Make VST3 plugin rows in the browser panel draggable with `application/x-vst3-plugin` MIME type
- Add drop handling in TrackLane to accept VST3 plugins and call `loadPlugin(pluginId, trackId)`
- Visual drag feedback (opacity change) on plugin rows during drag

Closes #889

## Test plan
- [x] Plugin rows have `draggable={true}` attribute
- [x] DragStart sets correct MIME type and plugin ID in dataTransfer
- [x] Plugin row opacity reduces to 0.5 during drag, restores on drag end
- [x] TrackLane accepts dragOver for VST3 plugin type
- [x] TrackLane shows blue highlight on VST3 plugin drag over
- [x] Drop on TrackLane calls `loadPlugin` with correct pluginId and trackId
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] All 2665 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)