### PR TITLE
feat: add sidechain compression routing UI

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -7,6 +7,7 @@ import { LevelMeter } from './LevelMeter';
 import { MasteringPanel } from './MasteringPanel';
 import { SpectrumAnalyzer } from './SpectrumAnalyzer';
 import { VerticalFader } from './VerticalFader';
+import { SidechainRoutingOverlay } from './SidechainRoutingOverlay';
 import type { Track, ReturnTrack, TrackEffectType } from '../../types/project';
 
 const MIXER_MIN_VISIBLE_HEIGHT = 360;
@@ -394,6 +395,7 @@ export function MixerPanel() {
   const project = useProjectStore((s) => s.project);
 
   const dragState = useRef<{ startY: number; startH: number } | null>(null);
+  const channelStripContainerRef = useRef<HTMLDivElement>(null);
 
   const onResizeMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -460,8 +462,9 @@ export function MixerPanel() {
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"><line x1="1" y1="1" x2="9" y2="9" /><line x1="9" y1="1" x2="1" y2="9" /></svg>
         </button>
       </div>
-      <div className="flex-1 overflow-x-auto overflow-y-hidden pb-3">
-        <div className="flex items-stretch h-full">
+      <div className="flex-1 overflow-x-auto overflow-y-hidden pb-3 relative">
+        <SidechainRoutingOverlay containerRef={channelStripContainerRef} />
+        <div ref={channelStripContainerRef} className="flex items-stretch h-full">
           {project.tracks.length === 0 && (
             <div className="flex-1 flex items-center justify-center text-sm text-zinc-600">
               Add tracks to see mixer channels

--- a/src/components/mixer/SidechainRoutingOverlay.tsx
+++ b/src/components/mixer/SidechainRoutingOverlay.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState, type RefObject } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { getSidechainRoutes } from '../../utils/sidechainRouting';
+
+interface RoutePosition {
+  sourceX: number;
+  targetX: number;
+  effectId: string;
+  sourceTrackId: string;
+  targetTrackId: string;
+}
+
+/**
+ * SVG overlay that draws dashed-line arrows in the mixer panel
+ * from sidechain source tracks to the compressor on target tracks.
+ */
+export function SidechainRoutingOverlay({
+  containerRef,
+}: {
+  containerRef: RefObject<HTMLElement | null>;
+}) {
+  const tracks = useProjectStore((s) => s.project?.tracks ?? []);
+  const routes = getSidechainRoutes(tracks);
+  const [positions, setPositions] = useState<RoutePosition[]>([]);
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || routes.length === 0) {
+      setPositions([]);
+      return;
+    }
+
+    const computePositions = () => {
+      const containerRect = container.getBoundingClientRect();
+      setContainerSize({ width: containerRect.width, height: containerRect.height });
+
+      const newPositions: RoutePosition[] = [];
+      for (const route of routes) {
+        const sourceEl = container.querySelector(`[data-track-id="${route.sourceTrackId}"]`);
+        const targetEl = container.querySelector(`[data-track-id="${route.targetTrackId}"]`);
+        if (!sourceEl || !targetEl) continue;
+
+        const sourceRect = sourceEl.getBoundingClientRect();
+        const targetRect = targetEl.getBoundingClientRect();
+
+        newPositions.push({
+          sourceX: sourceRect.left + sourceRect.width / 2 - containerRect.left,
+          targetX: targetRect.left + targetRect.width / 2 - containerRect.left,
+          effectId: route.effectId,
+          sourceTrackId: route.sourceTrackId,
+          targetTrackId: route.targetTrackId,
+        });
+      }
+      setPositions(newPositions);
+    };
+
+    computePositions();
+
+    // Recompute on resize
+    const observer = new ResizeObserver(computePositions);
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, [containerRef, routes.length, tracks.length]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const ARROW_Y = 28;
+  const CURVE_HEIGHT = 18;
+
+  return (
+    <svg
+      data-testid="sidechain-routing-overlay"
+      className="absolute inset-0 pointer-events-none"
+      style={{ width: containerSize.width || '100%', height: ARROW_Y + CURVE_HEIGHT + 8 }}
+      aria-hidden="true"
+    >
+      <defs>
+        <marker
+          id="sc-arrowhead"
+          markerWidth="6"
+          markerHeight="4"
+          refX="5"
+          refY="2"
+          orient="auto"
+        >
+          <polygon points="0 0, 6 2, 0 4" fill="#f59e0b" opacity="0.7" />
+        </marker>
+      </defs>
+
+      {routes.map((route) => {
+        const pos = positions.find(
+          (p) => p.sourceTrackId === route.sourceTrackId && p.targetTrackId === route.targetTrackId && p.effectId === route.effectId,
+        );
+
+        // When no DOM positions are available (e.g., in tests with no layout),
+        // still render the group so data-testid is queryable.
+        const sourceX = pos?.sourceX ?? 0;
+        const targetX = pos?.targetX ?? 0;
+        const midX = (sourceX + targetX) / 2;
+
+        return (
+          <g
+            key={`${route.sourceTrackId}-${route.targetTrackId}-${route.effectId}`}
+            data-testid={`sidechain-route-${route.sourceTrackId}-${route.targetTrackId}`}
+          >
+            {pos && (
+              <>
+                {/* Dashed curve from source to target */}
+                <path
+                  d={`M ${sourceX} ${ARROW_Y} Q ${midX} ${ARROW_Y - CURVE_HEIGHT} ${targetX} ${ARROW_Y}`}
+                  fill="none"
+                  stroke="#f59e0b"
+                  strokeWidth="1.5"
+                  strokeDasharray="4 3"
+                  opacity="0.6"
+                  markerEnd="url(#sc-arrowhead)"
+                />
+                {/* Source dot */}
+                <circle cx={sourceX} cy={ARROW_Y} r="3" fill="#f59e0b" opacity="0.7" />
+                {/* SC label at midpoint */}
+                <text
+                  x={midX}
+                  y={ARROW_Y - CURVE_HEIGHT - 2}
+                  textAnchor="middle"
+                  fill="#f59e0b"
+                  fontSize="8"
+                  fontWeight="600"
+                  opacity="0.7"
+                >
+                  SC
+                </text>
+              </>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/components/mixer/__tests__/SidechainRoutingOverlay.test.tsx
+++ b/src/components/mixer/__tests__/SidechainRoutingOverlay.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SidechainRoutingOverlay } from '../SidechainRoutingOverlay';
+import { useProjectStore } from '../../../store/projectStore';
+import type { CompressorParams } from '../../../types/project';
+
+vi.mock('../../../services/projectStorage', () => ({ saveProject: vi.fn() }));
+
+describe('SidechainRoutingOverlay', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject({ name: 'Test', bpm: 120 });
+  });
+
+  it('renders nothing when no sidechain routes exist', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('stems');
+    store.addTrack('stems');
+
+    const { container } = render(<SidechainRoutingOverlay containerRef={{ current: null }} />);
+    // Should render the SVG but with no path elements
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    const paths = container.querySelectorAll('[data-testid^="sidechain-route-"]');
+    expect(paths).toHaveLength(0);
+  });
+
+  it('renders a route indicator when a compressor has a sidechain source', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('stems');
+    store.addTrack('stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+    const kickId = tracks[0].id;
+    const bassId = tracks[1].id;
+
+    const effectId = store.addTrackEffect(bassId, 'compressor')!;
+    store.setSidechainSource(bassId, effectId, kickId);
+
+    const { container } = render(<SidechainRoutingOverlay containerRef={{ current: null }} />);
+    const routeGroups = container.querySelectorAll('[data-testid^="sidechain-route-"]');
+    expect(routeGroups).toHaveLength(1);
+  });
+
+  it('renders multiple route indicators for multiple sidechain connections', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('stems');
+    store.addTrack('stems');
+    store.addTrack('stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+    const kickId = tracks[0].id;
+    const bassId = tracks[1].id;
+    const padId = tracks[2].id;
+
+    const bassEffectId = store.addTrackEffect(bassId, 'compressor')!;
+    store.setSidechainSource(bassId, bassEffectId, kickId);
+
+    const padEffectId = store.addTrackEffect(padId, 'compressor')!;
+    store.setSidechainSource(padId, padEffectId, kickId);
+
+    const { container } = render(<SidechainRoutingOverlay containerRef={{ current: null }} />);
+    const routeGroups = container.querySelectorAll('[data-testid^="sidechain-route-"]');
+    expect(routeGroups).toHaveLength(2);
+  });
+
+  it('does not render routes for compressors without sidechain', () => {
+    const store = useProjectStore.getState();
+    store.addTrack('stems');
+    store.addTrack('stems');
+    const tracks = useProjectStore.getState().project!.tracks;
+    const bassId = tracks[1].id;
+
+    // Add compressor without sidechain source
+    store.addTrackEffect(bassId, 'compressor');
+
+    const { container } = render(<SidechainRoutingOverlay containerRef={{ current: null }} />);
+    const routeGroups = container.querySelectorAll('[data-testid^="sidechain-route-"]');
+    expect(routeGroups).toHaveLength(0);
+  });
+});

--- a/src/utils/__tests__/sidechainRouting.test.ts
+++ b/src/utils/__tests__/sidechainRouting.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { getSidechainRoutes, type SidechainRoute } from '../sidechainRouting';
+import type { Track, CompressorParams } from '../../types/project';
+
+function makeTrack(id: string, displayName: string, effects: Track['effects'] = []): Track {
+  return {
+    id,
+    trackName: 'custom',
+    displayName,
+    color: '#ff0000',
+    order: 0,
+    volume: 1,
+    muted: false,
+    soloed: false,
+    clips: [],
+    effects,
+  };
+}
+
+describe('getSidechainRoutes', () => {
+  it('returns empty array when no tracks have sidechain compressors', () => {
+    const tracks = [
+      makeTrack('t1', 'Kick'),
+      makeTrack('t2', 'Bass'),
+    ];
+    expect(getSidechainRoutes(tracks)).toEqual([]);
+  });
+
+  it('returns a route when a compressor has a sidechainSourceTrackId', () => {
+    const tracks = [
+      makeTrack('kick', 'Kick'),
+      makeTrack('bass', 'Bass', [
+        {
+          id: 'comp-1',
+          type: 'compressor',
+          enabled: true,
+          params: {
+            threshold: -24,
+            ratio: 4,
+            attack: 0.02,
+            release: 0.2,
+            knee: 6,
+            sidechainSourceTrackId: 'kick',
+          } as CompressorParams,
+        },
+      ]),
+    ];
+
+    const routes = getSidechainRoutes(tracks);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]).toEqual({
+      sourceTrackId: 'kick',
+      targetTrackId: 'bass',
+      effectId: 'comp-1',
+    });
+  });
+
+  it('returns multiple routes when multiple compressors have sidechain sources', () => {
+    const tracks = [
+      makeTrack('kick', 'Kick'),
+      makeTrack('bass', 'Bass', [
+        {
+          id: 'comp-1',
+          type: 'compressor',
+          enabled: true,
+          params: {
+            threshold: -24, ratio: 4, attack: 0.02, release: 0.2, knee: 6,
+            sidechainSourceTrackId: 'kick',
+          } as CompressorParams,
+        },
+      ]),
+      makeTrack('pad', 'Pad', [
+        {
+          id: 'comp-2',
+          type: 'compressor',
+          enabled: true,
+          params: {
+            threshold: -18, ratio: 3, attack: 0.01, release: 0.15, knee: 10,
+            sidechainSourceTrackId: 'kick',
+          } as CompressorParams,
+        },
+      ]),
+    ];
+
+    const routes = getSidechainRoutes(tracks);
+    expect(routes).toHaveLength(2);
+    expect(routes[0].targetTrackId).toBe('bass');
+    expect(routes[1].targetTrackId).toBe('pad');
+  });
+
+  it('ignores compressors without sidechainSourceTrackId', () => {
+    const tracks = [
+      makeTrack('kick', 'Kick'),
+      makeTrack('bass', 'Bass', [
+        {
+          id: 'comp-1',
+          type: 'compressor',
+          enabled: true,
+          params: {
+            threshold: -24, ratio: 4, attack: 0.02, release: 0.2, knee: 6,
+          } as CompressorParams,
+        },
+      ]),
+    ];
+
+    expect(getSidechainRoutes(tracks)).toEqual([]);
+  });
+
+  it('ignores non-compressor effects', () => {
+    const tracks = [
+      makeTrack('kick', 'Kick'),
+      makeTrack('bass', 'Bass', [
+        {
+          id: 'rev-1',
+          type: 'reverb',
+          enabled: true,
+          params: { decay: 2, preDelay: 0.02, wet: 0.3 },
+        },
+      ]),
+    ];
+
+    expect(getSidechainRoutes(tracks)).toEqual([]);
+  });
+
+  it('ignores routes where source track does not exist', () => {
+    const tracks = [
+      makeTrack('bass', 'Bass', [
+        {
+          id: 'comp-1',
+          type: 'compressor',
+          enabled: true,
+          params: {
+            threshold: -24, ratio: 4, attack: 0.02, release: 0.2, knee: 6,
+            sidechainSourceTrackId: 'nonexistent',
+          } as CompressorParams,
+        },
+      ]),
+    ];
+
+    expect(getSidechainRoutes(tracks)).toEqual([]);
+  });
+});

--- a/src/utils/sidechainRouting.ts
+++ b/src/utils/sidechainRouting.ts
@@ -1,0 +1,35 @@
+import type { Track, CompressorParams } from '../types/project';
+
+/** A sidechain routing connection between a source track and a target track's compressor effect. */
+export interface SidechainRoute {
+  sourceTrackId: string;
+  targetTrackId: string;
+  effectId: string;
+}
+
+/**
+ * Scans all tracks for compressor effects that have a sidechain source assigned.
+ * Returns an array of route descriptors for visual rendering.
+ * Only includes routes where the source track actually exists in the project.
+ */
+export function getSidechainRoutes(tracks: Track[]): SidechainRoute[] {
+  const trackIds = new Set(tracks.map((t) => t.id));
+  const routes: SidechainRoute[] = [];
+
+  for (const track of tracks) {
+    for (const effect of track.effects ?? []) {
+      if (effect.type !== 'compressor') continue;
+      const params = effect.params as CompressorParams;
+      if (!params.sidechainSourceTrackId) continue;
+      if (!trackIds.has(params.sidechainSourceTrackId)) continue;
+
+      routes.push({
+        sourceTrackId: params.sidechainSourceTrackId,
+        targetTrackId: track.id,
+        effectId: effect.id,
+      });
+    }
+  }
+
+  return routes;
+}


### PR DESCRIPTION
## Summary
- Add `SidechainRoutingOverlay` SVG component that draws dashed-line arrows in the mixer panel from sidechain source tracks to compressor target tracks
- Add `getSidechainRoutes()` utility to extract sidechain route data from project tracks
- Integrate the overlay into `MixerPanel` with a container ref for DOM position tracking
- The sidechain source selector dropdown and store action (`setSidechainSource`) were already implemented

## Test plan
- [x] Unit tests for `getSidechainRoutes` utility (6 tests covering routes, no-routes, multi-routes, missing source, non-compressor effects)
- [x] Component tests for `SidechainRoutingOverlay` (4 tests covering no routes, single route, multiple routes, compressor without sidechain)
- [x] Existing `sidechainCompression.test.ts` store tests still pass (5 tests)
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm run build` succeeds
- [ ] Visual verification: start dev server, add two tracks, add compressor to second track, set sidechain source to first track, verify dashed arrow appears in mixer

Closes #959

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>