### PR TITLE
feat: add routing validation with topological sort to prevent feedback loops

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -107,6 +107,7 @@ import { getSynthPresetById } from '../data/synthPresets';
 import { extractGroove, applyGroove, type ExtractGrooveOptions, type ApplyGrooveOptions } from '../utils/groovePool';
 import type { GrooveTemplate } from '../types/project';
 import { toastError, toastSuccess } from '../hooks/useToast';
+import { buildRoutingGraph, wouldCreateCycle } from '../utils/routingGraph';
 import { buildConsolidatedMidiClipData, renderConsolidatedAudioClip, validateClipConsolidation } from '../services/clipConsolidation';
 import type { MidiCaptureService } from '../services/midiCaptureService';
 import { snapTimeToZeroCrossing } from '../utils/zeroCrossing';
@@ -6743,6 +6744,16 @@ export const useProjectStore = create<ProjectState>()(
   setSidechainSource: (trackId, effectId, sourceTrackId) => {
     const state = get();
     if (!state.project) return;
+
+    // Validate: setting a sidechain source must not create a routing cycle
+    if (sourceTrackId !== undefined) {
+      const graph = buildRoutingGraph(state.project.tracks, state.project.returnTracks ?? []);
+      if (wouldCreateCycle(graph, sourceTrackId, trackId)) {
+        toastError('Cannot set sidechain source: it would create a feedback loop in the routing graph');
+        return;
+      }
+    }
+
     _pushHistory(state.project);
     set({
       project: {
@@ -7388,6 +7399,20 @@ export const useProjectStore = create<ProjectState>()(
   updateTrackSend: (trackId, returnTrackId, amount) => {
     const state = get();
     if (!state.project) return;
+
+    // Validate: adding a new send with amount > 0 must not create a routing cycle
+    if (amount > 0) {
+      const track = state.project.tracks.find((t) => t.id === trackId);
+      const isNewSend = !(track?.sends ?? []).some((s) => s.returnTrackId === returnTrackId);
+      if (isNewSend) {
+        const graph = buildRoutingGraph(state.project.tracks, state.project.returnTracks ?? []);
+        if (wouldCreateCycle(graph, trackId, returnTrackId)) {
+          toastError('Cannot add send: it would create a feedback loop in the routing graph');
+          return;
+        }
+      }
+    }
+
     _pushHistory(state.project);
     set({
       project: {

--- a/src/utils/__tests__/routingGraph.test.ts
+++ b/src/utils/__tests__/routingGraph.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildRoutingGraph,
+  detectRoutingCycles,
+  wouldCreateCycle,
+  type RoutingGraph,
+} from '../routingGraph';
+import type { Track, CompressorParams, ReturnTrack } from '../../types/project';
+
+function makeTrack(
+  id: string,
+  overrides: Partial<Track> = {},
+): Track {
+  return {
+    id,
+    trackName: 'custom',
+    displayName: id,
+    color: '#ff0000',
+    order: 0,
+    volume: 1,
+    muted: false,
+    soloed: false,
+    clips: [],
+    ...overrides,
+  };
+}
+
+function makeReturnTrack(id: string): ReturnTrack {
+  return { id, name: id, effects: [], volume: 1, pan: 0 };
+}
+
+// ─── buildRoutingGraph ───────────────────────────────────────────────────────
+
+describe('buildRoutingGraph', () => {
+  it('returns empty adjacency list for tracks with no routing', () => {
+    const tracks = [makeTrack('t1'), makeTrack('t2')];
+    const graph = buildRoutingGraph(tracks, []);
+    expect(graph.size).toBe(0);
+  });
+
+  it('builds edges from sends (track -> return track)', () => {
+    const tracks = [
+      makeTrack('t1', { sends: [{ returnTrackId: 'rt1', amount: 0.5 }] }),
+      makeTrack('t2'),
+    ];
+    const returns = [makeReturnTrack('rt1')];
+    const graph = buildRoutingGraph(tracks, returns);
+    expect(graph.get('t1')).toEqual(['rt1']);
+  });
+
+  it('builds edges from sidechain source (source -> target)', () => {
+    const tracks = [
+      makeTrack('t1'),
+      makeTrack('t2', {
+        effects: [
+          {
+            id: 'fx1',
+            type: 'compressor',
+            params: {
+              threshold: -24,
+              ratio: 4,
+              attack: 0.003,
+              release: 0.25,
+              knee: 30,
+              sidechainSourceTrackId: 't1',
+            } as CompressorParams,
+            bypass: false,
+          },
+        ],
+      }),
+    ];
+    const graph = buildRoutingGraph(tracks, []);
+    expect(graph.get('t1')).toEqual(['t2']);
+  });
+
+  it('builds edges from group bus (child -> parent)', () => {
+    const tracks = [
+      makeTrack('t1', { parentTrackId: 'g1' }),
+      makeTrack('g1', { isGroup: true }),
+    ];
+    const graph = buildRoutingGraph(tracks, []);
+    expect(graph.get('t1')).toEqual(['g1']);
+  });
+
+  it('combines send, sidechain and group edges', () => {
+    const tracks = [
+      makeTrack('t1', {
+        parentTrackId: 'g1',
+        sends: [{ returnTrackId: 'rt1', amount: 0.5 }],
+      }),
+      makeTrack('g1', { isGroup: true }),
+      makeTrack('t2', {
+        effects: [
+          {
+            id: 'fx1',
+            type: 'compressor',
+            params: {
+              threshold: -24,
+              ratio: 4,
+              attack: 0.003,
+              release: 0.25,
+              knee: 30,
+              sidechainSourceTrackId: 't1',
+            } as CompressorParams,
+            bypass: false,
+          },
+        ],
+      }),
+    ];
+    const returns = [makeReturnTrack('rt1')];
+    const graph = buildRoutingGraph(tracks, returns);
+    // t1 -> g1 (group), t1 -> rt1 (send), t1 -> t2 (sidechain)
+    const t1Edges = graph.get('t1') ?? [];
+    expect(t1Edges).toContain('g1');
+    expect(t1Edges).toContain('rt1');
+    expect(t1Edges).toContain('t2');
+  });
+
+  it('ignores sends with zero amount', () => {
+    const tracks = [
+      makeTrack('t1', { sends: [{ returnTrackId: 'rt1', amount: 0 }] }),
+    ];
+    const returns = [makeReturnTrack('rt1')];
+    const graph = buildRoutingGraph(tracks, returns);
+    expect(graph.size).toBe(0);
+  });
+});
+
+// ─── detectRoutingCycles ─────────────────────────────────────────────────────
+
+describe('detectRoutingCycles', () => {
+  it('returns empty array for acyclic graph', () => {
+    const graph: RoutingGraph = new Map([
+      ['a', ['b']],
+      ['b', ['c']],
+    ]);
+    expect(detectRoutingCycles(graph)).toEqual([]);
+  });
+
+  it('detects a simple 2-node cycle', () => {
+    const graph: RoutingGraph = new Map([
+      ['a', ['b']],
+      ['b', ['a']],
+    ]);
+    const cycles = detectRoutingCycles(graph);
+    expect(cycles.length).toBe(1);
+    expect(cycles[0]).toContain('a');
+    expect(cycles[0]).toContain('b');
+  });
+
+  it('detects a 3-node cycle', () => {
+    const graph: RoutingGraph = new Map([
+      ['a', ['b']],
+      ['b', ['c']],
+      ['c', ['a']],
+    ]);
+    const cycles = detectRoutingCycles(graph);
+    expect(cycles.length).toBe(1);
+    expect(cycles[0]).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+  });
+
+  it('detects self-loop', () => {
+    const graph: RoutingGraph = new Map([['a', ['a']]]);
+    const cycles = detectRoutingCycles(graph);
+    expect(cycles.length).toBe(1);
+    expect(cycles[0]).toContain('a');
+  });
+
+  it('handles disconnected components (one cyclic, one acyclic)', () => {
+    const graph: RoutingGraph = new Map([
+      ['a', ['b']],
+      ['b', ['a']],
+      ['c', ['d']],
+    ]);
+    const cycles = detectRoutingCycles(graph);
+    expect(cycles.length).toBe(1);
+    expect(cycles[0]).toContain('a');
+    expect(cycles[0]).toContain('b');
+  });
+
+  it('returns empty for empty graph', () => {
+    expect(detectRoutingCycles(new Map())).toEqual([]);
+  });
+});
+
+// ─── wouldCreateCycle ────────────────────────────────────────────────────────
+
+describe('wouldCreateCycle', () => {
+  it('returns false when adding an edge to an acyclic graph', () => {
+    const graph: RoutingGraph = new Map([['a', ['b']]]);
+    expect(wouldCreateCycle(graph, 'b', 'c')).toBe(false);
+  });
+
+  it('returns true when adding an edge that closes a cycle', () => {
+    const graph: RoutingGraph = new Map([
+      ['a', ['b']],
+      ['b', ['c']],
+    ]);
+    // c -> a would create a -> b -> c -> a
+    expect(wouldCreateCycle(graph, 'c', 'a')).toBe(true);
+  });
+
+  it('returns true for self-loop edge', () => {
+    const graph: RoutingGraph = new Map();
+    expect(wouldCreateCycle(graph, 'a', 'a')).toBe(true);
+  });
+
+  it('returns false when target cannot reach source', () => {
+    const graph: RoutingGraph = new Map([
+      ['a', ['b']],
+      ['c', ['d']],
+    ]);
+    expect(wouldCreateCycle(graph, 'd', 'a')).toBe(false);
+  });
+
+  it('returns true when edge would join two paths into a cycle', () => {
+    // a -> b, a -> c, b -> d, c -> d, now d -> a would cycle
+    const graph: RoutingGraph = new Map([
+      ['a', ['b', 'c']],
+      ['b', ['d']],
+      ['c', ['d']],
+    ]);
+    expect(wouldCreateCycle(graph, 'd', 'a')).toBe(true);
+  });
+});

--- a/src/utils/routingGraph.ts
+++ b/src/utils/routingGraph.ts
@@ -1,0 +1,132 @@
+import type { Track, CompressorParams, ReturnTrack } from '../types/project';
+
+/** Adjacency list: node id -> list of target node ids. */
+export type RoutingGraph = Map<string, string[]>;
+
+/**
+ * Builds a directed routing graph from DAW tracks and return tracks.
+ *
+ * Edges represent audio signal flow:
+ * - Send: track -> return track (when send amount > 0)
+ * - Sidechain: source track -> target track (compressor with sidechainSourceTrackId)
+ * - Group bus: child track -> parent group track
+ */
+export function buildRoutingGraph(
+  tracks: Track[],
+  returnTracks: ReturnTrack[],
+): RoutingGraph {
+  const graph: RoutingGraph = new Map();
+  const returnTrackIds = new Set(returnTracks.map((rt) => rt.id));
+
+  function addEdge(from: string, to: string): void {
+    const existing = graph.get(from);
+    if (existing) {
+      if (!existing.includes(to)) existing.push(to);
+    } else {
+      graph.set(from, [to]);
+    }
+  }
+
+  for (const track of tracks) {
+    // Send edges: track -> return track
+    for (const send of track.sends ?? []) {
+      if (send.amount > 0 && returnTrackIds.has(send.returnTrackId)) {
+        addEdge(track.id, send.returnTrackId);
+      }
+    }
+
+    // Sidechain edges: source -> target (the track with the compressor)
+    for (const effect of track.effects ?? []) {
+      if (effect.type !== 'compressor') continue;
+      const params = effect.params as CompressorParams;
+      if (params.sidechainSourceTrackId) {
+        addEdge(params.sidechainSourceTrackId, track.id);
+      }
+    }
+
+    // Group bus edges: child -> parent
+    if (track.parentTrackId) {
+      addEdge(track.id, track.parentTrackId);
+    }
+  }
+
+  return graph;
+}
+
+/**
+ * Detects all cycles in a directed routing graph using DFS.
+ * Returns an array of cycles, where each cycle is an array of node ids
+ * forming a loop (in traversal order).
+ */
+export function detectRoutingCycles(graph: RoutingGraph): string[][] {
+  const cycles: string[][] = [];
+  const visited = new Set<string>();
+  const inStack = new Set<string>();
+  const path: string[] = [];
+
+  // Collect all nodes (both sources and targets)
+  const allNodes = new Set<string>();
+  for (const [from, tos] of graph) {
+    allNodes.add(from);
+    for (const to of tos) allNodes.add(to);
+  }
+
+  function dfs(node: string): void {
+    visited.add(node);
+    inStack.add(node);
+    path.push(node);
+
+    for (const neighbor of graph.get(node) ?? []) {
+      if (!visited.has(neighbor)) {
+        dfs(neighbor);
+      } else if (inStack.has(neighbor)) {
+        // Found a cycle — extract it from the path
+        const cycleStart = path.indexOf(neighbor);
+        cycles.push(path.slice(cycleStart));
+      }
+    }
+
+    path.pop();
+    inStack.delete(node);
+  }
+
+  for (const node of allNodes) {
+    if (!visited.has(node)) {
+      dfs(node);
+    }
+  }
+
+  return cycles;
+}
+
+/**
+ * Checks whether adding edge `from -> to` to the existing graph would create a cycle.
+ * Uses reachability check: a cycle forms if `to` can already reach `from` in the current graph,
+ * or if `from === to` (self-loop).
+ */
+export function wouldCreateCycle(
+  graph: RoutingGraph,
+  from: string,
+  to: string,
+): boolean {
+  if (from === to) return true;
+
+  // BFS/DFS from `to` to see if `from` is reachable
+  const visited = new Set<string>();
+  const queue = [to];
+
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    if (current === from) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    for (const neighbor of graph.get(current) ?? []) {
+      if (!visited.has(neighbor)) {
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- Add `buildRoutingGraph()` utility that builds a directed graph from track routing (sends, sidechain, group bus)
- Add `detectRoutingCycles()` for DFS-based cycle detection and `wouldCreateCycle()` for pre-validation of new edges
- Integrate cycle validation into `updateTrackSend` and `setSidechainSource` store actions — rejects routes that would create feedback loops with an error toast
- 17 unit tests covering graph building, cycle detection, and cycle prevention

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — all 2989 tests pass (17 new)
- [x] `npm run build` — succeeds

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)