### PR TITLE
fix: EffectChain crash when adding effects (Closes #908)

### DIFF
--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -62,12 +62,36 @@ function applyParametricEqFilters(
   previous.connect(output);
 }
 
+/**
+ * Unwrap a Tone.js node to its underlying native AudioNode.
+ * Tone.Effect subclasses (Reverb, Delay, etc.) have `.input` = Tone.Gain,
+ * and Tone.Gain has `.input` = native GainNode.  We need to walk the chain
+ * until we reach a real AudioNode that native `.connect()` can accept.
+ *
+ * A native AudioNode does NOT have a nested `.input`/`.output` object property
+ * (its `.connect` is a native function, not a Tone.js method).
+ */
+function unwrapToNative(node: unknown, prop: 'input' | 'output'): AudioNode {
+  let current = node;
+  // Walk up to 3 levels deep (Tone.Effect → Tone.Gain → native GainNode)
+  for (let i = 0; i < 3; i++) {
+    if (!current || typeof current !== 'object') break;
+    const next = (current as Record<string, unknown>)[prop];
+    // If there's no deeper level or it's the same object, we've reached the native node
+    if (!next || next === current || typeof next !== 'object') break;
+    current = next;
+  }
+  return current as AudioNode;
+}
+
 function getEffectInput(effectNode: EffectNode): AudioNode {
-  return effectNode.inputNode ?? (effectNode.node as unknown as { input: AudioNode }).input;
+  const raw = effectNode.inputNode ?? (effectNode.node as unknown as { input: unknown }).input;
+  return unwrapToNative(raw, 'input');
 }
 
 function getEffectOutput(effectNode: EffectNode): AudioNode {
-  return effectNode.outputNode ?? (effectNode.node as unknown as { output: AudioNode }).output;
+  const raw = effectNode.outputNode ?? (effectNode.node as unknown as { output: unknown }).output;
+  return unwrapToNative(raw, 'output');
 }
 
 function createNode(effect: TrackEffect): EffectNode {

--- a/src/engine/__tests__/effectsEngineNativeNode.test.ts
+++ b/src/engine/__tests__/effectsEngineNativeNode.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock Tone.js — the key insight: Effect subclasses have `.input` = Tone.Gain,
+// and Tone.Gain has `.input` = native GainNode.  The unwrap must go 2 levels.
+const nativeGainIn = { connect: vi.fn(), disconnect: vi.fn(), __native: true } as unknown as AudioNode;
+const nativeGainOut = { connect: vi.fn(), disconnect: vi.fn(), __native: true } as unknown as AudioNode;
+
+vi.mock('tone', () => {
+  return {
+    EQ3: class {
+      low = { value: 0 }; mid = { value: 0 }; high = { value: 0 };
+      lowFrequency = { value: 0 }; highFrequency = { value: 0 };
+      connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn();
+      // EQ3 extends ToneAudioNode — input/output are native-ish
+      input = nativeGainIn;
+      output = nativeGainOut;
+    },
+    Reverb: class {
+      decay = 0; preDelay = 0; wet = { value: 0 };
+      connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn();
+      // Reverb extends Effect — input is Tone.Gain (wraps native GainNode)
+      input = { input: nativeGainIn, _gainNode: nativeGainIn };
+      output = { output: nativeGainOut, _gainNode: nativeGainOut };
+    },
+    FeedbackDelay: class {
+      delayTime = { value: 0 }; feedback = { value: 0 }; wet = { value: 0 };
+      connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn();
+      input = { input: nativeGainIn, _gainNode: nativeGainIn };
+      output = { output: nativeGainOut, _gainNode: nativeGainOut };
+    },
+    Compressor: class {
+      threshold = { value: -24 }; ratio = { value: 4 }; attack = { value: 0.02 };
+      release = { value: 0.2 }; knee = { value: 6 }; reduction = 0;
+      connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn();
+      input = nativeGainIn;
+      output = nativeGainOut;
+    },
+    Distortion: class {
+      distortion = 0; wet = { value: 0 };
+      connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn();
+      input = { input: nativeGainIn, _gainNode: nativeGainIn };
+      output = { output: nativeGainOut, _gainNode: nativeGainOut };
+    },
+    Filter: class {
+      frequency = { value: 0 }; Q = { value: 0 }; type = 'lowpass';
+      connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn();
+      input = nativeGainIn;
+      output = nativeGainOut;
+    },
+    Gain: class {
+      connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn();
+      input = nativeGainIn;
+      output = nativeGainOut;
+      _gainNode = nativeGainIn;
+    },
+    LFO: class {
+      frequency = { value: 0 }; min = 0; max = 0;
+      start = vi.fn(); stop = vi.fn(); connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn();
+    },
+    Phaser: class {
+      frequency = { value: 0 }; octaves = 0; stages = 0; Q = { value: 0 };
+      baseFrequency = { value: 0 }; wet = { value: 0 };
+      connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn();
+      input = { input: nativeGainIn, _gainNode: nativeGainIn };
+      output = { output: nativeGainOut, _gainNode: nativeGainOut };
+    },
+    Chorus: class {
+      frequency = { value: 0 }; delayTime = 0; depth = 0; wet = { value: 0 };
+      connect = vi.fn(); disconnect = vi.fn(); dispose = vi.fn(); start = vi.fn();
+      input = { input: nativeGainIn, _gainNode: nativeGainIn };
+      output = { output: nativeGainOut, _gainNode: nativeGainOut };
+    },
+  };
+});
+
+vi.mock('../sidechainFollower', () => ({
+  computeGainReduction: vi.fn(() => 6),
+  smoothGain: vi.fn((cur: number) => cur),
+  SidechainFollower: class {
+    gainNode = { gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() };
+    reduction = -6; dispose = vi.fn(); updateParams = vi.fn();
+  },
+}));
+
+vi.mock('../../store/projectStore', () => ({
+  useProjectStore: { getState: () => ({ project: null }) },
+}));
+
+import { effectsEngine } from '../EffectsEngine';
+import type { TrackEffect } from '../../types/project';
+
+function makeEffect(type: string): TrackEffect {
+  const defaults: Record<string, unknown> = {
+    reverb: { decay: 1.5, preDelay: 0.01, wet: 0.5 },
+    eq3: { low: 0, mid: 0, high: 0, lowFrequency: 400, highFrequency: 2500 },
+    compressor: { threshold: -24, ratio: 4, attack: 0.02, release: 0.2, knee: 6 },
+    delay: { delayTime: 0.25, feedback: 0.3, wet: 0.5 },
+    distortion: { distortion: 0.4, wet: 0.5 },
+    filter: { frequency: 1000, Q: 1, type: 'lowpass', rolloff: -12, wet: 1 },
+    chorus: { frequency: 1.5, delayTime: 3.5, depth: 0.7, wet: 0.5 },
+    phaser: { frequency: 0.5, octaves: 3, stages: 10, Q: 10, baseFrequency: 350, wet: 0.5 },
+  };
+  return {
+    id: `effect-${type}`,
+    type: type as TrackEffect['type'],
+    enabled: true,
+    params: defaults[type] as TrackEffect['params'],
+  };
+}
+
+describe('EffectsEngine native AudioNode unwrapping', () => {
+  beforeEach(() => {
+    effectsEngine.disposeChain('track-1');
+  });
+
+  it.each(['reverb', 'delay', 'distortion', 'chorus', 'phaser'])(
+    'getInputNode for %s returns a native-like AudioNode (not a Tone.js wrapper)',
+    (type) => {
+      const effect = makeEffect(type);
+      effectsEngine.rebuildChain('track-1', [effect]);
+
+      const inputNode = effectsEngine.getInputNode('track-1');
+      expect(inputNode).not.toBeNull();
+      // Must be the native node, not a Tone.js wrapper that has its own .input
+      expect((inputNode as unknown as { __native: boolean }).__native).toBe(true);
+    }
+  );
+
+  it.each(['reverb', 'delay', 'distortion', 'chorus', 'phaser'])(
+    'getOutputNode for %s returns a native-like AudioNode (not a Tone.js wrapper)',
+    (type) => {
+      const effect = makeEffect(type);
+      effectsEngine.rebuildChain('track-1', [effect]);
+
+      const outputNode = effectsEngine.getOutputNode('track-1');
+      expect(outputNode).not.toBeNull();
+      expect((outputNode as unknown as { __native: boolean }).__native).toBe(true);
+    }
+  );
+
+  it.each(['eq3', 'compressor', 'filter'])(
+    'getInputNode for %s (non-Effect subclass) returns native node directly',
+    (type) => {
+      const effect = makeEffect(type);
+      effectsEngine.rebuildChain('track-1', [effect]);
+
+      const inputNode = effectsEngine.getInputNode('track-1');
+      expect(inputNode).not.toBeNull();
+      expect((inputNode as unknown as { __native: boolean }).__native).toBe(true);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- Fixed `TypeError: Overload resolution failed` crash when adding any effect (Reverb, Delay, Distortion, Chorus, Phaser, etc.) to the Effect Chain
- Root cause: `getEffectInput()`/`getEffectOutput()` in `EffectsEngine.ts` returned Tone.js wrapper objects instead of native `AudioNode`s, causing `TrackNode.spliceEffects()` to fail on `nativeNode.connect(toneJsWrapper)`
- Added `unwrapToNative()` helper that walks `.input`/`.output` chain (up to 3 levels) to reach the underlying native AudioNode
- 13 new unit tests covering all 8 effect types

## Test plan

- [x] Unit tests: 2693/2693 passed (+13 new)
- [x] Type check: 0 errors
- [x] Build: passes
- [x] Visual: verified adding Reverb, EQ3, Compressor, Delay — all render correctly with knobs/sliders
- [x] No console errors after adding effects

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)