### PR TITLE
fix: thinking default to true, duration auto state on simple->custom switch

### DIFF
--- a/src/components/generation/FullSongForm.tsx
+++ b/src/components/generation/FullSongForm.tsx
@@ -136,7 +136,10 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
     if (!initialData) return;
     setPrompt(initialData.caption);
     setLyrics(initialData.lyrics);
-    if (initialData.duration > 0) setDurationSeconds(initialData.duration);
+    if (initialData.duration > 0) {
+      setDurationSeconds(initialData.duration);
+      setDurationAuto(false);
+    }
     if (initialData.vocalLanguage) setVocalLanguage(initialData.vocalLanguage);
   }, [initialData]);
 

--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -12,7 +12,7 @@ export const DEFAULT_GENERATION: GenerationDefaults = {
   inferenceSteps: 50,
   guidanceScale: 7.0,
   shift: 3.0,
-  thinking: false,
+  thinking: true,
   model: '',
 };
 


### PR DESCRIPTION
## Summary
- Change `DEFAULT_GENERATION.thinking` from `false` to `true` so Custom mode defaults to thinking enabled
- When switching from Simple to Custom with `initialData.duration > 0`, set `durationAuto = false` so the UI correctly shows the numeric duration instead of "Auto"

Closes #1054

## Test plan
- [ ] Open Generate panel → Custom mode → verify Thinking checkbox is checked by default
- [ ] Simple mode: create sample → auto-switch to Custom → verify duration shows the actual value (not Auto)
- [ ] Custom mode without initialData: verify duration stays in Auto mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)