### PR TITLE
feat: add clip drag-and-drop within session grid

### DIFF
--- a/src/components/session/SessionView.tsx
+++ b/src/components/session/SessionView.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from '../../store/uiStore';
 import { useTransport } from '../../hooks/useTransport';
 import { getSessionSlotProgress } from '../../utils/sessionProgress';
 import { getSessionClips } from '../../utils/sessionClips';
+import { useSessionDragDrop, type SessionDragState, type SessionDropTarget } from '../../hooks/useSessionDragDrop';
 import { ContextMenuWrapper, ContextMenuSeparator, ContextMenuItem } from '../ui/ContextMenu';
 import { ColorSwatchPalette } from '../ui/ColorSwatchPalette';
 import type { Clip, Track, SessionLaunchQuantization, SessionLaunchMode, SessionClipSlot, SessionPendingLaunch, SessionScene } from '../../types/project';
@@ -88,6 +89,7 @@ export function SessionView() {
   } = useTransport();
 
   const [colorMenu, setColorMenu] = useState<SlotContextMenuState | null>(null);
+  const { dragState, dropTarget, handlePointerDown, handlePointerMove, handlePointerUp, cancelDrag } = useSessionDragDrop();
 
   const handleCloseColorMenu = useCallback(() => setColorMenu(null), []);
 
@@ -121,6 +123,17 @@ export function SessionView() {
       setKeyboardContext(previousScope, previousTrackId);
     };
   }, [setKeyboardContext]);
+
+  // Cancel drag on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && dragState) {
+        cancelDrag();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [dragState, cancelDrag]);
 
   if (!project) {
     return <div className="flex-1 min-w-0 bg-[#202020]" />;
@@ -185,7 +198,12 @@ export function SessionView() {
         </div>
       </div>
 
-      <div className="grid min-w-[980px]" style={{ gridTemplateColumns: `220px repeat(${sceneCount}, minmax(150px, 1fr))` }}>
+      <div
+        className="grid min-w-[980px]"
+        style={{ gridTemplateColumns: `220px repeat(${sceneCount}, minmax(150px, 1fr))` }}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      >
         <div className="sticky top-[72px] z-10 border-b border-r border-[#333] bg-[#242424] px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-400">
           Tracks
         </div>
@@ -194,11 +212,27 @@ export function SessionView() {
             const clip = getSessionClips(track)[sceneIndex];
             return clip ? [{ trackId: track.id, clipId: clip.id }] : [];
           });
+          const isSceneDragTarget = dragState?.type === 'scene' && dropTarget?.sceneIndex === sceneIndex && dropTarget?.valid;
+          const isSceneDragSource = dragState?.type === 'scene' && dragState?.sourceSceneIndex === sceneIndex;
 
           return (
-            <div key={`scene-${sceneIndex}`} className="sticky top-[72px] z-10 border-b border-r border-[#333] bg-[#242424] px-3 py-2">
+            <div
+              key={`scene-${sceneIndex}`}
+              className={`sticky top-[72px] z-10 border-b border-r bg-[#242424] px-3 py-2 transition-colors ${
+                isSceneDragTarget ? 'border-blue-500 bg-blue-500/10' : isSceneDragSource ? 'opacity-40 border-[#333]' : 'border-[#333]'
+              }`}
+              data-scene-index={sceneIndex}
+              data-scene-header=""
+              onPointerDown={(e) => {
+                handlePointerDown(e, 'scene', {
+                  sourceSceneIndex: sceneIndex,
+                  label: `Scene ${sceneIndex + 1}`,
+                  color: '#6366f1',
+                });
+              }}
+            >
               <div className="flex items-center justify-between gap-2">
-                <div>
+                <div className="cursor-grab active:cursor-grabbing">
                   <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-400">Scene</div>
                   <div className="text-sm font-semibold text-zinc-100">{sceneIndex + 1}</div>
                 </div>
@@ -207,6 +241,7 @@ export function SessionView() {
                   disabled={sceneLaunches.length === 0}
                   className="rounded-md bg-[#303030] px-2.5 py-1 text-[11px] font-medium text-zinc-200 transition-colors hover:bg-daw-accent disabled:opacity-30"
                   aria-label={`Launch scene ${sceneIndex + 1}`}
+                  onPointerDown={(e) => e.stopPropagation()}
                 >
                   Launch
                 </button>
@@ -236,6 +271,9 @@ export function SessionView() {
               onSlotQuantizationChange={(slotId, q) => setSessionSlotQuantization(slotId, q)}
               onContextMenuSlot={setColorMenu}
               onSlotClick={(sceneIndex) => setSelectedSessionSlot({ trackId: track.id, sceneIndex })}
+              dragState={dragState}
+              dropTarget={dropTarget}
+              onDragStart={handlePointerDown}
             />
           );
         })}
