### PR TITLE
refactor: decompose ClipBlock.tsx into focused sub-components

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -1,96 +1,31 @@
 import React, { useRef, useCallback, useState, useEffect, useMemo } from 'react';
-import { createPortal } from 'react-dom';
 import type { Clip, Track } from '../../types/project';
 import { useUIStore } from '../../store/uiStore';
 import { useProjectStore } from '../../store/projectStore';
 import { useGenerationStore } from '../../store/generationStore';
 import { useTransportStore } from '../../store/transportStore';
-import { useGeneration } from '../../hooks/useGeneration';
-import { getAudioEngine } from '../../hooks/useAudioEngine';
-import { loadAudioBlobByKey } from '../../services/audioFileManager';
 import { hexToRgba } from '../../utils/color';
-import { snapToGrid } from '../../utils/time';
-import { Z } from '../../utils/zIndex';
-import { computeWaveformPeaks } from '../../utils/waveformPeaks';
-import {
-  CLIP_WAVEFORM_PEAK_COUNT,
-  getClipAudibleSourceEnd,
-  getClipContentOffset,
-  getClipSourceSpan,
-} from '../../utils/clipAudio';
+import { getClipContentOffset } from '../../utils/clipAudio';
+import { getClipPresentation } from './clipPresentation';
 import { AddLayerModal } from '../generation/AddLayerModal';
-import { regenerateClip } from '../../services/generationPipeline';
-import { ClipContextMenu } from './ClipContextMenu';
+import { ClipContextMenuContainer } from './ClipContextMenuContainer';
 import { ClipWaveform, ClipMidiThumbnail } from './ClipWaveform';
 import { ClipGainEnvelope } from './ClipGainEnvelope';
 import { ClipWarpMarkers } from './ClipWarpMarkers';
 import { ClipStatusOverlay } from './ClipStatusOverlay';
