### PR TITLE
fix: dock fades out when mixer opens instead of floating up

### DIFF
--- a/src/components/generation/GenerationSidePanel.tsx
+++ b/src/components/generation/GenerationSidePanel.tsx
@@ -114,10 +114,10 @@ export function GenerationSidePanel() {
         style={{
           left: dockLeft,
           zIndex: Z.toast,
-          bottom: (showSmartControls ? 208 : 68) + bottomPanelHeight,
-          opacity: activeBottomPanel ? 0 : 1,
-          pointerEvents: activeBottomPanel ? 'none' : 'auto',
-          transform: `translateX(-50%) translateY(${activeBottomPanel ? '16px' : '0px'})`,
+          bottom: showSmartControls ? 208 : 68,
+          opacity: activeBottomPanel || showMixer ? 0 : 1,
+          pointerEvents: activeBottomPanel || showMixer ? 'none' : 'auto',
+          transform: `translateX(-50%) translateY(${activeBottomPanel || showMixer ? '16px' : '0px'})`,
         }}
         data-testid="generation-dock"
       >


### PR DESCRIPTION
## Summary
- Reverts the `bottomPanelHeight` offset on the dock from #977 — it caused the dock to float up jarring
- Instead, adds `showMixer` to the existing sink-and-fade condition (`opacity: 0`, `pointerEvents: none`, `translateY(16px)`) — same smooth animation as editors/smart controls
- Other floating panels (GenerationSidePanel popup, EnhancePanel) correctly keep their `bottomPanelHeight` offset since they need to stay usable above the mixer

Closes #979

## Test plan
- [x] Type check passes (0 errors)
- [x] All 2737 unit tests pass
- [x] Visual: dock fades out when mixer opens
- [x] Visual: dock reappears when mixer closes
- [x] No regression with other bottom panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)