### PR TITLE
feat: add send amount to automatable parameters

### DIFF
--- a/src/components/timeline/AutomationLaneView.tsx
+++ b/src/components/timeline/AutomationLaneView.tsx
@@ -67,6 +67,14 @@ export function AutomationLaneView({ trackId, lane }: AutomationLaneViewProps) {
       lane.parameter.type === 'effect' && trackEffect.id === lane.parameter.effectId,
     ) ?? null,
   );
+  const sendReturnName = useProjectStore((s) => {
+    if (lane.parameter.type !== 'send') return null;
+    const track = s.project?.tracks.find((t) => t.id === trackId);
+    const send = track?.sends?.[lane.parameter.sendIndex];
+    if (!send) return null;
+    const rt = (s.project?.returnTracks ?? []).find((r) => r.id === send.returnTrackId);
+    return rt?.name ?? null;
+  });
 
   const [showLFODialog, setShowLFODialog] = useState(false);
   const [lfoShape, setLfoShape] = useState<LFOShape>('sine');
@@ -116,7 +124,9 @@ export function AutomationLaneView({ trackId, lane }: AutomationLaneViewProps) {
 
   const paramLabel = lane.parameter.type === 'mixer'
     ? lane.parameter.param.charAt(0).toUpperCase() + lane.parameter.param.slice(1)
-    : `${effect?.type ?? lane.parameter.effectType} • ${getEffectAutomationLabel(lane.parameter.effectType, lane.parameter.param)}`;
+    : lane.parameter.type === 'send'
+      ? `Send ${lane.parameter.sendIndex + 1}${sendReturnName ? ` (${sendReturnName})` : ''} • Amount`
+      : `${effect?.type ?? lane.parameter.effectType} • ${getEffectAutomationLabel(lane.parameter.effectType, lane.parameter.param)}`;
 
   // Double-click to add a new point
   const handleDoubleClick = useCallback((e: React.MouseEvent<SVGSVGElement>) => {

--- a/src/engine/AutomationEngine.ts
+++ b/src/engine/AutomationEngine.ts
@@ -2,6 +2,7 @@ import type { AutomationLane, AutomationParameter } from '../types/project';
 import { automationParamEquals, normalizedToMixerValue } from '../types/project';
 import { getAudioEngine } from '../hooks/useAudioEngine';
 import { effectsEngine } from './EffectsEngine';
+import { useProjectStore } from '../store/projectStore';
 
 /**
  * Automation playback engine.
@@ -14,6 +15,7 @@ export class AutomationEngine {
   private trackVolumes: Map<string, number> = new Map();
   private trackPans: Map<string, number> = new Map();
   private effectValues: Map<string, number> = new Map();
+  private sendValues: Map<string, number> = new Map();
 
   /**
    * Start applying automation during playback
@@ -27,6 +29,7 @@ export class AutomationEngine {
     this.trackVolumes.clear();
     this.trackPans.clear();
     this.effectValues.clear();
+    this.sendValues.clear();
     this.tick();
   }
 
@@ -42,6 +45,7 @@ export class AutomationEngine {
     this.trackVolumes.clear();
     this.trackPans.clear();
     this.effectValues.clear();
+    this.sendValues.clear();
   }
 
   /**
@@ -118,6 +122,26 @@ export class AutomationEngine {
       if (last !== undefined && Math.abs(last - normalized) < 0.001) return;
       this.effectValues.set(key, normalized);
       effectsEngine.applyAutomationValue(trackId, param.effectId, param, normalized);
+      return;
+    }
+
+    if (param.type === 'send') {
+      const key = `${trackId}:send:${param.sendIndex}`;
+      const last = this.sendValues.get(key);
+      if (last !== undefined && Math.abs(last - normalized) < 0.001) return;
+      this.sendValues.set(key, normalized);
+
+      // Look up the returnTrackId from the project store to use as the engine send ID
+      const project = useProjectStore.getState().project;
+      const track = project?.tracks.find((t) => t.id === trackId);
+      const send = track?.sends?.[param.sendIndex];
+      if (!send) return;
+
+      const engine = getAudioEngine();
+      const trackNode = engine.trackNodes.get(trackId);
+      if (trackNode) {
+        trackNode.updateSendAmount(send.returnTrackId, normalized);
+      }
     }
   }
 

--- a/src/engine/__tests__/automationEngineSend.test.ts
+++ b/src/engine/__tests__/automationEngineSend.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AutomationEngine } from '../AutomationEngine';
+import type { AutomationLane, AutomationParameter } from '../../types/project';
+
+// Mock the audio engine module
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: () => mockAudioEngine,
+}));
+
+vi.mock('../EffectsEngine', () => ({
+  effectsEngine: { applyAutomationValue: vi.fn() },
+}));
+
+vi.mock('../../store/projectStore', () => ({
+  useProjectStore: { getState: () => ({ project: null }) },
+}));
+
+const mockTrackNode = {
+  updateSendAmount: vi.fn(),
+};
+
+const mockAudioEngine = {
+  trackNodes: new Map<string, typeof mockTrackNode>(),
+  setTrackVolume: vi.fn(),
+  setTrackPan: vi.fn(),
+};
+
+describe('AutomationEngine send parameter', () => {
+  let engine: AutomationEngine;
+
+  beforeEach(() => {
+    engine = new AutomationEngine();
+    mockTrackNode.updateSendAmount.mockClear();
+    mockAudioEngine.trackNodes.clear();
+    mockAudioEngine.trackNodes.set('track-1', mockTrackNode);
+  });
+
+  it('getValueAtTime interpolates correctly for send lanes', () => {
+    const param: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    const lane: AutomationLane = {
+      id: 'lane-1',
+      trackId: 'track-1',
+      parameter: param,
+      points: [
+        { time: 0, value: 0.2 },
+        { time: 2, value: 0.8 },
+      ],
+    };
+
+    const val = AutomationEngine.getValueAtTime(lane, 1);
+    expect(val).toBeCloseTo(0.5, 1);
+  });
+
+  it('getValueAtTime returns boundary values for send lanes', () => {
+    const param: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    const lane: AutomationLane = {
+      id: 'lane-1',
+      trackId: 'track-1',
+      parameter: param,
+      points: [
+        { time: 0, value: 0 },
+        { time: 4, value: 1 },
+      ],
+    };
+
+    expect(AutomationEngine.getValueAtTime(lane, 0)).toBe(0);
+    expect(AutomationEngine.getValueAtTime(lane, 4)).toBe(1);
+    expect(AutomationEngine.getValueAtTime(lane, 2)).toBeCloseTo(0.5, 1);
+  });
+
+  it('hasAutomation returns true for send lanes with points', () => {
+    const param: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    const lane: AutomationLane = {
+      id: 'lane-1',
+      trackId: 'track-1',
+      parameter: param,
+      points: [{ time: 0, value: 0.5 }],
+    };
+
+    engine.start([lane], () => 0);
+    expect(engine.hasAutomation('track-1', param)).toBe(true);
+    engine.stop();
+  });
+
+  it('hasAutomation returns false for different sendIndex', () => {
+    const param0: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    const param1: AutomationParameter = { type: 'send', sendIndex: 1, param: 'amount' };
+    const lane: AutomationLane = {
+      id: 'lane-1',
+      trackId: 'track-1',
+      parameter: param0,
+      points: [{ time: 0, value: 0.5 }],
+    };
+
+    engine.start([lane], () => 0);
+    expect(engine.hasAutomation('track-1', param1)).toBe(false);
+    engine.stop();
+  });
+});

--- a/src/store/__tests__/sendAutomation.test.ts
+++ b/src/store/__tests__/sendAutomation.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+import type { AutomationParameter } from '../../types/project';
+import { automationParamEquals } from '../../types/project';
+
+vi.mock('../../services/projectStorage', () => ({ saveProject: vi.fn() }));
+
+describe('send amount automation', () => {
+  let trackId: string;
+
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject({ name: 'Test', bpm: 120 });
+    useProjectStore.getState().addTrack('custom', 'stems');
+    trackId = useProjectStore.getState().project!.tracks[0].id;
+
+    // Add a return track and a send to it
+    const rt = useProjectStore.getState().addReturnTrack('FX Bus');
+    useProjectStore.getState().updateTrackSend(trackId, rt.id, 0.5);
+  });
+
+  it('AutomationParameter type "send" is recognized', () => {
+    const param: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    expect(param.type).toBe('send');
+    expect(param.sendIndex).toBe(0);
+    expect(param.param).toBe('amount');
+  });
+
+  it('automationParamEquals correctly compares send params', () => {
+    const a: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    const b: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    const c: AutomationParameter = { type: 'send', sendIndex: 1, param: 'amount' };
+    const d: AutomationParameter = { type: 'mixer', param: 'volume' };
+
+    expect(automationParamEquals(a, b)).toBe(true);
+    expect(automationParamEquals(a, c)).toBe(false);
+    expect(automationParamEquals(a, d)).toBe(false);
+  });
+
+  it('ensureAutomationLane creates a lane for send amount', () => {
+    const store = useProjectStore.getState();
+    const param: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    store.ensureAutomationLane(trackId, param, 0.5);
+
+    const lanes = useProjectStore.getState().project!.automationLanes!;
+    const lane = lanes.find(
+      (l) => l.trackId === trackId && automationParamEquals(l.parameter, param),
+    );
+    expect(lane).toBeDefined();
+    expect(lane!.points.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it('addAutomationPoint works for send parameter', () => {
+    const store = useProjectStore.getState();
+    const param: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    store.addAutomationPoint(trackId, param, { time: 0, value: 0.3 });
+    store.addAutomationPoint(trackId, param, { time: 2, value: 0.8 });
+
+    const lanes = useProjectStore.getState().project!.automationLanes!;
+    const lane = lanes.find(
+      (l) => l.trackId === trackId && automationParamEquals(l.parameter, param),
+    );
+    expect(lane).toBeDefined();
+    expect(lane!.points).toHaveLength(2);
+    expect(lane!.points[0].value).toBe(0.3);
+    expect(lane!.points[1].value).toBe(0.8);
+  });
+
+  it('clearAutomationLane removes the send automation lane', () => {
+    const store = useProjectStore.getState();
+    const param: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    store.addAutomationPoint(trackId, param, { time: 0, value: 0.5 });
+
+    const lanesBefore = useProjectStore.getState().project!.automationLanes!;
+    expect(lanesBefore.some((l) => automationParamEquals(l.parameter, param))).toBe(true);
+
+    store.clearAutomationLane(trackId, param);
+
+    const lanesAfter = useProjectStore.getState().project!.automationLanes!;
+    expect(lanesAfter.some((l) => automationParamEquals(l.parameter, param))).toBe(false);
+  });
+});

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1020,7 +1020,8 @@ export type AutomatableEffectTarget =
 
 export type AutomationParameter =
   | { type: 'mixer'; param: 'volume' | 'pan' }
-  | ({ type: 'effect'; effectId: string } & AutomatableEffectTarget);
+  | ({ type: 'effect'; effectId: string } & AutomatableEffectTarget)
+  | { type: 'send'; sendIndex: number; param: 'amount' };
 
 export interface AutomationLane {
   id: string;
@@ -1038,6 +1039,9 @@ export function automationParamEquals(a: AutomationParameter, b: AutomationParam
   }
   if (a.type === 'effect' && b.type === 'effect') {
     return a.effectId === b.effectId && a.effectType === b.effectType && a.param === b.param;
+  }
+  if (a.type === 'send' && b.type === 'send') {
+    return a.sendIndex === b.sendIndex && a.param === b.param;
   }
   return false;
 }

--- a/src/utils/__tests__/sendAutomationLabel.test.ts
+++ b/src/utils/__tests__/sendAutomationLabel.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { getEffectAutomationColor } from '../effectAutomation';
+import type { AutomationParameter } from '../../types/project';
+
+describe('send automation label and color', () => {
+  it('getEffectAutomationColor returns orange for send params', () => {
+    const param: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    const color = getEffectAutomationColor(param);
+    expect(color).toBe('#f97316');
+  });
+
+  it('getEffectAutomationColor returns different color from mixer volume', () => {
+    const sendParam: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    const volParam: AutomationParameter = { type: 'mixer', param: 'volume' };
+    const sendColor = getEffectAutomationColor(sendParam);
+    const volColor = getEffectAutomationColor(volParam);
+    expect(sendColor).not.toBe(volColor);
+  });
+
+  it('getEffectAutomationColor works for different send indices', () => {
+    const param0: AutomationParameter = { type: 'send', sendIndex: 0, param: 'amount' };
+    const param1: AutomationParameter = { type: 'send', sendIndex: 1, param: 'amount' };
+    expect(getEffectAutomationColor(param0)).toBe('#f97316');
+    expect(getEffectAutomationColor(param1)).toBe('#f97316');
+  });
+});

--- a/src/utils/effectAutomation.ts
+++ b/src/utils/effectAutomation.ts
@@ -129,6 +129,9 @@ export function getEffectAutomationColor(parameter: AutomationParameter): string
   if (parameter.type === 'mixer') {
     return parameter.param === 'volume' ? '#22c55e' : '#3b82f6';
   }
+  if (parameter.type === 'send') {
+    return '#f97316'; // orange for sends
+  }
   return getEffectAutomationSpec(parameter.effectType, parameter.param)?.color ?? '#8b5cf6';
 }
 


### PR DESCRIPTION
## Summary
- Register send amounts as automatable parameters (`{ type: 'send', sendIndex, param: 'amount' }`) in the `AutomationParameter` union type
- Add `automationParamEquals` support for comparing send parameters by `sendIndex`
- Display send automation lanes with return track name labels and orange color (`#f97316`)
- Route real-time send amount automation through `TrackNode.updateSendAmount()` during playback
- Add 12 unit tests covering store operations, engine interpolation, and UI label/color

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 328 files pass, 3067 tests pass
- [x] `npm run build` — succeeds
- [ ] Manual: create a send on a track, right-click send amount knob, verify automation lane appears with orange color and correct label
- [ ] Manual: draw automation points, play back, verify send amount changes in real-time

Closes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)