### PR TITLE
fix: hide dock when settings dialog is open

### DIFF
--- a/src/components/generation/GenerationSidePanel.tsx
+++ b/src/components/generation/GenerationSidePanel.tsx
@@ -28,6 +28,7 @@ export function GenerationSidePanel() {
   const setBatchGenerateMode = useUIStore((s) => s.setBatchGenerateMode);
   const showSmartControls = useUIStore((s) => s.showSmartControls);
   const activeBottomPanel = useUIStore((s) => s.activeBottomPanel);
+  const showSettingsDialog = useUIStore((s) => s.showSettingsDialog);
   const trackListWidth = useUIStore((s) => s.trackListWidth);
   const bottomPanelHeight = useUIStore(getBottomPanelHeight);
   const project = useProjectStore((s) => s.project);
@@ -115,9 +116,9 @@ export function GenerationSidePanel() {
           left: dockLeft,
           zIndex: Z.toast,
           bottom: showSmartControls ? 208 : 68,
-          opacity: activeBottomPanel || showMixer ? 0 : 1,
-          pointerEvents: activeBottomPanel || showMixer ? 'none' : 'auto',
-          transform: `translateX(-50%) translateY(${activeBottomPanel || showMixer ? '16px' : '0px'})`,
+          opacity: activeBottomPanel || showMixer || showSettingsDialog ? 0 : 1,
+          pointerEvents: activeBottomPanel || showMixer || showSettingsDialog ? 'none' : 'auto',
+          transform: `translateX(-50%) translateY(${activeBottomPanel || showMixer || showSettingsDialog ? '16px' : '0px'})`,
         }}
         data-testid="generation-dock"
       >


### PR DESCRIPTION
## Summary
- Dock now fades out and sinks down when the settings dialog opens, matching existing behavior for bottom panels
- Added `showSettingsDialog` to the dock's visibility condition alongside `activeBottomPanel`

## Root Cause
The dock visibility was only controlled by `activeBottomPanel` state. The settings dialog sets `showSettingsDialog` (a modal flag) which didn't affect the dock, leaving it visible behind the dialog.

## Test plan
- [ ] Open settings dialog → dock should fade out and sink down
- [ ] Close settings dialog → dock should reappear
- [ ] Open bottom panels (editor, piano roll) → dock still hides as before
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes (2733/2733)

Closes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)