### PR TITLE
feat: add scene tempo/time signature and follow actions

### DIFF
--- a/src/components/session/SessionView.tsx
+++ b/src/components/session/SessionView.tsx
@@ -8,7 +8,7 @@ import { getSessionClips } from '../../utils/sessionClips';
 import { useSessionDragDrop, type SessionDragState, type SessionDropTarget } from '../../hooks/useSessionDragDrop';
 import { ContextMenuWrapper, ContextMenuSeparator, ContextMenuItem } from '../ui/ContextMenu';
 import { ColorSwatchPalette } from '../ui/ColorSwatchPalette';
-import type { Clip, Track, SessionLaunchQuantization, SessionLaunchMode, SessionClipSlot, SessionPendingLaunch, SessionScene } from '../../types/project';
+import type { Clip, Track, SessionLaunchQuantization, SessionLaunchMode, SessionClipSlot, SessionPendingLaunch, SessionScene, SceneFollowActionType } from '../../types/project';
 
 const LAUNCH_MODE_OPTIONS: SessionLaunchMode[] = ['trigger', 'gate', 'toggle', 'repeat'];
 
@@ -56,6 +56,22 @@ function isClipQueued(
 
 const PROGRESS_RING_CIRCUMFERENCE = 2 * Math.PI * 10; // r=10
 
+const FOLLOW_ACTION_OPTIONS: SceneFollowActionType[] = ['none', 'next', 'previous', 'random', 'stop'];
+const FOLLOW_ACTION_LABELS: Record<SceneFollowActionType, string> = {
+  none: 'None',
+  next: 'Next',
+  previous: 'Previous',
+  random: 'Random',
+  stop: 'Stop',
+};
+
+interface SceneContextMenuState {
+  x: number;
+  y: number;
+  sceneId: string;
+  sceneIndex: number;
+}
+
 interface SlotContextMenuState {
   x: number;
   y: number;
@@ -88,7 +104,10 @@ export function SessionView() {
     toggleSessionArrangementRecording,
   } = useTransport();
 
+  const updateSessionSceneProperties = useProjectStore((s) => s.updateSessionSceneProperties);
+  const setSessionSceneFollowAction = useProjectStore((s) => s.setSessionSceneFollowAction);
   const [colorMenu, setColorMenu] = useState<SlotContextMenuState | null>(null);
+  const [sceneMenu, setSceneMenu] = useState<SceneContextMenuState | null>(null);
   const { dragState, dropTarget, handlePointerDown, handlePointerMove, handlePointerUp, cancelDrag } = useSessionDragDrop();
 
   const handleCloseColorMenu = useCallback(() => setColorMenu(null), []);
@@ -230,6 +249,13 @@ export function SessionView() {
                   color: '#6366f1',
                 });
               }}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                const sceneId = scenes[sceneIndex]?.id;
+                if (sceneId) {
+                  setSceneMenu({ x: e.clientX, y: e.clientY, sceneId, sceneIndex });
+                }
+              }}
             >
               <div className="flex items-center justify-between gap-2">
                 <div className="cursor-grab active:cursor-grabbing">
@@ -246,6 +272,22 @@ export function SessionView() {
                   Launch
                 </button>
               </div>
+              {scenes[sceneIndex]?.followAction && scenes[sceneIndex].followAction !== 'none' && (
+                <div className="text-[9px] text-zinc-500 mt-0.5">
+                  Follow: {FOLLOW_ACTION_LABELS[scenes[sceneIndex].followAction!]}
+                  {scenes[sceneIndex].followActionTime ? ` (${scenes[sceneIndex].followActionTime} bars)` : ''}
+                </div>
+              )}
+              {scenes[sceneIndex]?.tempo && (
+                <div className="text-[9px] text-zinc-500">
+                  {scenes[sceneIndex].tempo} BPM
+                </div>
+              )}
+              {scenes[sceneIndex]?.timeSignature && (
+                <div className="text-[9px] text-zinc-500">
+                  {scenes[sceneIndex].timeSignature![0]}/{scenes[sceneIndex].timeSignature![1]}
+                </div>
+              )}
             </div>
           );
         })}
@@ -325,6 +367,126 @@ export function SessionView() {
           />
         </ContextMenuWrapper>
       )}
