### PR TITLE
feat: AI enhance buttons, non-blocking generation, and options tree UI

### DIFF
--- a/src/components/generation/FullSongForm.tsx
+++ b/src/components/generation/FullSongForm.tsx
@@ -1,19 +1,22 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useGenerationStore } from '../../store/generationStore';
 import { useModelStore } from '../../store/modelStore';
+import { useUIStore } from '../../store/uiStore';
 import { MAX_DURATION, MIN_DURATION } from '../../constants/defaults';
 import { VOCAL_LANGUAGES, DEFAULT_VOCAL_LANGUAGE } from '../../constants/languages';
 import { generateText2Music } from '../../services/generationPipeline';
-import { formatInput } from '../../services/aceStepApi';
+import { formatInput, createRandomSample } from '../../services/aceStepApi';
 import { toastError, toastInfo } from '../../hooks/useToast';
 import { PromptAutocompleteTextarea } from './PromptAutocompleteTextarea';
 
-/** Sparkle icon for AI enhance buttons */
-function SparkleIcon({ className }: { className?: string }) {
+/** Magic pen icon for AI enhance buttons */
+function MagicPenIcon({ size = 16 }: { size?: number }) {
   return (
-    <svg className={className} width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M12 3l1.912 5.813a2 2 0 001.275 1.275L21 12l-5.813 1.912a2 2 0 00-1.275 1.275L12 21l-1.912-5.813a2 2 0 00-1.275-1.275L3 12l5.813-1.912a2 2 0 001.275-1.275L12 3z" />
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M3.5 20.5l1.5-4.5 3 3-4.5 1.5zM7.5 13.5l3 3 9-9-3-3-9 9z" opacity="0.85" />
+      <path d="M17 2l-1.5 3.5L12 7l3.5 1.5L17 12l1.5-3.5L22 7l-3.5-1.5L17 2z" />
+      <path d="M7 2L6.25 3.75 4.5 4.5l1.75.75L7 7l.75-1.75L9.5 4.5 7.75 3.75 7 2z" opacity="0.6" />
     </svg>
   );
 }
@@ -41,20 +44,36 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
   const getPromptAutocompleteSuggestions = useGenerationStore((s) => s.getPromptAutocompleteSuggestions);
   const applyPromptAutocompleteSuggestion = useGenerationStore((s) => s.applyPromptAutocompleteSuggestion);
 
-  const [prompt, setPrompt] = useState('');
-  const [lyrics, setLyrics] = useState('');
+  // Persisted in generationStore — survives panel close/reopen
+  const prompt = useGenerationStore((s) => s.generationForm.prompt);
+  const setPrompt = useGenerationStore((s) => s.setGenerationPrompt);
+  const lyrics = useGenerationStore((s) => s.generationForm.lyrics);
+  const setLyrics = useGenerationStore((s) => s.setGenerationLyrics);
+  const thinking = useGenerationStore((s) => s.generationForm.thinking);
+  const setThinking = useGenerationStore((s) => s.setGenerationThinking);
+  const seedStr = useGenerationStore((s) => s.generationForm.seed);
+  const setSeedStr = useGenerationStore((s) => s.setGenerationSeed);
+  // Stable fallback seed — only generated once per component mount, not on every render
+  const fallbackSeed = useRef(Math.floor(Math.random() * 2147483647));
+  const parsedSeed = Number(seedStr);
+  const seed = Number.isFinite(parsedSeed) && parsedSeed > 0 ? parsedSeed : fallbackSeed.current;
+  const setSeed = useCallback((v: number) => setSeedStr(String(v)), [setSeedStr]);
+  const useRandomSeed = useGenerationStore((s) => s.generationForm.useRandomSeed);
+  const setUseRandomSeed = useGenerationStore((s) => s.setGenerationUseRandomSeed);
+
+  // Local state — reset on panel reopen (less critical)
   const [instrumental, setInstrumental] = useState(false);
-  const [durationSeconds, setDurationSeconds] = useState(30);
-  const [durationAuto, setDurationAuto] = useState(false);
-  const [seed, setSeed] = useState(Math.floor(Math.random() * 2147483647));
-  const [useRandomSeed, setUseRandomSeed] = useState(true);
+  const [durationSeconds, setDurationSeconds] = useState(-1);
+  const [durationAuto, setDurationAuto] = useState(true);
   const [vocalLanguage, setVocalLanguage] = useState(DEFAULT_VOCAL_LANGUAGE);
   const [splitToStems, setSplitToStems] = useState(false);
   const [stemCount, setStemCount] = useState<2 | 4 | 6>(4);
-  const [thinking, setThinking] = useState(project?.generationDefaults?.thinking ?? true);
+  const [useProjectMeta, setUseProjectMeta] = useState(true);
+  const [syncMetaToProject, setSyncMetaToProject] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [enhancingCaption, setEnhancingCaption] = useState(false);
   const [enhancingLyrics, setEnhancingLyrics] = useState(false);
+  const [loadingExample, setLoadingExample] = useState(false);
 
   const handleEnhanceCaption = useCallback(async () => {
     if (!prompt.trim()) return;
@@ -93,6 +112,25 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
     }
   }, [prompt, lyrics, vocalLanguage]);
 
