### PR TITLE
feat: add latency calibration UI with auto-detection and manual override

### DIFF
--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -5,7 +5,7 @@ import { useModelStore } from '../../store/modelStore';
 import { listModels, initModel, getBackendUrl, setBackendUrl } from '../../services/aceStepApi';
 import { DEFAULT_GENERATION, DEFAULT_MEASURES } from '../../constants/defaults';
 import { Button } from '../ui/Button';
-import { normalizePlaybackLatencySettings } from '../../utils/playbackLatency';
+import { normalizePlaybackLatencySettings, latencyMsToSamples } from '../../utils/playbackLatency';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
 import type { ModelEntry, LmModelEntry } from '../../types/api';
 import { THEME_LIST } from '../../themes';
@@ -431,13 +431,36 @@ export function SettingsDialog() {
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="block text-xs text-zinc-400 mb-1">Detected Latency</label>
-                <div className="rounded border border-daw-border bg-black/20 px-3 py-1.5 text-sm text-zinc-200">
-                  {playbackLatency.detectedLatencyMs !== null ? `${playbackLatency.detectedLatencyMs.toFixed(1)} ms` : 'Unavailable'}
+                <div className="flex items-center gap-1.5">
+                  <div className="flex-1 rounded border border-daw-border bg-black/20 px-3 py-1.5 text-sm text-zinc-200">
+                    {playbackLatency.detectedLatencyMs !== null
+                      ? `${playbackLatency.detectedLatencyMs.toFixed(1)} ms (${latencyMsToSamples(playbackLatency.detectedLatencyMs, getAudioEngine().sampleRate)} smp)`
+                      : 'Unavailable'}
+                  </div>
+                  <button
+                    type="button"
+                    data-testid="auto-detect-latency"
+                    onClick={() => {
+                      const engine = getAudioEngine();
+                      const latency = engine.refreshPlaybackLatencyCompensation();
+                      const store = useProjectStore.getState();
+                      store.detectPlaybackLatency(latency);
+                      engine.setPlaybackLatencyCompensation(
+                        store.project?.playbackLatency?.compensationMs
+                          ? store.project.playbackLatency.compensationMs / 1000
+                          : 0,
+                      );
+                    }}
+                    className="shrink-0 px-2 py-1.5 text-[10px] font-medium text-zinc-300 bg-daw-surface-2 border border-daw-border rounded hover:border-daw-accent hover:text-white transition-colors"
+                    title="Re-measure audio output latency from Web Audio API"
+                  >
+                    Re-detect
+                  </button>
                 </div>
               </div>
               <div>
                 <label className="block text-xs text-zinc-400 mb-1" htmlFor="manual-playback-latency">
-                  Manual Override
+                  Manual Override (ms)
                 </label>
                 <input
                   id="manual-playback-latency"
@@ -454,7 +477,7 @@ export function SettingsDialog() {
               </div>
             </div>
              <p className="text-[10px] text-zinc-400">
-               Active compensation: {playbackLatency.compensationMs.toFixed(1)} ms
+               Active compensation: {playbackLatency.compensationMs.toFixed(1)} ms ({latencyMsToSamples(playbackLatency.compensationMs, getAudioEngine().sampleRate)} samples @ {getAudioEngine().sampleRate} Hz)
              </p>
              {hasPendingManualOverride ? (
                <p className="text-[10px] text-zinc-400">

--- a/src/utils/__tests__/playbackLatency.test.ts
+++ b/src/utils/__tests__/playbackLatency.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   readAudioContextPlaybackLatency,
   detectPlaybackLatencySettings,
+  latencyMsToSamples,
+  normalizePlaybackLatencySettings,
+  setPlaybackLatencyOverrideSettings,
+  getPlaybackLatencyCompensationSeconds,
 } from '../playbackLatency';
 
 describe('readAudioContextPlaybackLatency', () => {
@@ -50,5 +54,99 @@ describe('detectPlaybackLatencySettings', () => {
       outputLatency: 0.01,
     });
     expect(settings.compensationMs).toBe(15);
+  });
+});
+
+describe('latencyMsToSamples', () => {
+  it('converts milliseconds to samples at 48000 Hz', () => {
+    // 10 ms at 48000 Hz = 480 samples
+    expect(latencyMsToSamples(10, 48000)).toBe(480);
+  });
+
+  it('converts milliseconds to samples at 44100 Hz', () => {
+    // 10 ms at 44100 Hz = 441 samples
+    expect(latencyMsToSamples(10, 44100)).toBe(441);
+  });
+
+  it('returns 0 for 0 ms', () => {
+    expect(latencyMsToSamples(0, 48000)).toBe(0);
+  });
+
+  it('returns 0 for null latency', () => {
+    expect(latencyMsToSamples(null, 48000)).toBe(0);
+  });
+
+  it('rounds to nearest integer sample count', () => {
+    // 15 ms at 48000 Hz = 720 samples (exact)
+    expect(latencyMsToSamples(15, 48000)).toBe(720);
+    // 1 ms at 44100 Hz = 44.1, rounds to 44
+    expect(latencyMsToSamples(1, 44100)).toBe(44);
+  });
+
+  it('handles fractional millisecond values', () => {
+    // 0.5 ms at 48000 Hz = 24 samples
+    expect(latencyMsToSamples(0.5, 48000)).toBe(24);
+  });
+});
+
+describe('manual override takes precedence over auto-detected', () => {
+  it('uses manual override for compensationMs when set', () => {
+    const detected = detectPlaybackLatencySettings(null, {
+      baseLatency: 0.005,
+      outputLatency: 0.01,
+    });
+    // detected = 15ms, now set manual override to 25ms
+    const withOverride = setPlaybackLatencyOverrideSettings(detected, 25);
+    expect(withOverride.source).toBe('manual');
+    expect(withOverride.compensationMs).toBe(25);
+    // detected values are preserved
+    expect(withOverride.detectedLatencyMs).toBe(15);
+  });
+
+  it('falls back to auto-detected when manual override is cleared', () => {
+    const detected = detectPlaybackLatencySettings(null, {
+      baseLatency: 0.005,
+      outputLatency: 0.01,
+    });
+    const withOverride = setPlaybackLatencyOverrideSettings(detected, 25);
+    const cleared = setPlaybackLatencyOverrideSettings(withOverride, null);
+    expect(cleared.source).toBe('auto');
+    expect(cleared.compensationMs).toBe(15);
+    expect(cleared.manualOverrideMs).toBeNull();
+  });
+});
+
+describe('getPlaybackLatencyCompensationSeconds', () => {
+  it('returns compensation in seconds', () => {
+    const settings = detectPlaybackLatencySettings(null, {
+      baseLatency: 0.005,
+      outputLatency: 0.01,
+    });
+    expect(getPlaybackLatencyCompensationSeconds(settings)).toBeCloseTo(0.015);
+  });
+
+  it('returns 0 for null settings', () => {
+    expect(getPlaybackLatencyCompensationSeconds(null)).toBe(0);
+  });
+});
+
+describe('latency value persistence', () => {
+  it('preserves manual override across normalize calls', () => {
+    const settings = setPlaybackLatencyOverrideSettings(null, 42);
+    const renormalized = normalizePlaybackLatencySettings(settings);
+    expect(renormalized.manualOverrideMs).toBe(42);
+    expect(renormalized.compensationMs).toBe(42);
+    expect(renormalized.source).toBe('manual');
+  });
+
+  it('preserves detected values across normalize calls', () => {
+    const settings = detectPlaybackLatencySettings(null, {
+      baseLatency: 0.005,
+      outputLatency: 0.01,
+    });
+    const renormalized = normalizePlaybackLatencySettings(settings);
+    expect(renormalized.detectedBaseLatencyMs).toBe(5);
+    expect(renormalized.detectedOutputLatencyMs).toBe(10);
+    expect(renormalized.detectedLatencyMs).toBe(15);
   });
 });

--- a/src/utils/playbackLatency.ts
+++ b/src/utils/playbackLatency.ts
@@ -151,3 +151,17 @@ export function readAudioContextPlaybackLatency(
     outputLatency: typeof ctx.outputLatency === 'number' ? ctx.outputLatency : null,
   };
 }
