### PR TITLE
feat: add freeze/bounce track to audio with visual indicators

### DIFF
--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -22,6 +22,30 @@ import { ContextMenuWrapper, ContextMenuItem, ContextMenuSeparator, ContextMenuS
 const MIN_LANE_HEIGHT = 40;
 const MAX_LANE_HEIGHT = 400;
 
+/** Snowflake-style icon shown next to frozen track names. */
+function FrozenIcon() {
+  return (
+    <svg
+      className="inline-block text-cyan-400 mr-0.5 align-text-bottom"
+      width="10"
+      height="10"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-label="Frozen"
+    >
+      <title>Frozen</title>
+      <line x1="12" y1="2" x2="12" y2="22" />
+      <line x1="2" y1="12" x2="22" y2="12" />
+      <line x1="5" y1="5" x2="19" y2="19" />
+      <line x1="19" y1="5" x2="5" y2="19" />
+    </svg>
+  );
+}
+
 interface TrackHeaderProps {
   track: Track;
   isCollapsed?: boolean;
@@ -402,7 +426,7 @@ export function TrackHeader({
                   title={track.displayName}
                   onDoubleClick={(e) => { e.stopPropagation(); startEditing(); }}
                 >
-                  {track.frozen && <span className="text-cyan-400 mr-0.5" title="Frozen">*</span>}
+                  {track.frozen && <FrozenIcon />}
                   {track.displayName}
                 </span>
               )}
@@ -435,11 +459,13 @@ export function TrackHeader({
                 <button
                   onClick={() => setOpenEffectChainTrackId(track.id)}
                   className={`w-[18px] h-[18px] rounded-full text-[9px] font-bold leading-none flex items-center justify-center transition-colors ${
-                    effectsBypassed
-                      ? 'bg-orange-500 text-white'
-                      : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600 hover:text-zinc-200'
+                    track.frozen
+                      ? 'bg-zinc-800 text-zinc-600 cursor-not-allowed'
+                      : effectsBypassed
+                        ? 'bg-orange-500 text-white'
+                        : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600 hover:text-zinc-200'
                   }`}
-                  title="Effects chain (FX)"
+                  title={track.frozen ? 'Effects bypassed (track frozen)' : 'Effects chain (FX)'}
                   aria-label={`Effects for ${track.displayName}`}
                 >FX</button>
               )}
@@ -480,7 +506,7 @@ export function TrackHeader({
                 title={track.displayName}
                 onDoubleClick={(e) => { e.stopPropagation(); startEditing(); }}
               >
-                {track.frozen && <span className="text-cyan-400 mr-0.5" title="Frozen">*</span>}
+                {track.frozen && <FrozenIcon />}
                 {track.displayName}
               </span>
             )}
@@ -596,6 +622,7 @@ export function TrackHeader({
           )}
         </div>
         <ContextMenuItem label="Bounce in Place..." onClick={() => { setCtxMenu(null); openBounceInPlaceDialog(track.id); }} />
+        <ContextMenuItem label="Bounce to Audio" onClick={() => { setCtxMenu(null); void useProjectStore.getState().bounceTrackToAudio(track.id); }} />
         {track.trackType === 'strudel' && (
           <>
             <ContextMenuSeparator />

--- a/src/components/tracks/__tests__/TrackHeader.test.tsx
+++ b/src/components/tracks/__tests__/TrackHeader.test.tsx
@@ -113,4 +113,21 @@ describe('TrackHeader icon bar', () => {
     expect(screen.getByTitle('Solo (S)')).toBeInTheDocument();
     expect(screen.getByTitle('Effects chain (FX)')).toBeInTheDocument();
   });
+
+  it('shows snowflake icon when track is frozen', () => {
+    render(<TrackHeader track={makeTrack({ frozen: true })} {...defaultProps} />);
+    expect(screen.getByTitle('Frozen')).toBeInTheDocument();
+  });
+
+  it('does not show snowflake icon when track is not frozen', () => {
+    render(<TrackHeader track={makeTrack({ frozen: false })} {...defaultProps} />);
+    expect(screen.queryByTitle('Frozen')).not.toBeInTheDocument();
+  });
+
+  it('FX button shows grayed-out style and frozen tooltip when track is frozen', () => {
+    render(<TrackHeader track={makeTrack({ frozen: true })} {...defaultProps} />);
+    const fxBtn = screen.getByTitle('Effects bypassed (track frozen)');
+    expect(fxBtn).toBeInTheDocument();
+    expect(fxBtn.className).toContain('cursor-not-allowed');
+  });
 });

--- a/src/services/__tests__/freezeTrack.test.ts
+++ b/src/services/__tests__/freezeTrack.test.ts
@@ -82,6 +82,11 @@ describe('freeze / flatten store actions', () => {
     expect(clip.waveformPeaks).toEqual([0.2, 0.8]);
   });
 
+  it('bounceTrackToAudio action exists in the store', () => {
+    const store = useProjectStore.getState();
+    expect(typeof store.bounceTrackToAudio).toBe('function');
+  });
+
   it('mute/solo still work on frozen tracks', () => {
     const trackId = useProjectStore.getState().project!.tracks[0].id;
     useProjectStore.getState().freezeTrack(trackId, 'frozen-key');

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -594,6 +594,7 @@ export interface ProjectState {
   unfreezeTrack: (trackId: string) => void;
   flattenTrack: (trackId: string, audioKey: string, waveformPeaks?: number[], duration?: number) => void;
   bounceInPlace: (trackId: string, options?: Partial<BounceInPlaceOptions>) => Promise<Clip | undefined>;
+  bounceTrackToAudio: (trackId: string) => Promise<Clip | undefined>;
 
   addTrack: (trackName: TrackName | TrackType, trackType?: TrackType, options?: { order?: number; color?: string; displayName?: string }) => Track;
   removeTrack: (trackId: string) => void;
@@ -2539,6 +2540,10 @@ export const useProjectStore = create<ProjectState>()(
     });
 
     return resultClip;
+  },
+
+  bounceTrackToAudio: async (trackId) => {
+    return get().bounceInPlace(trackId, { replaceOriginal: false });
   },
 
   addTrack: (trackName, trackType, options) => {


### PR DESCRIPTION
## Summary
- Add `bounceTrackToAudio(trackId)` store action that creates a new audio track with rendered output (wraps `bounceInPlace` with `replaceOriginal: false`)
- Add "Bounce to Audio" context menu item in track headers (right-click menu)
- Replace frozen track `*` indicator with a snowflake SVG icon (`FrozenIcon` component)
- Show grayed-out FX button with `cursor-not-allowed` and updated tooltip when track is frozen

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm run build` succeeds
- [x] All 26 freeze/TrackHeader tests pass (7 store + 11 service + 8 component)
- [x] Full suite: 2890 tests pass (1 pre-existing AppShell error unrelated)
- [ ] Visual verification: frozen track shows snowflake icon next to name
- [ ] Visual verification: FX button appears grayed-out on frozen tracks
- [ ] Right-click track header shows "Bounce to Audio" option

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)