-import { FADE_HANDLE_KEYBOARD_STEP, getClipFadeBounds } from '../../utils/clipFade';
-import { ARRANGEMENT_EMPTY_TRACK_ID_PREFIX, parseArrangementEmptyTrackSlotIndex } from '../arrangement/trackSlotLayout';
+import { ClipFadeHandles } from './ClipFadeHandles';
+import { ClipDragGhost } from './ClipDragGhost';
+import { ClipVersionNav } from './ClipVersionNav';
+import { getClipFadeBounds } from '../../utils/clipFade';
+import { useClipDrag, HEADER_RAIL_HEIGHT_PX } from './useClipDrag';
+import { useClipHover } from './useClipHover';
+import { useWaveformUpgrade } from './useWaveformUpgrade';
+import type { DragGhostInfo } from './useClipDrag';
+import { CURSOR_BRACKET_LEFT, CURSOR_BRACKET_RIGHT } from '../../utils/bracketCursor';
 
 interface ClipBlockProps {
   clip: Clip;
   track: Track;
-}
-
-const EDGE_HANDLE_PX = 16;
-const FADE_HANDLE_HIT_TARGET_PX = 14;
-const MIN_CLIP_DURATION = 0.5;
-const CLIP_DRAG_EPSILON = 0.0001;
-const HEADER_RAIL_HEIGHT_PX = 20;
-
-import { CURSOR_BRACKET_LEFT, CURSOR_BRACKET_RIGHT } from '../../utils/bracketCursor';
-
-const waveformUpgradeInFlight = new Set<string>();
-
-type DragMode = 'move' | 'resize-left' | 'resize-right' | 'slip';
-
-interface DragGhostInfo {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  targetTrackId: string | null;
-  targetLaneRect: { top: number; height: number } | null;
-  sourceLaneRect: { top: number; height: number } | null;
-  isShiftCopy?: boolean;
-}
-
-interface ClipPresentation {
-  waveformColor: string;
-  titleColor: string;
-  metaColor: string;
-  headerBackground: string;
-  bodyBackground: string;
-  bodyBorderColor: string;
-  containerShadow: string;
-  selectionRingColor: string;
-}
-
-function getClipPresentation(clipColor: string, isSelected: boolean): ClipPresentation {
-  if (isSelected) {
-    return {
-      waveformColor: '#16181f',
-      titleColor: '#181b22',
-      metaColor: 'rgba(24, 27, 34, 0.72)',
-      headerBackground: `linear-gradient(180deg, ${hexToRgba(clipColor, 0.96)} 0%, ${hexToRgba(clipColor, 0.88)} 100%)`,
-      bodyBackground: 'linear-gradient(180deg, rgba(253, 251, 246, 0.98) 0%, rgba(244, 238, 228, 0.96) 100%)',
-      bodyBorderColor: 'rgba(255, 255, 255, 0.92)',
-      containerShadow: '0 0 0 1px rgba(255,255,255,0.96), 0 14px 28px rgba(0,0,0,0.22)',
-      selectionRingColor: 'rgba(255,255,255,0.96)',
-    };
-  }
-
-  return {
-    waveformColor: '#1a1d26',
-    titleColor: '#18161a',
-    metaColor: 'rgba(24, 22, 26, 0.7)',
-    headerBackground: `linear-gradient(180deg, ${hexToRgba(clipColor, 0.96)} 0%, ${hexToRgba(clipColor, 0.9)} 100%)`,
-    bodyBackground: `linear-gradient(180deg, ${hexToRgba(clipColor, 0.56)} 0%, ${hexToRgba(clipColor, 0.42)} 100%)`,
-    bodyBorderColor: hexToRgba(clipColor, 0.34),
-    containerShadow: '0 8px 18px rgba(0,0,0,0.14)',
-    selectionRingColor: hexToRgba(clipColor, 0.42),
-  };
 }
 
 function ClipBlockInner({ clip, track }: ClipBlockProps) {
@@ -100,13 +35,6 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
   const setEditingClip = useUIStore((s) => s.setEditingClip);
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
   const contextWindow = useUIStore((s) => s.contextWindow);
-  const selectWindow = useUIStore((s) => s.selectWindow);
-  const openEnhancer = useUIStore((s) => s.openEnhancer);
-  const setVocal2BGMModal = useUIStore((s) => s.setVocal2BGMModal);
-  const setAnalysisPanel = useUIStore((s) => s.setAnalysisPanel);
-  const setStemSeparationModal = useUIStore((s) => s.setStemSeparationModal);
-  const setAudioToMidiModal = useUIStore((s) => s.setAudioToMidiModal);
-
   const generatingProgress = useGenerationStore((s) => {
     for (let i = s.jobs.length - 1; i >= 0; i--) {
       const j = s.jobs[i];
@@ -118,28 +46,9 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
     }
     return null;
   });
-  const updateClip = useProjectStore((s) => s.updateClip);
-  const setClipFade = useProjectStore((s) => s.setClipFade);
-  const removeClip = useProjectStore((s) => s.removeClip);
-  const duplicateClip = useProjectStore((s) => s.duplicateClip);
-  const consolidateClips = useProjectStore((s) => s.consolidateClips);
-  const snapClipEdgeToZeroCrossing = useProjectStore((s) => s.snapClipEdgeToZeroCrossing);
-  const createQuickSamplerFromClip = useProjectStore((s) => s.createQuickSamplerFromClip);
-  const applyAudioQuantize = useProjectStore((s) => s.applyAudioQuantize);
-  const clearAudioQuantize = useProjectStore((s) => s.clearAudioQuantize);
-  const exportMidiClip = useProjectStore((s) => s.exportMidiClip);
-  const convertMidiClipToStrudel = useProjectStore((s) => s.convertMidiClipToStrudel);
-  const applyStrudelCodeToTrack = useProjectStore((s) => s.applyStrudelCodeToTrack);
-  const sliceClipToRange = useProjectStore((s) => s.sliceClipToRange);
-  const splitClipAtZeroCrossing = useProjectStore((s) => s.splitClipAtZeroCrossing);
-  const batchDuplicateClips = useProjectStore((s) => s.batchDuplicateClips);
-  const batchMoveClips = useProjectStore((s) => s.batchMoveClips);
-  const updateClipColors = useProjectStore((s) => s.updateClipColors);
-  const setActiveVersion = useProjectStore((s) => s.setActiveVersion);
   const tracks = useProjectStore((s) => s.project?.tracks);
   const bpm = useProjectStore((s) => s.project?.bpm ?? 120);
   const totalDuration = useProjectStore((s) => s.project?.totalDuration ?? 600);
-  const { generateClip } = useGeneration();
   const isMidiClip = Boolean(clip.midiData);
   const hasAudioBody = Boolean(clip.isolatedAudioKey || clip.cumulativeMixKey || clip.waveformPeaks);
 
@@ -149,11 +58,39 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
   const [ghostLanding, setGhostLanding] = useState(false);
   const [scissorLine, setScissorLine] = useState<number | null>(null);
   const [rangePreview, setRangePreview] = useState<{ left: number; width: number } | null>(null);
-  const [hoveredResizeEdge, setHoveredResizeEdge] = useState<'left' | 'right' | null>(null);
-  const [hoverSeekX, setHoverSeekX] = useState<number | null>(null);
-  const scissorRef = useRef(false);
-  const suppressContextMenuRef = useRef(false);
-  const rangePreviewCommittedRef = useRef(false);
+  const clipBlockRef = useRef<HTMLDivElement>(null);
+
+  const {
+    hoveredResizeEdge,
+    hoverSeekX,
+    handleMouseEnter: handleMouseEnterLocal,
+    handleMouseMove: handleMouseMoveLocal,
+    handleMouseLeave: handleMouseLeaveLocal,
+    handleResizeHandleEnter,
+    handleResizeHandleLeave,
+  } = useClipHover(clipBlockRef);
+
+  const onGhostLanding = useCallback(() => {
+    setGhostLanding(true);
+    setTimeout(() => {
+      setDragGhost(null);
+      setGhostLanding(false);
+    }, 200);
+  }, []);
+
+  const { handleMouseDown, scissorRef, suppressContextMenuRef, rangePreviewCommittedRef } = useClipDrag({
+    clip,
+    track,
+    clipBlockRef,
+    pixelsPerSecond,
+    bpm,
+    totalDuration,
+    onDragGhostChange: setDragGhost,
+    onGhostLanding,
+    onScissorLineChange: setScissorLine,
+    onRangePreviewChange: setRangePreview,
+    onCtxMenuChange: (pos) => setCtxMenu(pos),
+  });
 
   // Cleanup cursor on unmount if scissor mode was active
   useEffect(() => {
@@ -162,7 +99,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
       if (/(?:^|-)resize$/.test(document.body.style.cursor)) document.body.style.cursor = '';
       if (/(?:^|-)resize$/.test(document.documentElement.style.cursor)) document.documentElement.style.cursor = '';
     };
-  }, []);
+  }, [scissorRef]);
 
   const editingClipId = useUIStore((s) => s.editingClipId);
   useEffect(() => {
@@ -176,57 +113,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
   const activeVersionIdx = clip.activeVersionIdx ?? (versions.length > 0 ? versions.length - 1 : -1);
   const totalVersions = versions.length;
 
-  useEffect(() => {
-    if (clip.generationStatus !== 'ready' || !clip.isolatedAudioKey) return;
-    if (clip.waveformPeaks && clip.waveformPeaks.length >= CLIP_WAVEFORM_PEAK_COUNT) return;
-    if (waveformUpgradeInFlight.has(clip.id)) return;
-
-    let cancelled = false;
-    waveformUpgradeInFlight.add(clip.id);
-
-    void (async () => {
-      try {
-        const blob = await loadAudioBlobByKey(clip.isolatedAudioKey!);
-        if (!blob || cancelled) return;
-
-        const buffer = await getAudioEngine().decodeAudioData(blob);
-        if (cancelled) return;
-
-        const upgradedPeaks = computeWaveformPeaks(buffer, CLIP_WAVEFORM_PEAK_COUNT);
-        useProjectStore.setState((state) => {
-          if (!state.project) return state;
-          return {
-            ...state,
-            project: {
-              ...state.project,
-              updatedAt: Date.now(),
-              tracks: state.project.tracks.map((candidate) => ({
-                ...candidate,
-                clips: candidate.clips.map((candidateClip) => (
-                  candidateClip.id === clip.id
-                    ? {
-                        ...candidateClip,
-                        waveformPeaks: upgradedPeaks,
-                        audioDuration: candidateClip.audioDuration ?? buffer.duration,
-                      }
-                    : candidateClip
-                )),
-              })),
-            },
-          };
-        });
-      } catch {
-        // Keep the existing waveform if the upgrade pass fails.
-      } finally {
-        waveformUpgradeInFlight.delete(clip.id);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      waveformUpgradeInFlight.delete(clip.id);
-    };
-  }, [clip.audioDuration, clip.generationStatus, clip.id, clip.isolatedAudioKey, clip.waveformPeaks]);
+  useWaveformUpgrade(clip.id, clip.generationStatus, clip.isolatedAudioKey, clip.waveformPeaks, clip.audioDuration);
 
   const left = clip.startTime * pixelsPerSecond;
   const width = clip.duration * pixelsPerSecond;
@@ -239,506 +126,11 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
   const clipColor = clip.color ?? track.color;
   const clipPresentation = useMemo(() => getClipPresentation(clipColor, isSelected), [clipColor, isSelected]);
 
-  const dragRef = useRef(false);
-
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
-
-  const getDragMode = useCallback((e: React.MouseEvent): DragMode => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const relX = e.clientX - rect.left;
-    const relY = e.clientY - rect.top;
-    // Resize only triggers in the header rail area
-    if (relY <= HEADER_RAIL_HEIGHT_PX) {
-      if (relX <= EDGE_HANDLE_PX) return 'resize-left';
-      if (relX >= rect.width - EDGE_HANDLE_PX) return 'resize-right';
-    }
-    if (e.altKey) return 'slip';
-    return 'move';
-  }, []);
-
-  const moveClipToTrack = useProjectStore((s) => s.moveClipToTrack);
-  const duplicateClipToTrack = useProjectStore((s) => s.duplicateClipToTrack);
-  const addTrack = useProjectStore((s) => s.addTrack);
-  const beginDrag = useProjectStore((s) => s.beginDrag);
-  const endDrag = useProjectStore((s) => s.endDrag);
-  const undo = useProjectStore((s) => s.undo);
-  const clipBlockRef = useRef<HTMLDivElement>(null);
-
-  const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    // Skip scissor tool on fade handles
-    if ((e.target as HTMLElement).closest('[data-fade-handle]')) return;
-    const isSecondaryPress = e.button === 2 || (e.button === 0 && e.ctrlKey);
-    if (e.button !== 0 && !isSecondaryPress) return;
-
-    const rect = e.currentTarget.getBoundingClientRect();
-    const relY = e.clientY - rect.top;
-    const isHeaderRailTarget = relY <= HEADER_RAIL_HEIGHT_PX
-      || Boolean((e.target as HTMLElement).closest('[data-clip-header-rail="true"]'));
-
-    const mode = getDragMode(e);
-    const canStartPrimaryDrag = mode === 'resize-left'
-      || mode === 'resize-right'
-      || (isHeaderRailTarget && (mode === 'move' || mode === 'slip'));
-    const canStartSecondaryGesture = isSecondaryPress && mode === 'move';
-
-    if (!isSecondaryPress && !canStartPrimaryDrag && mode === 'move') {
-      e.stopPropagation();
-      e.preventDefault();
-
-      const clipRect = clipBlockRef.current?.getBoundingClientRect();
-      if (!clipRect) return;
-
-      const startRelX = Math.max(0, Math.min(e.clientX - clipRect.left, clipRect.width));
-      let didDrag = false;
-
-      const updatePreview = (clientX: number) => {
-        const currentRelX = Math.max(0, Math.min(clientX - clipRect.left, clipRect.width));
-        const leftPx = Math.min(startRelX, currentRelX);
-        const widthPx = Math.abs(currentRelX - startRelX);
-        setRangePreview(widthPx > 0 ? { left: leftPx, width: widthPx } : null);
-        return { leftPx, widthPx };
-      };
-
-      const onMouseMove = (ev: MouseEvent) => {
-        const { widthPx } = updatePreview(ev.clientX);
-        if (widthPx >= 3) {
-          didDrag = true;
-        }
-      };
-
-      const onMouseUp = (ev: MouseEvent) => {
-        window.removeEventListener('mousemove', onMouseMove);
-        window.removeEventListener('mouseup', onMouseUp);
-
-        const { leftPx, widthPx } = updatePreview(ev.clientX);
-        setRangePreview(null);
-
-        if (!didDrag || widthPx < 3) {
-          return;
-        }
-
-        rangePreviewCommittedRef.current = true;
-
-        const previewStartTime = clip.startTime + (leftPx / pixelsPerSecond);
-        const previewEndTime = clip.startTime + ((leftPx + widthPx) / pixelsPerSecond);
-
-        void sliceClipToRange(clip.id, previewStartTime, previewEndTime).then((selectedClipId) => {
-          if (!selectedClipId) return;
-          selectClip(selectedClipId, false);
-          useUIStore.getState().selectTrack(track.id, false);
-        });
-      };
-
-      window.addEventListener('mousemove', onMouseMove);
-      window.addEventListener('mouseup', onMouseUp);
-      return;
-    }
-
-    if (!canStartPrimaryDrag && !canStartSecondaryGesture) {
-      return;
-    }
-
-    e.stopPropagation();
-    if (e.button === 0) {
-      e.preventDefault();
-    }
-
-    const startX = e.clientX;
-    const startY = e.clientY;
-    const origStart = clip.startTime;
-    const origDuration = clip.duration;
-    const origAudioOffset = clip.audioOffset ?? 0;
-    const origAudioDuration = clip.audioDuration ?? clip.duration;
-    const origContentOffset = getClipContentOffset(clip);
-    const origTimeStretchRate = clip.timeStretchRate;
-    const origStretchMode = clip.stretchMode;
-    const origSourceSpan = getClipSourceSpan(clip);
-    const origAudibleSourceEnd = getClipAudibleSourceEnd(clip);
-    dragRef.current = false;
-    scissorRef.current = false;
-    let isShiftCopy = e.shiftKey;
-
-    const currentSelectedClipIds = useUIStore.getState().selectedClipIds;
-    const isMultiSelected = currentSelectedClipIds.size > 1 && currentSelectedClipIds.has(clip.id);
-    let lastBatchOffset = 0;
-
-    const clipW = clip.duration * pixelsPerSecond;
-    const clipH = clipBlockRef.current?.offsetHeight ?? 48;
-    const clipRect = clipBlockRef.current?.getBoundingClientRect();
-    const clickOffsetPx = clipRect ? startX - clipRect.left : 0;
-    const supportsScissor = clip.generationStatus === 'ready' || Boolean(clip.midiData);
-    const canStartLongPressScissor = supportsScissor && isSecondaryPress && mode === 'move';
-    let secondaryMoved = false;
-    let pendingGhost: DragGhostInfo | null = null;
-    let ghostRafId = 0;
-    let pendingStoreUpdate: (() => void) | null = null;
-    let storeRafId = 0;
-    const scheduleStoreUpdate = (fn: () => void) => {
-      pendingStoreUpdate = fn;
-      if (!storeRafId) {
-        storeRafId = requestAnimationFrame(() => {
-          if (pendingStoreUpdate) pendingStoreUpdate();
-          pendingStoreUpdate = null;
-          storeRafId = 0;
-        });
-      }
-    };
-    const flushStoreUpdate = () => {
-      if (storeRafId) { cancelAnimationFrame(storeRafId); storeRafId = 0; }
-      if (pendingStoreUpdate) { pendingStoreUpdate(); pendingStoreUpdate = null; }
-    };
-
-    // Cache lane rects at drag start to avoid repeated DOM queries during drag
-    const laneElements = document.querySelectorAll<HTMLElement>('[data-timeline-lane][data-track-id]');
-    const cachedLaneRects = new Map<string, DOMRect>();
-    laneElements.forEach(el => {
-      const trackId = el.getAttribute('data-track-id');
-      if (trackId) cachedLaneRects.set(trackId, el.getBoundingClientRect());
-    });
-    const findClosestLaneCached = (clientY: number): { trackId: string; rect: DOMRect } | null => {
-      let best: { trackId: string; rect: DOMRect; dist: number } | null = null;
-      for (const [tid, r] of cachedLaneRects) {
-        const centerY = r.top + r.height / 2;
-        const dist = Math.abs(clientY - centerY);
-        if (!best || dist < best.dist) {
-          best = { trackId: tid, rect: r, dist };
-        }
-      }
-      return best ? { trackId: best.trackId, rect: best.rect } : null;
-    };
-    const sourceLane = findClosestLaneCached(startY);
-
-    // --- Long-press scissor detection (secondary press only) ---
-    let longPressTimer: ReturnType<typeof setTimeout> | null = null;
-    if (mode === 'move' && canStartLongPressScissor) {
-      e.preventDefault();
-      longPressTimer = setTimeout(() => {
-        longPressTimer = null;
-        scissorRef.current = true;
-        suppressContextMenuRef.current = true;
-        // Calculate initial scissor line position
-        if (clipRect) {
-          const relX = startX - clipRect.left;
-          const splitTime = origStart + relX / pixelsPerSecond;
-          const snapped = e.altKey ? splitTime : snapToGrid(splitTime, bpm, 1);
-          const snappedPx = (snapped - origStart) * pixelsPerSecond;
-          setScissorLine(Math.max(0, Math.min(snappedPx, clipW)));
-        }
-        // Override cursor
-        document.body.style.cursor = 'crosshair';
-      }, 300);
-    }
-
-    const onMouseMove = (ev: MouseEvent) => {
-      // If in scissor mode, just update the split line position
-      if (scissorRef.current) {
-        const liveRect = clipBlockRef.current?.getBoundingClientRect();
-        if (!liveRect) return;
-        const relX = ev.clientX - liveRect.left;
-        const splitTime = origStart + relX / pixelsPerSecond;
-        const snapped = ev.altKey ? splitTime : snapToGrid(splitTime, bpm, 1);
-        const snappedPx = (snapped - origStart) * pixelsPerSecond;
-        setScissorLine(Math.max(0, Math.min(snappedPx, clipW)));
-        return;
-      }
-      const dx = ev.clientX - startX;
-      const dy = ev.clientY - startY;
-      if (isSecondaryPress && (Math.abs(dx) >= 3 || Math.abs(dy) >= 3)) {
-        secondaryMoved = true;
-      }
-      if (isSecondaryPress && !scissorRef.current) {
-        if (Math.abs(dx) >= 3 || Math.abs(dy) >= 3) {
-          if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
-        }
-        return;
-      }
-      if (Math.abs(dx) < 3 && Math.abs(dy) < 3 && !dragRef.current) return;
-      // Cancel long-press timer once real drag starts
-      if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
-      if (!dragRef.current) beginDrag();
-      dragRef.current = true;
-      isShiftCopy = ev.shiftKey;
-
-      const deltaSec = dx / pixelsPerSecond;
-
-      if (mode === 'move') {
-        document.body.style.cursor = isShiftCopy ? 'copy' : 'grabbing';
-
-        const closest = findClosestLaneCached(ev.clientY);
-
-        // Never move the original clip during drag — the ghost alone shows
-        // the preview position. Store is only committed on mouseup.
-        // Revert any offset that may have been applied in earlier frames.
-        if (lastBatchOffset !== 0 && isMultiSelected) {
-          batchMoveClips([...currentSelectedClipIds], -lastBatchOffset);
-          lastBatchOffset = 0;
-        }
-
-        if (closest) {
-          const ghostLeftVp = ev.clientX - clickOffsetPx;
-          const clickOffsetY = clipRect ? startY - clipRect.top : 0;
-          const crossingTrack = closest.trackId !== track.id;
-          pendingGhost = {
-            x: ghostLeftVp,
-            y: ev.clientY - clickOffsetY,
-            width: clipW,
-            height: clipH,
-            targetTrackId: closest.trackId,
-            targetLaneRect: (crossingTrack || isShiftCopy)
-              ? { top: closest.rect.top, height: closest.rect.height }
-              : null,
-            sourceLaneRect: (crossingTrack || isShiftCopy) && sourceLane
-              ? { top: sourceLane.rect.top, height: sourceLane.rect.height }
-              : null,
-            isShiftCopy,
-          };
-          if (!ghostRafId) {
-            ghostRafId = requestAnimationFrame(() => {
-              if (pendingGhost) setDragGhost(pendingGhost);
-              ghostRafId = 0;
-            });
-          }
-        }
-      } else if (mode === 'resize-left') {
-        let newStart = ev.altKey ? origStart + deltaSec : snapToGrid(origStart + deltaSec, bpm, 1);
-        newStart = Math.max(0, newStart);
-        const maxStart = origStart + origDuration - MIN_CLIP_DURATION;
-        newStart = Math.min(newStart, maxStart);
-
-        const newDuration = origDuration + (origStart - newStart);
-        if (ev.shiftKey) {
-          scheduleStoreUpdate(() => updateClip(clip.id, {
-            startTime: newStart,
-            duration: newDuration,
-            contentOffset: undefined,
-            timeStretchRate: Math.max(CLIP_DRAG_EPSILON, origSourceSpan / newDuration),
-            stretchMode: 'repitch',
-          }));
-          return;
-        }
-
-        if (newStart < origStart) {
-          const extension = origStart - newStart;
-          scheduleStoreUpdate(() => updateClip(clip.id, {
-            startTime: newStart,
-            duration: newDuration,
-            contentOffset: origContentOffset + extension,
-            timeStretchRate: undefined,
-            stretchMode: undefined,
-          }));
-          return;
-        }
-
-        const trimAmount = newStart - origStart;
-        const silenceTrim = Math.min(origContentOffset, trimAmount);
-        const audioTrim = trimAmount - silenceTrim;
-        scheduleStoreUpdate(() => updateClip(clip.id, {
-          startTime: newStart,
-          duration: newDuration,
-          contentOffset: Math.max(0, origContentOffset - silenceTrim) || undefined,
-          audioOffset: Math.min(origAudioDuration, origAudioOffset + audioTrim),
-          timeStretchRate: undefined,
-          stretchMode: undefined,
-        }));
-      } else if (mode === 'slip') {
-        document.body.style.cursor = 'ew-resize';
-        const maxOffset = Math.max(0, origAudioDuration - origDuration);
-        if (maxOffset > 0) {
-          const newOffset = Math.max(0, Math.min(origAudioOffset + deltaSec, maxOffset));
-          scheduleStoreUpdate(() => updateClip(clip.id, { audioOffset: newOffset }));
-        }
-      } else {
-        let newDuration = ev.altKey ? origDuration + deltaSec : snapToGrid(origDuration + deltaSec, bpm, 1);
-        newDuration = Math.max(MIN_CLIP_DURATION, newDuration);
-        newDuration = Math.min(newDuration, totalDuration - origStart);
-        if (ev.shiftKey) {
-          scheduleStoreUpdate(() => updateClip(clip.id, {
-            duration: newDuration,
-            contentOffset: undefined,
-            timeStretchRate: Math.max(CLIP_DRAG_EPSILON, origSourceSpan / newDuration),
-            stretchMode: 'repitch',
-          }));
-          return;
-        }
-        scheduleStoreUpdate(() => updateClip(clip.id, {
-          duration: newDuration,
-          contentOffset: Math.min(origContentOffset, newDuration) || undefined,
-          timeStretchRate: undefined,
-          stretchMode: undefined,
-        }));
-      }
-    };
-
-    const onKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key !== 'Escape') return;
-      window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('mouseup', onMouseUp);
-      window.removeEventListener('keydown', onKeyDown);
-      cancelAnimationFrame(ghostRafId);
-      // Cancel any pending batched store update (escape reverts, so discard it)
-      if (storeRafId) { cancelAnimationFrame(storeRafId); storeRafId = 0; }
-      pendingStoreUpdate = null;
-      if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
-      // Cancel scissor mode
-      if (scissorRef.current) {
-        scissorRef.current = false;
-        setScissorLine(null);
-        document.body.style.cursor = '';
-        return;
-      }
-      setDragGhost(null);
-      document.body.style.cursor = '';
-      if (dragRef.current) {
-        // Restore original state for multi-select batch moves
-        if (isMultiSelected && lastBatchOffset !== 0) {
-          batchMoveClips([...currentSelectedClipIds], -lastBatchOffset);
-        } else if (mode === 'move') {
-          updateClip(clip.id, { startTime: origStart });
-        } else if (mode === 'resize-left') {
-          updateClip(clip.id, {
-            startTime: origStart,
-            duration: origDuration,
-            audioOffset: origAudioOffset,
-            contentOffset: origContentOffset || undefined,
-            timeStretchRate: origTimeStretchRate,
-            stretchMode: origStretchMode,
-          });
-        } else if (mode === 'resize-right') {
-          updateClip(clip.id, {
-            duration: origDuration,
-            contentOffset: origContentOffset || undefined,
-            timeStretchRate: origTimeStretchRate,
-            stretchMode: origStretchMode,
-          });
-        } else if (mode === 'slip') {
-          updateClip(clip.id, { audioOffset: origAudioOffset });
-        }
-        endDrag();
-        undo();
-      }
-      dragRef.current = false;
-    };
-
-    const onMouseUp = (ev: MouseEvent) => {
-      window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('mouseup', onMouseUp);
-      window.removeEventListener('keydown', onKeyDown);
-      cancelAnimationFrame(ghostRafId);
-      // Flush any pending batched store update so the final position is committed
-      flushStoreUpdate();
-      if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
-
-      // Execute scissor split
-      if (scissorRef.current) {
-        scissorRef.current = false;
-        setScissorLine(null);
-        document.body.style.cursor = '';
-        const liveRect = clipBlockRef.current?.getBoundingClientRect();
-        if (!liveRect) return;
-        const relX = ev.clientX - liveRect.left;
-        const splitTime = origStart + relX / pixelsPerSecond;
-        const snapped = ev.altKey ? splitTime : snapToGrid(splitTime, bpm, 1);
-        // Only split if within clip bounds (not at edges)
-        if (snapped > origStart + 0.01 && snapped < origStart + origDuration - 0.01) {
-          void splitClipAtZeroCrossing(clip.id, snapped);
-        }
-        return;
-      }
-
-      if (isSecondaryPress) {
-        if (!secondaryMoved && !suppressContextMenuRef.current) {
-          setCtxMenu({ x: ev.clientX, y: ev.clientY });
-        }
-        suppressContextMenuRef.current = false;
-        return;
-      }
-
-      // Trigger ghost "landing" animation: brighten then fade out
-      if (dragGhost) {
-        setGhostLanding(true);
-        setTimeout(() => {
-          setDragGhost(null);
-          setGhostLanding(false);
-        }, 200);
-      } else {
-        setDragGhost(null);
-      }
-      endDrag();
-      document.body.style.cursor = '';
-
-      if ((mode === 'resize-left' || mode === 'resize-right') && dragRef.current && !ev.shiftKey) {
-        const currentClip = useProjectStore.getState().getClipById(clip.id);
-        if (currentClip) {
-          if (mode === 'resize-left') {
-            const trimmedAudioLeft = (currentClip.audioOffset ?? 0) > origAudioOffset + CLIP_DRAG_EPSILON;
-            if (trimmedAudioLeft) {
-              void snapClipEdgeToZeroCrossing(clip.id, 'left');
-            }
-          } else {
-            const trimmedAudioRight = getClipAudibleSourceEnd(currentClip) < origAudibleSourceEnd - CLIP_DRAG_EPSILON;
-            if (trimmedAudioRight) {
-              void snapClipEdgeToZeroCrossing(clip.id, 'right');
-            }
-          }
-        }
-      }
-
-      if (mode === 'move' && dragRef.current) {
-        const closest = findClosestLaneCached(ev.clientY);
-        const deltaSec = (ev.clientX - startX) / pixelsPerSecond;
-        const isFineMove = ev.metaKey || ev.ctrlKey;
-        const dropStart = Math.max(0, isFineMove
-          ? Math.round((origStart + deltaSec) * 100) / 100
-          : snapToGrid(origStart + deltaSec, bpm, 1));
-
-        // Resolve target trackId — if dropping on an empty slot, create a new
-        // track that inherits the source track's color and display name prefix
-        // so the new lane looks cohesive with the clip being moved.
-        let resolvedTargetId = closest?.trackId;
-        if (resolvedTargetId) {
-          const emptySlotIndex = parseArrangementEmptyTrackSlotIndex(resolvedTargetId);
-          if (emptySlotIndex !== null) {
-            const newTrack = addTrack(track.trackName, track.trackType, {
-              order: emptySlotIndex + 1,
-              color: track.color,
-              displayName: track.displayName,
-            });
-            resolvedTargetId = newTrack.id;
-          }
-        }
-
-        if (ev.shiftKey && closest && resolvedTargetId) {
-          // Shift+drag = duplicate
-          const timeOffset = dropStart - origStart;
-          if (isMultiSelected) {
-            batchDuplicateClips([...currentSelectedClipIds], timeOffset);
-          } else {
-            duplicateClipToTrack(clip.id, resolvedTargetId, dropStart);
-          }
-        } else if (resolvedTargetId && resolvedTargetId !== track.id && !isMultiSelected) {
-          // Cross-track move
-          moveClipToTrack(clip.id, resolvedTargetId, dropStart);
-        } else if (!isMultiSelected) {
-          // Same-track move — commit final position
-          updateClip(clip.id, { startTime: dropStart });
-        } else {
-          // Same-track multi-select move — commit final offset
-          const timeOffset = dropStart - origStart;
-          if (timeOffset !== 0) {
-            batchMoveClips([...currentSelectedClipIds], timeOffset);
-          }
-        }
-      }
-    };
-
-    window.addEventListener('mousemove', onMouseMove);
-    window.addEventListener('mouseup', onMouseUp);
-    window.addEventListener('keydown', onKeyDown);
-  }, [addTrack, batchDuplicateClips, batchMoveClips, beginDrag, bpm, clip, duplicateClipToTrack, endDrag, getDragMode, moveClipToTrack, pixelsPerSecond, selectClip, sliceClipToRange, snapClipEdgeToZeroCrossing, splitClipAtZeroCrossing, totalDuration, track.id, track.trackName, track.trackType, undo, updateClip]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    if (dragRef.current || rangePreviewCommittedRef.current) {
+    if (rangePreviewCommittedRef.current) {
       rangePreviewCommittedRef.current = false;
       return;
     }
@@ -752,11 +144,11 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
       const clickTime = clip.startTime + relX / pixelsPerSecond;
       useTransportStore.getState().seek(clickTime);
     }