+
+/**
+ * Convert a latency value in milliseconds to the equivalent number of audio samples.
+ * Returns 0 for null/undefined input. Result is rounded to the nearest integer.
+ */
+export function latencyMsToSamples(
+  latencyMs: number | null | undefined,
+  sampleRate: number,
+): number {
+  if (latencyMs == null || !Number.isFinite(latencyMs) || latencyMs <= 0) {
+    return 0;
+  }
+  return Math.round((latencyMs / 1000) * sampleRate);
+}


### PR DESCRIPTION
## Summary
- Adds `latencyMsToSamples()` utility to convert latency from milliseconds to audio samples at the current sample rate
- Adds a "Re-detect" button in the Settings dialog Playback Latency section so users can re-measure audio output latency on demand
- Displays latency values in both ms and samples (e.g. "15.0 ms (720 smp)") alongside the active compensation readout with sample rate
- Adds 12 new unit tests covering ms-to-samples conversion, manual override precedence over auto-detected values, compensation seconds, and persistence across normalization calls

Closes #1106

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm test` passes (17 tests in playbackLatency.test.ts, all green)
- [x] `npm run build` succeeds
- [ ] Open Settings dialog, verify "Playback Latency" section shows detected latency in ms and samples
- [ ] Click "Re-detect" button and verify latency values refresh
- [ ] Enter a manual override value, save, verify "Manual override" badge appears
- [ ] Clear manual override, save, verify it falls back to auto-detected

https://claude.ai/code/session_01KYEjWp985CYRCcSm9J46ps