### PR TITLE
feat: add audio slice mode for loop/beat slicing

### DIFF
--- a/src/components/timeline/SliceMarkers.tsx
+++ b/src/components/timeline/SliceMarkers.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback } from 'react';
+
+interface SliceMarkersProps {
+  /** Clip id for data attributes and event handling. */
+  clipId: string;
+  /** Width of the clip in pixels. */
+  width: number;
+  /** Clip duration in seconds. */
+  clipDuration: number;
+  /** Array of slice point positions in seconds (relative to clip start). */
+  slicePoints: number[];
+  /** Called when the user clicks to add a marker at a time position (seconds). */
+  onAddSlice: (timeSeconds: number) => void;
+  /** Called when the user clicks an existing marker to remove it. */
+  onRemoveSlice: (index: number) => void;
+}
+
+/**
+ * Overlay that draws vertical slice markers on a clip waveform.
+ * Clicking on a blank area adds a new slice; clicking an existing marker removes it.
+ */
+export const SliceMarkers = React.memo(function SliceMarkers({
+  clipId,
+  width,
+  clipDuration,
+  slicePoints,
+  onAddSlice,
+  onRemoveSlice,
+}: SliceMarkersProps) {
+  const handleBackgroundClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      // Only handle direct clicks on the background, not on markers
+      if ((e.target as HTMLElement).dataset.sliceMarker) return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const fraction = x / width;
+      const timeSec = fraction * clipDuration;
+      onAddSlice(timeSec);
+    },
+    [width, clipDuration, onAddSlice],
+  );
+
+  if (width <= 0 || clipDuration <= 0) return null;
+
+  return (
+    <div
+      className="absolute inset-0 z-20"
+      style={{ cursor: 'crosshair' }}
+      onClick={handleBackgroundClick}
+      data-testid={`slice-markers-${clipId}`}
+    >
+      {slicePoints.map((timeSec, idx) => {
+        const xPos = (timeSec / clipDuration) * width;
+        return (
+          <div
+            key={idx}
+            data-slice-marker="true"
+            data-testid={`slice-marker-${idx}`}
+            className="absolute top-0 bottom-0"
+            style={{
+              left: xPos - 1,
+              width: 3,
+              backgroundColor: 'rgba(255, 90, 60, 0.85)',
+              cursor: 'pointer',
+            }}
+            title={`Slice at ${timeSec.toFixed(3)}s — click to remove`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemoveSlice(idx);
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+});

--- a/src/components/timeline/__tests__/SliceMarkers.test.tsx
+++ b/src/components/timeline/__tests__/SliceMarkers.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SliceMarkers } from '../SliceMarkers';
+
+describe('SliceMarkers', () => {
+  const defaultProps = {
+    clipId: 'clip-1',
+    width: 400,
+    clipDuration: 4,
+    slicePoints: [1.0, 2.0, 3.0],
+    onAddSlice: vi.fn(),
+    onRemoveSlice: vi.fn(),
+  };
+
+  it('renders a marker for each slice point', () => {
+    render(<SliceMarkers {...defaultProps} />);
+    expect(screen.getByTestId('slice-marker-0')).toBeInTheDocument();
+    expect(screen.getByTestId('slice-marker-1')).toBeInTheDocument();
+    expect(screen.getByTestId('slice-marker-2')).toBeInTheDocument();
+  });
+
+  it('positions markers proportionally within the clip width', () => {
+    render(<SliceMarkers {...defaultProps} />);
+    const marker0 = screen.getByTestId('slice-marker-0');
+    // 1.0s / 4.0s = 0.25 of 400px = 100px, minus 1 for centering = 99px
+    expect(marker0.style.left).toBe('99px');
+  });
+
+  it('calls onRemoveSlice when a marker is clicked', () => {
+    const onRemoveSlice = vi.fn();
+    render(<SliceMarkers {...defaultProps} onRemoveSlice={onRemoveSlice} />);
+    fireEvent.click(screen.getByTestId('slice-marker-1'));
+    expect(onRemoveSlice).toHaveBeenCalledWith(1);
+  });
+
+  it('calls onAddSlice when background is clicked', () => {
+    const onAddSlice = vi.fn();
+    render(<SliceMarkers {...defaultProps} slicePoints={[]} onAddSlice={onAddSlice} />);
+    const container = screen.getByTestId('slice-markers-clip-1');
+    // Simulate clicking at x=200 of 400px wide = 2.0s of 4.0s
+    const rect = { left: 0, top: 0, width: 400, height: 60 };
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      value: () => rect,
+    });
+    fireEvent.click(container, { clientX: 200, clientY: 30 });
+    expect(onAddSlice).toHaveBeenCalledWith(2.0);
+  });
+
+  it('does not call onAddSlice when a marker is clicked', () => {
+    const onAddSlice = vi.fn();
+    render(<SliceMarkers {...defaultProps} onAddSlice={onAddSlice} />);
+    fireEvent.click(screen.getByTestId('slice-marker-0'));
+    expect(onAddSlice).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing when width is 0', () => {
+    const { container } = render(<SliceMarkers {...defaultProps} width={0} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when clipDuration is 0', () => {
+    const { container } = render(<SliceMarkers {...defaultProps} clipDuration={0} />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/src/store/__tests__/sliceClipToMidi.test.ts
+++ b/src/store/__tests__/sliceClipToMidi.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('sliceClipToMidi', () => {
+  let clipId: string;
+  let trackId: string;
+
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('sample');
+    trackId = track.id;
+    const clip = useProjectStore.getState().addClip(trackId, {
+      startTime: 0,
+      duration: 4,
+      prompt: '',
+      lyrics: '',
+      audioDuration: 4,
+      audioOffset: 0,
+      sampleMode: true,
+    });
+    clipId = clip.id;
+    useProjectStore.getState().updateClip(clipId, {
+      generationStatus: 'ready',
+      isolatedAudioKey: 'sample-audio-key',
+      waveformPeaks: [0.1, 0.2, 0.3, 0.4],
+    });
+  });
+
+  it('creates MIDI notes from slice points', () => {
+    // Slice points at sample positions (assuming 44100 sample rate, 4s duration)
+    // Convert to seconds: 0.5s, 1.5s, 3.0s
+    const slicePoints = [22050, 66150, 132300];
+    useProjectStore.getState().sliceClipToMidi(clipId, slicePoints, 44100);
+
+    const clip = useProjectStore
+      .getState()
+      .project!.tracks.find((t) => t.id === trackId)!
+      .clips.find((c) => c.id === clipId)!;
+
+    expect(clip.midiData).toBeDefined();
+    // 4 slices: [0, 0.5), [0.5, 1.5), [1.5, 3.0), [3.0, 4.0)
+    expect(clip.midiData!.notes).toHaveLength(4);
+  });
+
+  it('creates first slice from time 0 to first slice point', () => {
+    const slicePoints = [22050]; // 0.5s at 44100 Hz
+    useProjectStore.getState().sliceClipToMidi(clipId, slicePoints, 44100);
+
+    const clip = useProjectStore
+      .getState()
+      .project!.tracks.find((t) => t.id === trackId)!
+      .clips.find((c) => c.id === clipId)!;
+
+    const notes = clip.midiData!.notes;
+    expect(notes).toHaveLength(2);
+    // First note starts at beat 0
+    expect(notes[0].startBeat).toBe(0);
+    // Duration should reflect the time up to the first slice point
+    expect(notes[0].durationBeats).toBeGreaterThan(0);
+  });
+
+  it('assigns ascending MIDI pitches starting from C3 (48)', () => {
+    const slicePoints = [22050, 44100];
+    useProjectStore.getState().sliceClipToMidi(clipId, slicePoints, 44100);
+
+    const clip = useProjectStore
+      .getState()
+      .project!.tracks.find((t) => t.id === trackId)!
+      .clips.find((c) => c.id === clipId)!;
+
+    const notes = clip.midiData!.notes;
+    expect(notes[0].pitch).toBe(48); // C3
+    expect(notes[1].pitch).toBe(49); // C#3
+    expect(notes[2].pitch).toBe(50); // D3
+  });
+
+  it('sets velocity to 0.8 for all slice notes', () => {
+    const slicePoints = [22050];
+    useProjectStore.getState().sliceClipToMidi(clipId, slicePoints, 44100);
+
+    const clip = useProjectStore
+      .getState()
+      .project!.tracks.find((t) => t.id === trackId)!
+      .clips.find((c) => c.id === clipId)!;
+
+    for (const note of clip.midiData!.notes) {
+      expect(note.velocity).toBe(0.8);
+    }
+  });
+
+  it('handles empty slice points — creates single note spanning entire clip', () => {
+    useProjectStore.getState().sliceClipToMidi(clipId, [], 44100);
+
+    const clip = useProjectStore
+      .getState()
+      .project!.tracks.find((t) => t.id === trackId)!
+      .clips.find((c) => c.id === clipId)!;
+
+    expect(clip.midiData).toBeDefined();
+    expect(clip.midiData!.notes).toHaveLength(1);
+    expect(clip.midiData!.notes[0].startBeat).toBe(0);
+  });
+
+  it('does nothing for non-existent clip', () => {
+    // Should not throw
+    useProjectStore.getState().sliceClipToMidi('non-existent', [22050], 44100);
+    // State should be unchanged
+    const clip = useProjectStore
+      .getState()
+      .project!.tracks.find((t) => t.id === trackId)!
+      .clips.find((c) => c.id === clipId)!;
+
+    expect(clip.midiData).toBeUndefined();
+  });
+
+  it('each note has a unique id', () => {
+    const slicePoints = [22050, 44100, 66150];
+    useProjectStore.getState().sliceClipToMidi(clipId, slicePoints, 44100);
+
+    const clip = useProjectStore
+      .getState()
+      .project!.tracks.find((t) => t.id === trackId)!
+      .clips.find((c) => c.id === clipId)!;
+
+    const ids = clip.midiData!.notes.map((n) => n.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -688,6 +688,8 @@ export interface ProjectState {
   /** Slip-edit: shift audioOffset by deltaSeconds without changing startTime/duration. */
   slipClip: (clipId: string, deltaSeconds: number) => void;
   sliceClipToRange: (clipId: string, startTime: number, endTime: number) => Promise<string | null>;
+  /** Convert a sample clip into MIDI-triggered slices based on detected transient positions. */
+  sliceClipToMidi: (clipId: string, slicePoints: number[], sampleRate: number) => void;
   splitClip: (clipId: string, splitTime: number) => void;
   splitClipAtZeroCrossing: (clipId: string, splitTime: number) => Promise<void>;
   snapClipEdgeToZeroCrossing: (clipId: string, edge: 'left' | 'right') => Promise<void>;
@@ -4022,6 +4024,71 @@ export const useProjectStore = create<ProjectState>()(
     });
 
     return clipId;
+  },
+
+  sliceClipToMidi: (clipId, slicePoints, sampleRate) => {
+    const state = get();
+    if (!state.project) return;
+
+    const targetClip = state.getClipById(clipId);
+    const track = state.getTrackForClip(clipId);
+    if (!targetClip || !track) return;
+    const trackId = track.id;
+
+    const clipDurationSeconds = targetClip.duration;
+    const bpm = state.project.bpm;
+    const beatsPerSecond = bpm / 60;
+
+    // Build time boundaries from slice points (in seconds)
+    const boundaries: number[] = [0];
+    for (const sp of slicePoints) {
+      const timeSec = sp / sampleRate;
+      if (timeSec > 0 && timeSec < clipDurationSeconds) {
+        boundaries.push(timeSec);
+      }
+    }
+    boundaries.push(clipDurationSeconds);
+
+    // Create MIDI notes — one per slice region, ascending pitch from C3 (48)
+    const notes: import('../types/project').MidiNote[] = [];
+    for (let i = 0; i < boundaries.length - 1; i++) {
+      const startSec = boundaries[i];
+      const endSec = boundaries[i + 1];
+      const startBeat = startSec * beatsPerSecond;
+      const durationBeats = (endSec - startSec) * beatsPerSecond;
+      if (durationBeats <= 0) continue;
+      notes.push({
+        id: uuidv4(),
+        pitch: 48 + i, // C3 and up
+        startBeat,
+        durationBeats,
+        velocity: 0.8,
+      });
+    }
+
+    // Update the clip with MIDI data
+    set((s) => {
+      if (!s.project) return s;
+      const newTracks = s.project.tracks.map((track) => {
+        if (track.id !== trackId) return track;
+        return {
+          ...track,
+          clips: track.clips.map((clip) => {
+            if (clip.id !== clipId) return clip;
+            return {
+              ...clip,
+              midiData: {
+                notes,
+                grid: '1/16' as const,
+              },
+            };
+          }),
+        };
+      });
+      return { project: { ...s.project, tracks: newTracks } };
+    });
+
+    _pushHistory(get().project, { scope: 'arrangement', label: 'Slice clip to MIDI', trackId });
   },
 
   splitClip: (clipId, splitTime) => {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -216,6 +216,12 @@ export interface UIState {
   aiAssistantError: string | null;
   workspaceComplexity: 'simple' | 'standard' | 'advanced';
 
+  // Audio Slice Mode
+  /** Clip ID currently in slice editing mode (null = inactive). */
+  sliceModeClipId: string | null;
+  /** Slice marker positions in seconds relative to clip start, keyed by clip ID. */
+  sliceMarkersByClip: Record<string, number[]>;
+
   // Theme
   theme: ThemeId;
 
@@ -418,6 +424,18 @@ export interface UIState {
   clearInlineSuggestions: () => void;
   setSuggestionFrequency: (v: 'off' | 'subtle' | 'active') => void;
   applyWorkspaceComplexity: (tier: 'simple' | 'standard' | 'advanced') => void;
+
+  // Audio Slice Mode actions
+  /** Enter slice mode for a clip (shows slice markers on waveform). */
+  enterSliceMode: (clipId: string) => void;
+  /** Exit slice mode. */
+  exitSliceMode: () => void;
+  /** Add a slice marker at a time position (seconds) for the current slice-mode clip. */
+  addSliceMarker: (clipId: string, timeSec: number) => void;
+  /** Remove a slice marker by index for a clip. */
+  removeSliceMarker: (clipId: string, index: number) => void;
+  /** Set all slice markers for a clip (e.g. from auto-detect). */
+  setSliceMarkers: (clipId: string, markers: number[]) => void;
 
   // Session view keyboard navigation
   setSelectedSessionSlot: (slot: { trackId: string; sceneIndex: number } | null) => void;
@@ -636,6 +654,9 @@ export const useUIStore = create<UIState>()(
   aiAssistantSuggestions: [],
   aiAssistantError: null,
   workspaceComplexity: 'standard',
+
+  sliceModeClipId: null,
+  sliceMarkersByClip: {},
 
   theme: 'ableton',
 
@@ -1229,6 +1250,25 @@ export const useUIStore = create<UIState>()(
   clearInlineSuggestions: () => set({ inlineSuggestions: [] }),
   setSuggestionFrequency: (v) => set({ suggestionFrequency: v }),
   applyWorkspaceComplexity: (tier) => set(getComplexityDefaults(tier)),
+
+  enterSliceMode: (clipId) => set({ sliceModeClipId: clipId }),
+  exitSliceMode: () => set({ sliceModeClipId: null }),
+  addSliceMarker: (clipId, timeSec) =>
+    set((s) => {
+      const existing = s.sliceMarkersByClip[clipId] ?? [];
+      const updated = [...existing, timeSec].sort((a, b) => a - b);
+      return { sliceMarkersByClip: { ...s.sliceMarkersByClip, [clipId]: updated } };
+    }),
+  removeSliceMarker: (clipId, index) =>
+    set((s) => {
+      const existing = s.sliceMarkersByClip[clipId] ?? [];
+      const updated = existing.filter((_, i) => i !== index);
+      return { sliceMarkersByClip: { ...s.sliceMarkersByClip, [clipId]: updated } };
+    }),
+  setSliceMarkers: (clipId, markers) =>
+    set((s) => ({
+      sliceMarkersByClip: { ...s.sliceMarkersByClip, [clipId]: [...markers].sort((a, b) => a - b) },
+    })),
 
   setSelectedSessionSlot: (slot) => set({ selectedSessionSlot: slot }),
   clearSelectedSessionSlot: () => set({ selectedSessionSlot: null }),

--- a/src/utils/__tests__/audioSlice.test.ts
+++ b/src/utils/__tests__/audioSlice.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { detectSlicePoints } from '../audioSlice';
+
+/** Helper to create a mock AudioBuffer with specific channel data. */
+function createMockAudioBuffer(
+  channelData: Float32Array,
+  sampleRate = 44100,
+): AudioBuffer {
+  return {
+    duration: channelData.length / sampleRate,
+    sampleRate,
+    length: channelData.length,
+    numberOfChannels: 1,
+    getChannelData: () => channelData,
+    copyFromChannel: () => {},
+    copyToChannel: () => {},
+  } as unknown as AudioBuffer;
+}
+
+describe('detectSlicePoints', () => {
+  it('returns empty array for silent buffer', () => {
+    const silence = new Float32Array(44100).fill(0);
+    const buffer = createMockAudioBuffer(silence);
+    const points = detectSlicePoints(buffer, 0.1, 1000);
+    expect(points).toEqual([]);
+  });
+
+  it('returns empty array for constant low-amplitude signal', () => {
+    const low = new Float32Array(44100).fill(0.01);
+    const buffer = createMockAudioBuffer(low);
+    const points = detectSlicePoints(buffer, 0.1, 1000);
+    expect(points).toEqual([]);
+  });
+
+  it('detects a single transient in the middle of a buffer', () => {
+    const data = new Float32Array(44100).fill(0);
+    // Place a transient spike at sample 22050 (0.5s)
+    for (let i = 22050; i < 22060; i++) {
+      data[i] = 0.8;
+    }
+    const buffer = createMockAudioBuffer(data);
+    const points = detectSlicePoints(buffer, 0.1, 1000);
+    expect(points.length).toBe(1);
+    expect(points[0]).toBeGreaterThanOrEqual(21500);
+    expect(points[0]).toBeLessThanOrEqual(22600);
+  });
+
+  it('detects multiple transients spaced apart', () => {
+    const data = new Float32Array(44100).fill(0);
+    // Three transient spikes at ~0.25s, ~0.5s, ~0.75s
+    const positions = [11025, 22050, 33075];
+    for (const pos of positions) {
+      for (let i = pos; i < pos + 20; i++) {
+        data[i] = 0.9;
+      }
+    }
+    const buffer = createMockAudioBuffer(data);
+    const points = detectSlicePoints(buffer, 0.1, 1000);
+    expect(points.length).toBe(3);
+    // Each detected point should be near the transient positions
+    for (let k = 0; k < 3; k++) {
+      expect(points[k]).toBeGreaterThanOrEqual(positions[k] - 512);
+      expect(points[k]).toBeLessThanOrEqual(positions[k] + 512);
+    }
+  });
+
+  it('respects minSliceLength and skips closely spaced transients', () => {
+    const data = new Float32Array(44100).fill(0);
+    // Two transients only 500 samples apart — below the min slice length of 2000
+    data[10000] = 0.8;
+    data[10500] = 0.8;
+    // Another transient far away
+    data[30000] = 0.8;
+    const buffer = createMockAudioBuffer(data);
+    const points = detectSlicePoints(buffer, 0.1, 2000);
+    // Should skip the second transient because it's within minSliceLength of the first
+    expect(points.length).toBe(2);
+    expect(points[0]).toBeGreaterThanOrEqual(9500);
+    expect(points[0]).toBeLessThanOrEqual(10500);
+    expect(points[1]).toBeGreaterThanOrEqual(29500);
+    expect(points[1]).toBeLessThanOrEqual(30500);
+  });
+
+  it('uses higher threshold to filter weaker transients', () => {
+    const data = new Float32Array(44100).fill(0);
+    // Weak transient at 0.25s
+    data[11025] = 0.15;
+    // Strong transient at 0.5s
+    data[22050] = 0.9;
+    const buffer = createMockAudioBuffer(data);
+    const highThreshold = detectSlicePoints(buffer, 0.5, 1000);
+    expect(highThreshold.length).toBe(1);
+    const lowThreshold = detectSlicePoints(buffer, 0.05, 1000);
+    expect(lowThreshold.length).toBe(2);
+  });
+
+  it('returns slice points sorted in ascending order', () => {
+    const data = new Float32Array(44100).fill(0);
+    for (let i = 5000; i < 5010; i++) data[i] = 0.9;
+    for (let i = 15000; i < 15010; i++) data[i] = 0.9;
+    for (let i = 35000; i < 35010; i++) data[i] = 0.9;
+    const buffer = createMockAudioBuffer(data);
+    const points = detectSlicePoints(buffer, 0.1, 1000);
+    for (let i = 1; i < points.length; i++) {
+      expect(points[i]).toBeGreaterThan(points[i - 1]);
+    }
+  });
+
+  it('handles stereo buffer by using first channel', () => {
+    const leftData = new Float32Array(44100).fill(0);
+    leftData[22050] = 0.8;
+    const rightData = new Float32Array(44100).fill(0);
+    const stereoBuffer = {
+      duration: 1,
+      sampleRate: 44100,
+      length: 44100,
+      numberOfChannels: 2,
+      getChannelData: (ch: number) => (ch === 0 ? leftData : rightData),
+      copyFromChannel: () => {},
+      copyToChannel: () => {},
+    } as unknown as AudioBuffer;
+    const points = detectSlicePoints(stereoBuffer, 0.1, 1000);
+    expect(points.length).toBe(1);
+  });
+});

--- a/src/utils/audioSlice.ts
+++ b/src/utils/audioSlice.ts
@@ -1,0 +1,80 @@
+/**
+ * Audio slice detection — find transient positions in an audio buffer
+ * using amplitude-based onset detection.
+ *
+ * The algorithm computes the short-term energy difference (spectral flux)
+ * over a hop window. When energy rises above the threshold, a transient
+ * onset is recorded, subject to the minimum slice length constraint.
+ */
+
+/**
+ * Detect transient slice points in an audio buffer.
+ *
+ * @param audioBuffer — The audio buffer to analyze (uses first channel).
+ * @param threshold  — Amplitude threshold (0–1). Energy increases above
+ *                     this fraction of the peak are flagged as onsets.
+ * @param minSliceLength — Minimum distance in samples between two slice
+ *                         points (prevents closely-spaced false positives).
+ * @returns Sorted array of sample positions where transients were detected.
+ */
+export function detectSlicePoints(
+  audioBuffer: AudioBuffer,
+  threshold: number,
+  minSliceLength: number,
+): number[] {
+  const data = audioBuffer.getChannelData(0);
+  const length = data.length;
+  if (length === 0) return [];
+
+  // Analysis window size: ~512 samples (~11ms at 44100 Hz).
+  // Hop by half the window for overlap.
+  const windowSize = 512;
+  const hopSize = windowSize / 2;
+
+  // Compute RMS energy for each analysis frame.
+  const numFrames = Math.floor((length - windowSize) / hopSize) + 1;
+  if (numFrames <= 1) return [];
+
+  const energy = new Float32Array(numFrames);
+  for (let f = 0; f < numFrames; f++) {
+    const start = f * hopSize;
+    let sum = 0;
+    for (let i = start; i < start + windowSize && i < length; i++) {
+      sum += data[i] * data[i];
+    }
+    energy[f] = Math.sqrt(sum / windowSize);
+  }
+
+  // Compute energy flux (positive differences only — onsets).
+  const flux = new Float32Array(numFrames);
+  for (let f = 1; f < numFrames; f++) {
+    const diff = energy[f] - energy[f - 1];
+    flux[f] = diff > 0 ? diff : 0;
+  }
+
+  // Scale the user threshold by peak flux so it works as a relative sensitivity.
+  const peakFlux = flux.reduce((max, v) => (v > max ? v : max), 0);
+  if (peakFlux === 0) return [];
+
+  const absoluteThreshold = threshold * peakFlux;
+
+  // Pick peaks in flux that exceed the threshold.
+  const slicePoints: number[] = [];
+  let lastSliceSample = -minSliceLength; // allow first point at position 0+
+
+  for (let f = 1; f < numFrames - 1; f++) {
+    if (
+      flux[f] > absoluteThreshold &&
+      flux[f] >= flux[f - 1] &&
+      flux[f] >= flux[f + 1]
+    ) {
+      const samplePos = f * hopSize;
+      if (samplePos - lastSliceSample >= minSliceLength) {
+        slicePoints.push(samplePos);
+        lastSliceSample = samplePos;
+      }
+    }
+  }
+
+  return slicePoints;
+}


### PR DESCRIPTION
## Summary
- Transient detection with configurable threshold and minimum slice length
- Visual slice markers on waveform clips
- Slice-to-MIDI conversion
- 22 unit tests

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)