### PR TITLE
feat: remove hardcoded send and insert slot limits

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -15,8 +15,6 @@ const MIXER_RESIZE_HANDLE_HEIGHT = 6;
 const CHANNEL_STRIP_RESERVED_HEIGHT = 380;
 const CHANNEL_STRIP_BOTTOM_PADDING = 12;
 const FADER_MIN_HEIGHT = 96;
-const MAX_INSERT_SLOTS = 4;
-const MAX_SEND_SLOTS = 2;
 
 const EFFECT_SHORT_NAMES: Record<string, string> = {
   eq3: 'EQ3',
@@ -30,6 +28,16 @@ const EFFECT_SHORT_NAMES: Record<string, string> = {
   flanger: 'Flanger',
   phaser: 'Phaser',
 };
+
+/** Small "X" icon used for remove buttons in insert/send slots. */
+function SlotRemoveIcon() {
+  return (
+    <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+      <line x1="1" y1="1" x2="7" y2="7" />
+      <line x1="7" y1="1" x2="1" y2="7" />
+    </svg>
+  );
+}
 
 function volumeToDb(v: number): string {
   if (v <= 0) return '-inf';
@@ -48,9 +56,12 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
   const renameTrack = useProjectStore((s) => s.renameTrack);
   const updateTrackMixer = useProjectStore((s) => s.updateTrackMixer);
   const addTrackEffect = useProjectStore((s) => s.addTrackEffect);
+  const removeTrackEffect = useProjectStore((s) => s.removeTrackEffect);
   const toggleTrackEffectsBypass = useProjectStore((s) => s.toggleTrackEffectsBypass);
   const updateTrackSend = useProjectStore((s) => s.updateTrackSend);
   const setSendPrePost = useProjectStore((s) => s.setSendPrePost);
+  const addReturnTrack = useProjectStore((s) => s.addReturnTrack);
+  const removeReturnTrack = useProjectStore((s) => s.removeReturnTrack);
   const setGroupMuted = useProjectStore((s) => s.setGroupMuted);
   const setGroupSoloed = useProjectStore((s) => s.setGroupSoloed);
   const setExpandedTrackId = useUIStore((s) => s.setExpandedTrackId);
@@ -199,53 +210,63 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
         {/* Section separator */}
         <div className="w-4/5 border-t border-[#3a3a3a]" />
 
-        {/* Inserts section — 4 effect slots */}
+        {/* Inserts section — dynamic effect slots */}
         <div data-testid="inserts-section" className={`w-full py-1 transition-opacity ${effectsBypassed ? 'opacity-45' : 'opacity-100'}`}>
           <div className="text-[10px] text-zinc-400 uppercase tracking-widest mb-1">Inserts</div>
           <div className="flex flex-col gap-1">
-            {Array.from({ length: MAX_INSERT_SLOTS }).map((_, i) => {
-              const effect = effects[i];
+            {effects.map((effect, i) => {
+              const label = EFFECT_SHORT_NAMES[effect.type] ?? effect.type;
               return (
-                <button
-                  key={i}
+                <div
+                  key={effect.id}
                   data-testid={`insert-slot-${i}`}
-                  className={`text-[10px] w-full rounded px-1.5 py-1 text-left truncate transition-colors ${
-                    effect
-                      ? effect.enabled
-                        ? 'bg-[#3a3a3a] text-zinc-300 hover:bg-[#444]'
-                        : 'bg-[#3a3a3a] text-zinc-300 hover:bg-[#444] opacity-50'
-                      : 'bg-[#333] text-zinc-600 hover:bg-[#3a3a3a]'
+                  className={`flex items-center gap-0.5 text-[10px] w-full rounded px-1.5 py-1 text-left truncate transition-colors ${
+                    effect.enabled
+                      ? 'bg-[#3a3a3a] text-zinc-300 hover:bg-[#444]'
+                      : 'bg-[#3a3a3a] text-zinc-300 hover:bg-[#444] opacity-50'
                   }`}
-                  title={effect ? `${EFFECT_SHORT_NAMES[effect.type] ?? effect.type}${effect.enabled ? '' : ' (bypassed)'}` : 'Add insert effect'}
-                  onClick={() => {
-                    if (!effect && !isFrozen) {
-                      addTrackEffect(track.id, 'reverb' as TrackEffectType);
-                    }
-                  }}
-                  disabled={isFrozen}
+                  title={`${label}${effect.enabled ? '' : ' (bypassed)'}`}
                 >
-                  {effect ? (EFFECT_SHORT_NAMES[effect.type] ?? effect.type) : '+'}
-                </button>
+                  <span className="flex-1 truncate">{label}</span>
+                  <button
+                    data-testid={`remove-insert-btn-${i}`}
+                    className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm text-zinc-500 hover:bg-red-500/20 hover:text-red-400 transition-colors"
+                    aria-label={`Remove ${label} insert`}
+                    title="Remove insert"
+                    onClick={() => removeTrackEffect(track.id, effect.id)}
+                    disabled={isFrozen}
+                  >
+                    <SlotRemoveIcon />
+                  </button>
+                </div>
               );
             })}
+            <button
+              data-testid="add-insert-btn"
+              className="text-[10px] w-full rounded px-1.5 py-1 text-center transition-colors bg-[#333] text-zinc-600 hover:bg-[#3a3a3a]"
+              title="Add insert effect"
+              onClick={() => addTrackEffect(track.id, 'reverb' as TrackEffectType)}
+              disabled={isFrozen}
+            >
+              +
+            </button>
           </div>
         </div>
 
         {/* Section separator */}
         <div className="w-4/5 border-t border-[#3a3a3a]" />
 
-        {/* Sends section — 2 send slots */}
+        {/* Sends section — dynamic send slots */}
         <div data-testid="sends-section" className="w-full py-1">
           <div className="text-[10px] text-zinc-400 uppercase tracking-widest mb-1">Sends</div>
           <div className="flex flex-col gap-1">
-            {Array.from({ length: MAX_SEND_SLOTS }).map((_, i) => {
-              const rt = returnTracks[i];
-              const send = rt ? sends.find((s) => s.returnTrackId === rt.id) : undefined;
+            {returnTracks.map((rt, i) => {
+              const send = sends.find((s) => s.returnTrackId === rt.id);
               const amount = send?.amount ?? 0;
               const isPre = (send?.prePost ?? 'post') === 'pre';
               return (
                 <div
-                  key={i}
+                  key={rt.id}
                   data-testid={`send-slot-${i}`}
                   className="flex items-center gap-1.5"
                 >
@@ -282,6 +303,15 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
                         className="w-14 h-3 accent-blue-500"
                         disabled={isFrozen}
                       />
+                      <button
+                        data-testid={`remove-send-btn-${i}`}
+                        className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm text-zinc-500 hover:bg-red-500/20 hover:text-red-400 transition-colors"
+                        aria-label={`Remove send to ${rt.name}`}
+                        title="Remove send"
+                        onClick={() => removeReturnTrack(rt.id)}
+                      >
+                        <SlotRemoveIcon />
+                      </button>
                     </>
                   ) : (
                     <span className="text-[10px] text-zinc-600 w-full text-center">&mdash;</span>
@@ -289,6 +319,17 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
                 </div>
               );
             })}
+            <button
+              data-testid="add-send-btn"
+              className="text-[10px] w-full rounded px-1.5 py-1 text-center transition-colors bg-[#333] text-zinc-600 hover:bg-[#3a3a3a]"
+              title="Add send bus"
+              onClick={() => {
+                const idx = returnTracks.length + 1;
+                addReturnTrack(`FX ${idx}`);
+              }}
+            >
+              +
+            </button>
           </div>
         </div>
 

--- a/tests/unit/channelStrip.test.tsx
+++ b/tests/unit/channelStrip.test.tsx
@@ -29,7 +29,7 @@ function setupProject() {
   useUIStore.getState().setMixerHeight(500);
 }
 
-describe('ChannelStrip — Inserts section', () => {
+describe('ChannelStrip — Dynamic Inserts section', () => {
   beforeEach(() => {
     localStorage.clear();
     useProjectStore.setState(useProjectStore.getInitialState(), true);
@@ -37,13 +37,27 @@ describe('ChannelStrip — Inserts section', () => {
     setupProject();
   });
 
-  it('renders 4 insert slots per channel strip', () => {
+  it('renders only an add-insert button when no effects exist', () => {
     render(<MixerPanel />);
     const strips = screen.getAllByTestId('channel-strip');
-    expect(strips.length).toBeGreaterThanOrEqual(1);
+    const insertsSection = within(strips[0]).getByTestId('inserts-section');
+    const slots = insertsSection.querySelectorAll('[data-testid^="insert-slot-"]');
+    expect(slots).toHaveLength(0);
+    expect(within(insertsSection).getByTestId('add-insert-btn')).toBeInTheDocument();
+  });
+
+  it('renders one insert slot per effect plus add button', () => {
+    const tracks = useProjectStore.getState().project!.tracks;
+    useProjectStore.getState().addTrackEffect(tracks[0].id, 'reverb');
+    useProjectStore.getState().addTrackEffect(tracks[0].id, 'delay');
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
     const insertsSection = within(strips[0]).getByTestId('inserts-section');
     const slots = within(insertsSection).getAllByTestId(/^insert-slot-/);
-    expect(slots).toHaveLength(4);
+    expect(slots).toHaveLength(2);
+    expect(slots[0]).toHaveTextContent(/reverb/i);
+    expect(slots[1]).toHaveTextContent(/delay/i);
+    expect(within(insertsSection).getByTestId('add-insert-btn')).toBeInTheDocument();
   });
 
   it('shows effect name when an insert slot is populated', () => {
@@ -53,10 +67,7 @@ describe('ChannelStrip — Inserts section', () => {
     const strips = screen.getAllByTestId('channel-strip');
     const insertsSection = within(strips[0]).getByTestId('inserts-section');
     const slots = within(insertsSection).getAllByTestId(/^insert-slot-/);
-    // First slot should show 'reverb'
     expect(slots[0]).toHaveTextContent(/reverb/i);
-    // Remaining slots should show '+' or be empty
-    expect(slots[1]).toHaveTextContent('+');
   });
 
   it('shows bypass state when effect is disabled', () => {
@@ -101,9 +112,54 @@ describe('ChannelStrip — Inserts section', () => {
     expect(fxButton).toHaveClass('rounded-sm');
     expect(fxButton).toHaveClass('text-[9px]');
   });
+
+  it('adds an effect when the add-insert button is clicked', () => {
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const insertsSection = within(strips[0]).getByTestId('inserts-section');
+    fireEvent.click(within(insertsSection).getByTestId('add-insert-btn'));
+    const effects = useProjectStore.getState().project!.tracks[0].effects ?? [];
+    expect(effects).toHaveLength(1);
+  });
+
+  it('removes an effect when the remove button on an insert slot is clicked', () => {
+    const tracks = useProjectStore.getState().project!.tracks;
+    useProjectStore.getState().addTrackEffect(tracks[0].id, 'reverb');
+    useProjectStore.getState().addTrackEffect(tracks[0].id, 'delay');
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const insertsSection = within(strips[0]).getByTestId('inserts-section');
+    const removeButtons = within(insertsSection).getAllByTestId(/^remove-insert-btn-/);
+    expect(removeButtons).toHaveLength(2);
+    fireEvent.click(removeButtons[0]);
+    const effects = useProjectStore.getState().project!.tracks[0].effects ?? [];
+    expect(effects).toHaveLength(1);
+    expect(effects[0].type).toBe('delay');
+  });
+
+  it('allows more than 4 insert effects (no hardcoded limit)', () => {
+    const tracks = useProjectStore.getState().project!.tracks;
+    for (let i = 0; i < 6; i++) {
+      useProjectStore.getState().addTrackEffect(tracks[0].id, 'reverb');
+    }
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const insertsSection = within(strips[0]).getByTestId('inserts-section');
+    const slots = within(insertsSection).getAllByTestId(/^insert-slot-/);
+    expect(slots).toHaveLength(6);
+  });
+
+  it('disables add-insert button when track is frozen', () => {
+    const track = useProjectStore.getState().project!.tracks[0];
+    useProjectStore.getState().updateTrack(track.id, { frozen: true });
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const insertsSection = within(strips[0]).getByTestId('inserts-section');
+    expect(within(insertsSection).getByTestId('add-insert-btn')).toBeDisabled();
+  });
 });
 
-describe('ChannelStrip — Sends section', () => {
+describe('ChannelStrip — Dynamic Sends section', () => {
   beforeEach(() => {
     localStorage.clear();
     useProjectStore.setState(useProjectStore.getInitialState(), true);
@@ -111,12 +167,24 @@ describe('ChannelStrip — Sends section', () => {
     setupProject();
   });
 
-  it('renders 2 send slots per channel strip', () => {
+  it('renders one send slot per return track', () => {
+    useProjectStore.getState().addReturnTrack('FX A');
+    useProjectStore.getState().addReturnTrack('FX B');
+    useProjectStore.getState().addReturnTrack('FX C');
     render(<MixerPanel />);
     const strips = screen.getAllByTestId('channel-strip');
     const sendsSection = within(strips[0]).getByTestId('sends-section');
     const slots = within(sendsSection).getAllByTestId(/^send-slot-/);
-    expect(slots).toHaveLength(2);
+    expect(slots).toHaveLength(3);
+  });
+
+  it('shows no send slots when no return tracks exist, only add button', () => {
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const sendsSection = within(strips[0]).getByTestId('sends-section');
+    const slots = sendsSection.querySelectorAll('[data-testid^="send-slot-"]');
+    expect(slots).toHaveLength(0);
+    expect(within(sendsSection).getByTestId('add-send-btn')).toBeInTheDocument();
   });
 
   it('shows send amount when a return track exists and send is active', () => {
@@ -130,13 +198,46 @@ describe('ChannelStrip — Sends section', () => {
     expect(slot).toHaveTextContent(/FX A/i);
   });
 
-  it('shows empty send slots when no return tracks exist', () => {
+  it('allows more than 2 sends (no hardcoded limit)', () => {
+    for (let i = 0; i < 5; i++) {
+      useProjectStore.getState().addReturnTrack(`FX ${String.fromCharCode(65 + i)}`);
+    }
     render(<MixerPanel />);
     const strips = screen.getAllByTestId('channel-strip');
     const sendsSection = within(strips[0]).getByTestId('sends-section');
     const slots = within(sendsSection).getAllByTestId(/^send-slot-/);
-    expect(slots[0]).toHaveTextContent('—');
-    expect(slots[1]).toHaveTextContent('—');
+    expect(slots).toHaveLength(5);
+  });
+
+  it('adds a return track when the add-send button is clicked', () => {
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const sendsSection = within(strips[0]).getByTestId('sends-section');
+    fireEvent.click(within(sendsSection).getByTestId('add-send-btn'));
+    const returnTracks = useProjectStore.getState().project!.returnTracks ?? [];
+    expect(returnTracks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('removes a return track when the remove button on a send slot is clicked', () => {
+    useProjectStore.getState().addReturnTrack('FX A');
+    useProjectStore.getState().addReturnTrack('FX B');
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const sendsSection = within(strips[0]).getByTestId('sends-section');
+    const removeButtons = within(sendsSection).getAllByTestId(/^remove-send-btn-/);
+    expect(removeButtons).toHaveLength(2);
+    fireEvent.click(removeButtons[0]);
+    const returnTracks = useProjectStore.getState().project!.returnTracks ?? [];
+    expect(returnTracks).toHaveLength(1);
+    expect(returnTracks[0].name).toBe('FX B');
+  });
+
+  it('has an add-send button at the end of the sends list', () => {
+    useProjectStore.getState().addReturnTrack('FX A');
+    render(<MixerPanel />);
+    const strips = screen.getAllByTestId('channel-strip');
+    const sendsSection = within(strips[0]).getByTestId('sends-section');
+    expect(within(sendsSection).getByTestId('add-send-btn')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `MAX_INSERT_SLOTS` (4) and `MAX_SEND_SLOTS` (2) constants from mixer channel strips
- Insert slots now render dynamically based on actual track effects, with a "+" button to add and "X" buttons to remove each effect
- Send slots now render dynamically based on return tracks, with a "+" button to add a new return track and "X" buttons to remove each
- Extract shared `SlotRemoveIcon` component to eliminate duplicated inline SVG

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] All 2927 unit tests pass (9 new tests added for dynamic slots)
- [x] `npm run build` succeeds
- [x] Tests verify no insert slots render when no effects exist
- [x] Tests verify 6+ insert effects render without limit
- [x] Tests verify add/remove insert buttons work correctly
- [x] Tests verify send slots match return track count
- [x] Tests verify add/remove send buttons work correctly
- [x] Tests verify frozen track disables add button

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)