-  }, [clip.id, clip.startTime, track.id, selectClip, pixelsPerSecond]);
+  }, [clip.id, clip.startTime, track.id, selectClip, pixelsPerSecond, rangePreviewCommittedRef]);
 
   const handleDoubleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    if (dragRef.current || rangePreviewCommittedRef.current) {
+    if (rangePreviewCommittedRef.current) {
       rangePreviewCommittedRef.current = false;
       return;
     }
@@ -765,7 +157,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
       return;
     }
     setCtxMenu({ x: e.clientX, y: e.clientY });
-  }, [isMidiClip, setOpenPianoRoll, track.id, clip.id]);
+  }, [isMidiClip, setOpenPianoRoll, track.id, clip.id, rangePreviewCommittedRef]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     if (suppressContextMenuRef.current) {
@@ -777,147 +169,9 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
     e.preventDefault();
     e.stopPropagation();
     setCtxMenu({ x: e.clientX, y: e.clientY });
-  }, []);
+  }, [suppressContextMenuRef]);
 
   const closeCtxMenu = useCallback(() => setCtxMenu(null), []);
-
-  const setResizeCursor = useCallback((cursor: 'w-resize' | 'e-resize' | null) => {
-    const nextCursor = cursor === 'w-resize' ? CURSOR_BRACKET_LEFT
-      : cursor === 'e-resize' ? CURSOR_BRACKET_RIGHT
-      : '';
-    if (clipBlockRef.current) {
-      clipBlockRef.current.style.cursor = nextCursor;
-    }
-    document.body.style.cursor = nextCursor;
-    document.documentElement.style.cursor = nextCursor;
-  }, []);
-
-  const syncHoverState = useCallback((clientX: number, clientY: number, altKey: boolean, currentTarget: HTMLElement) => {
-    const rect = currentTarget.getBoundingClientRect();
-    const relX = clientX - rect.left;
-    const relY = clientY - rect.top;
-
-    // Resize only triggers in the header rail area
-    const inHeaderRail = relY <= HEADER_RAIL_HEIGHT_PX;
-    const atEdge = relX <= EDGE_HANDLE_PX || relX >= rect.width - EDGE_HANDLE_PX;
-
-    if (inHeaderRail && atEdge) {
-      const edge = relX <= EDGE_HANDLE_PX ? 'left' : 'right';
-      const cursor = edge === 'left' ? 'w-resize' : 'e-resize';
-      const bracketCursor = edge === 'left' ? CURSOR_BRACKET_LEFT : CURSOR_BRACKET_RIGHT;
-      setHoveredResizeEdge(edge);
-      setHoverSeekX(null);
-      setResizeCursor(cursor);
-      currentTarget.style.cursor = bracketCursor;
-    } else {
-      setHoveredResizeEdge(null);
-      setResizeCursor(null);
-      if (inHeaderRail) {
-        setHoverSeekX(null);
-        currentTarget.style.cursor = altKey ? 'ew-resize' : 'grab';
-      } else {
-        setHoverSeekX(relX);
-        currentTarget.style.cursor = '';
-      }
-    }
-  }, [setResizeCursor]);
-
-  const handleMouseEnterLocal = useCallback((e: React.MouseEvent) => {
-    syncHoverState(e.clientX, e.clientY, e.altKey, e.currentTarget as HTMLElement);
-  }, [syncHoverState]);
-
-  const handleMouseMoveLocal = useCallback((e: React.MouseEvent) => {
-    syncHoverState(e.clientX, e.clientY, e.altKey, e.currentTarget as HTMLElement);
-  }, [syncHoverState]);
-
-  const handleMouseLeaveLocal = useCallback((e: React.MouseEvent) => {
-    const el = e.currentTarget as HTMLElement;
-    setHoveredResizeEdge(null);
-    setHoverSeekX(null);
-    el.style.cursor = '';
-    setResizeCursor(null);
-  }, [setResizeCursor]);
-
-  const handleResizeHandleEnter = useCallback((edge: 'left' | 'right') => () => {
-    setHoveredResizeEdge(edge);
-    setResizeCursor(edge === 'left' ? 'w-resize' : 'e-resize');
-  }, [setResizeCursor]);
-
-  const handleResizeHandleLeave = useCallback(() => {
-    setHoveredResizeEdge(null);
-    setResizeCursor(null);
-  }, [setResizeCursor]);
-
-  const updateFadeFromPointer = useCallback((edge: 'in' | 'out', clientX: number) => {
-    const rect = clipBlockRef.current?.getBoundingClientRect();
-    if (!rect) return;
-
-    if (edge === 'in') {
-      const nextFade = Math.max(0, Math.min((clientX - rect.left) / pixelsPerSecond, clip.duration));
-      setClipFade(clip.id, { fadeInDuration: nextFade });
-      return;
-    }
-
-    const nextFade = Math.max(0, Math.min((rect.right - clientX) / pixelsPerSecond, clip.duration));
-    setClipFade(clip.id, { fadeOutDuration: nextFade });
-  }, [clip.duration, clip.id, pixelsPerSecond, setClipFade]);
-
-  const handleFadeMouseDown = useCallback((edge: 'in' | 'out') => (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (e.button !== 0) return;
-    e.preventDefault();
-    e.stopPropagation();
-    beginDrag();
-    updateFadeFromPointer(edge, e.clientX);
-
-    const onMouseMove = (ev: MouseEvent) => {
-      updateFadeFromPointer(edge, ev.clientX);
-    };
-    const onKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key !== 'Escape') return;
-      window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('mouseup', onMouseUp);
-      window.removeEventListener('keydown', onKeyDown);
-      endDrag();
-      undo();
-    };
-    const onMouseUp = () => {
-      window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('mouseup', onMouseUp);
-      window.removeEventListener('keydown', onKeyDown);
-      endDrag();
-    };
-
-    window.addEventListener('mousemove', onMouseMove);
-    window.addEventListener('mouseup', onMouseUp);
-    window.addEventListener('keydown', onKeyDown);
-  }, [beginDrag, endDrag, undo, updateFadeFromPointer]);
-
-  const handleFadeKeyDown = useCallback((edge: 'in' | 'out') => (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    const growKey = edge === 'in' ? 'ArrowRight' : 'ArrowLeft';
-    const shrinkKey = edge === 'in' ? 'ArrowLeft' : 'ArrowRight';
-
-    if (e.key === 'Home') {
-      e.preventDefault();
-      setClipFade(clip.id, edge === 'in' ? { fadeInDuration: 0 } : { fadeOutDuration: 0 });
-      return;
-    }
-
-    if (e.key !== growKey && e.key !== shrinkKey) return;
-
-    e.preventDefault();
-    const delta = (e.shiftKey ? FADE_HANDLE_KEYBOARD_STEP * 5 : FADE_HANDLE_KEYBOARD_STEP) * (e.key === growKey ? 1 : -1);
-    if (edge === 'in') {
-      setClipFade(clip.id, { fadeInDuration: fadeInDuration + delta });
-      return;
-    }
-    setClipFade(clip.id, { fadeOutDuration: fadeOutDuration + delta });
-  }, [clip.id, fadeInDuration, fadeOutDuration, setClipFade]);
-
-  const handleFadeReset = useCallback((edge: 'in' | 'out') => (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setClipFade(clip.id, edge === 'in' ? { fadeInDuration: 0 } : { fadeOutDuration: 0 });
-  }, [clip.id, setClipFade]);
 
   const statusStyles: Record<string, string> = {
     empty: 'opacity-60',
@@ -942,14 +196,6 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
     && new Set(selectedActionClips.map((candidate) => Boolean(candidate.midiData))).size <= 1;
   const hasCustomColor = selectedActionClips.some((candidate) => Boolean(candidate.color));
 
-  const handleConsolidate = async () => {
-    const consolidatedClip = await consolidateClips(track.id, selectedActionClipIds);
-    closeCtxMenu();
-    if (consolidatedClip) {
-      selectClip(consolidatedClip.id, false);
-    }
-  };
-
   return (
     <>
       <div
@@ -960,7 +206,6 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           active:brightness-95
           ${clip.muted ? 'opacity-40' : (statusStyles[clip.generationStatus] ?? '')}
           ${isSelected ? 'ring-2 ring-offset-1 ring-offset-transparent' : ''}
-          ${''/* Original clip stays fully visible during drag — ghost shows the preview */}
         `}
         style={{
           left,
@@ -980,6 +225,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
         onMouseLeave={handleMouseLeaveLocal}
         onContextMenu={handleContextMenu}
         >
+        {/* Header rail */}
         <div
           data-clip-header-rail="true"
           data-testid="clip-header-rail"
@@ -992,6 +238,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           }}
         />
 
+        {/* Body surface */}
         <div
           className="absolute left-0 right-0 bottom-0 rounded-b-md overflow-hidden"
           data-testid="clip-body-surface"
@@ -1003,7 +250,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           }}
         />
 
-        {/* Resize handles — hit targets on header rail only, cursor is the bracket indicator */}
+        {/* Resize handles */}
         <div
           className="absolute top-0 left-0 w-[16px] z-10"
           data-testid="resize-handle-left"
@@ -1019,6 +266,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           onMouseLeave={handleResizeHandleLeave}
         />
 
+        {/* Waveform */}
         <div
           className="absolute left-0 right-0 bottom-0 overflow-hidden"
           style={{ top: HEADER_RAIL_HEIGHT_PX }}
@@ -1037,81 +285,24 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           />
         </div>
 
+        {/* Fade handles and overlays */}
         {!isMidiClip && hasAudioBody && (
-          <>
-            {fadeInWidth > 0 && (
-              <div
-                className="absolute left-0 bottom-0 pointer-events-none"
-                data-testid="fade-in-overlay"
-                style={{
-                  top: HEADER_RAIL_HEIGHT_PX,
-                  width: fadeInWidth,
-                  background: 'linear-gradient(90deg, rgba(10, 12, 18, 0.35) 0%, rgba(10, 12, 18, 0.05) 100%)',
-                  clipPath: 'polygon(0 0, 100% 0, 0 100%)',
-                }}
-              />
-            )}
-            {fadeOutWidth > 0 && (
-              <div
-                className="absolute bottom-0 right-0 pointer-events-none"
-                data-testid="fade-out-overlay"
-                style={{
-                  top: HEADER_RAIL_HEIGHT_PX,
-                  width: fadeOutWidth,
-                  background: 'linear-gradient(270deg, rgba(10, 12, 18, 0.35) 0%, rgba(10, 12, 18, 0.05) 100%)',
-                  clipPath: 'polygon(0 0, 100% 0, 100% 100%)',
-                }}
-              />
-            )}
-            {showFadeInHandle && (
-              <button
-                type="button"
-                role="slider"
-                aria-label={`Fade in handle for clip ${clip.id}`}
-                aria-valuemin={0}
-                aria-valuemax={clip.duration}
-                aria-valuenow={fadeInDuration}
-                className="absolute z-20 rounded-full border border-white/40 bg-black/55 shadow-[0_0_0_1px_rgba(0,0,0,0.18)] hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-sky-400"
-                style={{
-                  top: HEADER_RAIL_HEIGHT_PX + 1,
-                  bottom: 1,
-                  left: Math.max(EDGE_HANDLE_PX, fadeInWidth - FADE_HANDLE_HIT_TARGET_PX / 2),
-                  width: FADE_HANDLE_HIT_TARGET_PX,
-                }}
-                data-fade-handle="in"
-                onMouseDown={handleFadeMouseDown('in')}
-                onKeyDown={handleFadeKeyDown('in')}
-                onDoubleClick={handleFadeReset('in')}
-              >
-                <span className="pointer-events-none absolute inset-y-1 left-1/2 w-px -translate-x-1/2 bg-white/80" />
-              </button>
-            )}
-            {showFadeOutHandle && (
-              <button
-                type="button"
-                role="slider"
-                aria-label={`Fade out handle for clip ${clip.id}`}
-                aria-valuemin={0}
-                aria-valuemax={clip.duration}
-                aria-valuenow={fadeOutDuration}
-                className="absolute z-20 rounded-full border border-white/40 bg-black/55 shadow-[0_0_0_1px_rgba(0,0,0,0.18)] hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-sky-400"
-                style={{
-                  top: HEADER_RAIL_HEIGHT_PX + 1,
-                  bottom: 1,
-                  left: Math.max(EDGE_HANDLE_PX, width - fadeOutWidth - FADE_HANDLE_HIT_TARGET_PX / 2),
-                  width: FADE_HANDLE_HIT_TARGET_PX,
-                }}
-                data-fade-handle="out"
-                onMouseDown={handleFadeMouseDown('out')}
-                onKeyDown={handleFadeKeyDown('out')}
-                onDoubleClick={handleFadeReset('out')}
-              >
-                <span className="pointer-events-none absolute inset-y-1 left-1/2 w-px -translate-x-1/2 bg-white/80" />
-              </button>
-            )}
-          </>
+          <ClipFadeHandles
+            clipId={clip.id}
+            clipDuration={clip.duration}
+            width={width}
+            fadeInDuration={fadeInDuration}
+            fadeOutDuration={fadeOutDuration}
+            fadeInWidth={fadeInWidth}
+            fadeOutWidth={fadeOutWidth}
+            showFadeInHandle={showFadeInHandle}
+            showFadeOutHandle={showFadeOutHandle}
+            pixelsPerSecond={pixelsPerSecond}
+            clipBlockRef={clipBlockRef}
+          />
         )}
 
+        {/* Gain envelope */}
         {clip.gainEnvelope && clip.gainEnvelope.length > 0 && (
           <ClipGainEnvelope
             clipId={clip.id}
@@ -1122,6 +313,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           />
         )}
 
+        {/* Warp markers */}
         {clip.warpMarkers && clip.warpMarkers.length > 0 && (
           <ClipWarpMarkers
             clipId={clip.id}
@@ -1131,6 +323,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           />
         )}
 
+        {/* MIDI thumbnail */}
         {isMidiClip && clip.midiData && (
           <ClipMidiThumbnail
             midiData={clip.midiData}
@@ -1141,6 +334,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           />
         )}
 
+        {/* Title */}
         <div
           className="absolute left-1.5 text-[10px] font-medium truncate leading-4 z-10 pointer-events-none"
           style={{
@@ -1152,48 +346,19 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           {isMidiClip ? `${clip.midiData?.notes.length ?? 0} notes` : (clip.prompt || '(no prompt)')}
         </div>
 
-        {totalVersions >= 1 && (
-          <div
-            className="absolute top-0 flex items-center gap-0.5 z-20 transition-opacity duration-100"
-            style={{ right: EDGE_HANDLE_PX + 2, opacity: hoveredResizeEdge === 'right' ? 0 : 1 }}
-            onClick={(e) => e.stopPropagation()}
-            onMouseDown={(e) => e.stopPropagation()}
-          >
-            <button
-              onClick={(e) => { e.stopPropagation(); setActiveVersion(clip.id, activeVersionIdx - 1); }}
-              disabled={activeVersionIdx <= 0}
-              className="text-[8px] disabled:opacity-30 px-0.5 leading-4 transition-opacity"
-              style={{ color: clipPresentation.metaColor }}
-              title="Previous version"
-            >
-              ◀
-            </button>
-            <span className="text-[8px] font-mono leading-4" style={{ color: clipPresentation.metaColor }}>
-              {activeVersionIdx + 1}/{totalVersions}
-            </span>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                if (activeVersionIdx < totalVersions - 1) {
-                  setActiveVersion(clip.id, activeVersionIdx + 1);
-                } else {
-                  regenerateClip(clip.id);
-                }
-              }}
-              disabled={clip.generationStatus === 'generating' || clip.generationStatus === 'queued'}
-              className="text-[8px] disabled:opacity-30 px-0.5 leading-4 transition-opacity"
-              style={{ color: clipPresentation.metaColor }}
-              title={activeVersionIdx >= totalVersions - 1 ? 'Generate new version' : 'Next version'}
-            >
-              {clip.generationStatus === 'generating' || clip.generationStatus === 'queued'
-                ? <span className="inline-block w-2 h-2 border border-white/80 border-t-transparent rounded-full animate-spin" />
-                : '▶'}
-            </button>
-          </div>
-        )}
+        {/* Version navigation */}
+        <ClipVersionNav
+          clipId={clip.id}
+          activeVersionIdx={activeVersionIdx}
+          totalVersions={totalVersions}
+          generationStatus={clip.generationStatus}
+          metaColor={clipPresentation.metaColor}
+          hoveredResizeEdge={hoveredResizeEdge}
+        />
 
         <ClipStatusOverlay clip={clip} generatingProgress={generatingProgress} isMidiClip={isMidiClip} />
 
+        {/* Muted overlay */}
         {clip.muted && (
           <div
             className="absolute inset-0 pointer-events-none z-20 flex items-center justify-center"
@@ -1204,6 +369,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           </div>
         )}
 
+        {/* Hover seek line */}
         {hoverSeekX !== null && (
           <div
             className="absolute bottom-0 pointer-events-none z-20"
@@ -1218,6 +384,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           />
         )}
 
+        {/* Scissor line */}
         {scissorLine !== null && (
           <div
             className="absolute bottom-0 w-px pointer-events-none z-30"
@@ -1232,6 +399,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           </div>
         )}
 
+        {/* Range preview */}
         {rangePreview && (
           <div
             className="absolute bottom-0 pointer-events-none z-20"
@@ -1247,111 +415,23 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
         )}
       </div>
 
-      {ctxMenu && (() => {
-        const hasAudio = !!(clip.isolatedAudioKey || clip.cumulativeMixKey);
-        const isReady = clip.generationStatus === 'ready';
-        const isVocalTrack = track.trackName === 'vocals' || track.trackName === 'backing_vocals';
-        const hasWarpMarkers = !!(clip.warpMarkers && clip.warpMarkers.length > 0);
+      {/* Context menu */}
+      {ctxMenu && (
+        <ClipContextMenuContainer
+          x={ctxMenu.x}
+          y={ctxMenu.y}
+          clip={clip}
+          track={track}
+          isMidiClip={isMidiClip}
+          canConsolidate={canConsolidate}
+          hasCustomColor={hasCustomColor}
+          selectedActionClipIds={selectedActionClipIds}
+          onClose={closeCtxMenu}
+          onEditModalOpen={() => setEditModalOpen(true)}
+        />
+      )}
 
-        const handleEnhance = (!isMidiClip && isReady) ? () => {
-          closeCtxMenu();
-          let range: { start: number; end: number } | null = null;
-          if (selectWindow) {
-            const rs = Math.max(selectWindow.startTime, clip.startTime);
-            const re = Math.min(selectWindow.endTime, clip.startTime + clip.duration);
-            if (re > rs) range = { start: rs, end: re };
-          }
-          openEnhancer(clip.id, track.id, range);
-        } : undefined;
-
-        const clipAIContext = (!isMidiClip && isReady) ? {
-          onRegenerate: () => { closeCtxMenu(); regenerateClip(clip.id); },
-          hasPrompt: !!clip.prompt,
-          isReady,
-          ...(hasAudio ? { onSeparateStems: () => { closeCtxMenu(); setStemSeparationModal(clip.id); } } : {}),
-          ...(isVocalTrack ? { onGenerateAccompaniment: () => { closeCtxMenu(); setVocal2BGMModal(clip.id); } } : {}),
-          onAnalyze: () => { closeCtxMenu(); setAnalysisPanel(clip.id); },
-          ...(hasAudio ? {
-            onConvertToMidi: () => { closeCtxMenu(); setAudioToMidiModal(clip.id); },
-            onCreateQuickSampler: () => {
-              closeCtxMenu();
-              const samplerTrack = createQuickSamplerFromClip(track.id, clip.id);
-              if (samplerTrack) useUIStore.getState().setOpenPianoRoll(samplerTrack.id);
-            },
-            onQuantizeAudio: () => { closeCtxMenu(); applyAudioQuantize(clip.id); },
-            ...(hasWarpMarkers ? { onClearAudioQuantize: () => { closeCtxMenu(); clearAudioQuantize(clip.id); } } : {}),
-          } : {}),
-        } : undefined;
-
-        return (
-          <ClipContextMenu
-            x={ctxMenu.x}
-            y={ctxMenu.y}
-            onClose={closeCtxMenu}
-            onEnhance={handleEnhance}
-            onInspireMe={() => { closeCtxMenu(); useUIStore.getState().setShowGenerationPanel(true); }}
-            onAddLayer={() => { closeCtxMenu(); useUIStore.getState().setAddLayerOpen(true); }}
-            onMusicEnhancer={() => { closeCtxMenu(); openEnhancer(clip.id, track.id); }}
-            clipAIContext={clipAIContext}
-            onOpenMidi={isMidiClip ? () => { closeCtxMenu(); setOpenPianoRoll(track.id, clip.id); } : undefined}
-            onConvertToStrudel={isMidiClip ? () => {
-              closeCtxMenu();
-              void (async () => {
-                const result = await convertMidiClipToStrudel(clip.id);
-                if (!result) return;
-                await applyStrudelCodeToTrack(result.code, null, { label: 'Convert MIDI Clip' });
-              })();
-            } : undefined}
-            onExportMidi={isMidiClip ? () => { closeCtxMenu(); exportMidiClip(clip.id); } : undefined}
-            onEdit={() => { closeCtxMenu(); setEditModalOpen(true); }}
-            onDuplicate={() => { closeCtxMenu(); duplicateClip(clip.id); }}
-            onSplitAtPlayhead={() => {
-              closeCtxMenu();
-              const currentTime = useTransportStore.getState().currentTime;
-              if (currentTime > clip.startTime + 0.01 && currentTime < clip.startTime + clip.duration - 0.01) {
-                void splitClipAtZeroCrossing(clip.id, currentTime);
-              }
-            }}
-            onConsolidate={() => { void handleConsolidate(); }}
-            onDelete={() => { closeCtxMenu(); removeClip(clip.id); }}
-            onSelectAll={() => {
-              closeCtxMenu();
-              const p = useProjectStore.getState().project;
-              if (p) {
-                const allClipIds = p.tracks.flatMap((t) => t.clips.map((c) => c.id));
-                useUIStore.getState().selectClips(allClipIds);
-              }
-            }}
-            onLoopSelection={() => {
-              closeCtxMenu();
-              const sw = useUIStore.getState().selectWindow;
-              if (sw) {
-                useTransportStore.getState().setLoopRegion(sw.startTime, sw.endTime);
-                if (!useTransportStore.getState().loopEnabled) {
-                  useTransportStore.getState().toggleLoop();
-                }
-              }
-            }}
-            onToggleMute={() => {
-              closeCtxMenu();
-              useProjectStore.getState().toggleClipMuted(selectedActionClipIds);
-            }}
-            isMuted={selectedActionClipIds.length > 1
-              ? selectedActionClipIds.every((id) => {
-                  const c = (tracks ?? []).flatMap((t) => t.clips).find((cl) => cl.id === id);
-                  return c?.muted;
-                })
-              : !!clip.muted
-            }
-            onAssignColor={(color) => { closeCtxMenu(); updateClipColors(selectedActionClipIds, color); }}
-            onResetColor={() => { closeCtxMenu(); updateClipColors(selectedActionClipIds, undefined); }}
-            hasCustomColor={hasCustomColor}
-            canConsolidate={canConsolidate}
-            isMidiClip={isMidiClip}
-          />
-        );
-      })()}
-
+      {/* Add layer modal */}
       {addLayerOpen && (
         <AddLayerModal
           trackId={track.id}
@@ -1362,6 +442,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
         />
       )}
 
+      {/* Edit modal */}
       {editModalOpen && (
         <AddLayerModal
           trackId={track.id}
@@ -1373,104 +454,28 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
         />
       )}
 
-      {dragGhost && dragGhost.targetTrackId && createPortal(
-        <>
-          {dragGhost.sourceLaneRect && dragGhost.isShiftCopy && (
-            <div
-              className="fixed pointer-events-none"
-              data-layer="drag-ghost-source"
-              style={{
-                zIndex: Z.dragGhost,
-                left: left,
-                top: dragGhost.sourceLaneRect.top + 4,
-                width,
-                height: dragGhost.sourceLaneRect.height - 8,
-                border: `1.5px dashed ${hexToRgba(clipColor, 0.4)}`,
-                borderRadius: 2,
-                backgroundColor: hexToRgba(clipColor, 0.15),
-              }}
-            />
-          )}
-
-          <div
-            className="fixed pointer-events-none rounded-sm overflow-hidden"
-            style={{
-              zIndex: Z.tooltip,
-              left: dragGhost.x,
-              top: dragGhost.y,
-              width: dragGhost.width,
-              height: dragGhost.height,
-              background: clipPresentation.bodyBackground,
-              borderLeft: `2px solid ${clipColor}`,
-              boxShadow: `0 4px 20px ${hexToRgba(clipColor, 0.3)}, 0 0 0 1px ${clipPresentation.bodyBorderColor}`,
-              opacity: ghostLanding ? 1 : 0.5,
-              transition: ghostLanding ? 'opacity 180ms ease-out' : undefined,
-            }}
-          >
-            <div
-              className="absolute left-0 right-0 top-0"
-              style={{
-                height: HEADER_RAIL_HEIGHT_PX,
-                background: clipPresentation.headerBackground,
-                borderBottom: `1px solid ${hexToRgba(clipColor, 0.38)}`,
-              }}
-            />
-            <div
-              className="absolute left-0 right-0 bottom-0 overflow-hidden"
-              style={{ top: HEADER_RAIL_HEIGHT_PX }}
-            >
-              <ClipWaveform
-                peaks={peaks}
-                audioDuration={audioDuration}
-                audioOffset={audioOffset}
-                clipDuration={clip.duration}
-                contentOffset={contentOffset}
-                timeStretchRate={clip.timeStretchRate}
-                stretchMode={clip.stretchMode}
-                width={width}
-                color={clipPresentation.waveformColor}
-                opacityClassName="opacity-85"
-              />
-            </div>
-            {isMidiClip && clip.midiData && (
-              <ClipMidiThumbnail
-                midiData={clip.midiData}
-                width={dragGhost.width}
-                duration={clip.duration}
-                bpm={bpm}
-                color={clipPresentation.waveformColor}
-              />
-            )}
-            <div
-              className="absolute left-1.5 right-1.5 text-[10px] font-medium truncate leading-4 z-10"
-              style={{ top: 1, color: clipPresentation.titleColor }}
-            >
-              {clip.prompt || track.displayName}
-            </div>
-            {dragGhost.isShiftCopy && (
-              <div className="absolute -top-1 -right-1 w-4 h-4 bg-emerald-500 rounded-full flex items-center justify-center text-[10px] font-bold text-white shadow z-20">
-                +
-              </div>
-            )}
-          </div>
-
-          {dragGhost.targetLaneRect && (
-            <div
-              className="fixed pointer-events-none"
-              style={{
-                zIndex: Z.dragGhost + 1,
-                left: 0,
-                top: dragGhost.targetLaneRect.top,
-                width: '100vw',
-                height: dragGhost.targetLaneRect.height,
-                backgroundColor: hexToRgba(clipColor, 0.06),
-                borderTop: `1px solid ${hexToRgba(clipColor, 0.35)}`,
-                borderBottom: `1px solid ${hexToRgba(clipColor, 0.35)}`,
-              }}
-            />
-          )}
-        </>,
-        document.body
+      {/* Drag ghost */}
+      {dragGhost && dragGhost.targetTrackId && (
+        <ClipDragGhost
+          dragGhost={dragGhost}
+          ghostLanding={ghostLanding}
+          clipColor={clipColor}
+          clipPresentation={clipPresentation}
+          left={left}
+          width={width}
+          peaks={peaks}
+          audioDuration={audioDuration}
+          audioOffset={audioOffset}
+          clipDuration={clip.duration}
+          contentOffset={contentOffset}
+          timeStretchRate={clip.timeStretchRate}
+          stretchMode={clip.stretchMode}
+          isMidiClip={isMidiClip}
+          midiData={clip.midiData}
+          bpm={bpm}
+          prompt={clip.prompt}
+          displayName={track.displayName}
+        />
       )}
     </>
   );

--- a/src/components/timeline/ClipContextMenuContainer.tsx
+++ b/src/components/timeline/ClipContextMenuContainer.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import type { Clip, Track } from '../../types/project';
+import { useUIStore } from '../../store/uiStore';
+import { useProjectStore } from '../../store/projectStore';
+import { useTransportStore } from '../../store/transportStore';
+import { regenerateClip } from '../../services/generationPipeline';
+import { ClipContextMenu } from './ClipContextMenu';
+
+interface ClipContextMenuContainerProps {
+  x: number;
+  y: number;
+  clip: Clip;
+  track: Track;
+  isMidiClip: boolean;
+  canConsolidate: boolean;
+  hasCustomColor: boolean;
+  selectedActionClipIds: string[];
+  onClose: () => void;
+  onEditModalOpen: () => void;
+}
+
+export function ClipContextMenuContainer({
+  x,
+  y,
+  clip,
+  track,
+  isMidiClip,
+  canConsolidate,
+  hasCustomColor,
+  selectedActionClipIds,
+  onClose,
+  onEditModalOpen,
+}: ClipContextMenuContainerProps) {
+  const selectWindow = useUIStore((s) => s.selectWindow);
+  const openEnhancer = useUIStore((s) => s.openEnhancer);
+  const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
+  const setVocal2BGMModal = useUIStore((s) => s.setVocal2BGMModal);
+  const setAnalysisPanel = useUIStore((s) => s.setAnalysisPanel);
+  const setStemSeparationModal = useUIStore((s) => s.setStemSeparationModal);
+  const setAudioToMidiModal = useUIStore((s) => s.setAudioToMidiModal);
+  const selectClip = useUIStore((s) => s.selectClip);
+
+  const removeClip = useProjectStore((s) => s.removeClip);
+  const duplicateClip = useProjectStore((s) => s.duplicateClip);
+  const consolidateClips = useProjectStore((s) => s.consolidateClips);
+  const createQuickSamplerFromClip = useProjectStore((s) => s.createQuickSamplerFromClip);
+  const applyAudioQuantize = useProjectStore((s) => s.applyAudioQuantize);
+  const clearAudioQuantize = useProjectStore((s) => s.clearAudioQuantize);
+  const exportMidiClip = useProjectStore((s) => s.exportMidiClip);
+  const convertMidiClipToStrudel = useProjectStore((s) => s.convertMidiClipToStrudel);
+  const applyStrudelCodeToTrack = useProjectStore((s) => s.applyStrudelCodeToTrack);
+  const splitClipAtZeroCrossing = useProjectStore((s) => s.splitClipAtZeroCrossing);
+  const updateClipColors = useProjectStore((s) => s.updateClipColors);
+  const tracks = useProjectStore((s) => s.project?.tracks);
+
+  const hasAudio = !!(clip.isolatedAudioKey || clip.cumulativeMixKey);
+  const isReady = clip.generationStatus === 'ready';
+  const isVocalTrack = track.trackName === 'vocals' || track.trackName === 'backing_vocals';
+  const hasWarpMarkers = !!(clip.warpMarkers && clip.warpMarkers.length > 0);
+
+  const handleEnhance = (!isMidiClip && isReady) ? () => {
+    onClose();
+    let range: { start: number; end: number } | null = null;
+    if (selectWindow) {
+      const rs = Math.max(selectWindow.startTime, clip.startTime);
+      const re = Math.min(selectWindow.endTime, clip.startTime + clip.duration);
+      if (re > rs) range = { start: rs, end: re };
+    }
+    openEnhancer(clip.id, track.id, range);
+  } : undefined;
+
+  const clipAIContext = (!isMidiClip && isReady) ? {
+    onRegenerate: () => { onClose(); regenerateClip(clip.id); },
+    hasPrompt: !!clip.prompt,
+    isReady,
+    ...(hasAudio ? { onSeparateStems: () => { onClose(); setStemSeparationModal(clip.id); } } : {}),
+    ...(isVocalTrack ? { onGenerateAccompaniment: () => { onClose(); setVocal2BGMModal(clip.id); } } : {}),
+    onAnalyze: () => { onClose(); setAnalysisPanel(clip.id); },
+    ...(hasAudio ? {
+      onConvertToMidi: () => { onClose(); setAudioToMidiModal(clip.id); },
+      onCreateQuickSampler: () => {
+        onClose();
+        const samplerTrack = createQuickSamplerFromClip(track.id, clip.id);
+        if (samplerTrack) useUIStore.getState().setOpenPianoRoll(samplerTrack.id);
+      },
+      onQuantizeAudio: () => { onClose(); applyAudioQuantize(clip.id); },
+      ...(hasWarpMarkers ? { onClearAudioQuantize: () => { onClose(); clearAudioQuantize(clip.id); } } : {}),
+    } : {}),
+  } : undefined;
+
+  const handleConsolidate = async () => {
+    const consolidatedClip = await consolidateClips(track.id, selectedActionClipIds);
+    onClose();
+    if (consolidatedClip) {
+      selectClip(consolidatedClip.id, false);
+    }
+  };
+
+  return (
+    <ClipContextMenu
+      x={x}
+      y={y}
+      onClose={onClose}
+      onEnhance={handleEnhance}
+      onInspireMe={() => { onClose(); useUIStore.getState().setShowGenerationPanel(true); }}
+      onAddLayer={() => { onClose(); useUIStore.getState().setAddLayerOpen(true); }}
+      onMusicEnhancer={() => { onClose(); openEnhancer(clip.id, track.id); }}
+      clipAIContext={clipAIContext}
+      onOpenMidi={isMidiClip ? () => { onClose(); setOpenPianoRoll(track.id, clip.id); } : undefined}
+      onConvertToStrudel={isMidiClip ? () => {
+        onClose();
+        void (async () => {
+          const result = await convertMidiClipToStrudel(clip.id);
+          if (!result) return;
+          await applyStrudelCodeToTrack(result.code, null, { label: 'Convert MIDI Clip' });
+        })();
+      } : undefined}
+      onExportMidi={isMidiClip ? () => { onClose(); exportMidiClip(clip.id); } : undefined}
+      onEdit={() => { onClose(); onEditModalOpen(); }}
+      onDuplicate={() => { onClose(); duplicateClip(clip.id); }}
+      onSplitAtPlayhead={() => {
+        onClose();
+        const currentTime = useTransportStore.getState().currentTime;
+        if (currentTime > clip.startTime + 0.01 && currentTime < clip.startTime + clip.duration - 0.01) {
+          void splitClipAtZeroCrossing(clip.id, currentTime);
+        }
+      }}
+      onConsolidate={() => { void handleConsolidate(); }}
+      onDelete={() => { onClose(); removeClip(clip.id); }}
+      onSelectAll={() => {
+        onClose();
+        const p = useProjectStore.getState().project;
+        if (p) {
+          const allClipIds = p.tracks.flatMap((t) => t.clips.map((c) => c.id));
+          useUIStore.getState().selectClips(allClipIds);
+        }
+      }}
+      onLoopSelection={() => {
+        onClose();
+        const sw = useUIStore.getState().selectWindow;
+        if (sw) {
+          useTransportStore.getState().setLoopRegion(sw.startTime, sw.endTime);
+          if (!useTransportStore.getState().loopEnabled) {
+            useTransportStore.getState().toggleLoop();
+          }
+        }
+      }}
+      onToggleMute={() => {
+        onClose();
+        useProjectStore.getState().toggleClipMuted(selectedActionClipIds);
+      }}
+      isMuted={selectedActionClipIds.length > 1
+        ? selectedActionClipIds.every((id) => {
+            const c = (tracks ?? []).flatMap((t) => t.clips).find((cl) => cl.id === id);
+            return c?.muted;
+          })
+        : !!clip.muted
+      }
+      onAssignColor={(color) => { onClose(); updateClipColors(selectedActionClipIds, color); }}
+      onResetColor={() => { onClose(); updateClipColors(selectedActionClipIds, undefined); }}
+      hasCustomColor={hasCustomColor}
+      canConsolidate={canConsolidate}
+      isMidiClip={isMidiClip}
+    />
+  );
+}

--- a/src/components/timeline/ClipDragGhost.tsx
+++ b/src/components/timeline/ClipDragGhost.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import type { MidiClipData, StretchMode } from '../../types/project';
+import { hexToRgba } from '../../utils/color';
+import { Z } from '../../utils/zIndex';
+import { ClipWaveform, ClipMidiThumbnail } from './ClipWaveform';
+import type { DragGhostInfo } from './useClipDrag';
+import { HEADER_RAIL_HEIGHT_PX } from './useClipDrag';
+import type { ClipPresentation } from './clipPresentation';
+
+interface ClipDragGhostProps {
+  dragGhost: DragGhostInfo;
+  ghostLanding: boolean;
+  clipColor: string;
+  clipPresentation: ClipPresentation;
+  left: number;
+  width: number;
+  peaks: number[] | null;
+  audioDuration: number;
+  audioOffset: number;
+  clipDuration: number;
+  contentOffset: number;
+  timeStretchRate: number | undefined;
+  stretchMode: StretchMode | undefined;
+  isMidiClip: boolean;
+  midiData: MidiClipData | undefined;
+  bpm: number;
+  prompt: string | undefined;
+  displayName: string;
+}
+
+export function ClipDragGhost({
+  dragGhost,
+  ghostLanding,
+  clipColor,
+  clipPresentation,
+  left,
+  width,
+  peaks,
+  audioDuration,
+  audioOffset,
+  clipDuration,
+  contentOffset,
+  timeStretchRate,
+  stretchMode,
+  isMidiClip,
+  midiData,
+  bpm,
+  prompt,
+  displayName,
+}: ClipDragGhostProps) {
+  if (!dragGhost.targetTrackId) return null;
+
+  return createPortal(
+    <>
+      {dragGhost.sourceLaneRect && dragGhost.isShiftCopy && (
+        <div
+          className="fixed pointer-events-none"
+          data-layer="drag-ghost-source"
+          style={{
+            zIndex: Z.dragGhost,
+            left: left,
+            top: dragGhost.sourceLaneRect.top + 4,
+            width,
+            height: dragGhost.sourceLaneRect.height - 8,
+            border: `1.5px dashed ${hexToRgba(clipColor, 0.4)}`,
+            borderRadius: 2,
+            backgroundColor: hexToRgba(clipColor, 0.15),
+          }}
+        />
+      )}
+
+      <div
+        className="fixed pointer-events-none rounded-sm overflow-hidden"
+        style={{
+          zIndex: Z.tooltip,
+          left: dragGhost.x,
+          top: dragGhost.y,
+          width: dragGhost.width,
+          height: dragGhost.height,
+          background: clipPresentation.bodyBackground,
+          borderLeft: `2px solid ${clipColor}`,
+          boxShadow: `0 4px 20px ${hexToRgba(clipColor, 0.3)}, 0 0 0 1px ${clipPresentation.bodyBorderColor}`,
+          opacity: ghostLanding ? 1 : 0.5,
+          transition: ghostLanding ? 'opacity 180ms ease-out' : undefined,
+        }}
+      >
+        <div
+          className="absolute left-0 right-0 top-0"
+          style={{
+            height: HEADER_RAIL_HEIGHT_PX,
+            background: clipPresentation.headerBackground,
+            borderBottom: `1px solid ${hexToRgba(clipColor, 0.38)}`,
+          }}
+        />
+        <div
+          className="absolute left-0 right-0 bottom-0 overflow-hidden"
+          style={{ top: HEADER_RAIL_HEIGHT_PX }}
+        >
+          <ClipWaveform
+            peaks={peaks}
+            audioDuration={audioDuration}
+            audioOffset={audioOffset}
+            clipDuration={clipDuration}
+            contentOffset={contentOffset}
+            timeStretchRate={timeStretchRate}
+            stretchMode={stretchMode}
+            width={width}
+            color={clipPresentation.waveformColor}
+            opacityClassName="opacity-85"
+          />
+        </div>
+        {isMidiClip && midiData && (
+          <ClipMidiThumbnail
+            midiData={midiData}
+            width={dragGhost.width}
+            duration={clipDuration}
+            bpm={bpm}
+            color={clipPresentation.waveformColor}
+          />
+        )}
+        <div
+          className="absolute left-1.5 right-1.5 text-[10px] font-medium truncate leading-4 z-10"
+          style={{ top: 1, color: clipPresentation.titleColor }}
+        >
+          {prompt || displayName}
+        </div>
+        {dragGhost.isShiftCopy && (
+          <div className="absolute -top-1 -right-1 w-4 h-4 bg-emerald-500 rounded-full flex items-center justify-center text-[10px] font-bold text-white shadow z-20">
+            +
+          </div>
+        )}
+      </div>
+
+      {dragGhost.targetLaneRect && (
+        <div
+          className="fixed pointer-events-none"
+          style={{
+            zIndex: Z.dragGhost + 1,
+            left: 0,
+            top: dragGhost.targetLaneRect.top,
+            width: '100vw',
+            height: dragGhost.targetLaneRect.height,
+            backgroundColor: hexToRgba(clipColor, 0.06),
+            borderTop: `1px solid ${hexToRgba(clipColor, 0.35)}`,
+            borderBottom: `1px solid ${hexToRgba(clipColor, 0.35)}`,
+          }}
+        />
+      )}
+    </>,
+    document.body
+  );
+}

--- a/src/components/timeline/ClipFadeHandles.tsx
+++ b/src/components/timeline/ClipFadeHandles.tsx
@@ -1,0 +1,185 @@
+import React, { useCallback } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { FADE_HANDLE_KEYBOARD_STEP } from '../../utils/clipFade';
+import { EDGE_HANDLE_PX, HEADER_RAIL_HEIGHT_PX } from './useClipDrag';
+
+const FADE_HANDLE_HIT_TARGET_PX = 14;
+
+interface ClipFadeHandlesProps {
+  clipId: string;
+  clipDuration: number;
+  width: number;
+  fadeInDuration: number;
+  fadeOutDuration: number;
+  fadeInWidth: number;
+  fadeOutWidth: number;
+  showFadeInHandle: boolean;
+  showFadeOutHandle: boolean;
+  pixelsPerSecond: number;
+  clipBlockRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export function ClipFadeHandles({
+  clipId,
+  clipDuration,
+  width,
+  fadeInDuration,
+  fadeOutDuration,
+  fadeInWidth,
+  fadeOutWidth,
+  showFadeInHandle,
+  showFadeOutHandle,
+  pixelsPerSecond,
+  clipBlockRef,
+}: ClipFadeHandlesProps) {
+  const setClipFade = useProjectStore((s) => s.setClipFade);
+  const beginDrag = useProjectStore((s) => s.beginDrag);
+  const endDrag = useProjectStore((s) => s.endDrag);
+  const undo = useProjectStore((s) => s.undo);
+
+  const updateFadeFromPointer = useCallback((edge: 'in' | 'out', clientX: number) => {
+    const rect = clipBlockRef.current?.getBoundingClientRect();
+    if (!rect) return;
+
+    if (edge === 'in') {
+      const nextFade = Math.max(0, Math.min((clientX - rect.left) / pixelsPerSecond, clipDuration));
+      setClipFade(clipId, { fadeInDuration: nextFade });
+      return;
+    }
+
+    const nextFade = Math.max(0, Math.min((rect.right - clientX) / pixelsPerSecond, clipDuration));
+    setClipFade(clipId, { fadeOutDuration: nextFade });
+  }, [clipDuration, clipId, pixelsPerSecond, setClipFade, clipBlockRef]);
+
+  const handleFadeMouseDown = useCallback((edge: 'in' | 'out') => (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    beginDrag();
+    updateFadeFromPointer(edge, e.clientX);
+
+    const onMouseMove = (ev: MouseEvent) => {
+      updateFadeFromPointer(edge, ev.clientX);
+    };
+    const onKeyDown = (ev: KeyboardEvent) => {
+      if (ev.key !== 'Escape') return;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('keydown', onKeyDown);
+      endDrag();
+      undo();
+    };
+    const onMouseUp = () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('keydown', onKeyDown);
+      endDrag();
+    };
+
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('keydown', onKeyDown);
+  }, [beginDrag, endDrag, undo, updateFadeFromPointer]);
+
+  const handleFadeKeyDown = useCallback((edge: 'in' | 'out') => (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    const growKey = edge === 'in' ? 'ArrowRight' : 'ArrowLeft';
+    const shrinkKey = edge === 'in' ? 'ArrowLeft' : 'ArrowRight';
+
+    if (e.key === 'Home') {
+      e.preventDefault();
+      setClipFade(clipId, edge === 'in' ? { fadeInDuration: 0 } : { fadeOutDuration: 0 });
+      return;
+    }
+
+    if (e.key !== growKey && e.key !== shrinkKey) return;
+
+    e.preventDefault();
+    const delta = (e.shiftKey ? FADE_HANDLE_KEYBOARD_STEP * 5 : FADE_HANDLE_KEYBOARD_STEP) * (e.key === growKey ? 1 : -1);
+    if (edge === 'in') {
+      setClipFade(clipId, { fadeInDuration: fadeInDuration + delta });
+      return;
+    }
+    setClipFade(clipId, { fadeOutDuration: fadeOutDuration + delta });
+  }, [clipId, fadeInDuration, fadeOutDuration, setClipFade]);
+
+  const handleFadeReset = useCallback((edge: 'in' | 'out') => (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setClipFade(clipId, edge === 'in' ? { fadeInDuration: 0 } : { fadeOutDuration: 0 });
+  }, [clipId, setClipFade]);
+
+  return (
+    <>
+      {fadeInWidth > 0 && (
+        <div
+          className="absolute left-0 bottom-0 pointer-events-none"
+          data-testid="fade-in-overlay"
+          style={{
+            top: HEADER_RAIL_HEIGHT_PX,
+            width: fadeInWidth,
+            background: 'linear-gradient(90deg, rgba(10, 12, 18, 0.35) 0%, rgba(10, 12, 18, 0.05) 100%)',
+            clipPath: 'polygon(0 0, 100% 0, 0 100%)',
+          }}
+        />
+      )}
+      {fadeOutWidth > 0 && (
+        <div
+          className="absolute bottom-0 right-0 pointer-events-none"
+          data-testid="fade-out-overlay"
+          style={{
+            top: HEADER_RAIL_HEIGHT_PX,
+            width: fadeOutWidth,
+            background: 'linear-gradient(270deg, rgba(10, 12, 18, 0.35) 0%, rgba(10, 12, 18, 0.05) 100%)',
+            clipPath: 'polygon(0 0, 100% 0, 100% 100%)',
+          }}
+        />
+      )}
+      {showFadeInHandle && (
+        <button
+          type="button"
+          role="slider"
+          aria-label={`Fade in handle for clip ${clipId}`}
+          aria-valuemin={0}
+          aria-valuemax={clipDuration}
+          aria-valuenow={fadeInDuration}
+          className="absolute z-20 rounded-full border border-white/40 bg-black/55 shadow-[0_0_0_1px_rgba(0,0,0,0.18)] hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          style={{
+            top: HEADER_RAIL_HEIGHT_PX + 1,
+            bottom: 1,
+            left: Math.max(EDGE_HANDLE_PX, fadeInWidth - FADE_HANDLE_HIT_TARGET_PX / 2),
+            width: FADE_HANDLE_HIT_TARGET_PX,
+          }}
+          data-fade-handle="in"
+          onMouseDown={handleFadeMouseDown('in')}
+          onKeyDown={handleFadeKeyDown('in')}
+          onDoubleClick={handleFadeReset('in')}
+        >
+          <span className="pointer-events-none absolute inset-y-1 left-1/2 w-px -translate-x-1/2 bg-white/80" />
+        </button>
+      )}
+      {showFadeOutHandle && (
+        <button
+          type="button"
+          role="slider"
+          aria-label={`Fade out handle for clip ${clipId}`}
+          aria-valuemin={0}
+          aria-valuemax={clipDuration}
+          aria-valuenow={fadeOutDuration}
+          className="absolute z-20 rounded-full border border-white/40 bg-black/55 shadow-[0_0_0_1px_rgba(0,0,0,0.18)] hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          style={{
+            top: HEADER_RAIL_HEIGHT_PX + 1,
+            bottom: 1,
+            left: Math.max(EDGE_HANDLE_PX, width - fadeOutWidth - FADE_HANDLE_HIT_TARGET_PX / 2),
+            width: FADE_HANDLE_HIT_TARGET_PX,
+          }}
+          data-fade-handle="out"
+          onMouseDown={handleFadeMouseDown('out')}
+          onKeyDown={handleFadeKeyDown('out')}
+          onDoubleClick={handleFadeReset('out')}
+        >
+          <span className="pointer-events-none absolute inset-y-1 left-1/2 w-px -translate-x-1/2 bg-white/80" />
+        </button>
+      )}
+    </>
+  );
+}

--- a/src/components/timeline/ClipVersionNav.tsx
+++ b/src/components/timeline/ClipVersionNav.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { regenerateClip } from '../../services/generationPipeline';
+import { EDGE_HANDLE_PX } from './useClipDrag';
+
+interface ClipVersionNavProps {
+  clipId: string;
+  activeVersionIdx: number;
+  totalVersions: number;
+  generationStatus: string;
+  metaColor: string;
+  hoveredResizeEdge: 'left' | 'right' | null;
+}
+
+export function ClipVersionNav({
+  clipId,
+  activeVersionIdx,
+  totalVersions,
+  generationStatus,
+  metaColor,
+  hoveredResizeEdge,
+}: ClipVersionNavProps) {
+  const setActiveVersion = useProjectStore((s) => s.setActiveVersion);
+
+  if (totalVersions < 1) return null;
+
+  return (
+    <div
+      className="absolute top-0 flex items-center gap-0.5 z-20 transition-opacity duration-100"
+      style={{ right: EDGE_HANDLE_PX + 2, opacity: hoveredResizeEdge === 'right' ? 0 : 1 }}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <button
+        onClick={(e) => { e.stopPropagation(); setActiveVersion(clipId, activeVersionIdx - 1); }}
+        disabled={activeVersionIdx <= 0}
+        className="text-[8px] disabled:opacity-30 px-0.5 leading-4 transition-opacity"
+        style={{ color: metaColor }}
+        title="Previous version"
+      >
+        {'\u25C0'}
+      </button>
+      <span className="text-[8px] font-mono leading-4" style={{ color: metaColor }}>
+        {activeVersionIdx + 1}/{totalVersions}
+      </span>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          if (activeVersionIdx < totalVersions - 1) {
+            setActiveVersion(clipId, activeVersionIdx + 1);
+          } else {
+            regenerateClip(clipId);
+          }
+        }}
+        disabled={generationStatus === 'generating' || generationStatus === 'queued'}
+        className="text-[8px] disabled:opacity-30 px-0.5 leading-4 transition-opacity"
+        style={{ color: metaColor }}
+        title={activeVersionIdx >= totalVersions - 1 ? 'Generate new version' : 'Next version'}
+      >
+        {generationStatus === 'generating' || generationStatus === 'queued'
+          ? <span className="inline-block w-2 h-2 border border-white/80 border-t-transparent rounded-full animate-spin" />
+          : '\u25B6'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/timeline/clipPresentation.ts
+++ b/src/components/timeline/clipPresentation.ts
@@ -1,0 +1,38 @@
+import { hexToRgba } from '../../utils/color';
+
+export interface ClipPresentation {
+  waveformColor: string;
+  titleColor: string;
+  metaColor: string;
+  headerBackground: string;
+  bodyBackground: string;
+  bodyBorderColor: string;
+  containerShadow: string;
+  selectionRingColor: string;
+}
+
+export function getClipPresentation(clipColor: string, isSelected: boolean): ClipPresentation {
+  if (isSelected) {
+    return {
+      waveformColor: '#16181f',
+      titleColor: '#181b22',
+      metaColor: 'rgba(24, 27, 34, 0.72)',
+      headerBackground: `linear-gradient(180deg, ${hexToRgba(clipColor, 0.96)} 0%, ${hexToRgba(clipColor, 0.88)} 100%)`,
+      bodyBackground: 'linear-gradient(180deg, rgba(253, 251, 246, 0.98) 0%, rgba(244, 238, 228, 0.96) 100%)',
+      bodyBorderColor: 'rgba(255, 255, 255, 0.92)',
+      containerShadow: '0 0 0 1px rgba(255,255,255,0.96), 0 14px 28px rgba(0,0,0,0.22)',
+      selectionRingColor: 'rgba(255,255,255,0.96)',
+    };
+  }
+
+  return {
+    waveformColor: '#1a1d26',
+    titleColor: '#18161a',
+    metaColor: 'rgba(24, 22, 26, 0.7)',
+    headerBackground: `linear-gradient(180deg, ${hexToRgba(clipColor, 0.96)} 0%, ${hexToRgba(clipColor, 0.9)} 100%)`,
+    bodyBackground: `linear-gradient(180deg, ${hexToRgba(clipColor, 0.56)} 0%, ${hexToRgba(clipColor, 0.42)} 100%)`,
+    bodyBorderColor: hexToRgba(clipColor, 0.34),
+    containerShadow: '0 8px 18px rgba(0,0,0,0.14)',
+    selectionRingColor: hexToRgba(clipColor, 0.42),
+  };
+}

--- a/src/components/timeline/useClipDrag.ts
+++ b/src/components/timeline/useClipDrag.ts
@@ -1,0 +1,566 @@
+import { useRef, useCallback } from 'react';
+import type { Clip, Track } from '../../types/project';
+import { useUIStore } from '../../store/uiStore';
+import { useProjectStore } from '../../store/projectStore';
+import { useTransportStore } from '../../store/transportStore';
+import { snapToGrid } from '../../utils/time';
+import {
+  getClipAudibleSourceEnd,
+  getClipContentOffset,
+  getClipSourceSpan,
+} from '../../utils/clipAudio';
+import { ARRANGEMENT_EMPTY_TRACK_ID_PREFIX, parseArrangementEmptyTrackSlotIndex } from '../arrangement/trackSlotLayout';
+
+export type DragMode = 'move' | 'resize-left' | 'resize-right' | 'slip';
+
+export interface DragGhostInfo {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  targetTrackId: string | null;
+  targetLaneRect: { top: number; height: number } | null;
+  sourceLaneRect: { top: number; height: number } | null;
+  isShiftCopy?: boolean;
+}
+
+export const EDGE_HANDLE_PX = 16;
+const MIN_CLIP_DURATION = 0.5;
+const CLIP_DRAG_EPSILON = 0.0001;
+export const HEADER_RAIL_HEIGHT_PX = 20;
+
+interface UseClipDragParams {
+  clip: Clip;
+  track: Track;
+  clipBlockRef: React.RefObject<HTMLDivElement | null>;
+  pixelsPerSecond: number;
+  bpm: number;
+  totalDuration: number;
+  onDragGhostChange: (ghost: DragGhostInfo | null) => void;
+  onGhostLanding: () => void;
+  onScissorLineChange: (line: number | null) => void;
+  onRangePreviewChange: (preview: { left: number; width: number } | null) => void;
+  onCtxMenuChange: (pos: { x: number; y: number } | null) => void;
+}
+
+export function useClipDrag({
+  clip,
+  track,
+  clipBlockRef,
+  pixelsPerSecond,
+  bpm,
+  totalDuration,
+  onDragGhostChange,
+  onGhostLanding,
+  onScissorLineChange,
+  onRangePreviewChange,
+  onCtxMenuChange,
+}: UseClipDragParams) {
+  const updateClip = useProjectStore((s) => s.updateClip);
+  const moveClipToTrack = useProjectStore((s) => s.moveClipToTrack);
+  const duplicateClipToTrack = useProjectStore((s) => s.duplicateClipToTrack);
+  const addTrack = useProjectStore((s) => s.addTrack);
+  const beginDrag = useProjectStore((s) => s.beginDrag);
+  const endDrag = useProjectStore((s) => s.endDrag);
+  const undo = useProjectStore((s) => s.undo);
+  const snapClipEdgeToZeroCrossing = useProjectStore((s) => s.snapClipEdgeToZeroCrossing);
+  const splitClipAtZeroCrossing = useProjectStore((s) => s.splitClipAtZeroCrossing);
+  const batchDuplicateClips = useProjectStore((s) => s.batchDuplicateClips);
+  const batchMoveClips = useProjectStore((s) => s.batchMoveClips);
+  const sliceClipToRange = useProjectStore((s) => s.sliceClipToRange);
+  const selectClip = useUIStore((s) => s.selectClip);
+
+  const dragRef = useRef(false);
+  const scissorRef = useRef(false);
+  const suppressContextMenuRef = useRef(false);
+  const rangePreviewCommittedRef = useRef(false);
+
+  const getDragMode = useCallback((e: React.MouseEvent): DragMode => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const relX = e.clientX - rect.left;
+    const relY = e.clientY - rect.top;
+    // Resize only triggers in the header rail area
+    if (relY <= HEADER_RAIL_HEIGHT_PX) {
+      if (relX <= EDGE_HANDLE_PX) return 'resize-left';
+      if (relX >= rect.width - EDGE_HANDLE_PX) return 'resize-right';
+    }
+    if (e.altKey) return 'slip';
+    return 'move';
+  }, []);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    // Skip scissor tool on fade handles
+    if ((e.target as HTMLElement).closest('[data-fade-handle]')) return;
+    const isSecondaryPress = e.button === 2 || (e.button === 0 && e.ctrlKey);
+    if (e.button !== 0 && !isSecondaryPress) return;
+
+    const rect = e.currentTarget.getBoundingClientRect();
+    const relY = e.clientY - rect.top;
+    const isHeaderRailTarget = relY <= HEADER_RAIL_HEIGHT_PX
+      || Boolean((e.target as HTMLElement).closest('[data-clip-header-rail="true"]'));
+
+    const mode = getDragMode(e);
+    const canStartPrimaryDrag = mode === 'resize-left'
+      || mode === 'resize-right'
+      || (isHeaderRailTarget && (mode === 'move' || mode === 'slip'));
+    const canStartSecondaryGesture = isSecondaryPress && mode === 'move';
+
+    if (!isSecondaryPress && !canStartPrimaryDrag && mode === 'move') {
+      e.stopPropagation();
+      e.preventDefault();
+
+      const clipRect = clipBlockRef.current?.getBoundingClientRect();
+      if (!clipRect) return;
+
+      const startRelX = Math.max(0, Math.min(e.clientX - clipRect.left, clipRect.width));
+      let didDrag = false;
+
+      const updatePreview = (clientX: number) => {
+        const currentRelX = Math.max(0, Math.min(clientX - clipRect.left, clipRect.width));
+        const leftPx = Math.min(startRelX, currentRelX);
+        const widthPx = Math.abs(currentRelX - startRelX);
+        onRangePreviewChange(widthPx > 0 ? { left: leftPx, width: widthPx } : null);
+        return { leftPx, widthPx };
+      };
+
+      const onMouseMove = (ev: MouseEvent) => {
+        const { widthPx } = updatePreview(ev.clientX);
+        if (widthPx >= 3) {
+          didDrag = true;
+        }
+      };
+
+      const onMouseUp = (ev: MouseEvent) => {
+        window.removeEventListener('mousemove', onMouseMove);
+        window.removeEventListener('mouseup', onMouseUp);
+
+        const { leftPx, widthPx } = updatePreview(ev.clientX);
+        onRangePreviewChange(null);
+
+        if (!didDrag || widthPx < 3) {
+          return;
+        }
+
+        rangePreviewCommittedRef.current = true;
+
+        const previewStartTime = clip.startTime + (leftPx / pixelsPerSecond);
+        const previewEndTime = clip.startTime + ((leftPx + widthPx) / pixelsPerSecond);
+
+        void sliceClipToRange(clip.id, previewStartTime, previewEndTime).then((selectedClipId) => {
+          if (!selectedClipId) return;
+          selectClip(selectedClipId, false);
+          useUIStore.getState().selectTrack(track.id, false);
+        });
+      };
+
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mouseup', onMouseUp);
+      return;
+    }
+
+    if (!canStartPrimaryDrag && !canStartSecondaryGesture) {
+      return;
+    }
+
+    e.stopPropagation();
+    if (e.button === 0) {
+      e.preventDefault();
+    }
+
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const origStart = clip.startTime;
+    const origDuration = clip.duration;
+    const origAudioOffset = clip.audioOffset ?? 0;
+    const origAudioDuration = clip.audioDuration ?? clip.duration;
+    const origContentOffset = getClipContentOffset(clip);
+    const origTimeStretchRate = clip.timeStretchRate;
+    const origStretchMode = clip.stretchMode;
+    const origSourceSpan = getClipSourceSpan(clip);
+    const origAudibleSourceEnd = getClipAudibleSourceEnd(clip);
+    dragRef.current = false;
+    scissorRef.current = false;
+    let isShiftCopy = e.shiftKey;
+
+    const currentSelectedClipIds = useUIStore.getState().selectedClipIds;
+    const isMultiSelected = currentSelectedClipIds.size > 1 && currentSelectedClipIds.has(clip.id);
+    let lastBatchOffset = 0;
+
+    const clipW = clip.duration * pixelsPerSecond;
+    const clipH = clipBlockRef.current?.offsetHeight ?? 48;
+    const clipRect = clipBlockRef.current?.getBoundingClientRect();
+    const clickOffsetPx = clipRect ? startX - clipRect.left : 0;
+    const supportsScissor = clip.generationStatus === 'ready' || Boolean(clip.midiData);
+    const canStartLongPressScissor = supportsScissor && isSecondaryPress && mode === 'move';
+    let secondaryMoved = false;
+    let pendingGhost: DragGhostInfo | null = null;
+    let ghostRafId = 0;
+    let pendingStoreUpdate: (() => void) | null = null;
+    let storeRafId = 0;
+    const scheduleStoreUpdate = (fn: () => void) => {
+      pendingStoreUpdate = fn;
+      if (!storeRafId) {
+        storeRafId = requestAnimationFrame(() => {
+          if (pendingStoreUpdate) pendingStoreUpdate();
+          pendingStoreUpdate = null;
+          storeRafId = 0;
+        });
+      }
+    };
+    const flushStoreUpdate = () => {
+      if (storeRafId) { cancelAnimationFrame(storeRafId); storeRafId = 0; }
+      if (pendingStoreUpdate) { pendingStoreUpdate(); pendingStoreUpdate = null; }
+    };
+
+    // Cache lane rects at drag start to avoid repeated DOM queries during drag
+    const laneElements = document.querySelectorAll<HTMLElement>('[data-timeline-lane][data-track-id]');
+    const cachedLaneRects = new Map<string, DOMRect>();
+    laneElements.forEach(el => {
+      const trackId = el.getAttribute('data-track-id');
+      if (trackId) cachedLaneRects.set(trackId, el.getBoundingClientRect());
+    });
+    const findClosestLaneCached = (clientY: number): { trackId: string; rect: DOMRect } | null => {
+      let best: { trackId: string; rect: DOMRect; dist: number } | null = null;
+      for (const [tid, r] of cachedLaneRects) {
+        const centerY = r.top + r.height / 2;
+        const dist = Math.abs(clientY - centerY);
+        if (!best || dist < best.dist) {
+          best = { trackId: tid, rect: r, dist };
+        }
+      }
+      return best ? { trackId: best.trackId, rect: best.rect } : null;
+    };
+    const sourceLane = findClosestLaneCached(startY);
+
+    // --- Long-press scissor detection (secondary press only) ---
+    let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+    if (mode === 'move' && canStartLongPressScissor) {
+      e.preventDefault();
+      longPressTimer = setTimeout(() => {
+        longPressTimer = null;
+        scissorRef.current = true;
+        suppressContextMenuRef.current = true;
+        // Calculate initial scissor line position
+        if (clipRect) {
+          const relX = startX - clipRect.left;
+          const splitTime = origStart + relX / pixelsPerSecond;
+          const snapped = e.altKey ? splitTime : snapToGrid(splitTime, bpm, 1);
+          const snappedPx = (snapped - origStart) * pixelsPerSecond;
+          onScissorLineChange(Math.max(0, Math.min(snappedPx, clipW)));
+        }
+        // Override cursor
+        document.body.style.cursor = 'crosshair';
+      }, 300);
+    }
+
+    const onMouseMove = (ev: MouseEvent) => {
+      // If in scissor mode, just update the split line position
+      if (scissorRef.current) {
+        const liveRect = clipBlockRef.current?.getBoundingClientRect();
+        if (!liveRect) return;
+        const relX = ev.clientX - liveRect.left;
+        const splitTime = origStart + relX / pixelsPerSecond;
+        const snapped = ev.altKey ? splitTime : snapToGrid(splitTime, bpm, 1);
+        const snappedPx = (snapped - origStart) * pixelsPerSecond;
+        onScissorLineChange(Math.max(0, Math.min(snappedPx, clipW)));
+        return;
+      }
+      const dx = ev.clientX - startX;
+      const dy = ev.clientY - startY;
+      if (isSecondaryPress && (Math.abs(dx) >= 3 || Math.abs(dy) >= 3)) {
+        secondaryMoved = true;
+      }
+      if (isSecondaryPress && !scissorRef.current) {
+        if (Math.abs(dx) >= 3 || Math.abs(dy) >= 3) {
+          if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+        }
+        return;
+      }
+      if (Math.abs(dx) < 3 && Math.abs(dy) < 3 && !dragRef.current) return;
+      // Cancel long-press timer once real drag starts
+      if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+      if (!dragRef.current) beginDrag();
+      dragRef.current = true;
+      isShiftCopy = ev.shiftKey;
+
+      const deltaSec = dx / pixelsPerSecond;
+
+      if (mode === 'move') {
+        document.body.style.cursor = isShiftCopy ? 'copy' : 'grabbing';
+
+        const closest = findClosestLaneCached(ev.clientY);
+
+        // Never move the original clip during drag — the ghost alone shows
+        // the preview position. Store is only committed on mouseup.
+        // Revert any offset that may have been applied in earlier frames.
+        if (lastBatchOffset !== 0 && isMultiSelected) {
+          batchMoveClips([...currentSelectedClipIds], -lastBatchOffset);
+          lastBatchOffset = 0;
+        }
+
+        if (closest) {
+          const ghostLeftVp = ev.clientX - clickOffsetPx;
+          const clickOffsetY = clipRect ? startY - clipRect.top : 0;
+          const crossingTrack = closest.trackId !== track.id;
+          pendingGhost = {
+            x: ghostLeftVp,
+            y: ev.clientY - clickOffsetY,
+            width: clipW,
+            height: clipH,
+            targetTrackId: closest.trackId,
+            targetLaneRect: (crossingTrack || isShiftCopy)
+              ? { top: closest.rect.top, height: closest.rect.height }
+              : null,
+            sourceLaneRect: (crossingTrack || isShiftCopy) && sourceLane
+              ? { top: sourceLane.rect.top, height: sourceLane.rect.height }
+              : null,
+            isShiftCopy,
+          };
+          if (!ghostRafId) {
+            ghostRafId = requestAnimationFrame(() => {
+              if (pendingGhost) onDragGhostChange(pendingGhost);
+              ghostRafId = 0;
+            });
+          }
+        }
+      } else if (mode === 'resize-left') {
+        let newStart = ev.altKey ? origStart + deltaSec : snapToGrid(origStart + deltaSec, bpm, 1);
+        newStart = Math.max(0, newStart);
+        const maxStart = origStart + origDuration - MIN_CLIP_DURATION;
+        newStart = Math.min(newStart, maxStart);
+
+        const newDuration = origDuration + (origStart - newStart);
+        if (ev.shiftKey) {
+          scheduleStoreUpdate(() => updateClip(clip.id, {
+            startTime: newStart,
+            duration: newDuration,
+            contentOffset: undefined,
+            timeStretchRate: Math.max(CLIP_DRAG_EPSILON, origSourceSpan / newDuration),
+            stretchMode: 'repitch',
+          }));
+          return;
+        }
+
+        if (newStart < origStart) {
+          const extension = origStart - newStart;
+          scheduleStoreUpdate(() => updateClip(clip.id, {
+            startTime: newStart,
+            duration: newDuration,
+            contentOffset: origContentOffset + extension,
+            timeStretchRate: undefined,
+            stretchMode: undefined,
+          }));
+          return;
+        }
+
+        const trimAmount = newStart - origStart;
+        const silenceTrim = Math.min(origContentOffset, trimAmount);
+        const audioTrim = trimAmount - silenceTrim;
+        scheduleStoreUpdate(() => updateClip(clip.id, {
+          startTime: newStart,
+          duration: newDuration,
+          contentOffset: Math.max(0, origContentOffset - silenceTrim) || undefined,
+          audioOffset: Math.min(origAudioDuration, origAudioOffset + audioTrim),
+          timeStretchRate: undefined,
+          stretchMode: undefined,
+        }));
+      } else if (mode === 'slip') {
+        document.body.style.cursor = 'ew-resize';
+        const maxOffset = Math.max(0, origAudioDuration - origDuration);
+        if (maxOffset > 0) {
+          const newOffset = Math.max(0, Math.min(origAudioOffset + deltaSec, maxOffset));
+          scheduleStoreUpdate(() => updateClip(clip.id, { audioOffset: newOffset }));
+        }
+      } else {
+        let newDuration = ev.altKey ? origDuration + deltaSec : snapToGrid(origDuration + deltaSec, bpm, 1);
+        newDuration = Math.max(MIN_CLIP_DURATION, newDuration);
+        newDuration = Math.min(newDuration, totalDuration - origStart);
+        if (ev.shiftKey) {
+          scheduleStoreUpdate(() => updateClip(clip.id, {
+            duration: newDuration,
+            contentOffset: undefined,
+            timeStretchRate: Math.max(CLIP_DRAG_EPSILON, origSourceSpan / newDuration),
+            stretchMode: 'repitch',
+          }));
+          return;
+        }
+        scheduleStoreUpdate(() => updateClip(clip.id, {
+          duration: newDuration,
+          contentOffset: Math.min(origContentOffset, newDuration) || undefined,
+          timeStretchRate: undefined,
+          stretchMode: undefined,
+        }));
+      }
+    };
+
+    const onKeyDown = (ev: KeyboardEvent) => {
+      if (ev.key !== 'Escape') return;
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('keydown', onKeyDown);
+      cancelAnimationFrame(ghostRafId);
+      // Cancel any pending batched store update (escape reverts, so discard it)
+      if (storeRafId) { cancelAnimationFrame(storeRafId); storeRafId = 0; }
+      pendingStoreUpdate = null;
+      if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+      // Cancel scissor mode
+      if (scissorRef.current) {
+        scissorRef.current = false;
+        onScissorLineChange(null);
+        document.body.style.cursor = '';
+        return;
+      }
+      onDragGhostChange(null);
+      document.body.style.cursor = '';
+      if (dragRef.current) {
+        // Restore original state for multi-select batch moves
+        if (isMultiSelected && lastBatchOffset !== 0) {
+          batchMoveClips([...currentSelectedClipIds], -lastBatchOffset);
+        } else if (mode === 'move') {
+          updateClip(clip.id, { startTime: origStart });
+        } else if (mode === 'resize-left') {
+          updateClip(clip.id, {
+            startTime: origStart,
+            duration: origDuration,
+            audioOffset: origAudioOffset,
+            contentOffset: origContentOffset || undefined,
+            timeStretchRate: origTimeStretchRate,
+            stretchMode: origStretchMode,
+          });
+        } else if (mode === 'resize-right') {
+          updateClip(clip.id, {
+            duration: origDuration,
+            contentOffset: origContentOffset || undefined,
+            timeStretchRate: origTimeStretchRate,
+            stretchMode: origStretchMode,
+          });
+        } else if (mode === 'slip') {
+          updateClip(clip.id, { audioOffset: origAudioOffset });
+        }
+        endDrag();
+        undo();
+      }
+      dragRef.current = false;
+    };
+
+    const onMouseUp = (ev: MouseEvent) => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('keydown', onKeyDown);
+      cancelAnimationFrame(ghostRafId);
+      // Flush any pending batched store update so the final position is committed
+      flushStoreUpdate();
+      if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+
+      // Execute scissor split
+      if (scissorRef.current) {
+        scissorRef.current = false;
+        onScissorLineChange(null);
+        document.body.style.cursor = '';
+        const liveRect = clipBlockRef.current?.getBoundingClientRect();
+        if (!liveRect) return;
+        const relX = ev.clientX - liveRect.left;
+        const splitTime = origStart + relX / pixelsPerSecond;
+        const snapped = ev.altKey ? splitTime : snapToGrid(splitTime, bpm, 1);
+        // Only split if within clip bounds (not at edges)
+        if (snapped > origStart + 0.01 && snapped < origStart + origDuration - 0.01) {
+          void splitClipAtZeroCrossing(clip.id, snapped);
+        }
+        return;
+      }
+
+      if (isSecondaryPress) {
+        if (!secondaryMoved && !suppressContextMenuRef.current) {
+          onCtxMenuChange({ x: ev.clientX, y: ev.clientY });
+        }
+        suppressContextMenuRef.current = false;
+        return;
+      }
+
+      // Trigger ghost "landing" animation
+      if (pendingGhost || ghostRafId) {
+        onGhostLanding();
+      } else {
+        onDragGhostChange(null);
+      }
+      endDrag();
+      document.body.style.cursor = '';
+
+      if ((mode === 'resize-left' || mode === 'resize-right') && dragRef.current && !ev.shiftKey) {
+        const currentClip = useProjectStore.getState().getClipById(clip.id);
+        if (currentClip) {
+          if (mode === 'resize-left') {
+            const trimmedAudioLeft = (currentClip.audioOffset ?? 0) > origAudioOffset + CLIP_DRAG_EPSILON;
+            if (trimmedAudioLeft) {
+              void snapClipEdgeToZeroCrossing(clip.id, 'left');
+            }
+          } else {
+            const trimmedAudioRight = getClipAudibleSourceEnd(currentClip) < origAudibleSourceEnd - CLIP_DRAG_EPSILON;
+            if (trimmedAudioRight) {
+              void snapClipEdgeToZeroCrossing(clip.id, 'right');
+            }
+          }
+        }
+      }
+
+      if (mode === 'move' && dragRef.current) {
+        const closest = findClosestLaneCached(ev.clientY);
+        const deltaSec = (ev.clientX - startX) / pixelsPerSecond;
+        const isFineMove = ev.metaKey || ev.ctrlKey;
+        const dropStart = Math.max(0, isFineMove
+          ? Math.round((origStart + deltaSec) * 100) / 100
+          : snapToGrid(origStart + deltaSec, bpm, 1));
+
+        // Resolve target trackId — if dropping on an empty slot, create a new
+        // track that inherits the source track's color and display name prefix
+        let resolvedTargetId = closest?.trackId;
+        if (resolvedTargetId) {
+          const emptySlotIndex = parseArrangementEmptyTrackSlotIndex(resolvedTargetId);
+          if (emptySlotIndex !== null) {
+            const newTrack = addTrack(track.trackName, track.trackType, {
+              order: emptySlotIndex + 1,
+              color: track.color,
+              displayName: track.displayName,
+            });
+            resolvedTargetId = newTrack.id;
+          }
+        }
+
+        if (ev.shiftKey && closest && resolvedTargetId) {
+          // Shift+drag = duplicate
+          const timeOffset = dropStart - origStart;
+          if (isMultiSelected) {
+            batchDuplicateClips([...currentSelectedClipIds], timeOffset);
+          } else {
+            duplicateClipToTrack(clip.id, resolvedTargetId, dropStart);
+          }
+        } else if (resolvedTargetId && resolvedTargetId !== track.id && !isMultiSelected) {
+          // Cross-track move
+          moveClipToTrack(clip.id, resolvedTargetId, dropStart);
+        } else if (!isMultiSelected) {
+          // Same-track move — commit final position
+          updateClip(clip.id, { startTime: dropStart });
+        } else {
+          // Same-track multi-select move — commit final offset
+          const timeOffset = dropStart - origStart;
+          if (timeOffset !== 0) {
+            batchMoveClips([...currentSelectedClipIds], timeOffset);
+          }
+        }
+      }
+    };
+
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('keydown', onKeyDown);
+  }, [addTrack, batchDuplicateClips, batchMoveClips, beginDrag, bpm, clip, duplicateClipToTrack, endDrag, getDragMode, moveClipToTrack, pixelsPerSecond, selectClip, sliceClipToRange, snapClipEdgeToZeroCrossing, splitClipAtZeroCrossing, totalDuration, track.id, track.trackName, track.trackType, undo, updateClip, clipBlockRef, onDragGhostChange, onGhostLanding, onScissorLineChange, onRangePreviewChange, onCtxMenuChange, track.color, track.displayName]);
+
+  return {
+    handleMouseDown,
+    getDragMode,
+    dragRef,
+    scissorRef,
+    suppressContextMenuRef,
+    rangePreviewCommittedRef,
+  };
+}

--- a/src/components/timeline/useClipHover.ts
+++ b/src/components/timeline/useClipHover.ts
@@ -1,0 +1,84 @@
+import { useCallback, useState } from 'react';
+import { CURSOR_BRACKET_LEFT, CURSOR_BRACKET_RIGHT } from '../../utils/bracketCursor';
+import { EDGE_HANDLE_PX, HEADER_RAIL_HEIGHT_PX } from './useClipDrag';
+
+export function useClipHover(clipBlockRef: React.RefObject<HTMLDivElement | null>) {
+  const [hoveredResizeEdge, setHoveredResizeEdge] = useState<'left' | 'right' | null>(null);
+  const [hoverSeekX, setHoverSeekX] = useState<number | null>(null);
+
+  const setResizeCursor = useCallback((cursor: 'w-resize' | 'e-resize' | null) => {
+    const nextCursor = cursor === 'w-resize' ? CURSOR_BRACKET_LEFT
+      : cursor === 'e-resize' ? CURSOR_BRACKET_RIGHT
+      : '';
+    if (clipBlockRef.current) {
+      clipBlockRef.current.style.cursor = nextCursor;
+    }
+    document.body.style.cursor = nextCursor;
+    document.documentElement.style.cursor = nextCursor;
+  }, [clipBlockRef]);
+
+  const syncHoverState = useCallback((clientX: number, clientY: number, altKey: boolean, currentTarget: HTMLElement) => {
+    const rect = currentTarget.getBoundingClientRect();
+    const relX = clientX - rect.left;
+    const relY = clientY - rect.top;
+
+    const inHeaderRail = relY <= HEADER_RAIL_HEIGHT_PX;
+    const atEdge = relX <= EDGE_HANDLE_PX || relX >= rect.width - EDGE_HANDLE_PX;
+
+    if (inHeaderRail && atEdge) {
+      const edge = relX <= EDGE_HANDLE_PX ? 'left' : 'right';
+      const cursor = edge === 'left' ? 'w-resize' : 'e-resize';
+      const bracketCursor = edge === 'left' ? CURSOR_BRACKET_LEFT : CURSOR_BRACKET_RIGHT;
+      setHoveredResizeEdge(edge);
+      setHoverSeekX(null);
+      setResizeCursor(cursor);
+      currentTarget.style.cursor = bracketCursor;
+    } else {
+      setHoveredResizeEdge(null);
+      setResizeCursor(null);
+      if (inHeaderRail) {
+        setHoverSeekX(null);
+        currentTarget.style.cursor = altKey ? 'ew-resize' : 'grab';
+      } else {
+        setHoverSeekX(relX);
+        currentTarget.style.cursor = '';
+      }
+    }
+  }, [setResizeCursor]);
+
+  const handleMouseEnter = useCallback((e: React.MouseEvent) => {
+    syncHoverState(e.clientX, e.clientY, e.altKey, e.currentTarget as HTMLElement);
+  }, [syncHoverState]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    syncHoverState(e.clientX, e.clientY, e.altKey, e.currentTarget as HTMLElement);
+  }, [syncHoverState]);
+
+  const handleMouseLeave = useCallback((e: React.MouseEvent) => {
+    const el = e.currentTarget as HTMLElement;
+    setHoveredResizeEdge(null);
+    setHoverSeekX(null);
+    el.style.cursor = '';
+    setResizeCursor(null);
+  }, [setResizeCursor]);
+
+  const handleResizeHandleEnter = useCallback((edge: 'left' | 'right') => () => {
+    setHoveredResizeEdge(edge);
+    setResizeCursor(edge === 'left' ? 'w-resize' : 'e-resize');
+  }, [setResizeCursor]);
+
+  const handleResizeHandleLeave = useCallback(() => {
+    setHoveredResizeEdge(null);
+    setResizeCursor(null);
+  }, [setResizeCursor]);
+
+  return {
+    hoveredResizeEdge,
+    hoverSeekX,
+    handleMouseEnter,
+    handleMouseMove,
+    handleMouseLeave,
+    handleResizeHandleEnter,
+    handleResizeHandleLeave,
+  };
+}

--- a/src/components/timeline/useWaveformUpgrade.ts
+++ b/src/components/timeline/useWaveformUpgrade.ts
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { loadAudioBlobByKey } from '../../services/audioFileManager';
+import { computeWaveformPeaks } from '../../utils/waveformPeaks';
+import { CLIP_WAVEFORM_PEAK_COUNT } from '../../utils/clipAudio';
+
+const waveformUpgradeInFlight = new Set<string>();
+
+/**
+ * Upgrades a clip's waveform peaks to high resolution when the clip
+ * becomes ready and has an isolated audio key.
+ */
+export function useWaveformUpgrade(
+  clipId: string,
+  generationStatus: string,
+  isolatedAudioKey: string | null | undefined,
+  waveformPeaks: number[] | null,
+  audioDuration: number | undefined,
+) {
+  useEffect(() => {
+    if (generationStatus !== 'ready' || !isolatedAudioKey) return;
+    if (waveformPeaks && waveformPeaks.length >= CLIP_WAVEFORM_PEAK_COUNT) return;
+    if (waveformUpgradeInFlight.has(clipId)) return;
+
+    let cancelled = false;
+    waveformUpgradeInFlight.add(clipId);
+
+    void (async () => {
+      try {
+        const blob = await loadAudioBlobByKey(isolatedAudioKey);
+        if (!blob || cancelled) return;
+
+        const buffer = await getAudioEngine().decodeAudioData(blob);
+        if (cancelled) return;
+
+        const upgradedPeaks = computeWaveformPeaks(buffer, CLIP_WAVEFORM_PEAK_COUNT);
+        useProjectStore.setState((state) => {
+          if (!state.project) return state;
+          return {
+            ...state,
+            project: {
+              ...state.project,
+              updatedAt: Date.now(),
+              tracks: state.project.tracks.map((candidate) => ({
+                ...candidate,
+                clips: candidate.clips.map((candidateClip) => (
+                  candidateClip.id === clipId
+                    ? {
+                        ...candidateClip,
+                        waveformPeaks: upgradedPeaks,
+                        audioDuration: candidateClip.audioDuration ?? buffer.duration,
+                      }
+                    : candidateClip
+                )),
+              })),
+            },
+          };
+        });
+      } catch {
+        // Keep the existing waveform if the upgrade pass fails.
+      } finally {
+        waveformUpgradeInFlight.delete(clipId);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      waveformUpgradeInFlight.delete(clipId);
+    };
+  }, [audioDuration, generationStatus, clipId, isolatedAudioKey, waveformPeaks]);
+}


### PR DESCRIPTION
## Summary

Closes #1026

Decomposes `ClipBlock.tsx` from **1481 lines** down to **486 lines** (67% reduction) by extracting focused sub-components and hooks:

- **`useClipDrag.ts`** (566 lines) -- drag state machine (move, resize-left, resize-right, slip, scissor, range selection)
- **`useClipHover.ts`** (85 lines) -- cursor management and hover state tracking
- **`useWaveformUpgrade.ts`** (72 lines) -- async waveform peak upgrade effect
- **`ClipFadeHandles.tsx`** (185 lines) -- fade in/out handles, overlays, and keyboard/mouse interactions
- **`ClipDragGhost.tsx`** (153 lines) -- drag ghost portal rendering with cross-track highlight
- **`ClipContextMenuContainer.tsx`** (161 lines) -- context menu store wiring and callback assembly
- **`ClipVersionNav.tsx`** (70 lines) -- version navigation buttons
- **`clipPresentation.ts`** (41 lines) -- clip color/style computation

Pure refactor -- no behavior changes. Exported API of `ClipBlock` is unchanged.

## Test plan

- [x] `npx tsc --noEmit` -- 0 type errors
- [x] `npm test -- --run` -- all 3008 tests pass (319 test files)
- [x] `npm run build` -- succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)