### PR TITLE
fix: auto-expand timeline grid when clips exceed configured measures

### DIFF
--- a/src/components/timeline/GridOverlay.tsx
+++ b/src/components/timeline/GridOverlay.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
-import { getBeatDuration, getBarDuration } from '../../utils/time';
+import { getBeatDuration, getBarDuration, getEffectiveMeasures } from '../../utils/time';
 import { beatToTime, getBeatAtBar, getTimeSignatureAtBar, getTimeSignatureBeatLength } from '../../utils/tempoMap';
 import { getTimelineVisualDuration } from '../../utils/timelineZoom';
 import { useMetaKeyDown } from '../../hooks/useMetaKeyDown';
@@ -59,7 +59,8 @@ export function GridOverlay() {
       timeSignatureDenominator = 4,
       totalDuration,
     } = project;
-    const effectiveMeasures = project.measures ?? DEFAULT_MEASURES;
+    const configuredMeasures = project.measures ?? DEFAULT_MEASURES;
+    const effectiveMeasures = getEffectiveMeasures(configuredMeasures, totalDuration, bpm, timeSignature, timeSignatureDenominator);
     const visualDuration = getTimelineVisualDuration(totalDuration, pixelsPerSecond, timelineViewportWidth);
     const hasTempoMap = tempoMap && tempoMap.length > 0;
     const hasTsMap = timeSignatureMap && timeSignatureMap.length > 0;

--- a/src/components/timeline/TimeRuler.tsx
+++ b/src/components/timeline/TimeRuler.tsx
@@ -3,7 +3,7 @@ import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { useTransportStore } from '../../store/transportStore';
 import { useTransport } from '../../hooks/useTransport';
-import { getBarDuration, getBeatDuration, snapToGrid } from '../../utils/time';
+import { getBarDuration, getBeatDuration, getEffectiveMeasures, snapToGrid } from '../../utils/time';
 import { beatToTime, getBeatAtBar, getTimeSignatureAtBar, getTimeSignatureBeatLength } from '../../utils/tempoMap';
 import { TIMELINE_RULER_HEIGHT } from './timelineLayout';
 import { getTimelineVisualDuration } from '../../utils/timelineZoom';
@@ -25,7 +25,7 @@ export function TimeRuler() {
   const timeSignatureDenominator = useProjectStore((s) => s.project?.timeSignatureDenominator ?? 4);
   const tempoMap = useProjectStore((s) => s.project?.tempoMap);
   const timeSignatureMap = useProjectStore((s) => s.project?.timeSignatureMap);
-  const measures = useProjectStore((s) => s.project?.measures ?? DEFAULT_MEASURES);
+  const configuredMeasures = useProjectStore((s) => s.project?.measures ?? DEFAULT_MEASURES);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
   const timelineViewportWidth = useUIStore((s) => s.timelineViewportWidth);
   const isPlaying = useTransportStore((s) => s.isPlaying);
@@ -184,6 +184,7 @@ export function TimeRuler() {
 
   const markers = useMemo(() => {
     if (!hasProject) return [];
+    const measures = getEffectiveMeasures(configuredMeasures, totalDuration, bpm, timeSignature, timeSignatureDenominator);
     const visualDuration = getTimelineVisualDuration(totalDuration, pixelsPerSecond, timelineViewportWidth);
     const visibleDuration = Math.min(visualDuration, totalDuration);
     const hasTempoMap = tempoMap && tempoMap.length > 0;
@@ -241,7 +242,7 @@ export function TimeRuler() {
       }
     }
     return result;
-  }, [bpm, hasProject, measures, pixelsPerSecond, tempoMap, timeSignature, timeSignatureDenominator, timeSignatureMap, timelineViewportWidth, totalDuration]);
+  }, [bpm, hasProject, configuredMeasures, pixelsPerSecond, tempoMap, timeSignature, timeSignatureDenominator, timeSignatureMap, timelineViewportWidth, totalDuration]);
 
   if (!hasProject) return <div className="bg-[#1a1c20] border-b border-[color:var(--color-daw-grid-bar)]" style={{ height: TIMELINE_RULER_HEIGHT }} />;
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -950,6 +950,7 @@ function computeTotalDuration(
   return Math.max(measuredDuration, maxEnd + TIMELINE_PADDING);
 }
 
+
 function buildBouncedClip(trackId: string, input: {
   startTime: number;
   duration: number;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -77,3 +77,22 @@ export function getBarDuration(bpm: number, timeSignature: number, timeSignature
 export function getBeatDuration(bpm: number): number {
   return 60 / bpm;
 }
+
+/**
+ * Compute the effective measures for rendering grid/ruler.
+ * If totalDuration exceeds the configured measures boundary, expand to fit
+ * (rounded up to the next multiple of 8 bars).
+ */
+export function getEffectiveMeasures(
+  configuredMeasures: number,
+  totalDuration: number,
+  bpm: number,
+  timeSignature: number,
+  timeSignatureDenominator: number = 4,
+): number {
+  const barDur = getBarDuration(bpm, timeSignature, timeSignatureDenominator);
+  const configuredDuration = configuredMeasures * barDur;
+  if (totalDuration <= configuredDuration) return configuredMeasures;
+  const required = Math.ceil(totalDuration / barDur) + 4;
+  return Math.ceil(required / 8) * 8;
+}


### PR DESCRIPTION
## Summary
- Add `getEffectiveMeasures()` utility in `src/utils/time.ts` that computes expanded measure count when `totalDuration` exceeds the configured measures boundary
- Update `GridOverlay` and `TimeRuler` to use effective measures instead of raw `project.measures`
- Measures expand in multiples of 8 for clean bar boundaries

When a generated song exceeds 128 bars, the grid lines and ruler now extend to cover the full content — no more black empty area beyond bar 128.

Closes #1056

## Test plan
- [ ] Generate a song that exceeds 128 bars at current BPM
- [ ] Scroll to the end of the timeline — grid lines and ruler should extend to cover all content
- [ ] Verify grid lines remain correct at normal (< 128 bar) content
- [ ] Change BPM and verify grid still extends correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)