+
+      {sceneMenu && (() => {
+        const scene = scenes.find((s) => s.id === sceneMenu.sceneId);
+        return (
+          <ContextMenuWrapper
+            x={sceneMenu.x}
+            y={sceneMenu.y}
+            onClose={() => setSceneMenu(null)}
+            testId="session-scene-context-menu"
+            minWidth={200}
+          >
+            <div className="px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-zinc-400">
+              Tempo Override
+            </div>
+            <div className="px-2 py-1.5 flex items-center gap-1.5">
+              <input
+                type="number"
+                min={20}
+                max={300}
+                step={1}
+                placeholder={`${project.bpm}`}
+                defaultValue={scene?.tempo ?? ''}
+                className="w-16 rounded bg-[#2a2a2a] border border-[#444] px-1.5 py-0.5 text-[11px] text-zinc-200 outline-none focus:border-daw-accent"
+                onBlur={(e) => {
+                  const val = e.target.value.trim();
+                  updateSessionSceneProperties(sceneMenu.sceneId, {
+                    tempo: val ? Math.max(20, Math.min(300, Number(val))) : undefined,
+                  });
+                }}
+                onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+                data-testid="scene-tempo-input"
+              />
+              <span className="text-[10px] text-zinc-400">BPM</span>
+            </div>
+            <ContextMenuSeparator />
+            <div className="px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-zinc-400">
+              Time Signature Override
+            </div>
+            <div className="px-2 py-1.5 flex items-center gap-1">
+              <input
+                type="number"
+                min={1}
+                max={32}
+                step={1}
+                placeholder={`${project.timeSignature}`}
+                defaultValue={scene?.timeSignature?.[0] ?? ''}
+                className="w-10 rounded bg-[#2a2a2a] border border-[#444] px-1.5 py-0.5 text-[11px] text-zinc-200 outline-none focus:border-daw-accent"
+                onBlur={(e) => {
+                  const num = e.target.value.trim();
+                  if (!num) {
+                    updateSessionSceneProperties(sceneMenu.sceneId, { timeSignature: undefined });
+                  } else {
+                    const denom = scene?.timeSignature?.[1] ?? project.timeSignatureDenominator ?? 4;
+                    updateSessionSceneProperties(sceneMenu.sceneId, {
+                      timeSignature: [Math.max(1, Math.min(32, Number(num))), denom],
+                    });
+                  }
+                }}
+                onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+                data-testid="scene-timesig-num-input"
+              />
+              <span className="text-[10px] text-zinc-400">/</span>
+              <select
+                defaultValue={scene?.timeSignature?.[1] ?? project.timeSignatureDenominator ?? 4}
+                className="w-12 rounded bg-[#2a2a2a] border border-[#444] px-1 py-0.5 text-[11px] text-zinc-200 outline-none focus:border-daw-accent"
+                onChange={(e) => {
+                  const num = scene?.timeSignature?.[0] ?? project.timeSignature;
+                  updateSessionSceneProperties(sceneMenu.sceneId, {
+                    timeSignature: [num, Number(e.target.value)],
+                  });
+                }}
+                data-testid="scene-timesig-denom-select"
+              >
+                {[2, 4, 8, 16].map((d) => (
+                  <option key={d} value={d}>{d}</option>
+                ))}
+              </select>
+            </div>
+            <ContextMenuSeparator />
+            <div className="px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-zinc-400">
+              Follow Action
+            </div>
+            {FOLLOW_ACTION_OPTIONS.map((action) => (
+              <ContextMenuItem
+                key={action}
+                label={`${FOLLOW_ACTION_LABELS[action]}${scene?.followAction === action || (!scene?.followAction && action === 'none') ? ' \u2713' : ''}`}
+                onClick={() => {
+                  setSessionSceneFollowAction(sceneMenu.sceneId, action, action === 'none' ? undefined : (scene?.followActionTime ?? 4));
+                }}
+              />
+            ))}
+            {scene?.followAction && scene.followAction !== 'none' && (
+              <>
+                <ContextMenuSeparator />
+                <div className="px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-zinc-400">
+                  Follow After (bars)
+                </div>
+                <div className="px-2 py-1.5">
+                  <input
+                    type="number"
+                    min={1}
+                    max={64}
+                    step={1}
+                    defaultValue={scene.followActionTime ?? 4}
+                    className="w-14 rounded bg-[#2a2a2a] border border-[#444] px-1.5 py-0.5 text-[11px] text-zinc-200 outline-none focus:border-daw-accent"
+                    onBlur={(e) => {
+                      const val = Number(e.target.value);
+                      if (val >= 1 && val <= 64) {
+                        setSessionSceneFollowAction(sceneMenu.sceneId, scene.followAction!, val);
+                      }
+                    }}
+                    onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+                    data-testid="scene-follow-bars-input"
+                  />
+                </div>
+              </>
+            )}
+          </ContextMenuWrapper>
+        );
+      })()}
 
       {/* Drag ghost overlay */}
       {dragState && (

--- a/src/store/__tests__/sceneProperties.test.ts
+++ b/src/store/__tests__/sceneProperties.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSessionStore } from '../sessionStore';
+
+describe('Scene properties and follow actions', () => {
+  beforeEach(() => {
+    useSessionStore.getState().initSession(['track-1', 'track-2'], 4);
+  });
+
+  describe('updateSceneProperties', () => {
+    it('sets tempo override on a scene', () => {
+      const sceneId = useSessionStore.getState().scenes[0].id;
+      useSessionStore.getState().updateSceneProperties(sceneId, { tempo: 140 });
+      const scene = useSessionStore.getState().scenes.find((s) => s.id === sceneId);
+      expect(scene?.tempo).toBe(140);
+    });
+
+    it('sets time signature override on a scene', () => {
+      const sceneId = useSessionStore.getState().scenes[1].id;
+      useSessionStore.getState().updateSceneProperties(sceneId, { timeSignature: [3, 4] });
+      const scene = useSessionStore.getState().scenes.find((s) => s.id === sceneId);
+      expect(scene?.timeSignature).toEqual([3, 4]);
+    });
+
+    it('sets multiple properties at once', () => {
+      const sceneId = useSessionStore.getState().scenes[0].id;
+      useSessionStore.getState().updateSceneProperties(sceneId, { tempo: 160, timeSignature: [6, 8] });
+      const scene = useSessionStore.getState().scenes.find((s) => s.id === sceneId);
+      expect(scene?.tempo).toBe(160);
+      expect(scene?.timeSignature).toEqual([6, 8]);
+    });
+
+    it('clears a property when set to undefined', () => {
+      const sceneId = useSessionStore.getState().scenes[0].id;
+      useSessionStore.getState().updateSceneProperties(sceneId, { tempo: 120 });
+      expect(useSessionStore.getState().scenes.find((s) => s.id === sceneId)?.tempo).toBe(120);
+      useSessionStore.getState().updateSceneProperties(sceneId, { tempo: undefined });
+      expect(useSessionStore.getState().scenes.find((s) => s.id === sceneId)?.tempo).toBeUndefined();
+    });
+
+    it('does not modify other scenes', () => {
+      const scenes = useSessionStore.getState().scenes;
+      useSessionStore.getState().updateSceneProperties(scenes[0].id, { tempo: 200 });
+      const updated = useSessionStore.getState().scenes;
+      expect(updated.find((s) => s.id === scenes[0].id)?.tempo).toBe(200);
+      expect(updated.find((s) => s.id === scenes[1].id)?.tempo).toBeUndefined();
+    });
+
+    it('ignores unknown scene id', () => {
+      const before = useSessionStore.getState().scenes;
+      useSessionStore.getState().updateSceneProperties('nonexistent-id', { tempo: 100 });
+      expect(useSessionStore.getState().scenes).toEqual(before);
+    });
+  });
+
+  describe('setSceneFollowAction', () => {
+    it('sets follow action type and bars', () => {
+      const sceneId = useSessionStore.getState().scenes[0].id;
+      useSessionStore.getState().setSceneFollowAction(sceneId, 'next', 4);
+      const scene = useSessionStore.getState().scenes.find((s) => s.id === sceneId);
+      expect(scene?.followAction).toBe('next');
+      expect(scene?.followActionTime).toBe(4);
+    });
+
+    it('sets follow action to stop', () => {
+      const sceneId = useSessionStore.getState().scenes[2].id;
+      useSessionStore.getState().setSceneFollowAction(sceneId, 'stop', 2);
+      const scene = useSessionStore.getState().scenes.find((s) => s.id === sceneId);
+      expect(scene?.followAction).toBe('stop');
+      expect(scene?.followActionTime).toBe(2);
+    });
+
+    it('sets follow action to none and clears followActionTime', () => {
+      const sceneId = useSessionStore.getState().scenes[0].id;
+      useSessionStore.getState().setSceneFollowAction(sceneId, 'next', 4);
+      useSessionStore.getState().setSceneFollowAction(sceneId, 'none');
+      const scene = useSessionStore.getState().scenes.find((s) => s.id === sceneId);
+      expect(scene?.followAction).toBe('none');
+      expect(scene?.followActionTime).toBeUndefined();
+    });
+
+    it('sets random follow action', () => {
+      const sceneId = useSessionStore.getState().scenes[1].id;
+      useSessionStore.getState().setSceneFollowAction(sceneId, 'random', 8);
+      const scene = useSessionStore.getState().scenes.find((s) => s.id === sceneId);
+      expect(scene?.followAction).toBe('random');
+      expect(scene?.followActionTime).toBe(8);
+    });
+
+    it('sets previous follow action', () => {
+      const sceneId = useSessionStore.getState().scenes[3].id;
+      useSessionStore.getState().setSceneFollowAction(sceneId, 'previous', 1);
+      const scene = useSessionStore.getState().scenes.find((s) => s.id === sceneId);
+      expect(scene?.followAction).toBe('previous');
+      expect(scene?.followActionTime).toBe(1);
+    });
+  });
+
+  describe('scene properties persist through addScene', () => {
+    it('new scenes have no tempo/timeSignature/followAction by default', () => {
+      useSessionStore.getState().addScene(['track-1', 'track-2']);
+      const scenes = useSessionStore.getState().scenes;
+      const lastScene = scenes[scenes.length - 1];
+      expect(lastScene.tempo).toBeUndefined();
+      expect(lastScene.timeSignature).toBeUndefined();
+      expect(lastScene.followAction).toBeUndefined();
+      expect(lastScene.followActionTime).toBeUndefined();
+    });
+  });
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -59,6 +59,7 @@ import type {
   SessionLaunchMode,
   SessionLaunchQuantization,
   SessionPendingLaunch,
+  SceneFollowActionType,
   SessionScene,
   SessionState,
   PlaybackLatencySettings,
@@ -735,6 +736,8 @@ export interface ProjectState {
   stopSessionArrangementRecording: (endTime?: number) => Clip[];
   moveSessionSlotClip: (sourceSlotId: string, targetSlotId: string) => void;
   reorderSessionScenes: (fromIndex: number, toIndex: number) => void;
+  updateSessionSceneProperties: (sceneId: string, properties: Partial<Pick<SessionScene, 'tempo' | 'timeSignature' | 'followAction' | 'followActionTime'>>) => void;
+  setSessionSceneFollowAction: (sceneId: string, action: SceneFollowActionType, bars?: number) => void;
 
   removeAsset: (assetId: string) => void;
   toggleAssetStar: (assetId: string) => void;
@@ -5305,6 +5308,47 @@ export const useProjectStore = create<ProjectState>()(
         session: {
           ...session,
           scenes: reindexed,
+        },
+      },
+    });
+  },
+
+  updateSessionSceneProperties: (sceneId, properties) => {
+    const state = get();
+    if (!state.project) return;
+    const session = ensureProjectSession(state.project).session!;
+    if (!session.scenes.some((scene) => scene.id === sceneId)) return;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        session: {
+          ...session,
+          scenes: session.scenes.map((scene) =>
+            scene.id === sceneId ? { ...scene, ...properties } : scene,
+          ),
+        },
+      },
+    });
+  },
+
+  setSessionSceneFollowAction: (sceneId, action, bars?) => {
+    const state = get();
+    if (!state.project) return;
+    const session = ensureProjectSession(state.project).session!;
+    _pushHistory(state.project);
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        session: {
+          ...session,
+          scenes: session.scenes.map((scene) =>
+            scene.id === sceneId
+              ? { ...scene, followAction: action, followActionTime: action === 'none' ? undefined : bars }
+              : scene,
+          ),
         },
       },
     });

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { v4 as uuidv4 } from 'uuid';
-import type { SessionClipSlot, SessionScene, BufferedMidiEvent } from '../types/session';
+import type { SessionClipSlot, SessionScene, BufferedMidiEvent, SceneFollowActionType } from '../types/session';
 import { MidiCaptureBuffer } from '../utils/midiCaptureBuffer';
 
 const DEFAULT_SCENE_COUNT = 8;
