### PR TITLE
feat: add integrated mixer panel in session view

### DIFF
--- a/src/components/session/SessionMixer.tsx
+++ b/src/components/session/SessionMixer.tsx
@@ -1,0 +1,76 @@
+import { useCallback } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { SessionMixerStrip } from './SessionMixerStrip';
+
+interface SessionMixerProps {
+  visible: boolean;
+  onToggle: () => void;
+}
+
+export function SessionMixer({ visible, onToggle }: SessionMixerProps) {
+  const project = useProjectStore((s) => s.project);
+  const updateTrack = useProjectStore((s) => s.updateTrack);
+
+  const handleVolumeChange = useCallback((trackId: string, volume: number) => {
+    updateTrack(trackId, { volume });
+  }, [updateTrack]);
+
+  const handlePanChange = useCallback((trackId: string, pan: number) => {
+    // updateTrackMixer handles pan updates
+    useProjectStore.getState().updateTrackMixer(trackId, { pan });
+  }, []);
+
+  const handleMuteToggle = useCallback((trackId: string, currentMuted: boolean) => {
+    updateTrack(trackId, { muted: !currentMuted });
+  }, [updateTrack]);
+
+  const handleSoloToggle = useCallback((trackId: string, currentSoloed: boolean) => {
+    updateTrack(trackId, { soloed: !currentSoloed });
+  }, [updateTrack]);
+
+  if (!project) return null;
+
+  const tracks = [...project.tracks].sort((a, b) => a.order - b.order);
+
+  return (
+    <div data-testid="session-mixer">
+      {/* Toggle button */}
+      <div className="flex items-center justify-center border-t border-[#333]">
+        <button
+          onClick={onToggle}
+          className="w-full py-1 text-[10px] uppercase tracking-[0.16em] text-zinc-500 hover:text-zinc-300 hover:bg-[#252525] transition-colors"
+          aria-label={visible ? 'Hide session mixer' : 'Show session mixer'}
+          title={visible ? 'Hide Mixer' : 'Show Mixer'}
+        >
+          {visible ? 'Hide Mixer' : 'Show Mixer'}
+        </button>
+      </div>
+
+      {/* Mixer strips container */}
+      <div
+        className="overflow-hidden transition-[height,opacity] duration-150 ease-out"
+        style={{
+          height: visible ? `${tracks.length * 40}px` : '0px',
+          opacity: visible ? 1 : 0,
+        }}
+      >
+        {tracks.map((track) => (
+          <SessionMixerStrip
+            key={track.id}
+            trackId={track.id}
+            trackName={track.displayName}
+            trackColor={track.color}
+            volume={track.volume}
+            pan={track.pan ?? 0}
+            muted={track.muted}
+            soloed={track.soloed}
+            onVolumeChange={(v) => handleVolumeChange(track.id, v)}
+            onPanChange={(v) => handlePanChange(track.id, v)}
+            onMuteToggle={() => handleMuteToggle(track.id, track.muted)}
+            onSoloToggle={() => handleSoloToggle(track.id, track.soloed)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/session/SessionMixerStrip.tsx
+++ b/src/components/session/SessionMixerStrip.tsx
@@ -1,0 +1,196 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { Knob } from '../ui/Knob';
+
+/** Convert linear level (0..1+) to a 0..1 fill fraction mapping -60dB..0dB */
+function levelToFill(linear: number): number {
+  if (linear <= 0) return 0;
+  const db = 20 * Math.log10(linear);
+  return Math.max(0, Math.min(1, (db + 60) / 60));
+}
+
+export interface SessionMixerStripProps {
+  trackId: string;
+  trackName: string;
+  trackColor: string;
+  volume: number;
+  pan: number;
+  muted: boolean;
+  soloed: boolean;
+  onVolumeChange?: (volume: number) => void;
+  onPanChange?: (pan: number) => void;
+  onMuteToggle?: () => void;
+  onSoloToggle?: () => void;
+}
+
+export function SessionMixerStrip({
+  trackId,
+  trackName,
+  trackColor,
+  volume,
+  pan,
+  muted,
+  soloed,
+  onVolumeChange,
+  onPanChange,
+  onMuteToggle,
+  onSoloToggle,
+}: SessionMixerStripProps) {
+  const rafRef = useRef<number>(0);
+  const [leftFill, setLeftFill] = useState(0);
+  const [rightFill, setRightFill] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragging = useRef(false);
+
+  // Animate meter levels
+  useEffect(() => {
+    const engine = getAudioEngine();
+    const tick = () => {
+      const meter = engine.getTrackMeter(trackId);
+      setLeftFill(levelToFill(meter.leftLevel));
+      setRightFill(levelToFill(meter.rightLevel));
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [trackId]);
+
+  // Fader drag logic
+  const getVolumeFromX = useCallback((clientX: number) => {
+    const el = containerRef.current;
+    if (!el) return volume;
+    const rect = el.getBoundingClientRect();
+    const ratio = (clientX - rect.left) / rect.width;
+    return Math.max(0, Math.min(1, ratio));
+  }, [volume]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+    onVolumeChange?.(getVolumeFromX(e.clientX));
+  }, [getVolumeFromX, onVolumeChange]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!dragging.current) return;
+    onVolumeChange?.(getVolumeFromX(e.clientX));
+  }, [getVolumeFromX, onVolumeChange]);
+
+  const onPointerUp = useCallback(() => {
+    dragging.current = false;
+  }, []);
+
+  const onDoubleClick = useCallback(() => {
+    onVolumeChange?.(0.8);
+  }, [onVolumeChange]);
+
+  const faderPct = volume * 100;
+
+  return (
+    <div
+      className="flex items-center gap-2 h-10 px-2 bg-[#1b1b1b] border-b border-[#2e2e2e]"
+      data-testid={`session-mixer-strip-${trackId}`}
+    >
+      {/* Track color accent */}
+      <div
+        className="w-1 h-6 rounded-sm shrink-0"
+        style={{ backgroundColor: trackColor }}
+        data-testid="track-color-accent"
+      />
+
+      {/* Track name (truncated) */}
+      <div className="w-16 truncate text-[10px] text-zinc-400 shrink-0" title={trackName}>
+        {trackName}
+      </div>
+
+      {/* Volume fader with meter */}
+      <div
+        ref={containerRef}
+        className="relative flex-1 min-w-[80px] max-w-[160px] cursor-ew-resize select-none"
+        style={{ height: '14px' }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onDoubleClick={onDoubleClick}
+        title={`Volume: ${Math.round(volume * 100)}%`}
+        aria-label={`${trackName} volume`}
+        role="slider"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(volume * 100)}
+      >
+        {/* Meter bars */}
+        <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 flex flex-col gap-[1px]">
+          <div className="h-[4px] rounded-[2px] bg-zinc-800/50 overflow-hidden">
+            <div
+              className="h-full rounded-[2px]"
+              style={{
+                width: `${leftFill * 100}%`,
+                background: 'linear-gradient(to right, #22c55e 0%, #84cc16 35%, #eab308 65%, #ef4444 95%)',
+                opacity: 0.7,
+              }}
+            />
+          </div>
+          <div className="h-[4px] rounded-[2px] bg-zinc-800/50 overflow-hidden">
+            <div
+              className="h-full rounded-[2px]"
+              style={{
+                width: `${rightFill * 100}%`,
+                background: 'linear-gradient(to right, #22c55e 0%, #84cc16 35%, #eab308 65%, #ef4444 95%)',
+                opacity: 0.7,
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Fader position indicator */}
+        <div
+          className="absolute top-0 h-full w-[2px] bg-zinc-300 pointer-events-none"
+          style={{ left: `${faderPct}%`, transform: 'translateX(-50%)' }}
+        />
+      </div>
+
+      {/* Pan knob */}
+      <div className="shrink-0">
+        <Knob
+          value={pan}
+          min={-1}
+          max={1}
+          defaultValue={0}
+          onChange={(v) => onPanChange?.(v)}
+          label="Pan"
+          size={24}
+          step={0.01}
+        />
+      </div>
+
+      {/* Solo button */}
+      <button
+        onClick={onSoloToggle}
+        className={`w-6 h-6 rounded text-[10px] font-bold shrink-0 transition-colors ${
+          soloed
+            ? 'bg-green-500 text-white'
+            : 'bg-[#343434] text-zinc-400 hover:bg-[#404040]'
+        }`}
+        aria-label={`Solo ${trackName}`}
+        title={soloed ? 'Unsolo' : 'Solo'}
+      >
+        S
+      </button>
+
+      {/* Mute button */}
+      <button
+        onClick={onMuteToggle}
+        className={`w-6 h-6 rounded text-[10px] font-bold shrink-0 transition-colors ${
+          muted
+            ? 'bg-amber-500 text-white'
+            : 'bg-[#343434] text-zinc-400 hover:bg-[#404040]'
+        }`}
+        aria-label={`Mute ${trackName}`}
+        title={muted ? 'Unmute' : 'Mute'}
+      >
+        M
+      </button>
+    </div>
+  );
+}

--- a/src/components/session/SessionView.tsx
+++ b/src/components/session/SessionView.tsx
@@ -8,6 +8,7 @@ import { getSessionClips } from '../../utils/sessionClips';
 import { useSessionDragDrop, type SessionDragState, type SessionDropTarget } from '../../hooks/useSessionDragDrop';
 import { ContextMenuWrapper, ContextMenuSeparator, ContextMenuItem } from '../ui/ContextMenu';
 import { ColorSwatchPalette } from '../ui/ColorSwatchPalette';
+import { SessionMixer } from './SessionMixer';
 import type { Clip, Track, SessionLaunchQuantization, SessionLaunchMode, SessionClipSlot, SessionPendingLaunch, SessionScene, SceneFollowActionType } from '../../types/project';
 
 const LAUNCH_MODE_OPTIONS: SessionLaunchMode[] = ['trigger', 'gate', 'toggle', 'repeat'];
@@ -109,6 +110,7 @@ export function SessionView() {
   const [colorMenu, setColorMenu] = useState<SlotContextMenuState | null>(null);
   const [sceneMenu, setSceneMenu] = useState<SceneContextMenuState | null>(null);
   const { dragState, dropTarget, handlePointerDown, handlePointerMove, handlePointerUp, cancelDrag } = useSessionDragDrop();
+  const [showSessionMixer, setShowSessionMixer] = useState(false);
 
   const handleCloseColorMenu = useCallback(() => setColorMenu(null), []);
 
@@ -320,6 +322,11 @@ export function SessionView() {
           );
         })}
       </div>
+
+      <SessionMixer
+        visible={showSessionMixer}
+        onToggle={() => setShowSessionMixer((v) => !v)}
+      />
 
       {colorMenu && (
         <ContextMenuWrapper

--- a/src/components/session/__tests__/SessionMixer.test.tsx
+++ b/src/components/session/__tests__/SessionMixer.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useProjectStore } from '../../../store/projectStore';
+import { SessionMixer } from '../SessionMixer';
+import { SessionMixerStrip } from '../SessionMixerStrip';
+
+vi.mock('../../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    getTrackMeter: () => ({ leftLevel: 0, rightLevel: 0, clipped: false }),
+    getTrackLevel: () => 0,
+    resetTrackClip: vi.fn(),
+    masterVolume: 1,
+    getMasterLevel: () => ({ left: 0, right: 0 }),
+    getMasterInputLevel: () => ({ left: 0, right: 0 }),
+    getAnalyserData: () => null,
+  }),
+}));
+
+function setupProjectWithTrack() {
+  useProjectStore.getState().createProject();
+  useProjectStore.getState().addTrack('stems');
+}
+
+describe('SessionMixerStrip', () => {
+  it('renders volume fader for the given track', () => {
+    render(
+      <SessionMixerStrip
+        trackId="track-1"
+        trackName="Vocals"
+        trackColor="#ff5555"
+        volume={0.8}
+        pan={0}
+        muted={false}
+        soloed={false}
+      />
+    );
+
+    expect(screen.getByRole('slider', { name: /volume/i })).toBeInTheDocument();
+  });
+
+  it('renders pan knob', () => {
+    render(
+      <SessionMixerStrip
+        trackId="track-1"
+        trackName="Vocals"
+        trackColor="#ff5555"
+        volume={0.8}
+        pan={0}
+        muted={false}
+        soloed={false}
+      />
+    );
+
+    expect(screen.getByLabelText(/pan knob/i)).toBeInTheDocument();
+  });
+
+  it('renders solo and mute buttons', () => {
+    render(
+      <SessionMixerStrip
+        trackId="track-1"
+        trackName="Vocals"
+        trackColor="#ff5555"
+        volume={0.8}
+        pan={0}
+        muted={false}
+        soloed={false}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /solo/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /mute/i })).toBeInTheDocument();
+  });
+
+  it('calls onVolumeChange when fader is interacted with', () => {
+    const onVolumeChange = vi.fn();
+
+    render(
+      <SessionMixerStrip
+        trackId="track-1"
+        trackName="Vocals"
+        trackColor="#ff5555"
+        volume={0.8}
+        pan={0}
+        muted={false}
+        soloed={false}
+        onVolumeChange={onVolumeChange}
+      />
+    );
+
+    const fader = screen.getByRole('slider', { name: /volume/i });
+    fireEvent.pointerDown(fader, { clientX: 50 });
+    expect(onVolumeChange).toHaveBeenCalled();
+  });
+
+  it('calls onMuteToggle when M button is clicked', () => {
+    const onMuteToggle = vi.fn();
+
+    render(
+      <SessionMixerStrip
+        trackId="track-1"
+        trackName="Vocals"
+        trackColor="#ff5555"
+        volume={0.8}
+        pan={0}
+        muted={false}
+        soloed={false}
+        onMuteToggle={onMuteToggle}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /mute/i }));
+    expect(onMuteToggle).toHaveBeenCalled();
+  });
+
+  it('calls onSoloToggle when S button is clicked', () => {
+    const onSoloToggle = vi.fn();
+
+    render(
+      <SessionMixerStrip
+        trackId="track-1"
+        trackName="Vocals"
+        trackColor="#ff5555"
+        volume={0.8}
+        pan={0}
+        muted={false}
+        soloed={false}
+        onSoloToggle={onSoloToggle}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /solo/i }));
+    expect(onSoloToggle).toHaveBeenCalled();
+  });
+
+  it('shows active state on solo button when track is soloed', () => {
+    render(
+      <SessionMixerStrip
+        trackId="track-1"
+        trackName="Vocals"
+        trackColor="#ff5555"
+        volume={0.8}
+        pan={0}
+        muted={false}
+        soloed={true}
+      />
+    );
+
+    const soloBtn = screen.getByRole('button', { name: /solo/i });
+    expect(soloBtn.className).toContain('bg-green');
+  });
+
+  it('shows active state on mute button when track is muted', () => {
+    render(
+      <SessionMixerStrip
+        trackId="track-1"
+        trackName="Vocals"
+        trackColor="#ff5555"
+        volume={0.8}
+        pan={0}
+        muted={true}
+        soloed={false}
+      />
+    );
+
+    const muteBtn = screen.getByRole('button', { name: /mute/i });
+    expect(muteBtn.className).toContain('bg-amber');
+  });
+
+  it('shows track color accent on left edge', () => {
+    const { container } = render(
+      <SessionMixerStrip
+        trackId="track-1"
+        trackName="Vocals"
+        trackColor="#ff5555"
+        volume={0.8}
+        pan={0}
+        muted={false}
+        soloed={false}
+      />
+    );
+
+    const colorAccent = container.querySelector('[data-testid="track-color-accent"]');
+    expect(colorAccent).toBeInTheDocument();
+    // JSDOM converts hex colors to rgb() format
+    expect(colorAccent!.getAttribute('style')).toContain('background-color');
+  });
+});
+
+describe('SessionMixer', () => {
+  beforeEach(() => {
+    setupProjectWithTrack();
+  });
+
+  it('renders a mixer strip for each track when visible', () => {
+    const project = useProjectStore.getState().project!;
+
+    render(<SessionMixer visible={true} onToggle={() => {}} />);
+
+    for (const track of project.tracks) {
+      expect(screen.getByTestId(`session-mixer-strip-${track.id}`)).toBeInTheDocument();
+    }
+  });
+
+  it('does not render strips when hidden', () => {
+    render(<SessionMixer visible={false} onToggle={() => {}} />);
+
+    const mixer = screen.getByTestId('session-mixer');
+    // The inner container should have height 0
+    const container = mixer.querySelector('.overflow-hidden');
+    expect(container).toBeInTheDocument();
+    expect((container as HTMLElement).style.height).toBe('0px');
+  });
+
+  it('calls onToggle when toggle button is clicked', () => {
+    const onToggle = vi.fn();
+    render(<SessionMixer visible={true} onToggle={onToggle} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mixer/i }));
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it('updates store when volume is changed on a strip', () => {
+    render(<SessionMixer visible={true} onToggle={() => {}} />);
+
+    const project = useProjectStore.getState().project!;
+    const track = project.tracks[0];
+    const fader = screen.getAllByRole('slider', { name: /volume/i })[0];
+
+    // Simulate fader interaction
+    const rect = { left: 0, width: 100, top: 0, bottom: 14, height: 14, right: 100, x: 0, y: 0, toJSON: () => {} };
+    vi.spyOn(fader, 'getBoundingClientRect').mockReturnValue(rect as DOMRect);
+    fireEvent.pointerDown(fader, { clientX: 50 });
+
+    const updatedTrack = useProjectStore.getState().project!.tracks.find(t => t.id === track.id)!;
+    expect(updatedTrack.volume).toBeCloseTo(0.5, 1);
+  });
+
+  it('updates store when mute is toggled', () => {
+    render(<SessionMixer visible={true} onToggle={() => {}} />);
+
+    const project = useProjectStore.getState().project!;
+    const track = project.tracks[0];
+    const initialMuted = track.muted;
+
+    const muteButtons = screen.getAllByRole('button', { name: /mute/i });
+    fireEvent.click(muteButtons[0]);
+
+    const updatedTrack = useProjectStore.getState().project!.tracks.find(t => t.id === track.id)!;
+    expect(updatedTrack.muted).toBe(!initialMuted);
+  });
+
+  it('updates store when solo is toggled', () => {
+    render(<SessionMixer visible={true} onToggle={() => {}} />);
+
+    const project = useProjectStore.getState().project!;
+    const track = project.tracks[0];
+    const initialSoloed = track.soloed;
+
+    const soloButtons = screen.getAllByRole('button', { name: /solo/i });
+    fireEvent.click(soloButtons[0]);
+
+    const updatedTrack = useProjectStore.getState().project!.tracks.find(t => t.id === track.id)!;
+    expect(updatedTrack.soloed).toBe(!initialSoloed);
+  });
+});


### PR DESCRIPTION
## Summary
- Add collapsible mixer panel below the session view clip grid with per-track volume fader, pan knob, solo/mute buttons, and level meters
- New `SessionMixerStrip` component renders a compact horizontal strip (~40px) per track with track color accent
- New `SessionMixer` container with show/hide toggle, integrated into `SessionView`
- 15 unit tests covering rendering, user interactions, and Zustand store updates

Closes #925

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm test` passes (2770 tests, 15 new)
- [x] `npm run build` succeeds
- [ ] Visual verification: toggle mixer visibility in session view
- [ ] Verify volume fader, pan knob, solo/mute buttons work correctly
- [ ] Verify level meters animate during playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)