### PR TITLE
feat: add clip launch modes (Trigger, Gate, Toggle, Repeat) for session view

### DIFF
--- a/src/components/session/SessionView.tsx
+++ b/src/components/session/SessionView.tsx
@@ -7,7 +7,22 @@ import { getSessionSlotProgress } from '../../utils/sessionProgress';
 import { getSessionClips } from '../../utils/sessionClips';
 import { ContextMenuWrapper, ContextMenuSeparator, ContextMenuItem } from '../ui/ContextMenu';
 import { ColorSwatchPalette } from '../ui/ColorSwatchPalette';
-import type { Clip, Track, SessionLaunchQuantization, SessionClipSlot, SessionPendingLaunch, SessionScene } from '../../types/project';
+import type { Clip, Track, SessionLaunchQuantization, SessionLaunchMode, SessionClipSlot, SessionPendingLaunch, SessionScene } from '../../types/project';
+
+const LAUNCH_MODE_OPTIONS: SessionLaunchMode[] = ['trigger', 'gate', 'toggle', 'repeat'];
+
+const LAUNCH_MODE_LABELS: Record<SessionLaunchMode, string> = {
+  trigger: 'Trigger',
+  gate: 'Gate',
+  toggle: 'Toggle',
+  repeat: 'Repeat',
+};
+
+/** Short badge letter for non-default launch modes. Trigger shows no badge. */
+function getLaunchModeBadge(mode: SessionLaunchMode | undefined): string | null {
+  if (!mode || mode === 'trigger') return null;
+  return mode[0].toUpperCase(); // G, T, R
+}
 
 const SESSION_QUANTIZATION_OPTIONS: SessionLaunchQuantization[] = [
   'none', '1/32', '1/16', '1/8', '1/4', '1/2', '1 bar', '2 bars', '4 bars', '8 bars',
@@ -40,12 +55,13 @@ function isClipQueued(
 
 const PROGRESS_RING_CIRCUMFERENCE = 2 * Math.PI * 10; // r=10
 
-interface SlotColorMenuState {
+interface SlotContextMenuState {
   x: number;
   y: number;
   slotId: string;
   currentColor: string | null;
   legato: boolean;
+  currentLaunchMode: SessionLaunchMode;
 }
 
 
@@ -59,6 +75,7 @@ export function SessionView() {
   const setMainView = useUIStore((s) => s.setMainView);
   const setSessionSlotColor = useProjectStore((s) => s.setSessionSlotColor);
   const setSessionSlotLegato = useProjectStore((s) => s.setSessionSlotLegato);
+  const setSessionSlotLaunchMode = useProjectStore((s) => s.setSessionSlotLaunchMode);
   const selectedSessionSlot = useUIStore((s) => s.selectedSessionSlot);
   const setSelectedSessionSlot = useUIStore((s) => s.setSelectedSessionSlot);
   const setKeyboardContext = useUIStore((s) => s.setKeyboardContext);
@@ -70,7 +87,7 @@ export function SessionView() {
     toggleSessionArrangementRecording,
   } = useTransport();
 
-  const [colorMenu, setColorMenu] = useState<SlotColorMenuState | null>(null);
+  const [colorMenu, setColorMenu] = useState<SlotContextMenuState | null>(null);
 
   const handleCloseColorMenu = useCallback(() => setColorMenu(null), []);
 
@@ -87,6 +104,13 @@ export function SessionView() {
       setColorMenu(null);
     }
   }, [colorMenu, setSessionSlotColor]);
+
+  const handleSetLaunchMode = useCallback((mode: SessionLaunchMode) => {
+    if (colorMenu) {
+      setSessionSlotLaunchMode(colorMenu.slotId, mode);
+      setColorMenu(null);
+    }
+  }, [colorMenu, setSessionSlotLaunchMode]);
 
   // Set keyboard context to 'session' on mount, restore previous on unmount
   useEffect(() => {
@@ -222,9 +246,21 @@ export function SessionView() {
           x={colorMenu.x}
           y={colorMenu.y}
           onClose={handleCloseColorMenu}
-          testId="session-slot-color-menu"
+          testId="session-slot-context-menu"
           minWidth={180}
         >
+          <div className="px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-zinc-400">
+            Launch Mode
+          </div>
+          <ContextMenuSeparator />
+          {LAUNCH_MODE_OPTIONS.map((mode) => (
+            <ContextMenuItem
+              key={mode}
+              label={`${LAUNCH_MODE_LABELS[mode]}${colorMenu.currentLaunchMode === mode ? ' (active)' : ''}`}
+              onClick={() => handleSetLaunchMode(mode)}
+            />
+          ))}
+          <ContextMenuSeparator />
           <div className="px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-zinc-400">
             Slot Color
           </div>
@@ -292,7 +328,7 @@ function FragmentRow({
   onLaunch: (clipId: string, sceneIndex: number) => void | Promise<void>;
   onStop: () => void | Promise<void>;
   onSlotQuantizationChange: (slotId: string, quantization: 'global' | SessionLaunchQuantization) => void;
-  onContextMenuSlot: (state: SlotColorMenuState) => void;
+  onContextMenuSlot: (state: SlotContextMenuState) => void;
   onSlotClick: (sceneIndex: number) => void;
 }) {
   const trackSlots = sessionSlots.filter((s) => s.trackId === track.id);
@@ -374,6 +410,9 @@ function FragmentRow({
         const slotColor = slot?.color ?? null;
         const hasStopButton = slot ? slot.hasStopButton !== false : true;
 
+        const slotLaunchMode: SessionLaunchMode = slot?.launchMode ?? 'trigger';
+        const launchModeBadge = getLaunchModeBadge(slotLaunchMode);
+
         const handleContextMenu = (e: React.MouseEvent) => {
           if (!clip || !slot) return;
           e.preventDefault();
@@ -383,6 +422,7 @@ function FragmentRow({
             slotId: slot.id,
             currentColor: slotColor,
             legato: slot.legato ?? false,
+            currentLaunchMode: slotLaunchMode,
           });
         };
 
@@ -393,7 +433,23 @@ function FragmentRow({
                 <button
                   onClick={() => {
                     onSlotClick(sceneIndex);
+                    // Gate and Repeat modes use pointer events, not click
+                    if (slotLaunchMode === 'gate' || slotLaunchMode === 'repeat') return;
                     void onLaunch(clip.id, sceneIndex);
+                  }}
+                  onPointerDown={(e) => {
+                    if (slotLaunchMode !== 'gate' && slotLaunchMode !== 'repeat') return;
+                    // Prevent default to avoid focus issues; capture pointer for reliable up events
+                    e.currentTarget.setPointerCapture(e.pointerId);
+                    void onLaunch(clip.id, sceneIndex);
+                  }}
+                  onPointerUp={(e) => {
+                    if (slotLaunchMode !== 'gate' && slotLaunchMode !== 'repeat') return;
+                    e.currentTarget.releasePointerCapture(e.pointerId);
+                    // Gate: stop the track on release; Repeat: last trigger continues (no stop)
+                    if (slotLaunchMode === 'gate') {
+                      void onStop();
+                    }
                   }}
                   onContextMenu={handleContextMenu}
                   className={`relative flex h-24 w-full flex-col justify-between rounded-xl border px-3 py-2 text-left transition-all ${
@@ -413,10 +469,11 @@ function FragmentRow({
                           : { backgroundColor: '#262626' }),
                     ...(isQueued && !isActive ? { animation: 'session-blink 500ms ease-in-out infinite' } : {}),
                   }}
-                  aria-label={`Launch ${getClipLabel(clip, sceneIndex)} on ${track.displayName} in scene ${sceneIndex + 1}`}
+                  aria-label={`Launch ${getClipLabel(clip, sceneIndex)} on ${track.displayName} in scene ${sceneIndex + 1}${slotLaunchMode !== 'trigger' ? ` (${slotLaunchMode} mode)` : ''}`}
                   data-slot-id={slot?.id}
                   data-track-id={track.id}
                   data-scene-index={sceneIndex}
+                  data-launch-mode={slotLaunchMode}
                 >
                   <div>
                     <div className="text-[10px] uppercase tracking-[0.16em] text-zinc-400">
@@ -449,6 +506,15 @@ function FragmentRow({
                     )}
                   </div>
                 </button>
+                {launchModeBadge && (
+                  <span
+                    className="absolute top-1 left-1 rounded bg-violet-600/80 px-1 py-0.5 text-[9px] font-bold text-white leading-none pointer-events-none"
+                    title={`Launch mode: ${LAUNCH_MODE_LABELS[slotLaunchMode]}`}
+                    data-testid={`launch-mode-badge-${slot?.id}`}
+                  >
+                    {launchModeBadge}
+                  </span>
+                )}
                 {hasOverride && (
                   <span
                     className="absolute top-1 right-1 rounded bg-daw-accent/80 px-1 py-0.5 text-[9px] font-semibold text-white leading-none pointer-events-none"

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -47,6 +47,7 @@ import type {
   SamplerConfig,
   SessionClipSlot,
   SessionLaunchEvent,
+  SessionLaunchMode,
   SessionLaunchQuantization,
   SessionPendingLaunch,
   SessionScene,
@@ -679,6 +680,7 @@ export interface ProjectState {
   setSessionLaunchQuantization: (quantization: SessionLaunchQuantization) => void;
   setSessionSlotQuantization: (slotId: string, quantization: 'global' | SessionLaunchQuantization) => void;
   setSessionSlotLegato: (slotId: string, legato: boolean) => void;
+  setSessionSlotLaunchMode: (slotId: string, launchMode: SessionLaunchMode) => void;
   launchSessionClip: (trackId: string, sceneId: string) => void;
   launchSessionScene: (sceneId: string) => void;
   stopSessionTrack: (trackId: string) => void;
@@ -4269,6 +4271,24 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
+  setSessionSlotLaunchMode: (slotId, launchMode) => {
+    const state = get();
+    if (!state.project) return;
+    const session = ensureProjectSession(state.project).session!;
+    const slotIndex = session.slots.findIndex((s) => s.id === slotId);
+    if (slotIndex === -1) return;
+    _pushHistory(state.project);
+    const nextSlots = [...session.slots];
+    nextSlots[slotIndex] = { ...nextSlots[slotIndex], launchMode };
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        session: { ...session, slots: nextSlots },
+      },
+    });
+  },
+
   launchSessionClip: (trackId, sceneId) => {
     const state = get();
     if (!state.project) return;
@@ -4277,6 +4297,13 @@ export const useProjectStore = create<ProjectState>()(
     const session = ensureProjectSession(state.project).session!;
     const slot = session.slots.find((candidate) => candidate.trackId === trackId && candidate.sceneId === sceneId);
     if (!slot?.clipId || !track.clips.some((clip) => clip.id === slot.clipId)) return;
+
+    // Toggle mode: if the clip is already active, stop the track instead of re-launching
+    const launchMode = slot.launchMode ?? 'trigger';
+    if (launchMode === 'toggle' && session.activeClipIdsByTrackId[trackId] === slot.clipId) {
+      get().stopSessionTrack(trackId);
+      return;
+    }
 
     const transport = useTransportStore.getState();
     const effectiveQuantization = slot.quantization && slot.quantization !== 'global' ? slot.quantization : session.quantization;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -616,6 +616,9 @@ export interface Marker {
 
 export type SessionLaunchQuantization = 'none' | '1/32' | '1/16' | '1/8' | '1/4' | '1/2' | '1 bar' | '2 bars' | '4 bars' | '8 bars';
 
+/** Clip launch behavior mode for session view slots. */
+export type SessionLaunchMode = 'trigger' | 'gate' | 'toggle' | 'repeat';
+
 export interface SessionScene {
   id: string;
   name: string;
@@ -635,6 +638,8 @@ export interface SessionClipSlot {
   hasStopButton?: boolean;
   /** When true, the incoming clip starts at the outgoing clip's current position. */
   legato?: boolean;
+  /** Clip launch behavior: trigger (default), gate, toggle, or repeat. */
+  launchMode?: SessionLaunchMode;
 }
 
 export interface SessionPendingLaunch {

--- a/tests/unit/sessionLaunchModes.test.ts
+++ b/tests/unit/sessionLaunchModes.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useTransportStore } from '../../src/store/transportStore';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('session clip launch modes', () => {
+  let trackId: string;
+  let clipId: string;
+  let sceneId: string;
+
+  beforeEach(() => {
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useTransportStore.setState(useTransportStore.getInitialState(), true);
+    useProjectStore.getState().createProject({ bpm: 120, timeSignature: 4 });
+
+    const store = useProjectStore.getState();
+    const track = store.addTrack('drums');
+    trackId = track.id;
+    const clip = store.addClip(trackId, {
+      startTime: 0,
+      duration: 2,
+      prompt: 'Kick groove',
+      globalCaption: '',
+      lyrics: '',
+      source: 'uploaded',
+    });
+    clipId = clip.id;
+
+    const session = useProjectStore.getState().project?.session;
+    sceneId = session!.scenes[0].id;
+
+    // Not playing — immediate launches
+    useTransportStore.setState({ currentTime: 0, isPlaying: false });
+  });
+
+  describe('setSessionSlotLaunchMode', () => {
+    it('sets the launch mode on a session slot', () => {
+      const session = useProjectStore.getState().project?.session;
+      const slot = session?.slots.find((s) => s.trackId === trackId && s.sceneId === sceneId);
+      expect(slot).toBeDefined();
+
+      useProjectStore.getState().setSessionSlotLaunchMode(slot!.id, 'gate');
+
+      const updated = useProjectStore.getState().project?.session?.slots.find((s) => s.id === slot!.id);
+      expect(updated?.launchMode).toBe('gate');
+    });
+
+    it('supports undo after setting launch mode', () => {
+      const session = useProjectStore.getState().project?.session;
+      const slot = session?.slots.find((s) => s.trackId === trackId && s.sceneId === sceneId);
+
+      useProjectStore.getState().setSessionSlotLaunchMode(slot!.id, 'toggle');
+      expect(useProjectStore.getState().project?.session?.slots.find((s) => s.id === slot!.id)?.launchMode).toBe('toggle');
+
+      useProjectStore.getState().undo();
+      const afterUndo = useProjectStore.getState().project?.session?.slots.find((s) => s.id === slot!.id);
+      // After undo, launchMode should be back to default (undefined or 'trigger')
+      expect(afterUndo?.launchMode === undefined || afterUndo?.launchMode === 'trigger').toBe(true);
+    });
+
+    it('defaults to trigger when launchMode is not set', () => {
+      const session = useProjectStore.getState().project?.session;
+      const slot = session?.slots.find((s) => s.trackId === trackId && s.sceneId === sceneId);
+      // Default slots should not have launchMode set (defaults to trigger behavior)
+      expect(slot?.launchMode === undefined || slot?.launchMode === 'trigger').toBe(true);
+    });
+  });
+
+  describe('toggle mode', () => {
+    it('stops the clip when launching an already-active clip in toggle mode', () => {
+      const session = useProjectStore.getState().project?.session;
+      const slot = session?.slots.find((s) => s.trackId === trackId && s.sceneId === sceneId);
+      useProjectStore.getState().setSessionSlotLaunchMode(slot!.id, 'toggle');
+
+      // First launch — should activate
+      useProjectStore.getState().launchSessionClip(trackId, sceneId);
+      expect(useProjectStore.getState().project?.session?.activeClipIdsByTrackId[trackId]).toBe(clipId);
+
+      // Second launch of same clip — toggle mode should stop it
+      useProjectStore.getState().launchSessionClip(trackId, sceneId);
+      expect(useProjectStore.getState().project?.session?.activeClipIdsByTrackId[trackId]).toBeNull();
+    });
+
+    it('launches normally when clip is not active in toggle mode', () => {
+      const session = useProjectStore.getState().project?.session;
+      const slot = session?.slots.find((s) => s.trackId === trackId && s.sceneId === sceneId);
+      useProjectStore.getState().setSessionSlotLaunchMode(slot!.id, 'toggle');
+
+      useProjectStore.getState().launchSessionClip(trackId, sceneId);
+      expect(useProjectStore.getState().project?.session?.activeClipIdsByTrackId[trackId]).toBe(clipId);
+    });
+  });
+
+  describe('trigger mode (default)', () => {
+    it('always launches the clip regardless of active state', () => {
+      // Launch once
+      useProjectStore.getState().launchSessionClip(trackId, sceneId);
+      expect(useProjectStore.getState().project?.session?.activeClipIdsByTrackId[trackId]).toBe(clipId);
+
+      // Launch again — trigger mode should not stop, just re-launch
+      useProjectStore.getState().launchSessionClip(trackId, sceneId);
+      expect(useProjectStore.getState().project?.session?.activeClipIdsByTrackId[trackId]).toBe(clipId);
+    });
+  });
+
+  describe('launch mode type on SessionClipSlot', () => {
+    it('accepts all four valid launch mode values', () => {
+      const session = useProjectStore.getState().project?.session;
+      const slot = session?.slots.find((s) => s.trackId === trackId && s.sceneId === sceneId);
+
+      for (const mode of ['trigger', 'gate', 'toggle', 'repeat'] as const) {
+        useProjectStore.getState().setSessionSlotLaunchMode(slot!.id, mode);
+        const updated = useProjectStore.getState().project?.session?.slots.find((s) => s.id === slot!.id);
+        expect(updated?.launchMode).toBe(mode);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `SessionLaunchMode` type (`trigger | gate | toggle | repeat`) to `SessionClipSlot`
- Implements `setSessionSlotLaunchMode` store action with undo support
- Toggle mode: clicking an already-active clip stops it instead of re-launching
- Gate mode: clip plays while pointer is held, stops on pointer release
- Repeat mode: re-triggers on pointer down, last trigger continues on release
- Context menu now shows launch mode selection alongside slot color
- Visual badge (G/T/R) on clip slots with non-default launch modes

Closes #919

## Test plan
- [x] Unit tests for `setSessionSlotLaunchMode` (set, undo, defaults)
- [x] Unit tests for toggle mode state transitions (active clip stops on re-launch)
- [x] Unit tests for trigger mode (always re-launches regardless of active state)
- [x] Unit tests for all four mode values accepted
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm test` passes (2762 tests)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)