### PR TITLE
feat: enhance piano roll with ghost notes, velocity painting, and chord stamp

### DIFF
--- a/src/components/pianoroll/PianoRoll.tsx
+++ b/src/components/pianoroll/PianoRoll.tsx
@@ -21,10 +21,10 @@ const PIANO_ROLL_TOOL_BUTTONS = [
   { tool: 'pencil', label: 'Pencil', icon: '✏' },
   { tool: 'paint', label: 'Paint', icon: '▦' },
   { tool: 'erase', label: 'Erase', icon: '⌫' },
+  { tool: 'velocityPaint', label: 'Vel Paint', icon: '⇕' },
 ] as const satisfies ReadonlyArray<{ tool: PianoRollTool; label: string; icon: string }>;
 
 export function PianoRoll() {
-  const [showGhostNotes, setShowGhostNotes] = useState(false);
   const [gridSize, setGridSize] = useState<PianoRollGrid>('1/16');
   const [prZoomX, setPrZoomX] = useState(1);
   const [samplerDropActive, setSamplerDropActive] = useState(false);
@@ -48,6 +48,8 @@ export function PianoRoll() {
   const selectedPianoRollNoteIds = useUIStore((s) => s.selectedPianoRollNoteIds);
   const activeTool = useUIStore((s) => s.activePianoRollTool);
   const activeChordShapeAbbr = useUIStore((s) => s.activePianoRollChordShape);
+  const showGhostNotes = useUIStore((s) => s.showGhostNotes);
+  const toggleGhostNotes = useUIStore((s) => s.toggleGhostNotes);
   const pianoRollHeight = useUIStore((s) => s.pianoRollHeight);
   const setPianoRollHeight = useUIStore((s) => s.setPianoRollHeight);
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
@@ -76,6 +78,7 @@ export function PianoRoll() {
         Digit3: 'paint',
         Digit4: 'erase',
         Digit5: 'slide',
+        Digit6: 'velocityPaint',
       };
 
       const tool = toolByCode[event.code];
@@ -289,7 +292,7 @@ export function PianoRoll() {
           className={`px-2 py-1 rounded text-[10px] transition-colors ${
             showGhostNotes ? 'bg-cyan-600/50 text-cyan-200' : 'bg-white/5 text-zinc-400 hover:bg-white/10'
           }`}
-          onClick={() => setShowGhostNotes((v) => !v)}
+          onClick={toggleGhostNotes}
           title="Show notes from other tracks"
         >
           Ghost

--- a/src/components/pianoroll/PianoRollCanvas.tsx
+++ b/src/components/pianoroll/PianoRollCanvas.tsx
@@ -95,6 +95,7 @@ export function PianoRollCanvas({
   const stampChord = useProjectStore((s) => s.stampChord);
   const removeMidiNote = useProjectStore((s) => s.removeMidiNote);
   const updateMidiNote = useProjectStore((s) => s.updateMidiNote);
+  const setNoteVelocity = useProjectStore((s) => s.setNoteVelocity);
   const resizeMidiNote = useProjectStore((s) => s.resizeMidiNote);
   const quantizeMidiNotes = useProjectStore((s) => s.quantizeMidiNotes);
   const beginDrag = useProjectStore((s) => s.beginDrag);
@@ -130,7 +131,9 @@ export function PianoRollCanvas({
       ? 'not-allowed'
       : activeTool === 'slide'
         ? 'alias'
-        : 'crosshair';
+        : activeTool === 'velocityPaint'
+          ? 'ns-resize'
+          : 'crosshair';
   const canvasCursor = hoverCursor ?? defaultCanvasCursor;
   const canvasTitle = activeTool === 'select'
     ? 'Select notes, drag a marquee, or resize existing notes'
@@ -140,7 +143,9 @@ export function PianoRollCanvas({
         ? 'Paint tool: drag across the grid to stamp repeated notes'
         : activeTool === 'erase'
           ? 'Erase tool: click or drag across notes to remove them'
-          : 'Slide tool: create slide notes for portamento transitions';
+          : activeTool === 'velocityPaint'
+            ? 'Velocity paint: drag across notes to set velocity based on vertical position'
+            : 'Slide tool: create slide notes for portamento transitions';
 
   const beatToX = useCallback(
     (beat: number) => PIANO_KEYBOARD_WIDTH + beat * pixelsPerBeat - prScrollX,
@@ -604,6 +609,27 @@ export function PianoRollCanvas({
         return;
       }
 
+      if (activeTool === 'velocityPaint') {
+        if (hit) {
+          // Map vertical position within the note area: top = 127, bottom = 1
+          const velocityFromY = Math.round(Math.max(1, Math.min(127, ((noteAreaHeight - y) / noteAreaHeight) * 127)));
+          beginDrag({ scope: 'pianoRoll', label: 'Velocity paint', clipId: clip.id });
+          setNoteVelocity(clip.id, hit.note.id, velocityFromY);
+          toolStrokeRef.current.noteIds.add(hit.note.id);
+          dragRef.current = {
+            mode: 'velocity',
+            noteId: hit.note.id,
+            startMouseX: x,
+            startMouseY: y,
+            originalPitch: hit.note.pitch,
+            originalStartBeat: hit.note.startBeat,
+            originalDurationBeats: hit.note.durationBeats,
+            originalVelocity: hit.note.velocity,
+          };
+        }
+        return;
+      }
+
       if (activeTool === 'erase') {
         if (hit) {
           toolStrokeRef.current.noteIds.add(hit.note.id);
@@ -722,6 +748,7 @@ export function PianoRollCanvas({
       previewEnabled,
       previewNoteAtPitch,
       selectedNoteIds,
+      setNoteVelocity,
       stampChordAt,
       updateMidiNote,
       velocityHeight,
@@ -799,6 +826,14 @@ export function PianoRollCanvas({
       const isPrimaryButtonDown = (e.buttons & 1) === 1;
 
       if (!drag && isPrimaryButtonDown && y <= noteAreaHeight && x >= PIANO_KEYBOARD_WIDTH) {
+        if (activeTool === 'velocityPaint') {
+          const hit = findNoteAt(x, y);
+          if (hit && !toolStrokeRef.current.noteIds.has(hit.note.id)) {
+            const velocityFromY = Math.round(Math.max(1, Math.min(127, ((noteAreaHeight - y) / noteAreaHeight) * 127)));
+            setNoteVelocity(clip.id, hit.note.id, velocityFromY);
+            toolStrokeRef.current.noteIds.add(hit.note.id);
+          }
+        }
         if (activeTool === 'erase') {
           const hit = findNoteAt(x, y);
           if (hit && !toolStrokeRef.current.noteIds.has(hit.note.id)) {
@@ -950,6 +985,7 @@ export function PianoRollCanvas({
     previewEnabled,
     previewNoteAtPitch,
     resizeMidiNote,
+    setNoteVelocity,
     snapBeat,
     undo,
     updateMidiNote,

--- a/src/components/pianoroll/PianoRollConstants.ts
+++ b/src/components/pianoroll/PianoRollConstants.ts
@@ -1,6 +1,12 @@
 import type { PianoRollGrid } from '../../types/project';
 
-export type PianoRollTool = 'select' | 'pencil' | 'paint' | 'erase' | 'slide';
+export type PianoRollTool =
+  | 'select'
+  | 'pencil'
+  | 'paint'
+  | 'erase'
+  | 'slide'
+  | 'velocityPaint';
 
 export const MIDI_MAX_NOTE = 127;
 export const PIANO_ROLL_KEY_HEIGHT = 14;
@@ -124,6 +130,8 @@ export function getPianoRollToolShortcut(tool: PianoRollTool): string {
       return '4';
     case 'slide':
       return '5';
+    case 'velocityPaint':
+      return '6';
   }
 }
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -757,6 +757,8 @@ export interface ProjectState {
     minDurationBeats?: number;
   }) => void;
   removeMidiNote: (clipId: string, noteId: string) => void;
+  /** Set a single note's velocity, clamped to 1–127. */
+  setNoteVelocity: (clipId: string, noteId: string, velocity: number) => void;
   quantizeMidiNotes: (clipId: string, noteIds: string[], gridBeatsOrOptions: number | QuantizeOptions) => void;
   stampChord: (clipId: string, rootPitch: number, intervals: number[], startBeat: number, durationBeats: number, velocity?: number) => string[];
   populateMidiPattern: (clipId: string, options: PatternOptions) => string[];
@@ -5913,6 +5915,36 @@ export const useProjectStore = create<ProjectState>()(
                   midiData: {
                     ...clip.midiData,
                     notes: clip.midiData.notes.filter((note) => note.id !== noteId),
+                  },
+                }
+              : clip,
+          ),
+        })),
+      },
+    });
+  },
+
+  setNoteVelocity: (clipId, noteId, velocity) => {
+    const state = get();
+    if (_isViewerMode()) return;
+    if (!state.project) return;
+    const clampedVelocity = Math.round(Math.max(1, Math.min(127, velocity)));
+    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Set note velocity', clipId });
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((track) => ({
+          ...track,
+          clips: track.clips.map((clip) =>
+            clip.id === clipId && clip.midiData
+              ? {
+                  ...clip,
+                  midiData: {
+                    ...clip.midiData,
+                    notes: clip.midiData.notes.map((note) =>
+                      note.id === noteId ? { ...note, velocity: clampedVelocity } : note,
+                    ),
                   },
                 }
               : clip,

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -120,6 +120,8 @@ export interface UIState {
   openPianoRollClipId: string | null;
   selectedPianoRollNoteIds: string[];
   activePianoRollTool: PianoRollTool;
+  /** Whether ghost notes from other tracks are visible in the piano roll. */
+  showGhostNotes: boolean;
   /** Abbreviation of the currently selected chord shape for chord stamp (e.g. 'maj', 'min', '7', 'dim'). */
   activeChordShape: PianoRollChordShape;
   /** Alias for activeChordShape — used by PianoRoll component and tests. */
@@ -294,6 +296,8 @@ export interface UIState {
   setOpenPianoRoll: (trackId: string | null, clipId?: string | null) => void;
   setSelectedPianoRollNoteIds: (noteIds: string[]) => void;
   setActivePianoRollTool: (tool: PianoRollTool) => void;
+  toggleGhostNotes: () => void;
+  setShowGhostNotes: (v: boolean) => void;
   setActiveChordShape: (abbr: PianoRollChordShape | string) => void;
   /** Alias for setActiveChordShape. */
   setActivePianoRollChordShape: (abbr: PianoRollChordShape | string) => void;
@@ -555,6 +559,7 @@ export const useUIStore = create<UIState>()(
   openPianoRollClipId: null,
   selectedPianoRollNoteIds: [],
   activePianoRollTool: 'select',
+  showGhostNotes: false,
   activeChordShape: DEFAULT_PIANO_ROLL_CHORD_SHAPE,
   activePianoRollChordShape: DEFAULT_PIANO_ROLL_CHORD_SHAPE,
   openEffectChainTrackId: null,
@@ -908,6 +913,8 @@ export const useUIStore = create<UIState>()(
   })),
   setSelectedPianoRollNoteIds: (noteIds) => set({ selectedPianoRollNoteIds: [...noteIds] }),
   setActivePianoRollTool: (tool) => set({ activePianoRollTool: tool }),
+  toggleGhostNotes: () => set((state) => ({ showGhostNotes: !state.showGhostNotes })),
+  setShowGhostNotes: (v) => set({ showGhostNotes: v }),
   setActiveChordShape: (abbr) => {
     const clamped = clampPianoRollChordShape(abbr);
     set({ activeChordShape: clamped, activePianoRollChordShape: clamped });
@@ -1235,6 +1242,7 @@ export const useUIStore = create<UIState>()(
         showSmartControls: state.showSmartControls,
         keyboardContext: state.keyboardContext,
         activePianoRollTool: state.activePianoRollTool,
+        showGhostNotes: state.showGhostNotes,
         activeChordShape: state.activeChordShape,
         activePianoRollChordShape: state.activePianoRollChordShape,
         // Panel sizes

--- a/tests/unit/pianoRollEnhancements.test.ts
+++ b/tests/unit/pianoRollEnhancements.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../../src/store/projectStore';
+import { useUIStore } from '../../src/store/uiStore';
+
+vi.mock('../../src/services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useToast', () => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    ctx: {
+      createBuffer: vi.fn((channels: number, length: number, sampleRate: number) => ({
+        numberOfChannels: channels,
+        length,
+        sampleRate,
+        duration: length / sampleRate,
+        getChannelData: () => new Float32Array(length),
+      })),
+    },
+    decodeAudioData: vi.fn(),
+  }),
+}));
+
+function setupClipWithNote(opts: {
+  pitch?: number;
+  startBeat?: number;
+  durationBeats?: number;
+  velocity?: number;
+} = {}) {
+  useProjectStore.getState().createProject();
+  const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+  const clip = useProjectStore.getState().ensureMidiClip(track.id);
+  const noteId = useProjectStore.getState().addMidiNote(clip.id, {
+    pitch: opts.pitch ?? 60,
+    startBeat: opts.startBeat ?? 0,
+    durationBeats: opts.durationBeats ?? 1,
+    velocity: opts.velocity ?? 100,
+  })!;
+  return { track, clip, noteId };
+}
+
+function getNote(noteId: string) {
+  const project = useProjectStore.getState().project!;
+  for (const track of project.tracks) {
+    for (const clip of track.clips) {
+      const note = clip.midiData?.notes.find((n) => n.id === noteId);
+      if (note) return note;
+    }
+  }
+  return undefined;
+}
+
+// ─── Ghost Notes (uiStore) ──────────────────────────────────────────────────
+
+describe('Ghost notes toggle in uiStore', () => {
+  beforeEach(() => {
+    useUIStore.setState({ showGhostNotes: false });
+  });
+
+  it('defaults showGhostNotes to false', () => {
+    expect(useUIStore.getState().showGhostNotes).toBe(false);
+  });
+
+  it('toggles showGhostNotes via toggleGhostNotes', () => {
+    useUIStore.getState().toggleGhostNotes();
+    expect(useUIStore.getState().showGhostNotes).toBe(true);
+    useUIStore.getState().toggleGhostNotes();
+    expect(useUIStore.getState().showGhostNotes).toBe(false);
+  });
+
+  it('sets showGhostNotes directly', () => {
+    useUIStore.getState().setShowGhostNotes(true);
+    expect(useUIStore.getState().showGhostNotes).toBe(true);
+    useUIStore.getState().setShowGhostNotes(false);
+    expect(useUIStore.getState().showGhostNotes).toBe(false);
+  });
+});
+
+// ─── setNoteVelocity (projectStore) ─────────────────────────────────────────
+
+describe('setNoteVelocity', () => {
+  beforeEach(() => {
+    useProjectStore.getState().createProject();
+  });
+
+  it('sets the velocity of a specific note', () => {
+    const { clip, noteId } = setupClipWithNote({ velocity: 100 });
+    useProjectStore.getState().setNoteVelocity(clip.id, noteId, 42);
+    const note = getNote(noteId);
+    expect(note?.velocity).toBe(42);
+  });
+
+  it('clamps velocity to 1–127 range', () => {
+    const { clip, noteId } = setupClipWithNote({ velocity: 100 });
+    useProjectStore.getState().setNoteVelocity(clip.id, noteId, 0);
+    expect(getNote(noteId)?.velocity).toBe(1);
+
+    useProjectStore.getState().setNoteVelocity(clip.id, noteId, 200);
+    expect(getNote(noteId)?.velocity).toBe(127);
+  });
+
+  it('does nothing for a non-existent note', () => {
+    const { clip, noteId } = setupClipWithNote({ velocity: 80 });
+    useProjectStore.getState().setNoteVelocity(clip.id, 'nonexistent', 50);
+    expect(getNote(noteId)?.velocity).toBe(80);
+  });
+
+  it('does nothing for a non-existent clip', () => {
+    const { noteId } = setupClipWithNote({ velocity: 80 });
+    useProjectStore.getState().setNoteVelocity('nonexistent-clip', noteId, 50);
+    expect(getNote(noteId)?.velocity).toBe(80);
+  });
+});
+
+// ─── Velocity paint tool mode (uiStore) ─────────────────────────────────────
+
+describe('Velocity paint tool mode in uiStore', () => {
+  beforeEach(() => {
+    useUIStore.setState({ activePianoRollTool: 'select' });
+  });
+
+  it('can set activePianoRollTool to velocityPaint', () => {
+    useUIStore.getState().setActivePianoRollTool('velocityPaint');
+    expect(useUIStore.getState().activePianoRollTool).toBe('velocityPaint');
+  });
+
+  it('velocityPaint is a valid tool mode', () => {
+    useUIStore.getState().setActivePianoRollTool('velocityPaint');
+    expect(useUIStore.getState().activePianoRollTool).toBe('velocityPaint');
+    // Can switch back
+    useUIStore.getState().setActivePianoRollTool('select');
+    expect(useUIStore.getState().activePianoRollTool).toBe('select');
+  });
+});
+
+// ─── Chord stamp (already exists, verify integration) ───────────────────────
+
+describe('Chord stamp via stampChord store action', () => {
+  beforeEach(() => {
+    useProjectStore.getState().createProject();
+  });
+
+  it('stamps a major chord (3 notes) at root pitch', () => {
+    const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+    const clip = useProjectStore.getState().ensureMidiClip(track.id);
+    const noteIds = useProjectStore.getState().stampChord(
+      clip.id,
+      60,         // root = C4
+      [0, 4, 7],  // major intervals
+      0,           // startBeat
+      1,           // durationBeats
+      100,         // velocity
+    );
+    expect(noteIds).toHaveLength(3);
+
+    const project = useProjectStore.getState().project!;
+    const updatedClip = project.tracks
+      .flatMap((t) => t.clips)
+      .find((c) => c.id === clip.id)!;
+    const notes = updatedClip.midiData!.notes;
+    expect(notes).toHaveLength(3);
+    expect(notes.map((n) => n.pitch).sort((a, b) => a - b)).toEqual([60, 64, 67]);
+    expect(notes.every((n) => n.startBeat === 0)).toBe(true);
+    expect(notes.every((n) => n.durationBeats === 1)).toBe(true);
+    expect(notes.every((n) => n.velocity === 100)).toBe(true);
+  });
+
+  it('stamps a minor 7th chord (4 notes)', () => {
+    const track = useProjectStore.getState().addTrack('keyboard', 'pianoRoll');
+    const clip = useProjectStore.getState().ensureMidiClip(track.id);
+    const noteIds = useProjectStore.getState().stampChord(
+      clip.id,
+      60,
+      [0, 3, 7, 10], // minor 7th
+      2,
+      0.5,
+      90,
+    );
+    expect(noteIds).toHaveLength(4);
+
+    const project = useProjectStore.getState().project!;
+    const updatedClip = project.tracks
+      .flatMap((t) => t.clips)
+      .find((c) => c.id === clip.id)!;
+    const notes = updatedClip.midiData!.notes;
+    expect(notes.map((n) => n.pitch).sort((a, b) => a - b)).toEqual([60, 63, 67, 70]);
+  });
+});


### PR DESCRIPTION
## Summary
- Move `showGhostNotes` from local component state to `uiStore` with localStorage persistence, so the toggle survives session reloads
- Add `velocityPaint` tool mode to the piano roll toolbar (shortcut: `6`) — drag across notes to set velocity based on vertical mouse position (top=127, bottom=1)
- Add `setNoteVelocity(clipId, noteId, velocity)` store action with 1–127 clamping
- Chord stamp tool was already implemented — added integration tests to verify correctness

Closes #967

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 2803 tests pass (11 new tests in `pianoRollEnhancements.test.ts`)
- [x] `npm run build` — succeeds
- [ ] Visual verification: open piano roll, toggle Ghost button, select Vel Paint tool, drag across notes
- [ ] Verify ghost notes toggle persists across page reload (localStorage)
- [ ] Verify Shift+click chord stamp still works with various chord shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)