### PR TITLE
refactor: extract MIDI slice from projectStore (8461→8147 lines)

### DIFF
--- a/src/store/__tests__/midiSlice.test.ts
+++ b/src/store/__tests__/midiSlice.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMidiSlice, appendMidiNotesToClip, type MidiSliceDeps, type MidiSliceActions } from '../slices/midiSlice';
+import type { Project, MidiNote } from '../../types/project';
+
+function makeProject(clipId: string, notes: MidiNote[] = []): Project {
+  return {
+    id: 'test-project',
+    name: 'Test',
+    bpm: 120,
+    timeSignature: 4,
+    timeSignatureDenominator: 4,
+    masterVolume: 1,
+    measures: 16,
+    tracks: [{
+      id: 'track-1',
+      trackName: 'piano',
+      trackType: 'pianoRoll',
+      color: '#ff0000',
+      volume: 1,
+      clips: [{
+        id: clipId,
+        startTime: 0,
+        duration: 4,
+        name: 'Clip 1',
+        color: '#ff0000',
+        midiData: { notes, grid: '1/16' },
+      }],
+    }],
+    updatedAt: Date.now(),
+    createdAt: Date.now(),
+    globalCaption: '',
+    assets: [],
+    returnTracks: [],
+  } as unknown as Project;
+}
+
+function makeNote(overrides?: Partial<MidiNote>): MidiNote {
+  return {
+    id: 'note-1',
+    pitch: 60,
+    startBeat: 0,
+    durationBeats: 1,
+    velocity: 100,
+    ...overrides,
+  };
+}
+
+describe('midiSlice', () => {
+  let project: Project | null;
+  let setFn: (partial: { project: Project | null }) => void;
+  let getFn: () => { project: Project | null };
+  let deps: MidiSliceDeps;
+  let slice: MidiSliceActions;
+
+  beforeEach(() => {
+    project = makeProject('clip-1', [makeNote()]);
+    setFn = vi.fn((partial) => { project = partial.project; });
+    getFn = () => ({ project });
+    deps = {
+      isViewerMode: vi.fn(() => false),
+      pushHistory: vi.fn(),
+    };
+    slice = createMidiSlice(setFn, getFn, deps);
+  });
+
+  describe('addMidiNote', () => {
+    it('adds a note to the clip and returns the note ID', () => {
+      const noteId = slice.addMidiNote('clip-1', { pitch: 64, startBeat: 2, durationBeats: 0.5, velocity: 80 });
+      expect(noteId).toBeDefined();
+      expect(project!.tracks[0].clips[0].midiData!.notes).toHaveLength(2);
+      expect(project!.tracks[0].clips[0].midiData!.notes[1].pitch).toBe(64);
+    });
+
+    it('pushes history before mutation', () => {
+      slice.addMidiNote('clip-1', { pitch: 64, startBeat: 2, durationBeats: 0.5, velocity: 80 });
+      expect(deps.pushHistory).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ scope: 'pianoRoll', clipId: 'clip-1' }),
+      );
+    });
+
+    it('returns undefined in viewer mode', () => {
+      (deps.isViewerMode as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      const result = slice.addMidiNote('clip-1', { pitch: 64, startBeat: 0, durationBeats: 1, velocity: 100 });
+      expect(result).toBeUndefined();
+    });
+
+    it('uses provided ID if given', () => {
+      const noteId = slice.addMidiNote('clip-1', { id: 'custom-id', pitch: 60, startBeat: 0, durationBeats: 1, velocity: 100 });
+      expect(noteId).toBe('custom-id');
+    });
+  });
+
+  describe('updateMidiNote', () => {
+    it('updates a note by ID', () => {
+      slice.updateMidiNote('clip-1', 'note-1', { pitch: 72 });
+      expect(project!.tracks[0].clips[0].midiData!.notes[0].pitch).toBe(72);
+    });
+
+    it('preserves other note properties', () => {
+      slice.updateMidiNote('clip-1', 'note-1', { pitch: 72 });
+      const note = project!.tracks[0].clips[0].midiData!.notes[0];
+      expect(note.velocity).toBe(100);
+      expect(note.startBeat).toBe(0);
+    });
+  });
+
+  describe('removeMidiNote', () => {
+    it('removes a note by ID', () => {
+      slice.removeMidiNote('clip-1', 'note-1');
+      expect(project!.tracks[0].clips[0].midiData!.notes).toHaveLength(0);
+    });
+  });
+
+  describe('setNoteVelocity', () => {
+    it('clamps velocity to 1–127', () => {
+      slice.setNoteVelocity('clip-1', 'note-1', 200);
+      expect(project!.tracks[0].clips[0].midiData!.notes[0].velocity).toBe(127);
+
+      slice.setNoteVelocity('clip-1', 'note-1', -5);
+      expect(project!.tracks[0].clips[0].midiData!.notes[0].velocity).toBe(1);
+    });
+  });
+
+  describe('resizeMidiNote', () => {
+    it('resizes from right edge', () => {
+      slice.resizeMidiNote('clip-1', 'note-1', { edge: 'right', endBeat: 3 });
+      expect(project!.tracks[0].clips[0].midiData!.notes[0].durationBeats).toBe(3);
+    });
+
+    it('resizes from left edge', () => {
+      project = makeProject('clip-1', [makeNote({ startBeat: 1, durationBeats: 2 })]);
+      slice.resizeMidiNote('clip-1', 'note-1', { edge: 'left', startBeat: 0.5 });
+      const note = project!.tracks[0].clips[0].midiData!.notes[0];
+      expect(note.startBeat).toBe(0.5);
+      expect(note.durationBeats).toBe(2.5);
+    });
+
+    it('enforces minimum duration', () => {
+      slice.resizeMidiNote('clip-1', 'note-1', { edge: 'right', endBeat: 0.001, minDurationBeats: 0.25 });
+      expect(project!.tracks[0].clips[0].midiData!.notes[0].durationBeats).toBe(0.25);
+    });
+  });
+
+  describe('stampChord', () => {
+    it('creates notes for each interval', () => {
+      const ids = slice.stampChord('clip-1', 60, [0, 4, 7], 0, 1, 90);
+      expect(ids).toHaveLength(3);
+      const notes = project!.tracks[0].clips[0].midiData!.notes;
+      // Original note + 3 chord notes
+      expect(notes).toHaveLength(4);
+      expect(notes.slice(1).map((n) => n.pitch)).toEqual([60, 64, 67]);
+    });
+
+    it('filters out-of-range pitches', () => {
+      const ids = slice.stampChord('clip-1', 126, [0, 4, 7], 0, 1, 90);
+      // 126+0 = 126 (ok), 126+4 = 130 > 127 (filtered), 126+7 = 133 > 127 (filtered)
+      expect(ids).toHaveLength(1);
+    });
+  });
+
+  describe('appendMidiNotesToClip (pure function)', () => {
+    it('appends notes to existing midiData', () => {
+      const proj = makeProject('clip-1', [makeNote()]);
+      const result = appendMidiNotesToClip(proj, 'clip-1', [makeNote({ id: 'note-2', pitch: 64 })]);
+      expect(result.tracks[0].clips[0].midiData!.notes).toHaveLength(2);
+    });
+
+    it('creates midiData if missing', () => {
+      const proj = makeProject('clip-1');
+      // Remove midiData
+      proj.tracks[0].clips[0].midiData = undefined as never;
+      const result = appendMidiNotesToClip(proj, 'clip-1', [makeNote()]);
+      expect(result.tracks[0].clips[0].midiData!.notes).toHaveLength(1);
+    });
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist, type PersistStorage, type StorageValue } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
+import { createMidiSlice, appendMidiNotesToClip, type MidiSliceActions } from './slices/midiSlice';
 import { type TrackHeightPreset, getTrackHeightForPreset } from '../constants/trackHeight';
 import type {
   BounceInPlaceOptions,
@@ -460,26 +461,8 @@ function _pushHistory(project: Project | null, options: HistoryOptions = {}) {
   _future[entry.scope][key] = [];
 }
 
-function _appendMidiNotesToClip(project: Project, clipId: string, newNotes: MidiNote[]): Project {
-  return {
-    ...project,
-    updatedAt: Date.now(),
-    tracks: project.tracks.map((track) => ({
-      ...track,
-      clips: track.clips.map((clip) =>
-        clip.id === clipId
-          ? {
-              ...clip,
-              midiData: {
-                notes: [...(clip.midiData?.notes ?? []), ...newNotes],
-                grid: clip.midiData?.grid ?? '1/16',
-              },
-            }
-          : clip,
-      ),
-    })),
-  };
-}
+/** @deprecated Use appendMidiNotesToClip from slices/midiSlice instead */
+const _appendMidiNotesToClip = appendMidiNotesToClip;
 
 /** Call before starting a drag/continuous operation. Captures undo snapshot once. */
 function _beginDrag(project: Project | null, options: HistoryOptions = {}) {
@@ -563,7 +546,7 @@ function _applyHistorySnapshot(current: Project | null, snapshot: Project, entry
   }
 }
 
-export interface ProjectState {
+export interface ProjectState extends MidiSliceActions {
   project: Project | null;
 
   setProject: (project: Project) => void;
@@ -778,22 +761,8 @@ export interface ProjectState {
   setDrumPadPan: (trackId: string, padIndex: number, pan: number) => void;
   renameDrumPad: (trackId: string, padIndex: number, name: string) => void;
   setDrumMachineKit: (trackId: string, kit: DrumKitName) => void;
-  addMidiNote: (clipId: string, note: Omit<MidiNote, 'id'> & { id?: string }) => string | undefined;
-  updateMidiNote: (clipId: string, noteId: string, updates: Partial<MidiNote>) => void;
-  resizeMidiNote: (clipId: string, noteId: string, input: {
-    edge: 'left' | 'right';
-    startBeat?: number;
-    endBeat?: number;
-    minDurationBeats?: number;
-  }) => void;
-  removeMidiNote: (clipId: string, noteId: string) => void;
-  /** Set a single note's velocity, clamped to 1–127. */
-  setNoteVelocity: (clipId: string, noteId: string, velocity: number) => void;
-  quantizeMidiNotes: (clipId: string, noteIds: string[], gridBeatsOrOptions: number | QuantizeOptions) => void;
-  stampChord: (clipId: string, rootPitch: number, intervals: number[], startBeat: number, durationBeats: number, velocity?: number) => string[];
-  populateMidiPattern: (clipId: string, options: PatternOptions) => string[];
-  setMidiGrid: (clipId: string, grid: PianoRollGrid) => void;
-  transformMidiNotes: (clipId: string, noteIds: string[], transform: TransformOptions) => void;
+  // MIDI actions: inherited from MidiSliceActions via extends
+
   addTrackEffect: (trackId: string, type: TrackEffectType) => string | undefined;
   updateTrackEffect: (trackId: string, effectId: string, updates: Partial<TrackEffect>) => void;
   removeTrackEffect: (trackId: string, effectId: string) => void;
@@ -6368,294 +6337,11 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
-  addMidiNote: (clipId, note) => {
-    const state = get();
-    if (_isViewerMode()) return undefined;
-    if (!state.project) return undefined;
-    const noteId = note.id ?? uuidv4();
-    const noteWithId: MidiNote = { ...note, id: noteId };
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Add MIDI note', clipId });
-    set({ project: _appendMidiNotesToClip(state.project, clipId, [noteWithId]) });
-    return noteId;
-  },
-
-  updateMidiNote: (clipId, noteId, updates) => {
-    const state = get();
-    if (_isViewerMode()) return;
-    if (!state.project) return;
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Edit MIDI note', clipId });
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        tracks: state.project.tracks.map((track) => ({
-          ...track,
-          clips: track.clips.map((clip) =>
-            clip.id === clipId && clip.midiData
-              ? {
-                  ...clip,
-                  midiData: {
-                    ...clip.midiData,
-                    notes: clip.midiData.notes.map((note) =>
-                      note.id === noteId ? { ...note, ...updates } : note,
-                    ),
-                  },
-                }
-              : clip,
-          ),
-        })),
-      },
-    });
-  },
-
-  resizeMidiNote: (clipId, noteId, input) => {
-    const state = get();
-    if (_isViewerMode()) return;
-    if (!state.project) return;
-    const minDurationBeats = Math.max(0.001, input.minDurationBeats ?? 0.125);
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Resize MIDI note', clipId });
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        tracks: state.project.tracks.map((track) => ({
-          ...track,
-          clips: track.clips.map((clip) => {
-            if (clip.id !== clipId || !clip.midiData) {
-              return clip;
-            }
-
-            return {
-              ...clip,
-              midiData: {
-                ...clip.midiData,
-                notes: clip.midiData.notes.map((note) => {
-                  if (note.id !== noteId) {
-                    return note;
-                  }
-
-                  const originalEndBeat = note.startBeat + note.durationBeats;
-                  if (input.edge === 'left') {
-                    const requestedStartBeat = Math.max(0, input.startBeat ?? note.startBeat);
-                    const nextStartBeat = Math.min(requestedStartBeat, originalEndBeat - minDurationBeats);
-                    return {
-                      ...note,
-                      startBeat: nextStartBeat,
-                      durationBeats: Math.max(minDurationBeats, originalEndBeat - nextStartBeat),
-                    };
-                  }
-
-                  const requestedEndBeat = input.endBeat ?? originalEndBeat;
-                  return {
-                    ...note,
-                    durationBeats: Math.max(minDurationBeats, requestedEndBeat - note.startBeat),
-                  };
-                }),
-              },
-            };
-          }),
-        })),
-      },
-    });
-  },
-
-  removeMidiNote: (clipId, noteId) => {
-    const state = get();
-    if (_isViewerMode()) return;
-    if (!state.project) return;
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Delete MIDI note', clipId });
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        tracks: state.project.tracks.map((track) => ({
-          ...track,
-          clips: track.clips.map((clip) =>
-            clip.id === clipId && clip.midiData
-              ? {
-                  ...clip,
-                  midiData: {
-                    ...clip.midiData,
-                    notes: clip.midiData.notes.filter((note) => note.id !== noteId),
-                  },
-                }
-              : clip,
-          ),
-        })),
-      },
-    });
-  },
-
-  setNoteVelocity: (clipId, noteId, velocity) => {
-    const state = get();
-    if (_isViewerMode()) return;
-    if (!state.project) return;
-    const clampedVelocity = Math.round(Math.max(1, Math.min(127, velocity)));
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Set note velocity', clipId });
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        tracks: state.project.tracks.map((track) => ({
-          ...track,
-          clips: track.clips.map((clip) =>
-            clip.id === clipId && clip.midiData
-              ? {
-                  ...clip,
-                  midiData: {
-                    ...clip.midiData,
-                    notes: clip.midiData.notes.map((note) =>
-                      note.id === noteId ? { ...note, velocity: clampedVelocity } : note,
-                    ),
-                  },
-                }
-              : clip,
-          ),
-        })),
-      },
-    });
-  },
-
-  quantizeMidiNotes: (clipId, noteIds, gridBeatsOrOptions) => {
-    const state = get();
-    const options: QuantizeOptions =
-      typeof gridBeatsOrOptions === 'number'
-        ? { gridBeats: gridBeatsOrOptions, strength: 100, swing: 0, scope: 'start' }
-        : gridBeatsOrOptions;
-    if (!state.project || options.gridBeats <= 0) return;
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Quantize MIDI notes', clipId });
-    const noteIdSet = new Set(noteIds);
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        tracks: state.project.tracks.map((track) => ({
-          ...track,
-          clips: track.clips.map((clip) =>
-            clip.id === clipId && clip.midiData
-              ? {
-                  ...clip,
-                  midiData: {
-                    ...clip.midiData,
-                    notes: applyQuantize(clip.midiData.notes, noteIdSet, options),
-                  },
-                }
-              : clip,
-          ),
-        })),
-      },
-    });
-  },
-
-  stampChord: (clipId, rootPitch, intervals, startBeat, durationBeats, velocity = 100) => {
-    const state = get();
-    if (_isViewerMode()) return [];
-    if (!state.project) return [];
-    const newNotes: MidiNote[] = intervals
-      .map((interval) => rootPitch + interval)
-      .filter((pitch) => pitch >= 0 && pitch <= 127)
-      .map((pitch) => ({
-        id: crypto.randomUUID(),
-        pitch,
-        startBeat,
-        durationBeats,
-        velocity,
-      }));
-
-    if (newNotes.length === 0) return [];
-
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Stamp chord', clipId });
-    set({ project: _appendMidiNotesToClip(state.project, clipId, newNotes) });
-    return newNotes.map((note) => note.id);
-  },
-
-  populateMidiPattern: (clipId, options) => {
-    const state = get();
-    if (!state.project) return [];
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Generate MIDI pattern', clipId });
-
-    const generated = generatePattern(options);
-    const noteIds: string[] = [];
-    const newNotes: MidiNote[] = generated.map((g) => {
-      const id = crypto.randomUUID();
-      noteIds.push(id);
-      return { id, ...g };
-    });
-
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        tracks: state.project.tracks.map((track) => ({
-          ...track,
-          clips: track.clips.map((clip) =>
-            clip.id === clipId && clip.midiData
-              ? {
-                  ...clip,
-                  midiData: {
-                    ...clip.midiData,
-                    notes: newNotes, // Replace all notes with generated pattern
-                  },
-                }
-              : clip,
-          ),
-        })),
-      },
-    });
-    return noteIds;
-  },
-
-  setMidiGrid: (clipId, grid) => {
-    const state = get();
-    if (!state.project) return;
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Set MIDI grid', clipId });
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        tracks: state.project.tracks.map((track) => ({
-          ...track,
-          clips: track.clips.map((clip) =>
-            clip.id === clipId
-              ? {
-                  ...clip,
-                  midiData: {
-                    notes: clip.midiData?.notes ?? [],
-                    grid,
-                  },
-                }
-              : clip,
-          ),
-        })),
-      },
-    });
-  },
-
-  transformMidiNotes: (clipId, noteIds, transform) => {
-    const state = get();
-    if (!state.project) return;
-    _pushHistory(state.project, { scope: 'pianoRoll', label: 'Transform MIDI notes', clipId });
-    const noteIdSet = new Set(noteIds);
-    set({
-      project: {
-        ...state.project,
-        updatedAt: Date.now(),
-        tracks: state.project.tracks.map((track) => ({
-          ...track,
-          clips: track.clips.map((clip) => {
-            if (clip.id !== clipId || !clip.midiData) return clip;
-            const selected = clip.midiData.notes.filter((n) => noteIdSet.has(n.id));
-            const unselected = clip.midiData.notes.filter((n) => !noteIdSet.has(n.id));
-            const transformed = applyTransform(selected, transform);
-            return {
-              ...clip,
-              midiData: { ...clip.midiData, notes: [...unselected, ...transformed] },
-            };
-          }),
-        })),
-      },
-    });
-  },
+  // ── MIDI actions (delegated to midiSlice) ──
+  ...createMidiSlice(set, get, {
+    isViewerMode: _isViewerMode,
+    pushHistory: _pushHistory,
+  }),
 
   addTrackEffect: (trackId, type) => {
     const state = get();

--- a/src/store/slices/midiSlice.ts
+++ b/src/store/slices/midiSlice.ts
@@ -1,0 +1,308 @@
+/**
+ * MIDI note operations slice for projectStore.
+ *
+ * Extracted from projectStore.ts to reduce file size and improve testability.
+ * This slice handles: addMidiNote, updateMidiNote, resizeMidiNote, removeMidiNote,
+ * setNoteVelocity, quantizeMidiNotes, stampChord, populateMidiPattern, setMidiGrid,
+ * transformMidiNotes.
+ */
+import { v4 as uuidv4 } from 'uuid';
+import type { MidiNote, PianoRollGrid, Project } from '../../types/project';
+import { quantizeNotes as applyQuantize, type QuantizeOptions } from '../../utils/midiQuantize';
+import { applyTransform, type TransformOptions } from '../../utils/midiTransforms';
+import { generatePattern, type PatternOptions } from '../../utils/midiPatternGenerator';
+
+/** History scope for undo/redo bucketing (mirrors projectStore's HistoryScope). */
+type HistoryScope = 'arrangement' | 'track' | 'pianoRoll' | 'mixer';
+
+/** History options accepted by the shared pushHistory helper. */
+interface HistoryOptions {
+  trackId?: string;
+  clipId?: string;
+  scope?: HistoryScope;
+  label?: string;
+}
+
+// Shared helpers injected from projectStore
+export interface MidiSliceDeps {
+  isViewerMode: () => boolean;
+  pushHistory: (project: Project | null, options?: HistoryOptions) => void;
+}
+
+// Zustand set/get functions
+type SetFn = (partial: { project: Project | null }) => void;
+type GetFn = () => { project: Project | null };
+
+/** Append notes to a clip's midiData (pure function). */
+export function appendMidiNotesToClip(project: Project, clipId: string, newNotes: MidiNote[]): Project {
+  return {
+    ...project,
+    updatedAt: Date.now(),
+    tracks: project.tracks.map((track) => ({
+      ...track,
+      clips: track.clips.map((clip) =>
+        clip.id === clipId
+          ? {
+              ...clip,
+              midiData: {
+                notes: [...(clip.midiData?.notes ?? []), ...newNotes],
+                grid: clip.midiData?.grid ?? '1/16',
+              },
+            }
+          : clip,
+      ),
+    })),
+  };
+}
+
+/** Update a clip's midiData notes immutably (pure function). */
+function updateClipMidiNotes(
+  project: Project,
+  clipId: string,
+  updater: (notes: MidiNote[]) => MidiNote[],
+): Project {
+  return {
+    ...project,
+    updatedAt: Date.now(),
+    tracks: project.tracks.map((track) => ({
+      ...track,
+      clips: track.clips.map((clip) =>
+        clip.id === clipId && clip.midiData
+          ? {
+              ...clip,
+              midiData: {
+                ...clip.midiData,
+                notes: updater(clip.midiData.notes),
+              },
+            }
+          : clip,
+      ),
+    })),
+  };
+}
+
+export interface MidiSliceActions {
+  addMidiNote: (clipId: string, note: Omit<MidiNote, 'id'> & { id?: string }) => string | undefined;
+  updateMidiNote: (clipId: string, noteId: string, updates: Partial<MidiNote>) => void;
+  resizeMidiNote: (clipId: string, noteId: string, input: {
+    edge: 'left' | 'right';
+    startBeat?: number;
+    endBeat?: number;
+    minDurationBeats?: number;
+  }) => void;
+  removeMidiNote: (clipId: string, noteId: string) => void;
+  setNoteVelocity: (clipId: string, noteId: string, velocity: number) => void;
+  quantizeMidiNotes: (clipId: string, noteIds: string[], gridBeatsOrOptions: number | QuantizeOptions) => void;
+  stampChord: (clipId: string, rootPitch: number, intervals: number[], startBeat: number, durationBeats: number, velocity?: number) => string[];
+  populateMidiPattern: (clipId: string, options: PatternOptions) => string[];
+  setMidiGrid: (clipId: string, grid: PianoRollGrid) => void;
+  transformMidiNotes: (clipId: string, noteIds: string[], transform: TransformOptions) => void;
+}
+
+export function createMidiSlice(
+  set: SetFn,
+  get: GetFn,
+  deps: MidiSliceDeps,
+): MidiSliceActions {
+  return {
+    addMidiNote: (clipId, note) => {
+      const state = get();
+      if (deps.isViewerMode()) return undefined;
+      if (!state.project) return undefined;
+      const noteId = note.id ?? uuidv4();
+      const noteWithId: MidiNote = { ...note, id: noteId };
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Add MIDI note', clipId });
+      set({ project: appendMidiNotesToClip(state.project, clipId, [noteWithId]) });
+      return noteId;
+    },
+
+    updateMidiNote: (clipId, noteId, updates) => {
+      const state = get();
+      if (deps.isViewerMode()) return;
+      if (!state.project) return;
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Edit MIDI note', clipId });
+      set({
+        project: updateClipMidiNotes(state.project, clipId, (notes) =>
+          notes.map((note) => (note.id === noteId ? { ...note, ...updates } : note)),
+        ),
+      });
+    },
+
+    resizeMidiNote: (clipId, noteId, input) => {
+      const state = get();
+      if (deps.isViewerMode()) return;
+      if (!state.project) return;
+      const minDurationBeats = Math.max(0.001, input.minDurationBeats ?? 0.125);
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Resize MIDI note', clipId });
+      set({
+        project: updateClipMidiNotes(state.project, clipId, (notes) =>
+          notes.map((note) => {
+            if (note.id !== noteId) return note;
+            const originalEndBeat = note.startBeat + note.durationBeats;
+            if (input.edge === 'left') {
+              const requestedStartBeat = Math.max(0, input.startBeat ?? note.startBeat);
+              const nextStartBeat = Math.min(requestedStartBeat, originalEndBeat - minDurationBeats);
+              return {
+                ...note,
+                startBeat: nextStartBeat,
+                durationBeats: Math.max(minDurationBeats, originalEndBeat - nextStartBeat),
+              };
+            }
+            const requestedEndBeat = input.endBeat ?? originalEndBeat;
+            return {
+              ...note,
+              durationBeats: Math.max(minDurationBeats, requestedEndBeat - note.startBeat),
+            };
+          }),
+        ),
+      });
+    },
+
+    removeMidiNote: (clipId, noteId) => {
+      const state = get();
+      if (deps.isViewerMode()) return;
+      if (!state.project) return;
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Delete MIDI note', clipId });
+      set({
+        project: updateClipMidiNotes(state.project, clipId, (notes) =>
+          notes.filter((note) => note.id !== noteId),
+        ),
+      });
+    },
+
+    setNoteVelocity: (clipId, noteId, velocity) => {
+      const state = get();
+      if (deps.isViewerMode()) return;
+      if (!state.project) return;
+      const clampedVelocity = Math.round(Math.max(1, Math.min(127, velocity)));
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Set note velocity', clipId });
+      set({
+        project: updateClipMidiNotes(state.project, clipId, (notes) =>
+          notes.map((note) => (note.id === noteId ? { ...note, velocity: clampedVelocity } : note)),
+        ),
+      });
+    },
+
+    quantizeMidiNotes: (clipId, noteIds, gridBeatsOrOptions) => {
+      const state = get();
+      const options: QuantizeOptions =
+        typeof gridBeatsOrOptions === 'number'
+          ? { gridBeats: gridBeatsOrOptions, strength: 100, swing: 0, scope: 'start' }
+          : gridBeatsOrOptions;
+      if (!state.project || options.gridBeats <= 0) return;
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Quantize MIDI notes', clipId });
+      const noteIdSet = new Set(noteIds);
+      set({
+        project: updateClipMidiNotes(state.project, clipId, (notes) =>
+          applyQuantize(notes, noteIdSet, options),
+        ),
+      });
+    },
+
+    stampChord: (clipId, rootPitch, intervals, startBeat, durationBeats, velocity = 100) => {
+      const state = get();
+      if (deps.isViewerMode()) return [];
+      if (!state.project) return [];
+      const newNotes: MidiNote[] = intervals
+        .map((interval) => rootPitch + interval)
+        .filter((pitch) => pitch >= 0 && pitch <= 127)
+        .map((pitch) => ({
+          id: crypto.randomUUID(),
+          pitch,
+          startBeat,
+          durationBeats,
+          velocity,
+        }));
+      if (newNotes.length === 0) return [];
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Stamp chord', clipId });
+      set({ project: appendMidiNotesToClip(state.project, clipId, newNotes) });
+      return newNotes.map((note) => note.id);
+    },
+
+    populateMidiPattern: (clipId, options) => {
+      const state = get();
+      if (!state.project) return [];
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Generate MIDI pattern', clipId });
+      const generated = generatePattern(options);
+      const noteIds: string[] = [];
+      const newNotes: MidiNote[] = generated.map((g) => {
+        const id = crypto.randomUUID();
+        noteIds.push(id);
+        return { id, ...g };
+      });
+      set({
+        project: {
+          ...state.project,
+          updatedAt: Date.now(),
+          tracks: state.project.tracks.map((track) => ({
+            ...track,
+            clips: track.clips.map((clip) =>
+              clip.id === clipId && clip.midiData
+                ? {
+                    ...clip,
+                    midiData: {
+                      ...clip.midiData,
+                      notes: newNotes,
+                    },
+                  }
+                : clip,
+            ),
+          })),
+        },
+      });
+      return noteIds;
+    },
+
+    setMidiGrid: (clipId, grid) => {
+      const state = get();
+      if (!state.project) return;
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Set MIDI grid', clipId });
+      set({
+        project: {
+          ...state.project,
+          updatedAt: Date.now(),
+          tracks: state.project.tracks.map((track) => ({
+            ...track,
+            clips: track.clips.map((clip) =>
+              clip.id === clipId
+                ? {
+                    ...clip,
+                    midiData: {
+                      notes: clip.midiData?.notes ?? [],
+                      grid,
+                    },
+                  }
+                : clip,
+            ),
+          })),
+        },
+      });
+    },
+
+    transformMidiNotes: (clipId, noteIds, transform) => {
+      const state = get();
+      if (!state.project) return;
+      deps.pushHistory(state.project, { scope: 'pianoRoll', label: 'Transform MIDI notes', clipId });
+      const noteIdSet = new Set(noteIds);
+      set({
+        project: {
+          ...state.project,
+          updatedAt: Date.now(),
+          tracks: state.project.tracks.map((track) => ({
+            ...track,
+            clips: track.clips.map((clip) => {
+              if (clip.id !== clipId || !clip.midiData) return clip;
+              const selected = clip.midiData.notes.filter((n) => noteIdSet.has(n.id));
+              const unselected = clip.midiData.notes.filter((n) => !noteIdSet.has(n.id));
+              const transformed = applyTransform(selected, transform);
+              return {
+                ...clip,
+                midiData: { ...clip.midiData, notes: [...unselected, ...transformed] },
+              };
+            }),
+          })),
+        },
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Establishes **slice pattern** for projectStore decomposition
- Extracts all 10 MIDI note operations into `src/store/slices/midiSlice.ts`
- Adds `appendMidiNotesToClip` and `updateClipMidiNotes` as reusable pure helpers
- Reduces projectStore.ts from 8461 → 8147 lines (314 lines extracted)
- MidiSliceActions interface composable via `extends` on ProjectState
- Backward-compatible: `window.__store` API unchanged

## Pattern for future slices
```typescript
// 1. Define slice actions interface
export interface FooSliceActions { ... }

// 2. Create slice factory with deps injection
export function createFooSlice(set, get, deps): FooSliceActions { ... }

// 3. Spread into store: ...createFooSlice(set, get, { isViewerMode, pushHistory })
// 4. Extend ProjectState: interface ProjectState extends FooSliceActions { ... }
```

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 2987 tests pass (15 new for midiSlice)
- [x] `npm run build` — succeeds
- [x] All existing MIDI tests pass through the same store API

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)