### PR TITLE
feat: add AI enhance buttons for caption and lyrics in Custom mode

### DIFF
--- a/src/components/generation/FullSongForm.tsx
+++ b/src/components/generation/FullSongForm.tsx
@@ -5,7 +5,18 @@ import { useModelStore } from '../../store/modelStore';
 import { MAX_DURATION, MIN_DURATION } from '../../constants/defaults';
 import { VOCAL_LANGUAGES, DEFAULT_VOCAL_LANGUAGE } from '../../constants/languages';
 import { generateText2Music } from '../../services/generationPipeline';
+import { formatInput } from '../../services/aceStepApi';
+import { toastError, toastInfo } from '../../hooks/useToast';
 import { PromptAutocompleteTextarea } from './PromptAutocompleteTextarea';
+
+/** Sparkle icon for AI enhance buttons */
+function SparkleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 3l1.912 5.813a2 2 0 001.275 1.275L21 12l-5.813 1.912a2 2 0 00-1.275 1.275L12 21l-1.912-5.813a2 2 0 00-1.275-1.275L3 12l5.813-1.912a2 2 0 001.275-1.275L12 3z" />
+    </svg>
+  );
+}
 
 
 interface FullSongFormProps {
@@ -42,6 +53,45 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
   const [stemCount, setStemCount] = useState<2 | 4 | 6>(4);
   const [thinking, setThinking] = useState(project?.generationDefaults?.thinking ?? true);
   const [error, setError] = useState<string | null>(null);
+  const [enhancingCaption, setEnhancingCaption] = useState(false);
+  const [enhancingLyrics, setEnhancingLyrics] = useState(false);
+
+  const handleEnhanceCaption = useCallback(async () => {
+    if (!prompt.trim()) return;
+    setEnhancingCaption(true);
+    try {
+      const result = await formatInput({
+        prompt: prompt.trim(),
+        lyrics,
+        language: vocalLanguage !== 'unknown' ? vocalLanguage : undefined,
+      });
+      if (result.caption) setPrompt(result.caption);
+      toastInfo('Caption enhanced');
+    } catch (err) {
+      toastError(err instanceof Error ? err.message : 'Failed to enhance caption');
+    } finally {
+      setEnhancingCaption(false);
+    }
+  }, [prompt, lyrics, vocalLanguage]);
+
+  const handleEnhanceLyrics = useCallback(async () => {
+    if (!lyrics.trim() && !prompt.trim()) return;
+    setEnhancingLyrics(true);
+    try {
+      const result = await formatInput({
+        prompt: prompt.trim(),
+        lyrics: lyrics.trim(),
+        language: vocalLanguage !== 'unknown' ? vocalLanguage : undefined,
+      });
+      if (result.lyrics) setLyrics(result.lyrics);
+      if (result.caption && !prompt.trim()) setPrompt(result.caption);
+      toastInfo('Lyrics enhanced');
+    } catch (err) {
+      toastError(err instanceof Error ? err.message : 'Failed to enhance lyrics');
+    } finally {
+      setEnhancingLyrics(false);
+    }
+  }, [prompt, lyrics, vocalLanguage]);
 
   // Apply initial data from Simple mode's Create Sample
   useEffect(() => {
@@ -103,9 +153,20 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
 
       {/* Music Caption */}
       <section className="space-y-1.5">
-        <label className="block text-[11px] font-medium uppercase text-zinc-400">
-          Music Caption
-        </label>
+        <div className="flex items-center justify-between">
+          <label className="text-[11px] font-medium uppercase text-zinc-400">
+            Music Caption
+          </label>
+          <button
+            type="button"
+            onClick={handleEnhanceCaption}
+            disabled={isDisabled || enhancingCaption || !prompt.trim()}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-zinc-400 transition-colors hover:bg-white/5 hover:text-zinc-200 disabled:opacity-40 disabled:cursor-not-allowed"
+            title="AI enhance caption"
+          >
+            <SparkleIcon className={enhancingCaption ? 'animate-spin' : ''} />
+          </button>
+        </div>
         <PromptAutocompleteTextarea
           value={prompt}
           onChange={setPrompt}
@@ -118,7 +179,18 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
       {/* Lyrics — with Language + Instrumental inline */}
       <section className="space-y-1.5">
         <div className="flex items-center justify-between">
-          <label className="text-[11px] font-medium uppercase text-zinc-400">Lyrics</label>
+          <div className="flex items-center gap-1">
+            <label className="text-[11px] font-medium uppercase text-zinc-400">Lyrics</label>
+            <button
+              type="button"
+              onClick={handleEnhanceLyrics}
+              disabled={isDisabled || enhancingLyrics || instrumental || (!lyrics.trim() && !prompt.trim())}
+              className="flex items-center rounded px-1 py-0.5 text-zinc-400 transition-colors hover:bg-white/5 hover:text-zinc-200 disabled:opacity-40 disabled:cursor-not-allowed"
+              title="AI enhance lyrics"
+            >
+              <SparkleIcon className={enhancingLyrics ? 'animate-spin' : ''} />
+            </button>
+          </div>
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-1">
               <span className="text-[9px] text-zinc-500">Lang</span>

--- a/src/services/aceStepApi.ts
+++ b/src/services/aceStepApi.ts
@@ -219,6 +219,53 @@ export async function createSample(req: CreateSampleRequest): Promise<CreateSamp
   return envelope.data;
 }
 
+/** Format/enhance input — LM refines prompt, lyrics, and infers metadata. */
+export interface FormatInputRequest {
+  prompt: string;
+  lyrics: string;
+  language?: string;
+  bpm?: number;
+  duration?: number;
+  key_scale?: string;
+  time_signature?: string;
+}
+
+export interface FormatInputResponse {
+  caption: string;
+  lyrics: string;
+  bpm?: number;
+  key_scale?: string;
+  time_signature?: string;
+  duration?: number;
+  vocal_language?: string;
+}
+
+export async function formatInput(req: FormatInputRequest): Promise<FormatInputResponse> {
+  const base = getApiBase();
+  const paramObj: Record<string, unknown> = {};
+  if (req.language) paramObj.language = req.language;
+  if (req.bpm) paramObj.bpm = req.bpm;
+  if (req.duration) paramObj.duration = req.duration;
+  if (req.key_scale) paramObj.key = req.key_scale;
+  if (req.time_signature) paramObj.time_signature = req.time_signature;
+
+  const res = await fetch(`${base}/format_input`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      prompt: req.prompt,
+      lyrics: req.lyrics,
+      param_obj: JSON.stringify(paramObj),
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`formatInput failed: ${res.status} - ${text}`);
+  }
+  const envelope: ApiEnvelope<FormatInputResponse> = await res.json();
+  return envelope.data;
+}
+
 export async function initModel(req: InitModelRequest): Promise<InitModelResponse> {
   const base = getApiBase();
   const res = await fetch(`${base}/v1/init`, {


### PR DESCRIPTION
## Summary

- Add `formatInput()` API function — calls `POST /format_input` to let LM refine prompt/lyrics
- Add ✨ sparkle buttons next to **Music Caption** and **Lyrics** labels in Custom mode (FullSongForm)
- Caption enhance: sends current prompt+lyrics → LM returns refined caption
- Lyrics enhance: sends current prompt+lyrics → LM returns refined lyrics (+ fills caption if empty)

## Behavior

- Button shows sparkle icon (✨), spins while loading
- Disabled when: textarea empty, instrumental mode, or already generating
- Toast feedback on success/error

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 286 passed, 0 failed
- [x] `npm run build` — succeeds
- [ ] Visual: ✨ buttons visible next to Caption and Lyrics labels
- [ ] E2E: click ✨ → LM enhances text → textarea updates

Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)