@@ -287,6 +325,21 @@ export function SessionView() {
           />
         </ContextMenuWrapper>
       )}
+
+      {/* Drag ghost overlay */}
+      {dragState && (
+        <div
+          className="pointer-events-none fixed z-50 flex items-center gap-2 rounded-lg border border-white/20 px-3 py-2 shadow-xl backdrop-blur-sm"
+          style={{
+            left: dragState.ghostX + 12,
+            top: dragState.ghostY - 16,
+            backgroundColor: `${dragState.color}cc`,
+          }}
+          data-testid="session-drag-ghost"
+        >
+          <span className="text-xs font-medium text-white truncate max-w-[140px]">{dragState.label}</span>
+        </div>
+      )}
     </div>
   );
 }
@@ -314,6 +367,9 @@ function FragmentRow({
   onSlotQuantizationChange,
   onContextMenuSlot,
   onSlotClick,
+  dragState,
+  dropTarget,
+  onDragStart,
 }: {
   track: Track;
   sessionClips: Clip[];
@@ -330,6 +386,9 @@ function FragmentRow({
   onSlotQuantizationChange: (slotId: string, quantization: 'global' | SessionLaunchQuantization) => void;
   onContextMenuSlot: (state: SlotContextMenuState) => void;
   onSlotClick: (sceneIndex: number) => void;
+  dragState: SessionDragState | null;
+  dropTarget: SessionDropTarget | null;
+  onDragStart: (e: React.PointerEvent, type: 'clip' | 'scene', opts: { sourceSlotId?: string; sourceSceneIndex?: number; label: string; color: string }) => void;
 }) {
   const trackSlots = sessionSlots.filter((s) => s.trackId === track.id);
 
@@ -426,18 +485,31 @@ function FragmentRow({
           });
         };
 
+        // Drag visual feedback
+        const isDragSource = dragState?.type === 'clip' && dragState?.sourceSlotId === slot?.id;
+        const isDropTarget = dragState?.type === 'clip' && dropTarget?.slotId === slot?.id && dropTarget?.valid && !isDragSource;
+
         return (
           <div key={`${track.id}-${sceneIndex}`} className="border-r border-b border-[#2e2e2e] bg-[#1b1b1b] p-2">
             {clip ? (
               <div className="relative">
                 <button
                   onClick={() => {
+                    if (dragState) return; // Don't launch during drag
                     onSlotClick(sceneIndex);
                     // Gate and Repeat modes use pointer events, not click
                     if (slotLaunchMode === 'gate' || slotLaunchMode === 'repeat') return;
                     void onLaunch(clip.id, sceneIndex);
                   }}
                   onPointerDown={(e) => {
+                    // Drag-and-drop initiation
+                    if (slot) {
+                      onDragStart(e, 'clip', {
+                        sourceSlotId: slot.id,
+                        label: getClipLabel(clip, sceneIndex),
+                        color: slotColor ?? track.color ?? '#6366f1',
+                      });
+                    }
                     if (slotLaunchMode !== 'gate' && slotLaunchMode !== 'repeat') return;
                     // Prevent default to avoid focus issues; capture pointer for reliable up events
                     e.currentTarget.setPointerCapture(e.pointerId);
@@ -453,15 +525,19 @@ function FragmentRow({
                   }}
                   onContextMenu={handleContextMenu}
                   className={`relative flex h-24 w-full flex-col justify-between rounded-xl border px-3 py-2 text-left transition-all ${
-                    isActive
-                      ? 'border-emerald-400 shadow-[0_0_0_1px_rgba(74,222,128,0.35)]'
-                      : isQueued
-                        ? 'border-amber-400'
-                        : 'border-[#3a3a3a] hover:border-daw-accent'
-                  } ${isSelected ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-[#1b1b1b]' : ''}`}
+                    isDragSource
+                      ? 'opacity-40 border-dashed border-zinc-500'
+                      : isDropTarget
+                        ? 'border-blue-500 shadow-[0_0_0_2px_rgba(59,130,246,0.5)]'
+                        : isActive
+                          ? 'border-emerald-400 shadow-[0_0_0_1px_rgba(74,222,128,0.35)]'
+                          : isQueued
+                            ? 'border-amber-400'
+                            : 'border-[#3a3a3a] hover:border-daw-accent'
+                  } ${isSelected && !isDragSource ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-[#1b1b1b]' : ''}`}
                   style={{
                     ...((slotColor ?? track.color)
-                      ? { backgroundColor: `${slotColor ?? track.color}33`, borderColor: isActive ? undefined : isQueued ? undefined : `${slotColor ?? track.color}88` }
+                      ? { backgroundColor: `${slotColor ?? track.color}33`, borderColor: isDragSource ? undefined : isDropTarget ? undefined : isActive ? undefined : isQueued ? undefined : `${slotColor ?? track.color}88` }
                       : isActive
                         ? { backgroundColor: 'rgba(16, 185, 129, 0.2)' }
                         : isQueued
@@ -540,15 +616,19 @@ function FragmentRow({
             ) : hasStopButton ? (
               <button
                 onClick={() => {
+                  if (dragState) return;
                   onSlotClick(sceneIndex);
                   void onStop();
                 }}
                 onContextMenu={(e) => handleEmptySlotContextMenu(e, sceneIndex)}
-                className={`flex h-24 w-full items-center justify-center rounded-xl border border-dashed border-[#343434] bg-[#202020] transition-colors hover:border-[#555] hover:bg-[#272727] ${
-                  isSelected ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-[#1b1b1b]' : ''
-                }`}
+                className={`flex h-24 w-full items-center justify-center rounded-xl border border-dashed transition-colors ${
+                  isDropTarget
+                    ? 'border-blue-500 bg-blue-500/10 shadow-[0_0_0_2px_rgba(59,130,246,0.5)]'
+                    : 'border-[#343434] bg-[#202020] hover:border-[#555] hover:bg-[#272727]'
+                } ${isSelected ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-[#1b1b1b]' : ''}`}
                 aria-label={`Stop ${track.displayName} in scene ${sceneIndex + 1}`}
                 data-testid={`stop-slot-${track.id}-${sceneIndex}`}
+                data-slot-id={slot?.id}
                 data-track-id={track.id}
                 data-scene-index={sceneIndex}
               >
@@ -557,12 +637,18 @@ function FragmentRow({
             ) : (
               <button
                 type="button"
-                onClick={() => onSlotClick(sceneIndex)}
+                onClick={() => {
+                  if (dragState) return;
+                  onSlotClick(sceneIndex);
+                }}
                 onContextMenu={(e) => handleEmptySlotContextMenu(e, sceneIndex)}
-                className={`flex h-24 w-full items-center justify-center rounded-xl border border-dashed border-[#2a2a2a] bg-[#1d1d1d] text-[11px] uppercase tracking-[0.16em] text-zinc-600 cursor-pointer ${
-                  isSelected ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-[#1b1b1b]' : ''
-                }`}
+                className={`flex h-24 w-full items-center justify-center rounded-xl border border-dashed text-[11px] uppercase tracking-[0.16em] text-zinc-600 cursor-pointer ${
+                  isDropTarget
+                    ? 'border-blue-500 bg-blue-500/10 shadow-[0_0_0_2px_rgba(59,130,246,0.5)]'
+                    : 'border-[#2a2a2a] bg-[#1d1d1d]'
+                } ${isSelected ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-[#1b1b1b]' : ''}`}
                 data-testid={`empty-slot-${track.id}-${sceneIndex}`}
+                data-slot-id={slot?.id}
                 data-track-id={track.id}
                 data-scene-index={sceneIndex}
                 aria-label={`Empty slot, ${track.displayName} scene ${sceneIndex + 1}`}

--- a/src/hooks/useSessionDragDrop.ts
+++ b/src/hooks/useSessionDragDrop.ts
@@ -1,0 +1,182 @@
+import { useCallback, useRef, useState } from 'react';
+import { useProjectStore } from '../store/projectStore';
+
+/** Minimum pixel movement before drag starts. */
+const DRAG_THRESHOLD = 5;
+
+export type SessionDragType = 'clip' | 'scene';
+
+export interface SessionDragState {
+  type: SessionDragType;
+  /** Slot ID being dragged (for clip drags). */
+  sourceSlotId?: string;
+  /** Scene index being dragged (for scene drags). */
+  sourceSceneIndex?: number;
+  /** Current ghost position in viewport coordinates. */
+  ghostX: number;
+  ghostY: number;
+  /** Label shown on the ghost element. */
+  label: string;
+  /** Color for the ghost element. */
+  color: string;
+}
+
+export interface SessionDropTarget {
+  /** Slot ID of the drop target cell. */
+  slotId?: string;
+  /** Track ID of the hovered cell. */
+  trackId?: string;
+  /** Scene index of the hovered cell or header. */
+  sceneIndex?: number;
+  /** Whether this is a valid drop target. */
+  valid: boolean;
+}
+
+interface PointerOrigin {
+  x: number;
+  y: number;
+  type: SessionDragType;
+  sourceSlotId?: string;
+  sourceSceneIndex?: number;
+  label: string;
+  color: string;
+}
+
+/**
+ * Hook for managing drag-and-drop in the Session View grid.
+ * Supports clip slot moves (same/cross-track) and scene reordering.
+ */
+export function useSessionDragDrop() {
+  const moveSessionSlotClip = useProjectStore((s) => s.moveSessionSlotClip);
+  const reorderSessionScenes = useProjectStore((s) => s.reorderSessionScenes);
+
+  const [dragState, setDragState] = useState<SessionDragState | null>(null);
+  const [dropTarget, setDropTarget] = useState<SessionDropTarget | null>(null);
+  const originRef = useRef<PointerOrigin | null>(null);
+  const isDraggingRef = useRef(false);
+
+  const handlePointerDown = useCallback((
+    e: React.PointerEvent,
+    type: SessionDragType,
+    opts: {
+      sourceSlotId?: string;
+      sourceSceneIndex?: number;
+      label: string;
+      color: string;
+    },
+  ) => {
+    // Only handle primary button
+    if (e.button !== 0) return;
+    e.preventDefault();
+    originRef.current = {
+      x: e.clientX,
+      y: e.clientY,
+      type,
+      sourceSlotId: opts.sourceSlotId,
+      sourceSceneIndex: opts.sourceSceneIndex,
+      label: opts.label,
+      color: opts.color,
+    };
+    isDraggingRef.current = false;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const findDropTarget = useCallback((clientX: number, clientY: number, dragType: SessionDragType): SessionDropTarget | null => {
+    // Temporarily hide ghost to find element underneath
+    const elements = document.elementsFromPoint(clientX, clientY);
+    for (const el of elements) {
+      const htmlEl = el as HTMLElement;
+      if (dragType === 'clip') {
+        const slotId = htmlEl.dataset?.slotId;
+        const trackId = htmlEl.dataset?.trackId;
+        const sceneIndexStr = htmlEl.dataset?.sceneIndex;
+        if (trackId && sceneIndexStr !== undefined) {
+          return {
+            slotId: slotId || undefined,
+            trackId,
+            sceneIndex: parseInt(sceneIndexStr, 10),
+            valid: true,
+          };
+        }
+      } else if (dragType === 'scene') {
+        const sceneIndexStr = htmlEl.dataset?.sceneIndex;
+        if (sceneIndexStr !== undefined && htmlEl.dataset?.sceneHeader !== undefined) {
+          return {
+            sceneIndex: parseInt(sceneIndexStr, 10),
+            valid: true,
+          };
+        }
+      }
+    }
+    return null;
+  }, []);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    const origin = originRef.current;
+    if (!origin) return;
+
+    const dx = e.clientX - origin.x;
+    const dy = e.clientY - origin.y;
+
+    if (!isDraggingRef.current) {
+      if (Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) return;
+      isDraggingRef.current = true;
+      setDragState({
+        type: origin.type,
+        sourceSlotId: origin.sourceSlotId,
+        sourceSceneIndex: origin.sourceSceneIndex,
+        ghostX: e.clientX,
+        ghostY: e.clientY,
+        label: origin.label,
+        color: origin.color,
+      });
+    }
+
+    setDragState((prev) => prev ? { ...prev, ghostX: e.clientX, ghostY: e.clientY } : null);
+
+    const target = findDropTarget(e.clientX, e.clientY, origin.type);
+    setDropTarget(target);
+  }, [findDropTarget]);
+
+  const handlePointerUp = useCallback((e: React.PointerEvent) => {
+    const origin = originRef.current;
+    const wasDragging = isDraggingRef.current;
+    originRef.current = null;
+    isDraggingRef.current = false;
+
+    if (!wasDragging || !origin) {
+      setDragState(null);
+      setDropTarget(null);
+      return;
+    }
+
+    const target = findDropTarget(e.clientX, e.clientY, origin.type);
+
+    if (target?.valid) {
+      if (origin.type === 'clip' && origin.sourceSlotId && target.slotId) {
+        moveSessionSlotClip(origin.sourceSlotId, target.slotId);
+      } else if (origin.type === 'scene' && origin.sourceSceneIndex !== undefined && target.sceneIndex !== undefined) {
+        reorderSessionScenes(origin.sourceSceneIndex, target.sceneIndex);
+      }
+    }
+
+    setDragState(null);
+    setDropTarget(null);
+  }, [findDropTarget, moveSessionSlotClip, reorderSessionScenes]);
+
+  const cancelDrag = useCallback(() => {
+    originRef.current = null;
+    isDraggingRef.current = false;
+    setDragState(null);
+    setDropTarget(null);
+  }, []);
+
+  return {
+    dragState,
+    dropTarget,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    cancelDrag,
+  };
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -688,6 +688,8 @@ export interface ProjectState {
   commitPendingSessionLaunches: (currentTime: number) => void;
   startSessionArrangementRecording: (startTime?: number) => void;
   stopSessionArrangementRecording: (endTime?: number) => Clip[];
+  moveSessionSlotClip: (sourceSlotId: string, targetSlotId: string) => void;
+  reorderSessionScenes: (fromIndex: number, toIndex: number) => void;
 
   removeAsset: (assetId: string) => void;
   toggleAssetStar: (assetId: string) => void;
@@ -4563,6 +4565,58 @@ export const useProjectStore = create<ProjectState>()(
       },
     });
     return printedClips;
+  },
+
+  moveSessionSlotClip: (sourceSlotId, targetSlotId) => {
+    const state = get();
+    if (!state.project) return;
+    if (sourceSlotId === targetSlotId) return;
+    const session = ensureProjectSession(state.project).session!;
+    const sourceSlot = session.slots.find((s) => s.id === sourceSlotId);
+    const targetSlot = session.slots.find((s) => s.id === targetSlotId);
+    if (!sourceSlot || !targetSlot) return;
+    // Don't move if source slot has no clip
+    if (sourceSlot.clipId === null) return;
+    _pushHistory(state.project);
+    const sourceClipId = sourceSlot.clipId;
+    const targetClipId = targetSlot.clipId;
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        session: {
+          ...session,
+          slots: session.slots.map((slot) => {
+            if (slot.id === sourceSlotId) return { ...slot, clipId: targetClipId };
+            if (slot.id === targetSlotId) return { ...slot, clipId: sourceClipId };
+            return slot;
+          }),
+        },
+      },
+    });
+  },
+
+  reorderSessionScenes: (fromIndex, toIndex) => {
+    const state = get();
+    if (!state.project) return;
+    if (fromIndex === toIndex) return;
+    const session = ensureProjectSession(state.project).session!;
+    if (fromIndex < 0 || fromIndex >= session.scenes.length || toIndex < 0 || toIndex >= session.scenes.length) return;
+    _pushHistory(state.project);
+    const scenes = [...session.scenes].sort((a, b) => a.index - b.index);
+    const [removed] = scenes.splice(fromIndex, 1);
+    scenes.splice(toIndex, 0, removed);
+    const reindexed = scenes.map((scene, idx) => ({ ...scene, index: idx }));
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        session: {
+          ...session,
+          scenes: reindexed,
+        },
+      },
+    });
   },
 
   removeAsset: (assetId) => {

--- a/tests/unit/sessionDragDrop.test.ts
+++ b/tests/unit/sessionDragDrop.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../../src/store/projectStore';
+import type { SessionClipSlot } from '../../src/types/project';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+function addTrackWithClips(trackType: 'drums' | 'bass' | 'vocals', clipCount: number) {
+  const store = useProjectStore.getState();
+  const track = store.addTrack(trackType);
+  const clips = [];
+  for (let i = 0; i < clipCount; i++) {
+    clips.push(
+      store.addClip(track.id, {
+        startTime: i * 2,
+        duration: 2,
+        prompt: `${trackType} clip ${i + 1}`,
+        globalCaption: '',
+        lyrics: '',
+        source: 'uploaded',
+      }),
+    );
+  }
+  return { track, clips };
+}
+
+function getSlot(trackId: string, sceneIndex: number): SessionClipSlot | undefined {
+  const session = useProjectStore.getState().project?.session;
+  if (!session) return undefined;
+  const scene = session.scenes[sceneIndex];
+  if (!scene) return undefined;
+  return session.slots.find((s) => s.trackId === trackId && s.sceneId === scene.id);
+}
+
+describe('session drag-and-drop store actions', () => {
+  beforeEach(() => {
+    useProjectStore.setState(useProjectStore.getInitialState(), true);
+    useProjectStore.getState().createProject({ bpm: 120, timeSignature: 4 });
+  });
+
+  describe('moveSessionSlotClip', () => {
+    it('moves a clip from one slot to an empty slot on the same track', () => {
+      const { track, clips } = addTrackWithClips('drums', 1);
+      const sourceSlot = getSlot(track.id, 0);
+      const targetSlot = getSlot(track.id, 1);
+      expect(sourceSlot?.clipId).toBe(clips[0].id);
+      expect(targetSlot?.clipId).toBeNull();
+
+      useProjectStore.getState().moveSessionSlotClip(sourceSlot!.id, targetSlot!.id);
+
+      const updatedSource = getSlot(track.id, 0);
+      const updatedTarget = getSlot(track.id, 1);
+      expect(updatedSource?.clipId).toBeNull();
+      expect(updatedTarget?.clipId).toBe(clips[0].id);
+    });
+
+    it('swaps clips between two occupied slots', () => {
+      const { track, clips } = addTrackWithClips('drums', 2);
+      const slotA = getSlot(track.id, 0);
+      const slotB = getSlot(track.id, 1);
+      expect(slotA?.clipId).toBe(clips[0].id);
+      expect(slotB?.clipId).toBe(clips[1].id);
+
+      useProjectStore.getState().moveSessionSlotClip(slotA!.id, slotB!.id);
+
+      const updatedA = getSlot(track.id, 0);
+      const updatedB = getSlot(track.id, 1);
+      expect(updatedA?.clipId).toBe(clips[1].id);
+      expect(updatedB?.clipId).toBe(clips[0].id);
+    });
+
+    it('moves a clip across different tracks', () => {
+      const drums = addTrackWithClips('drums', 1);
+      const bass = addTrackWithClips('bass', 0);
+      const sourceSlot = getSlot(drums.track.id, 0);
+      const targetSlot = getSlot(bass.track.id, 0);
+      expect(sourceSlot?.clipId).toBe(drums.clips[0].id);
+      expect(targetSlot?.clipId).toBeNull();
+
+      useProjectStore.getState().moveSessionSlotClip(sourceSlot!.id, targetSlot!.id);
+
+      const updatedSource = getSlot(drums.track.id, 0);
+      const updatedTarget = getSlot(bass.track.id, 0);
+      expect(updatedSource?.clipId).toBeNull();
+      expect(updatedTarget?.clipId).toBe(drums.clips[0].id);
+    });
+
+    it('does nothing when source and target are the same slot', () => {
+      const { track, clips } = addTrackWithClips('drums', 1);
+      const slot = getSlot(track.id, 0);
+
+      useProjectStore.getState().moveSessionSlotClip(slot!.id, slot!.id);
+
+      const updated = getSlot(track.id, 0);
+      expect(updated?.clipId).toBe(clips[0].id);
+    });
+
+    it('does nothing when source slot has no clip', () => {
+      const { track } = addTrackWithClips('drums', 1);
+      const emptySlot = getSlot(track.id, 1);
+      const occupiedSlot = getSlot(track.id, 0);
+
+      useProjectStore.getState().moveSessionSlotClip(emptySlot!.id, occupiedSlot!.id);
+
+      // Nothing should change
+      const updated0 = getSlot(track.id, 0);
+      const updated1 = getSlot(track.id, 1);
+      expect(updated0?.clipId).not.toBeNull();
+      expect(updated1?.clipId).toBeNull();
+    });
+
+    it('supports undo after move', () => {
+      const { track, clips } = addTrackWithClips('drums', 1);
+      const sourceSlot = getSlot(track.id, 0);
+      const targetSlot = getSlot(track.id, 1);
+
+      useProjectStore.getState().moveSessionSlotClip(sourceSlot!.id, targetSlot!.id);
+
+      // Verify the move happened
+      expect(getSlot(track.id, 0)?.clipId).toBeNull();
+      expect(getSlot(track.id, 1)?.clipId).toBe(clips[0].id);
+
+      // Undo
+      useProjectStore.getState().undo();
+
+      expect(getSlot(track.id, 0)?.clipId).toBe(clips[0].id);
+      expect(getSlot(track.id, 1)?.clipId).toBeNull();
+    });
+  });
+
+  describe('reorderSessionScenes', () => {
+    it('moves a scene from index 0 to index 2', () => {
+      // Default project has 4 scenes; adding clips just populates slots
+      addTrackWithClips('drums', 3);
+      const sessionBefore = useProjectStore.getState().project?.session;
+      const sceneCount = sessionBefore!.scenes.length;
+      expect(sceneCount).toBe(4); // default scene count
+      const sceneIds = sessionBefore!.scenes.map((s) => s.id);
+
+      useProjectStore.getState().reorderSessionScenes(0, 2);
+
+      const sessionAfter = useProjectStore.getState().project?.session;
+      const reorderedIds = sessionAfter!.scenes.map((s) => s.id);
+      // Original: [A, B, C, D], after moving 0->2: [B, C, A, D]
+      expect(reorderedIds).toEqual([sceneIds[1], sceneIds[2], sceneIds[0], sceneIds[3]]);
+      // Indices should be renumbered
+      expect(sessionAfter!.scenes.map((s) => s.index)).toEqual([0, 1, 2, 3]);
+    });
+
+    it('moves a scene from index 2 to index 0', () => {
+      addTrackWithClips('drums', 3);
+      const sessionBefore = useProjectStore.getState().project?.session;
+      const sceneIds = sessionBefore!.scenes.map((s) => s.id);
+
+      useProjectStore.getState().reorderSessionScenes(2, 0);
+
+      const sessionAfter = useProjectStore.getState().project?.session;
+      const reorderedIds = sessionAfter!.scenes.map((s) => s.id);
+      // Original: [A, B, C, D], after moving 2->0: [C, A, B, D]
+      expect(reorderedIds).toEqual([sceneIds[2], sceneIds[0], sceneIds[1], sceneIds[3]]);
+    });
+
+    it('does nothing when from and to are the same', () => {
+      addTrackWithClips('drums', 3);
+      const sessionBefore = useProjectStore.getState().project?.session;
+      const sceneIds = sessionBefore!.scenes.map((s) => s.id);
+
+      useProjectStore.getState().reorderSessionScenes(1, 1);
+
+      const sessionAfter = useProjectStore.getState().project?.session;
+      expect(sessionAfter!.scenes.map((s) => s.id)).toEqual(sceneIds);
+    });
+
+    it('supports undo after reorder', () => {
+      addTrackWithClips('drums', 3);
+      const sessionBefore = useProjectStore.getState().project?.session;
+      const sceneIdsBefore = sessionBefore!.scenes.map((s) => s.id);
+
+      useProjectStore.getState().reorderSessionScenes(0, 2);
+
+      // Verify reorder happened
+      const sessionAfter = useProjectStore.getState().project?.session;
+      expect(sessionAfter!.scenes.map((s) => s.id)).not.toEqual(sceneIdsBefore);
+
+      // Undo
+      useProjectStore.getState().undo();
+
+      const sessionRestored = useProjectStore.getState().project?.session;
+      expect(sessionRestored!.scenes.map((s) => s.id)).toEqual(sceneIdsBefore);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `moveSessionSlotClip` and `reorderSessionScenes` store actions for session grid drag operations
- Create `useSessionDragDrop` hook with pointer-event-based drag system (5px threshold, ghost preview, drop zone detection via `elementsFromPoint`)
- Integrate drag-and-drop into `SessionView.tsx` with visual feedback: drag source opacity reduction, blue highlight borders on valid drop targets, fixed ghost overlay following cursor
- Escape key cancels in-progress drag; all operations push to undo history

## Test plan
- [x] 10 unit tests for store actions: move to empty slot, swap occupied slots, cross-track move, same-slot no-op, empty source no-op, undo support, scene reorder (forward/backward/same-index/undo)
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] All 2765 existing tests still pass
- [x] `npm run build` succeeds

Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)