@@ -33,6 +33,8 @@ export interface SessionState {
   stopScene: (sceneIndex: number) => void;
   stopAll: () => void;
   renameScene: (sceneId: string, name: string) => void;
+  updateSceneProperties: (sceneId: string, properties: Partial<Pick<SessionScene, 'tempo' | 'timeSignature' | 'followAction' | 'followActionTime'>>) => void;
+  setSceneFollowAction: (sceneId: string, action: SceneFollowActionType, bars?: number) => void;
   addScene: (trackIds: string[]) => void;
   setRecordingToArrangement: (v: boolean) => void;
   recordSessionEvent: (event: SessionRecordedEvent) => void;
@@ -166,6 +168,31 @@ export const useSessionStore = create<SessionState>()((set, get) => ({
     set((s) => ({
       scenes: s.scenes.map((scene) =>
         scene.id === sceneId ? { ...scene, name } : scene,
+      ),
+    }));
+  },
+
+  updateSceneProperties: (sceneId, properties) => {
+    set((s) => {
+      if (!s.scenes.some((scene) => scene.id === sceneId)) return s;
+      return {
+        scenes: s.scenes.map((scene) =>
+          scene.id === sceneId ? { ...scene, ...properties } : scene,
+        ),
+      };
+    });
+  },
+
+  setSceneFollowAction: (sceneId, action, bars?) => {
+    set((s) => ({
+      scenes: s.scenes.map((scene) =>
+        scene.id === sceneId
+          ? {
+              ...scene,
+              followAction: action,
+              followActionTime: action === 'none' ? undefined : bars,
+            }
+          : scene,
       ),
     }));
   },

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -860,10 +860,21 @@ export type SessionLaunchQuantization = 'none' | '1/32' | '1/16' | '1/8' | '1/4'
 /** Clip launch behavior mode for session view slots. */
 export type SessionLaunchMode = 'trigger' | 'gate' | 'toggle' | 'repeat';
 
+/** Action to perform automatically when a scene finishes playing. */
+export type SceneFollowActionType = 'none' | 'next' | 'previous' | 'random' | 'stop';
+
 export interface SessionScene {
   id: string;
   name: string;
   index: number;
+  /** Optional tempo override (BPM) applied when this scene launches. */
+  tempo?: number;
+  /** Optional time signature override [numerator, denominator] applied when this scene launches. */
+  timeSignature?: [number, number];
+  /** Action to trigger after the scene finishes playing. Defaults to 'none'. */
+  followAction?: SceneFollowActionType;
+  /** Duration in bars after which the follow action triggers. */
+  followActionTime?: number;
 }
 
 export interface SessionClipSlot {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -22,12 +22,23 @@ export interface SessionClipSlot {
   legato?: boolean;
 }
 
+/** Action to perform automatically when a scene finishes playing. */
+export type SceneFollowActionType = 'none' | 'next' | 'previous' | 'random' | 'stop';
+
 /** A scene (horizontal row) that can trigger all slots at once. */
 export interface SessionScene {
   id: string;
   name: string;
   /** Row index in the session grid. */
   index: number;
+  /** Optional tempo override (BPM) applied when this scene launches. */
+  tempo?: number;
+  /** Optional time signature override [numerator, denominator] applied when this scene launches. */
+  timeSignature?: [number, number];
+  /** Action to trigger after the scene finishes playing. Defaults to 'none'. */
+  followAction?: SceneFollowActionType;
+  /** Duration in bars after which the follow action triggers. */
+  followActionTime?: number;
 }
 
 /** A buffered MIDI event for retroactive capture. */


### PR DESCRIPTION
## Summary
- Add `tempo`, `timeSignature`, `followAction`, and `followActionTime` optional properties to `SessionScene` type in both `types/project.ts` and `types/session.ts`
- Implement `updateSceneProperties` and `setSceneFollowAction` store actions in both `sessionStore` (runtime) and `projectStore` (persistent)
- Add right-click context menu on scene headers in Session View with tempo override input, time signature override fields, follow action selector, and follow-after-bars input
- Scene headers display active follow action, tempo override, and time signature override as compact labels

## Test plan
- [x] 12 unit tests covering `updateSceneProperties` and `setSceneFollowAction` in sessionStore
- [x] All 3129 existing tests pass (no regressions)
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm run build` succeeds
- [ ] Manual: right-click scene header opens context menu with tempo, time sig, and follow action controls
- [ ] Manual: setting tempo override shows BPM label on scene header
- [ ] Manual: setting follow action shows follow label on scene header

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)