### PR TITLE
test: add clip operations test coverage (split, duplicate, fade)

### DIFF
--- a/src/store/__tests__/duplicateClip.test.ts
+++ b/src/store/__tests__/duplicateClip.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('duplicateClip', () => {
+  let clipId: string;
+  let trackId: string;
+
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('stems');
+    trackId = track.id;
+    const clip = useProjectStore.getState().addClip(trackId, {
+      startTime: 2, duration: 3, prompt: 'my prompt', lyrics: 'la la',
+    });
+    clipId = clip.id;
+    useProjectStore.getState().updateClip(clipId, {
+      generationStatus: 'ready',
+      isolatedAudioKey: 'audio-key-1',
+      waveformPeaks: [0.1, 0.5, 0.3],
+    });
+  });
+
+  it('creates a second clip on the same track', () => {
+    useProjectStore.getState().duplicateClip(clipId);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(2);
+  });
+
+  it('places duplicate immediately after the source clip', () => {
+    useProjectStore.getState().duplicateClip(clipId);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const dup = clips.find((c) => c.id !== clipId)!;
+    expect(dup.startTime).toBe(2 + 3); // source start + source duration
+  });
+
+  it('duplicate has the same duration as source', () => {
+    useProjectStore.getState().duplicateClip(clipId);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const dup = clips.find((c) => c.id !== clipId)!;
+    expect(dup.duration).toBe(3);
+  });
+
+  it('duplicate gets a new unique id', () => {
+    useProjectStore.getState().duplicateClip(clipId);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const ids = clips.map((c) => c.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('duplicate inherits audio data when source is ready', () => {
+    useProjectStore.getState().duplicateClip(clipId);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const dup = clips.find((c) => c.id !== clipId)!;
+    expect(dup.isolatedAudioKey).toBe('audio-key-1');
+    expect(dup.generationStatus).toBe('ready');
+    expect(dup.waveformPeaks).toEqual([0.1, 0.5, 0.3]);
+  });
+
+  it('duplicate gets empty status when source has no audio', () => {
+    useProjectStore.getState().updateClip(clipId, {
+      generationStatus: 'empty',
+      isolatedAudioKey: null,
+      waveformPeaks: null,
+    });
+    useProjectStore.getState().duplicateClip(clipId);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const dup = clips.find((c) => c.id !== clipId)!;
+    expect(dup.generationStatus).toBe('empty');
+    expect(dup.isolatedAudioKey).toBeNull();
+  });
+
+  it('returns the new clip object', () => {
+    const result = useProjectStore.getState().duplicateClip(clipId);
+    expect(result).toBeDefined();
+    expect(result!.id).not.toBe(clipId);
+    expect(result!.startTime).toBe(5);
+  });
+
+  it('returns undefined for nonexistent clipId', () => {
+    const result = useProjectStore.getState().duplicateClip('nonexistent');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when project is null', () => {
+    useProjectStore.setState({ project: null });
+    const result = useProjectStore.getState().duplicateClip(clipId);
+    expect(result).toBeUndefined();
+  });
+
+  it('duplicate preserves prompt and lyrics', () => {
+    const dup = useProjectStore.getState().duplicateClip(clipId)!;
+    expect(dup.prompt).toBe('my prompt');
+    expect(dup.lyrics).toBe('la la');
+  });
+
+  it('clears generationJobId on the duplicate', () => {
+    useProjectStore.getState().updateClip(clipId, { generationJobId: 'job-123' });
+    const dup = useProjectStore.getState().duplicateClip(clipId)!;
+    expect(dup.generationJobId).toBeNull();
+  });
+});

--- a/src/store/__tests__/setClipFade.test.ts
+++ b/src/store/__tests__/setClipFade.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('setClipFade', () => {
+  let clipId: string;
+
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('stems');
+    const clip = useProjectStore.getState().addClip(track.id, {
+      startTime: 0, duration: 4, prompt: 'test', lyrics: '',
+    });
+    clipId = clip.id;
+  });
+
+  it('sets fadeInDuration on a clip', () => {
+    useProjectStore.getState().setClipFade(clipId, { fadeInDuration: 1 });
+    const clip = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(clip.fadeInDuration).toBe(1);
+  });
+
+  it('sets fadeOutDuration on a clip', () => {
+    useProjectStore.getState().setClipFade(clipId, { fadeOutDuration: 0.5 });
+    const clip = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(clip.fadeOutDuration).toBe(0.5);
+  });
+
+  it('sets both fade in and out simultaneously', () => {
+    useProjectStore.getState().setClipFade(clipId, {
+      fadeInDuration: 1,
+      fadeOutDuration: 1,
+    });
+    const clip = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(clip.fadeInDuration).toBe(1);
+    expect(clip.fadeOutDuration).toBe(1);
+  });
+
+  it('clamps total fades to clip duration', () => {
+    useProjectStore.getState().setClipFade(clipId, {
+      fadeInDuration: 3,
+      fadeOutDuration: 3,
+    });
+    const clip = useProjectStore.getState().project!.tracks[0].clips[0];
+    // Total fades should not exceed clip duration (4s)
+    expect((clip.fadeInDuration ?? 0) + (clip.fadeOutDuration ?? 0)).toBeLessThanOrEqual(4);
+  });
+
+  it('clamps negative values to zero', () => {
+    useProjectStore.getState().setClipFade(clipId, { fadeInDuration: -1 });
+    const clip = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(clip.fadeInDuration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('preserves existing fadeIn when only setting fadeOut', () => {
+    useProjectStore.getState().setClipFade(clipId, { fadeInDuration: 1 });
+    useProjectStore.getState().setClipFade(clipId, { fadeOutDuration: 0.5 });
+    const clip = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(clip.fadeInDuration).toBe(1);
+    expect(clip.fadeOutDuration).toBe(0.5);
+  });
+
+  it('sets fade curve type', () => {
+    useProjectStore.getState().setClipFade(clipId, {
+      fadeInDuration: 1,
+      fadeInCurve: 'exponential',
+    });
+    const clip = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(clip.fadeInCurve).toBe('exponential');
+  });
+
+  it('does nothing for nonexistent clip', () => {
+    // Should not throw
+    useProjectStore.getState().setClipFade('nonexistent', { fadeInDuration: 1 });
+    const clip = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(clip.fadeInDuration).toBeUndefined();
+  });
+
+  it('handles equal-power fade curve', () => {
+    useProjectStore.getState().setClipFade(clipId, {
+      fadeOutDuration: 2,
+      fadeOutCurve: 'equal-power',
+    });
+    const clip = useProjectStore.getState().project!.tracks[0].clips[0];
+    expect(clip.fadeOutCurve).toBe('equal-power');
+    expect(clip.fadeOutDuration).toBe(2);
+  });
+});

--- a/src/store/__tests__/splitClip.test.ts
+++ b/src/store/__tests__/splitClip.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('splitClip', () => {
+  let clipId: string;
+  let trackId: string;
+
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('stems');
+    trackId = track.id;
+    const clip = useProjectStore.getState().addClip(trackId, {
+      startTime: 0, duration: 4, prompt: 'test clip', lyrics: 'hello',
+    });
+    clipId = clip.id;
+    useProjectStore.getState().updateClip(clipId, {
+      audioDuration: 4,
+      audioOffset: 0,
+      generationStatus: 'ready',
+      isolatedAudioKey: 'audio-key-1',
+    });
+  });
+
+  it('splits a clip into two at the given time', () => {
+    useProjectStore.getState().splitClip(clipId, 2);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(2);
+  });
+
+  it('left clip retains original start and has shortened duration', () => {
+    useProjectStore.getState().splitClip(clipId, 1.5);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const left = clips.find((c) => c.id === clipId)!;
+    expect(left.startTime).toBe(0);
+    expect(left.duration).toBe(1.5);
+  });
+
+  it('right clip starts at split time with remaining duration', () => {
+    useProjectStore.getState().splitClip(clipId, 1.5);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const right = clips.find((c) => c.id !== clipId)!;
+    expect(right.startTime).toBe(1.5);
+    expect(right.duration).toBe(2.5);
+  });
+
+  it('right clip has correct audioOffset', () => {
+    useProjectStore.getState().splitClip(clipId, 1);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const right = clips.find((c) => c.id !== clipId)!;
+    expect(right.audioOffset).toBe(1);
+  });
+
+  it('preserves audioOffset from source when splitting', () => {
+    useProjectStore.getState().updateClip(clipId, {
+      audioOffset: 2,
+      audioDuration: 8,
+    });
+    useProjectStore.getState().splitClip(clipId, 1);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const right = clips.find((c) => c.id !== clipId)!;
+    // original offset (2) + left duration (1) = 3
+    expect(right.audioOffset).toBe(3);
+  });
+
+  it('does nothing when split time is before clip start', () => {
+    useProjectStore.getState().splitClip(clipId, -1);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(1);
+  });
+
+  it('does nothing when split time equals clip start', () => {
+    useProjectStore.getState().splitClip(clipId, 0);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(1);
+  });
+
+  it('does nothing when split time is at or past clip end', () => {
+    useProjectStore.getState().splitClip(clipId, 4);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(1);
+  });
+
+  it('does nothing when split time is past clip end', () => {
+    useProjectStore.getState().splitClip(clipId, 10);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(1);
+  });
+
+  it('right clip inherits isolatedAudioKey when source is ready', () => {
+    useProjectStore.getState().splitClip(clipId, 2);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const right = clips.find((c) => c.id !== clipId)!;
+    expect(right.isolatedAudioKey).toBe('audio-key-1');
+    expect(right.generationStatus).toBe('ready');
+  });
+
+  it('right clip gets empty status when source has no audio', () => {
+    useProjectStore.getState().updateClip(clipId, {
+      generationStatus: 'empty',
+      isolatedAudioKey: null,
+    });
+    useProjectStore.getState().splitClip(clipId, 2);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    const right = clips.find((c) => c.id !== clipId)!;
+    expect(right.isolatedAudioKey).toBeNull();
+    expect(right.generationStatus).toBe('empty');
+  });
+
+  it('both clips retain the same prompt and lyrics', () => {
+    useProjectStore.getState().splitClip(clipId, 2);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips[0].prompt).toBe('test clip');
+    expect(clips[0].lyrics).toBe('hello');
+    expect(clips[1].prompt).toBe('test clip');
+    expect(clips[1].lyrics).toBe('hello');
+  });
+
+  it('does nothing for nonexistent clipId', () => {
+    useProjectStore.getState().splitClip('nonexistent', 2);
+    const clips = useProjectStore.getState().project!.tracks[0].clips;
+    expect(clips).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 33 dedicated unit tests for three core clip operations: `splitClip`, `duplicateClip`, and `setClipFade`
- These store actions were already implemented but lacked test coverage
- Tests cover happy paths, edge cases (invalid IDs, boundary split times), audio inheritance, fade clamping, and curve types

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm test` passes (2814 tests, 0 failures)
- [x] `npm run build` succeeds
- [x] New tests: `splitClip.test.ts` (12 tests), `duplicateClip.test.ts` (11 tests), `setClipFade.test.ts` (10 tests)

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)