### PR TITLE
feat: add user sample loading to drum machine pads

### DIFF
--- a/src/components/sequencer/SequencerEditor.tsx
+++ b/src/components/sequencer/SequencerEditor.tsx
@@ -302,22 +302,7 @@ export function SequencerEditor() {
   };
 
   const updateSelectedRowSample = (rowId: string, key: string, name: string) => {
-    setRowSample(track.id, rowId, key);
-    const state = useProjectStore.getState();
-    if (!state.project) return;
-    const updatedTracks = state.project.tracks.map((candidate) => {
-      if (candidate.id !== track.id || !candidate.sequencerPattern) return candidate;
-      return {
-        ...candidate,
-        sequencerPattern: {
-          ...candidate.sequencerPattern,
-          rows: candidate.sequencerPattern.rows.map((row) => (row.id === rowId ? { ...row, name } : row)),
-        },
-      };
-    });
-    useProjectStore.setState({
-      project: { ...state.project, tracks: updatedTracks, updatedAt: Date.now() },
-    });
+    setRowSample(track.id, rowId, key, name);
   };
 
   const renderVelocityLane = () => {

--- a/src/components/sequencer/SequencerGrid.tsx
+++ b/src/components/sequencer/SequencerGrid.tsx
@@ -138,7 +138,8 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
     const audioBuffer = await engine.ctx.decodeAudioData(arrayBuffer);
     const key = `user-sample-${Date.now()}-${file.name}`;
     cacheUserSample(key, audioBuffer);
-    setRowSample(track.id, rowId, key);
+    const displayName = file.name.replace(/\.[^.]+$/, '');
+    setRowSample(track.id, rowId, key, displayName);
   }, [track.id, setRowSample]);
 
   const handleRowContextMenu = useCallback((rowId: string, e: React.MouseEvent) => {
@@ -297,25 +298,7 @@ export function SequencerGrid({ track, height }: SequencerGridProps) {
               <SamplePickerDropdown
                 currentKey={pattern.rows.find((r) => r.id === samplePickerRow)?.sampleKey ?? ''}
                 onSelect={(key, name) => {
-                  setRowSample(track.id, samplePickerRow, key);
-                  const state = useProjectStore.getState();
-                  if (state.project) {
-                    const updatedTracks = state.project.tracks.map((t) => {
-                      if (t.id !== track.id || !t.sequencerPattern) return t;
-                      return {
-                        ...t,
-                        sequencerPattern: {
-                          ...t.sequencerPattern,
-                          rows: t.sequencerPattern.rows.map((r) =>
-                            r.id === samplePickerRow ? { ...r, name } : r,
-                          ),
-                        },
-                      };
-                    });
-                    useProjectStore.setState({
-                      project: { ...state.project, tracks: updatedTracks, updatedAt: Date.now() },
-                    });
-                  }
+                  setRowSample(track.id, samplePickerRow, key, name);
                   setSamplePickerRow(null);
                 }}
                 onClose={() => setSamplePickerRow(null)}

--- a/src/components/sequencer/SequencerRowHeader.tsx
+++ b/src/components/sequencer/SequencerRowHeader.tsx
@@ -177,7 +177,7 @@ export function SequencerRowHeader({
             padding: '0 3px',
             lineHeight: 1.2,
           }}
-          title={`${row.name} — click to select, double-click to rename`}
+          title={`${row.name}${row.sampleName ? ` (${row.sampleName})` : ''} — click to select, double-click to rename`}
           onClick={(e) => {
             e.stopPropagation();
             onToggleSamplePicker(samplePickerRow === row.id ? '' : row.id);

--- a/src/store/__tests__/sequencerRowSample.test.ts
+++ b/src/store/__tests__/sequencerRowSample.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useProjectStore } from '../projectStore';
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+describe('sequencer row sample assignment and clearing', () => {
+  let trackId: string;
+  let rowId: string;
+
+  beforeEach(() => {
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+    const track = useProjectStore.getState().addTrack('drums', 'sequencer');
+    trackId = track.id;
+    rowId = track.sequencerPattern!.rows[0].id;
+  });
+
+  const getRow = (rid?: string) => {
+    const track = useProjectStore.getState().project!.tracks[0];
+    return track.sequencerPattern!.rows.find((r) => r.id === (rid ?? rowId))!;
+  };
+
+  describe('setSequencerRowSample', () => {
+    it('updates sampleKey on the target row', () => {
+      useProjectStore.getState().setSequencerRowSample(trackId, rowId, 'user-sample-abc');
+      expect(getRow().sampleKey).toBe('user-sample-abc');
+    });
+
+    it('updates sampleName when provided', () => {
+      useProjectStore.getState().setSequencerRowSample(trackId, rowId, 'user-sample-abc', 'My Kick');
+      expect(getRow().sampleKey).toBe('user-sample-abc');
+      expect(getRow().sampleName).toBe('My Kick');
+    });
+
+    it('clears sampleName when not provided', () => {
+      // First set a sampleName
+      useProjectStore.getState().setSequencerRowSample(trackId, rowId, 'user-sample-abc', 'My Kick');
+      expect(getRow().sampleName).toBe('My Kick');
+
+      // Then set without sampleName
+      useProjectStore.getState().setSequencerRowSample(trackId, rowId, 'snare');
+      expect(getRow().sampleKey).toBe('snare');
+      expect(getRow().sampleName).toBeUndefined();
+    });
+
+    it('does not affect other rows', () => {
+      const secondRowId = useProjectStore.getState().project!.tracks[0].sequencerPattern!.rows[1].id;
+      const originalKey = getRow(secondRowId).sampleKey;
+
+      useProjectStore.getState().setSequencerRowSample(trackId, rowId, 'user-sample-xyz', 'Custom');
+      expect(getRow(secondRowId).sampleKey).toBe(originalKey);
+      expect(getRow(secondRowId).sampleName).toBeUndefined();
+    });
+
+    it('is a no-op when project is null', () => {
+      useProjectStore.setState({ project: null });
+      // Should not throw
+      useProjectStore.getState().setSequencerRowSample(trackId, rowId, 'test');
+    });
+  });
+
+  describe('clearSequencerRowSample', () => {
+    it('resets sampleKey to the row default and clears sampleName', () => {
+      // Assign a custom sample first
+      useProjectStore.getState().setSequencerRowSample(trackId, rowId, 'user-sample-abc', 'Custom Kick');
+      expect(getRow().sampleKey).toBe('user-sample-abc');
+      expect(getRow().sampleName).toBe('Custom Kick');
+
+      // Clear it
+      useProjectStore.getState().clearSequencerRowSample(trackId, rowId);
+      // sampleName should be cleared
+      expect(getRow().sampleName).toBeUndefined();
+      // sampleKey should still exist (reset to built-in default)
+      expect(getRow().sampleKey).toBeTruthy();
+      // Should not be the user sample anymore
+      expect(getRow().sampleKey).not.toBe('user-sample-abc');
+    });
+
+    it('is a no-op when project is null', () => {
+      useProjectStore.setState({ project: null });
+      // Should not throw
+      useProjectStore.getState().clearSequencerRowSample(trackId, rowId);
+    });
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -751,7 +751,8 @@ export interface ProjectState {
   setSequencerRowVolume: (trackId: string, rowId: string, volume: number) => void;
   setSequencerRowPan: (trackId: string, rowId: string, pan: number) => void;
   toggleSequencerRowMute: (trackId: string, rowId: string) => void;
-  setSequencerRowSample: (trackId: string, rowId: string, sampleKey: string) => void;
+  setSequencerRowSample: (trackId: string, rowId: string, sampleKey: string, sampleName?: string) => void;
+  clearSequencerRowSample: (trackId: string, rowId: string) => void;
   clearSequencerRow: (trackId: string, rowId: string) => void;
   reorderSequencerRows: (trackId: string, fromIndex: number, toIndex: number) => void;
   cloneSequencerRow: (trackId: string, rowId: string) => void;
@@ -5738,7 +5739,7 @@ export const useProjectStore = create<ProjectState>()(
     });
   },
 
-  setSequencerRowSample: (trackId, rowId, sampleKey) => {
+  setSequencerRowSample: (trackId, rowId, sampleKey, sampleName) => {
     const state = get();
     if (!state.project) return;
     _pushHistory(state.project, { scope: 'track', label: 'Assign sequencer row sample', trackId });
@@ -5752,9 +5753,44 @@ export const useProjectStore = create<ProjectState>()(
             ...t,
             sequencerPattern: {
               ...t.sequencerPattern,
-              rows: t.sequencerPattern.rows.map((r) =>
-                r.id === rowId ? { ...r, sampleKey } : r,
-              ),
+              rows: t.sequencerPattern.rows.map((r) => {
+                if (r.id !== rowId) return r;
+                const updated = { ...r, sampleKey };
+                if (sampleName !== undefined) {
+                  updated.sampleName = sampleName;
+                } else {
+                  delete updated.sampleName;
+                }
+                return updated;
+              }),
+            },
+          };
+        }),
+      },
+    });
+  },
+
+  clearSequencerRowSample: (trackId, rowId) => {
+    const state = get();
+    if (!state.project) return;
+    _pushHistory(state.project, { scope: 'track', label: 'Clear sequencer row sample', trackId });
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        tracks: state.project.tracks.map((t) => {
+          if (t.id !== trackId || !t.sequencerPattern) return t;
+          return {
+            ...t,
+            sequencerPattern: {
+              ...t.sequencerPattern,
+              rows: t.sequencerPattern.rows.map((r, idx) => {
+                if (r.id !== rowId) return r;
+                const defaultKey = DRUM_PAD_DEFAULTS[idx % DRUM_PAD_DEFAULTS.length].sampleKey;
+                const updated = { ...r, sampleKey: defaultKey };
+                delete updated.sampleName;
+                return updated;
+              }),
             },
           };
         }),

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -637,6 +637,7 @@ export interface SequencerRow {
   id: string;
   name: string;           // e.g. "Kick", "Snare", "Hi-Hat"
   sampleKey: string;      // built-in sample id or IndexedDB key for user sample
+  sampleName?: string;    // display name for user-loaded samples (undefined for built-in)
   steps: SequencerStep[];
   volume: number;         // 0–1
   pan: number;            // -1 (full left) to +1 (full right), default 0


### PR DESCRIPTION
## Summary
- Add `sampleName?: string` field to `SequencerRow` type for tracking user-loaded sample display names
- Extend `setSequencerRowSample` store action to accept optional `sampleName` parameter, consolidating duplicated name-update logic from UI components
- Add `clearSequencerRowSample` store action to reset a row back to its default built-in sample
- Simplify `SequencerEditor` and `SequencerGrid` by removing manual `setState` calls for name updates
- Show sample name in row header tooltip when a user sample is loaded
- Add 7 unit tests covering sample assignment and clearing

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm test` passes (3124 tests)
- [x] `npm run build` succeeds
- [ ] Manually verify drag-and-drop sample loading on drum pads
- [ ] Manually verify click-to-browse sample loading via SamplePicker

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)