+  const handleRandomExample = useCallback(async () => {
+    setLoadingExample(true);
+    try {
+      const sample = await createRandomSample('custom_mode');
+      if (sample.caption) setPrompt(sample.caption);
+      if (sample.lyrics) setLyrics(sample.lyrics);
+      if (sample.language) setVocalLanguage(sample.language);
+      if (sample.duration && sample.duration > 0) {
+        setDurationSeconds(sample.duration);
+        setDurationAuto(false);
+      }
+      toastInfo('Random example loaded');
+    } catch (err) {
+      toastError(err instanceof Error ? err.message : 'Failed to load example');
+    } finally {
+      setLoadingExample(false);
+    }
+  }, []);
+
   // Apply initial data from Simple mode's Create Sample
   useEffect(() => {
     if (!initialData) return;
@@ -102,7 +140,10 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
     if (initialData.vocalLanguage) setVocalLanguage(initialData.vocalLanguage);
   }, [initialData]);
 
-  const isDisabled = isGenerating || modelLoadingState === 'loading';
+  // Only disable form during model loading, NOT during generation.
+  // Generation runs in background — user should be able to edit/start new tasks.
+  const isDisabled = modelLoadingState === 'loading';
+  const isSubmitDisabled = isGenerating || isDisabled;
 
   const handleGenerate = useCallback(async () => {
     if (!prompt.trim()) {
@@ -111,36 +152,42 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
     }
     setError(null);
 
-    try {
-      await generateText2Music({
-        prompt: prompt.trim(),
-        lyrics: instrumental ? '[Instrumental]' : lyrics,
-        durationSeconds: durationSeconds === -1 ? undefined as unknown as number : durationSeconds,
-        bpm: project?.bpm ?? null,
-        keyScale: project?.keyScale ?? '',
-        timeSignature: String(project?.timeSignature ?? 4),
-        splitToStems,
-        stemCount,
-        inferenceSteps: project?.generationDefaults?.inferenceSteps,
-        guidanceScale: project?.generationDefaults?.guidanceScale,
-        shift: project?.generationDefaults?.shift,
-        thinking,
-        seed: useRandomSeed ? undefined : seed,
-        useRandomSeed,
-        vocalLanguage: instrumental ? 'unknown' : vocalLanguage,
-      });
-    } catch (err) {
+    // Close the generation panel so user sees the timeline with the loading clip
+    useUIStore.getState().setShowGenerationPanel(false);
+
+    // Fire-and-forget: generation runs in background, UI stays interactive.
+    // The pipeline creates track/clip placeholder immediately, then polls.
+    generateText2Music({
+      prompt: prompt.trim(),
+      lyrics: instrumental ? '[Instrumental]' : lyrics,
+      durationSeconds: durationSeconds === -1 ? undefined as unknown as number : durationSeconds,
+      // Only pass project meta when "Match project" is enabled
+      bpm: useProjectMeta ? (project?.bpm ?? null) : null,
+      keyScale: useProjectMeta ? (project?.keyScale ?? '') : '',
+      timeSignature: useProjectMeta ? String(project?.timeSignature ?? 4) : '',
+      splitToStems,
+      stemCount,
+      inferenceSteps: project?.generationDefaults?.inferenceSteps,
+      guidanceScale: project?.generationDefaults?.guidanceScale,
+      shift: project?.generationDefaults?.shift,
+      thinking,
+      seed: useRandomSeed ? undefined : seed,
+      useRandomSeed,
+      vocalLanguage: instrumental ? 'unknown' : vocalLanguage,
+      // When not using project meta, optionally sync results back to project
+      syncMetaToProject: !useProjectMeta && syncMetaToProject,
+    }).catch((err) => {
       setError(err instanceof Error ? err.message : 'Generation failed');
-    }
-  }, [prompt, lyrics, instrumental, durationSeconds, project, splitToStems, stemCount, thinking, seed, useRandomSeed]);
+    });
+  }, [prompt, lyrics, instrumental, durationSeconds, project, splitToStems, stemCount, thinking, seed, useRandomSeed, useProjectMeta, syncMetaToProject, vocalLanguage]);
 
   // Sync footer state to parent on every render
   const footerAction = useCallback(() => void handleGenerate(), [handleGenerate]);
   onFooterChange({
-    label: isDisabled ? 'Generating...' : 'Generate Full Song',
-    disabled: isDisabled || !prompt.trim(),
+    label: isGenerating ? 'Generating...' : 'Generate Full Song',
+    disabled: isSubmitDisabled || !prompt.trim(),
     action: footerAction,
-    thinkingState: { checked: thinking, onChange: setThinking, disabled: isDisabled },
+    thinkingState: { checked: thinking, onChange: setThinking, disabled: isSubmitDisabled },
   });
 
   return (
@@ -153,44 +200,33 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
 
       {/* Music Caption */}
       <section className="space-y-1.5">
-        <div className="flex items-center justify-between">
-          <label className="text-[11px] font-medium uppercase text-zinc-400">
-            Music Caption
-          </label>
+        <label className="block text-[11px] font-medium uppercase text-zinc-400">
+          Music Caption
+        </label>
+        <div className="relative">
+          <PromptAutocompleteTextarea
+            value={prompt}
+            onChange={setPrompt}
+            disabled={isDisabled}
+            getSuggestions={getPromptAutocompleteSuggestions}
+            applySuggestion={applyPromptAutocompleteSuggestion}
+          />
           <button
             type="button"
             onClick={handleEnhanceCaption}
-            disabled={isDisabled || enhancingCaption || !prompt.trim()}
-            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-zinc-400 transition-colors hover:bg-white/5 hover:text-zinc-200 disabled:opacity-40 disabled:cursor-not-allowed"
+            disabled={isDisabled || enhancingCaption}
+            className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded text-white/80 transition-colors hover:text-white disabled:opacity-20 disabled:cursor-not-allowed"
             title="AI enhance caption"
           >
-            <SparkleIcon className={enhancingCaption ? 'animate-spin' : ''} />
+            {enhancingCaption ? <span className="animate-spin">...</span> : <MagicPenIcon />}
           </button>
         </div>
-        <PromptAutocompleteTextarea
-          value={prompt}
-          onChange={setPrompt}
-          disabled={isDisabled}
-          getSuggestions={getPromptAutocompleteSuggestions}
-          applySuggestion={applyPromptAutocompleteSuggestion}
-        />
       </section>
 
       {/* Lyrics — with Language + Instrumental inline */}
       <section className="space-y-1.5">
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1">
-            <label className="text-[11px] font-medium uppercase text-zinc-400">Lyrics</label>
-            <button
-              type="button"
-              onClick={handleEnhanceLyrics}
-              disabled={isDisabled || enhancingLyrics || instrumental || (!lyrics.trim() && !prompt.trim())}
-              className="flex items-center rounded px-1 py-0.5 text-zinc-400 transition-colors hover:bg-white/5 hover:text-zinc-200 disabled:opacity-40 disabled:cursor-not-allowed"
-              title="AI enhance lyrics"
-            >
-              <SparkleIcon className={enhancingLyrics ? 'animate-spin' : ''} />
-            </button>
-          </div>
+          <label className="text-[11px] font-medium uppercase text-zinc-400">Lyrics</label>
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-1">
               <span className="text-[9px] text-zinc-500">Lang</span>
@@ -221,118 +257,179 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
             </label>
           </div>
         </div>
-        <textarea
-          value={lyrics}
-          onChange={(e) => setLyrics(e.target.value)}
-          rows={5}
-          placeholder="[Verse 1]\nYour lyrics here..."
-          className="w-full resize-none rounded border border-[#444] bg-[#2a2a2a] px-2 py-1.5 text-xs font-mono text-zinc-200 placeholder:text-zinc-600 focus:border-indigo-500 focus:outline-none"
-          disabled={isDisabled || instrumental}
-          data-testid="full-song-lyrics"
-        />
-      </section>
-
-      {/* Parameters — clean two-row grid */}
-      {/* Duration + Seed — compact inline */}
-      <section className="flex items-center gap-3">
-        <div className="flex items-center gap-1.5">
-          <label className="text-[10px] font-medium uppercase text-zinc-500 shrink-0">Duration</label>
-          <input
-            type="number"
-            value={durationSeconds === -1 ? '' : durationSeconds}
-            onChange={(e) => setDurationSeconds(e.target.value === '' ? -1 : Number(e.target.value))}
-            placeholder="Auto"
-            min={MIN_DURATION}
-            max={MAX_DURATION}
-            step={1}
-            className="w-[60px] rounded border border-[#444] bg-[#2a2a2a] px-1.5 py-0.5 text-[11px] focus:border-indigo-500 focus:outline-none"
-            disabled={isDisabled || durationAuto}
-          />
-          <label className="flex items-center gap-1 cursor-pointer" title="Auto-detect duration">
-            <input
-              type="checkbox"
-              checked={durationAuto}
-              onChange={(e) => {
-                setDurationAuto(e.target.checked);
-                if (e.target.checked) setDurationSeconds(-1);
-                else setDurationSeconds(30);
-              }}
-              className="h-3 w-3 rounded border-[#444] accent-indigo-500"
-              disabled={isDisabled}
-            />
-            <span className="text-[9px] text-zinc-600">Auto</span>
-          </label>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <label className="text-[10px] font-medium uppercase text-zinc-500 shrink-0">Seed</label>
-          <input
-            type="number"
-            value={seed}
-            onChange={(e) => setSeed(Number(e.target.value))}
-            className="w-[110px] rounded border border-[#444] bg-[#2a2a2a] px-1.5 py-0.5 text-[11px] font-mono focus:border-indigo-500 focus:outline-none"
-            disabled={isDisabled || useRandomSeed}
+        <div className="relative">
+          <textarea
+            value={lyrics}
+            onChange={(e) => setLyrics(e.target.value)}
+            rows={5}
+            placeholder="[Verse 1]\nYour lyrics here..."
+            className="w-full resize-none rounded border border-[#444] bg-[#2a2a2a] px-2 py-1.5 pr-8 text-xs font-mono text-zinc-200 placeholder:text-zinc-600 focus:border-indigo-500 focus:outline-none"
+            disabled={isDisabled || instrumental}
+            data-testid="full-song-lyrics"
           />
           <button
             type="button"
-            onClick={() => {
-              setSeed(Math.floor(Math.random() * 2147483647));
-              setUseRandomSeed(false);
-            }}
-            className="shrink-0 text-[14px] leading-none transition-opacity hover:opacity-80"
-            title="Random seed"
-            disabled={isDisabled}
+            onClick={handleEnhanceLyrics}
+            disabled={isDisabled || enhancingLyrics || instrumental}
+            className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded text-white/80 transition-colors hover:text-white disabled:opacity-20 disabled:cursor-not-allowed"
+            title="AI enhance lyrics"
           >
-            🎲
+            {enhancingLyrics ? <span className="animate-spin">...</span> : <MagicPenIcon />}
           </button>
-          <label className="flex items-center gap-1 cursor-pointer" title="Use random seed each time">
-            <input
-              type="checkbox"
-              checked={useRandomSeed}
-              onChange={(e) => setUseRandomSeed(e.target.checked)}
-              className="h-3 w-3 rounded border-[#444] accent-indigo-500"
-              disabled={isDisabled}
-            />
-            <span className="text-[9px] text-zinc-600">Random</span>
-          </label>
         </div>
       </section>
 
-      {/* Split to stems */}
-      <section className="space-y-2">
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={splitToStems}
-            onChange={(e) => setSplitToStems(e.target.checked)}
-            className="h-4 w-4 rounded border-[#444] bg-[#2a2a2a] accent-indigo-500"
-            disabled={isDisabled}
-            data-testid="full-song-split-stems"
-          />
-          <span className="text-[11px] font-medium text-zinc-300">Split into stems after generation</span>
-        </label>
-        {splitToStems && (
-          <div className="ml-6 flex items-center gap-2">
-            <span className="text-[10px] text-zinc-500">Stems:</span>
-            {([2, 4, 6] as const).map((count) => (
-              <button
-                key={count}
-                type="button"
-                onClick={() => setStemCount(count)}
-                className={`rounded px-2 py-0.5 text-[10px] ${
-                  stemCount === count
-                    ? 'bg-indigo-600 text-white'
-                    : 'bg-[#333] text-zinc-400 hover:bg-[#444]'
-                }`}
+      {/* Random Example */}
+      <button
+        type="button"
+        onClick={handleRandomExample}
+        disabled={isDisabled || loadingExample}
+        className="w-full rounded border border-dashed border-zinc-600 py-1.5 text-[11px] text-zinc-400 transition-colors hover:border-zinc-400 hover:text-zinc-200 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {loadingExample ? 'Loading...' : '🎲 Random Example'}
+      </button>
+
+      {/* Parameters grid */}
+      <section className="grid grid-cols-2 gap-x-3 gap-y-2">
+        <div className="space-y-1">
+          <label className="text-[10px] font-medium uppercase text-zinc-500">Duration</label>
+          <div className="flex items-center gap-1.5">
+            <input
+              type="number"
+              value={durationSeconds === -1 ? '' : durationSeconds}
+              onChange={(e) => setDurationSeconds(e.target.value === '' ? -1 : Number(e.target.value))}
+              placeholder="Auto"
+              min={MIN_DURATION}
+              max={MAX_DURATION}
+              step={1}
+              className="w-full rounded border border-[#444] bg-[#2a2a2a] px-1.5 py-1 text-[11px] focus:border-indigo-500 focus:outline-none"
+              disabled={isDisabled || durationAuto}
+            />
+            <label className="flex items-center gap-1 cursor-pointer shrink-0" title="Auto-detect duration">
+              <input
+                type="checkbox"
+                checked={durationAuto}
+                onChange={(e) => {
+                  setDurationAuto(e.target.checked);
+                  if (e.target.checked) setDurationSeconds(-1);
+                  else setDurationSeconds(30);
+                }}
+                className="h-3 w-3 rounded border-[#444] accent-indigo-500"
                 disabled={isDisabled}
-              >
-                {count}
-              </button>
-            ))}
+              />
+              <span className="text-[9px] text-zinc-500">Auto</span>
+            </label>
           </div>
-        )}
+        </div>
+        <div className="space-y-1">
+          <label className="text-[10px] font-medium uppercase text-zinc-500">Seed</label>
+          <div className="flex items-center gap-1.5">
+            <input
+              type="number"
+              value={seed}
+              onChange={(e) => setSeed(Number(e.target.value))}
+              className="w-full rounded border border-[#444] bg-[#2a2a2a] px-1.5 py-1 text-[11px] font-mono focus:border-indigo-500 focus:outline-none"
+              disabled={isDisabled || useRandomSeed}
+            />
+            <button
+              type="button"
+              onClick={() => { setSeed(Math.floor(Math.random() * 2147483647)); setUseRandomSeed(false); }}
+              className="shrink-0 text-[13px] leading-none transition-opacity hover:opacity-80"
+              title="Random seed"
+              disabled={isDisabled}
+            >🎲</button>
+            <label className="flex items-center gap-1 cursor-pointer shrink-0" title="Use random seed each time">
+              <input
+                type="checkbox"
+                checked={useRandomSeed}
+                onChange={(e) => setUseRandomSeed(e.target.checked)}
+                className="h-3 w-3 rounded border-[#444] accent-indigo-500"
+                disabled={isDisabled}
+              />
+              <span className="text-[9px] text-zinc-500">Rand</span>
+            </label>
+          </div>
+        </div>
       </section>
 
-      {/* Advanced Parameters removed — use Settings > Generation Defaults instead */}
+      {/* Options — two-column tree layout */}
+      <section className="grid grid-cols-2 gap-x-3">
+
+        {/* ── Split to stems ── */}
+        <div>
+          <label className="flex items-center gap-1.5 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={splitToStems}
+              onChange={(e) => setSplitToStems(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-[#444] bg-[#2a2a2a] accent-indigo-500"
+              disabled={isDisabled}
+              data-testid="full-song-split-stems"
+            />
+            <span className="text-[11px] font-medium text-zinc-300">Split to stems</span>
+          </label>
+          {splitToStems && (
+            <div className="ml-4 mt-1 border-l border-zinc-700 pl-3">
+              <div className="flex items-center gap-1.5">
+                <span className="text-[10px] text-zinc-500">Count</span>
+                {([2, 4, 6] as const).map((count) => (
+                  <button
+                    key={count}
+                    type="button"
+                    onClick={() => setStemCount(count)}
+                    className={`rounded px-2 py-0.5 text-[10px] transition-colors ${
+                      stemCount === count
+                        ? 'bg-indigo-600 text-white'
+                        : 'bg-[#333] text-zinc-400 hover:bg-[#444]'
+                    }`}
+                    disabled={isDisabled}
+                  >
+                    {count}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* ── Match project settings ── */}
+        <div>
+          <label className="flex items-center gap-1.5 cursor-pointer flex-wrap">
+            <input
+              type="checkbox"
+              checked={useProjectMeta}
+              onChange={(e) => setUseProjectMeta(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-[#444] bg-[#2a2a2a] accent-indigo-500"
+              disabled={isDisabled}
+            />
+            <span className="text-[11px] font-medium text-zinc-300">Match project</span>
+            {useProjectMeta && project && (
+              <span className="text-[9px] text-zinc-500">
+                {[
+                  project.bpm ? `${project.bpm} BPM` : null,
+                  project.keyScale || null,
+                  project.timeSignature ? `${project.timeSignature}/4` : null,
+                ].filter(Boolean).join(' · ') || ''}
+              </span>
+            )}
+          </label>
+          {!useProjectMeta && (
+            <div className="ml-4 mt-1 border-l border-zinc-700 pl-3">
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={syncMetaToProject}
+                  onChange={(e) => setSyncMetaToProject(e.target.checked)}
+                  className="h-3 w-3 rounded border-[#444] bg-[#2a2a2a] accent-indigo-500"
+                  disabled={isDisabled}
+                />
+                <span className="text-[10px] text-zinc-400">Apply to project</span>
+              </label>
+            </div>
+          )}
+        </div>
+
+      </section>
 
     </div>
   );

--- a/src/services/aceStepApi.ts
+++ b/src/services/aceStepApi.ts
@@ -219,6 +219,33 @@ export async function createSample(req: CreateSampleRequest): Promise<CreateSamp
   return envelope.data;
 }
 
+/** Fetch a random pre-loaded example (custom mode). */
+export interface RandomSampleResponse {
+  think?: boolean;
+  caption?: string;
+  lyrics?: string;
+  bpm?: number;
+  duration?: number;
+  keyscale?: string;
+  language?: string;
+  timesignature?: string;
+}
+
+export async function createRandomSample(sampleType: 'simple_mode' | 'custom_mode' = 'custom_mode'): Promise<RandomSampleResponse> {
+  const base = getApiBase();
+  const res = await fetch(`${base}/create_random_sample`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sample_type: sampleType }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`createRandomSample failed: ${res.status} - ${text}`);
+  }
+  const envelope: ApiEnvelope<RandomSampleResponse> = await res.json();
+  return envelope.data;
+}
+
 /** Format/enhance input — LM refines prompt, lyrics, and infers metadata. */
 export interface FormatInputRequest {
   prompt: string;

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -2197,6 +2197,8 @@ export interface Text2MusicRequest {
   useCotCaption?: boolean;
   /** Vocal language code — "unknown" = server auto-detects via CoT */
   vocalLanguage?: string;
+  /** When true, update project BPM/key/timeSignature from generated result */
+  syncMetaToProject?: boolean;
 }
 
 export interface Text2MusicResult {
@@ -2234,6 +2236,8 @@ export async function generateText2Music(request: Text2MusicRequest): Promise<Te
     throw new Error('No project open');
   }
 
+  genStore.setIsGenerating(true);
+
   // Step 1: Ensure text2music model + LM are loaded
   await modelStore.ensureModelForIntent('full-song');
 
@@ -2246,9 +2250,12 @@ export async function generateText2Music(request: Text2MusicRequest): Promise<Te
     throw new Error('Failed to create mix track');
   }
 
+  // Use a placeholder duration for the clip when Auto mode (undefined duration).
+  // The actual duration will be updated when the audio comes back.
+  const placeholderDuration = request.durationSeconds ?? 60;
   const clip = store.addClip(mixTrack.id, {
     startTime: 0,
-    duration: request.durationSeconds,
+    duration: placeholderDuration,
     prompt: request.prompt,
     lyrics: request.lyrics,
     globalCaption: request.prompt, // For text2music, the prompt IS the global caption
@@ -2395,14 +2402,17 @@ export async function generateText2Music(request: Text2MusicRequest): Promise<Te
         }
       : undefined;
 
-    // Update clip as ready
+    // Update clip as ready — use actual audio buffer duration, not the request duration
+    const actualDuration = audioBuffer.duration;
     useProjectStore.getState().updateClipStatus(clipId, 'ready', {
       isolatedAudioKey: audioKey,
       waveformPeaks: peaks,
       inferredMetas,
-      audioDuration: request.durationSeconds,
+      audioDuration: actualDuration,
       audioOffset: 0,
     });
+    // Also update the clip's visual duration on the timeline to match actual audio
+    useProjectStore.getState().updateClip(clipId, { duration: actualDuration });
 
     genStore.updateJob(jobId, {
       status: 'done',
@@ -2413,6 +2423,22 @@ export async function generateText2Music(request: Text2MusicRequest): Promise<Te
     // Seed project global caption if empty
     if (request.prompt && !project.globalCaption) {
       useProjectStore.getState().updateProject({ globalCaption: request.prompt });
+    }
+
+    // Sync generated metadata back to project settings when requested
+    if (request.syncMetaToProject && inferredMetas) {
+      const updates: Record<string, unknown> = {};
+      if (inferredMetas.bpm && inferredMetas.bpm > 0) updates.bpm = inferredMetas.bpm;
+      if (inferredMetas.keyScale) updates.keyScale = inferredMetas.keyScale;
+      if (inferredMetas.timeSignature) {
+        const ts = Number(inferredMetas.timeSignature);
+        if (Number.isFinite(ts) && ts > 0) updates.timeSignature = ts;
+      }
+      if (Object.keys(updates).length > 0) {
+        useProjectStore.getState().updateProject(updates);
+        const parts = Object.entries(updates).map(([k, v]) => `${k}=${v}`).join(', ');
+        toastInfo(`Project updated: ${parts}`);
+      }
     }
 
     toastSuccess('Full song generated');
@@ -2466,6 +2492,7 @@ export async function generateText2Music(request: Text2MusicRequest): Promise<Te
       }
     }
 
+    useGenerationStore.getState().setIsGenerating(false);
     return {
       mixTrackId: mixTrack.id,
       mixClipId: clipId,
@@ -2474,6 +2501,7 @@ export async function generateText2Music(request: Text2MusicRequest): Promise<Te
       succeeded: true,
     };
   } catch (error) {
+    useGenerationStore.getState().setIsGenerating(false);
     const message = error instanceof Error ? error.message : 'Unknown error';
     useProjectStore.getState().updateClipStatus(clipId, 'error', { errorMessage: message });
     genStore.updateJob(jobId, { status: 'error', progress: message, error: message });


### PR DESCRIPTION
## Summary

Closes #1040

- **Magic pen AI enhance buttons** — inside Caption and Lyrics textareas (corner absolute position), calls `/format_input`
- **Random Example button** — loads a server-generated sample via `createRandomSample`
- **Non-blocking generation** — `generateText2Music` is fire-and-forget; placeholder clip created immediately; generation panel auto-closes on Generate click
- **Persistent form state** — prompt/lyrics/thinking/seed now live in `generationStore`, survive panel close/reopen
- **Stable seed** — `useRef` fallback seed prevents value jumping during playback
- **Two-column tree options layout** — "Split to stems" (left) and "Match project" (right) sit side by side; each expands its sub-options below with a left-border tree line
- **`syncMetaToProject`** — when "Match project" is unchecked, optional "Apply to project" sub-option syncs generated BPM & key back to project
- **NaN crash fix** — placeholder duration = 60s when Auto mode; updated to actual `audioBuffer.duration` after decode
- **`setIsGenerating` lifecycle** — properly set true at start, false in both success and error paths

## Test plan

- [ ] Magic pen button in Caption textarea corner → calls `/format_input`, updates caption
- [ ] Magic pen button in Lyrics textarea corner → calls `/format_input`, updates lyrics
- [ ] Empty caption → enhance button does nothing (guard: `if (!prompt.trim()) return`)
- [ ] Random Example → loads caption/lyrics/language from server
- [ ] Click Generate → panel closes immediately, placeholder clip appears on timeline
- [ ] Generation completes in background → clip updated with actual audio
- [ ] Reopen panel → prompt/lyrics/seed values preserved
- [ ] Seed value does not change during playback
- [ ] Auto duration mode → no NaN crash on timeline
- [ ] Options row: two columns side by side
- [ ] Check "Split to stems" → stem count [2][4][6] appears below
- [ ] Uncheck "Match project" → "Apply to project" sub-option appears below

🤖 Generated with [Claude Code](https://claude.com/claude-code)