### PR TITLE
feat: wire RecordingEngine to UI — record arm button and tests

### DIFF
--- a/.llm/todo.md
+++ b/.llm/todo.md
@@ -5,13 +5,20 @@
 
 ---
 
+## Current: Issue #1104 — Wire RecordingEngine to UI
+
+- [ ] Write failing tests: arm button renders, toggles, visual state
+- [ ] Add arm button to TrackHeader (non-group tracks only)
+- [ ] Verify toolbar record button works (no regression)
+- [ ] All quality gates pass: tsc, tests, build
+
 ## Priority 1: Test Coverage Foundation
 
 - [x] Write Vitest unit tests for uiStore (panel toggles, selection state)
 - [x] Write Vitest unit tests for generationStore (queue management, status)
 - [x] Write Vitest unit tests for color utilities (src/utils/color.ts)
 - [x] Write Vitest unit tests for WAV export utilities (src/utils/wav.ts)
-- [x] Write Vitest unit tests for waveform peak calculation (src/utils/waveformPeaks.ts)
+- [x] Write Vitest unit tests for waveformPeaks calculation (src/utils/waveformPeaks.ts)
 - [x] Write Vitest unit tests for audio downsample utility (src/utils/audioDownsample.ts)
 - [ ] Write Vitest unit tests for generationPipeline service state machine
 - [x] Write Vitest unit tests for automation types (normalizedToMixerValue, automationParamEquals)

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -475,6 +475,20 @@ export function TrackHeader({
                   aria-label={`Effects for ${track.displayName}`}
                 >FX</button>
               )}
+              {!track.isGroup && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); toggleArmTrack(track.id); }}
+                  className={`w-[18px] h-[18px] rounded-full text-[9px] font-bold leading-none flex items-center justify-center transition-colors ${
+                    isArmed
+                      ? 'bg-red-500 text-white'
+                      : 'bg-zinc-700 text-zinc-400 hover:bg-zinc-600 hover:text-zinc-200'
+                  }`}
+                  title="Record Arm"
+                  aria-label={`Record arm ${track.displayName}`}
+                >
+                  <div className={`w-[8px] h-[8px] rounded-full ${isArmed ? 'bg-white' : 'bg-zinc-500'}`} />
+                </button>
+              )}
             </div>
           </div>
 

--- a/src/components/tracks/__tests__/TrackHeader.test.tsx
+++ b/src/components/tracks/__tests__/TrackHeader.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { TrackHeader } from '../TrackHeader';
 import { useProjectStore } from '../../../store/projectStore';
 import type { Track } from '../../../types/project';
+
+const mockToggleArmTrack = vi.fn();
+let mockArmedTrackIds: string[] = [];
 
 // Mock modules that use browser APIs not available in jsdom
 vi.mock('../../../services/projectStorage', () => ({
@@ -10,8 +13,8 @@ vi.mock('../../../services/projectStorage', () => ({
 }));
 vi.mock('../../../hooks/useRecording', () => ({
   useRecording: () => ({
-    armedTrackIds: [],
-    toggleArmTrack: vi.fn(),
+    armedTrackIds: mockArmedTrackIds,
+    toggleArmTrack: mockToggleArmTrack,
   }),
 }));
 vi.mock('../../../services/freezeTrack', () => ({
@@ -129,5 +132,54 @@ describe('TrackHeader icon bar', () => {
     const fxBtn = screen.getByTitle('Effects bypassed (track frozen)');
     expect(fxBtn).toBeInTheDocument();
     expect(fxBtn.className).toContain('cursor-not-allowed');
+  });
+});
+
+describe('TrackHeader arm button', () => {
+  beforeEach(() => {
+    mockArmedTrackIds = [];
+    mockToggleArmTrack.mockClear();
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+  });
+
+  it('renders arm button for non-group tracks', () => {
+    render(<TrackHeader track={makeTrack()} {...defaultProps} />);
+    const armBtn = screen.getByTitle('Record Arm');
+    expect(armBtn).toBeInTheDocument();
+    expect(armBtn).toBeVisible();
+  });
+
+  it('does not render arm button for group tracks', () => {
+    render(<TrackHeader track={makeTrack({ isGroup: true })} {...defaultProps} />);
+    expect(screen.queryByTitle('Record Arm')).not.toBeInTheDocument();
+  });
+
+  it('calls toggleArmTrack when clicked', () => {
+    render(<TrackHeader track={makeTrack({ id: 'track-42' })} {...defaultProps} />);
+    const armBtn = screen.getByTitle('Record Arm');
+    fireEvent.click(armBtn);
+    expect(mockToggleArmTrack).toHaveBeenCalledWith('track-42');
+  });
+
+  it('shows bright red style when track is armed', () => {
+    mockArmedTrackIds = ['track-1'];
+    render(<TrackHeader track={makeTrack({ id: 'track-1', armed: true })} {...defaultProps} />);
+    const armBtn = screen.getByTitle('Record Arm');
+    expect(armBtn.className).toContain('bg-red-500');
+  });
+
+  it('shows muted style when track is not armed', () => {
+    mockArmedTrackIds = [];
+    render(<TrackHeader track={makeTrack({ id: 'track-1', armed: false })} {...defaultProps} />);
+    const armBtn = screen.getByTitle('Record Arm');
+    expect(armBtn.className).not.toContain('bg-red-500');
+  });
+
+  it('arm button is inside the primary actions container', () => {
+    render(<TrackHeader track={makeTrack()} {...defaultProps} />);
+    const armBtn = screen.getByTitle('Record Arm');
+    const primaryRail = armBtn.closest('[data-primary-actions]');
+    expect(primaryRail).not.toBeNull();
   });
 });

--- a/src/hooks/__tests__/useRecording.test.ts
+++ b/src/hooks/__tests__/useRecording.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTransportStore } from '../../store/transportStore';
+import { useProjectStore } from '../../store/projectStore';
+
+// Mock RecordingEngine
+const mockRequestPermission = vi.fn().mockResolvedValue(true);
+const mockStartRecording = vi.fn().mockResolvedValue(true);
+const mockStopAllRecordings = vi.fn().mockResolvedValue(new Map());
+const mockSetMonitoring = vi.fn();
+const mockGetCountInLength = vi.fn().mockReturnValue('off');
+const mockGetSession = vi.fn().mockReturnValue(undefined);
+let mockHasPermission = false;
+
+vi.mock('../../engine/RecordingEngine', () => ({
+  recordingEngine: {
+    requestPermission: (...args: unknown[]) => mockRequestPermission(...args),
+    startRecording: (...args: unknown[]) => mockStartRecording(...args),
+    stopAllRecordings: (...args: unknown[]) => mockStopAllRecordings(...args),
+    setMonitoring: (...args: unknown[]) => mockSetMonitoring(...args),
+    getCountInLength: () => mockGetCountInLength(),
+    getSession: (...args: unknown[]) => mockGetSession(...args),
+    get hasPermission() { return mockHasPermission; },
+    get denied() { return false; },
+    playCountIn: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/projectStorage', () => ({
+  saveProject: vi.fn(),
+}));
+
+vi.mock('../../services/audioFileManager', () => ({
+  saveAudioBlob: vi.fn().mockResolvedValue('audio-key-1'),
+}));
+
+vi.mock('../../utils/waveformPeaks', () => ({
+  computeWaveformPeaks: vi.fn().mockReturnValue([0.1, 0.2, 0.3]),
+}));
+
+vi.mock('../../utils/wav', () => ({
+  audioBufferToWavBlob: vi.fn().mockReturnValue(new Blob()),
+}));
+
+// Dynamic import after mocks are set up
+const { useRecording } = await import('../../hooks/useRecording');
+
+describe('useRecording', () => {
+  beforeEach(() => {
+    mockHasPermission = false;
+    mockRequestPermission.mockClear().mockResolvedValue(true);
+    mockStartRecording.mockClear().mockResolvedValue(true);
+    mockStopAllRecordings.mockClear().mockResolvedValue(new Map());
+    mockSetMonitoring.mockClear();
+    mockGetCountInLength.mockReturnValue('off');
+
+    useTransportStore.setState({
+      isRecording: false,
+      armedTrackIds: [],
+      currentTime: 0,
+      punchEnabled: false,
+      punchInTime: null,
+      punchOutTime: null,
+    });
+    useProjectStore.setState({ project: null });
+    useProjectStore.getState().createProject();
+  });
+
+  it('returns isRecording from transport store', () => {
+    const { result } = renderHook(() => useRecording());
+    expect(result.current.isRecording).toBe(false);
+
+    act(() => { useTransportStore.getState().setIsRecording(true); });
+    expect(result.current.isRecording).toBe(true);
+  });
+
+  it('returns armedTrackIds from transport store', () => {
+    const { result } = renderHook(() => useRecording());
+    expect(result.current.armedTrackIds).toEqual([]);
+
+    act(() => { useTransportStore.getState().armTrack('track-1'); });
+    expect(result.current.armedTrackIds).toEqual(['track-1']);
+  });
+
+  it('armTrack sets monitoring and updates track armed state', () => {
+    const { result } = renderHook(() => useRecording());
+
+    act(() => { result.current.armTrack('track-1'); });
+
+    expect(mockSetMonitoring).toHaveBeenCalledWith('track-1', true);
+    expect(useTransportStore.getState().armedTrackIds).toContain('track-1');
+  });
+
+  it('disarmTrack clears monitoring and updates track armed state', () => {
+    const { result } = renderHook(() => useRecording());
+
+    act(() => { result.current.armTrack('track-1'); });
+    act(() => { result.current.disarmTrack('track-1'); });
+
+    expect(mockSetMonitoring).toHaveBeenCalledWith('track-1', false);
+    expect(useTransportStore.getState().armedTrackIds).not.toContain('track-1');
+  });
+
+  it('toggleRecord shows error when no tracks armed', async () => {
+    const { result } = renderHook(() => useRecording());
+
+    await act(async () => { await result.current.toggleRecord(); });
+
+    // Should not have requested permission or started recording
+    expect(mockRequestPermission).not.toHaveBeenCalled();
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it('toggleRecord requests mic permission when tracks are armed', async () => {
+    const { result } = renderHook(() => useRecording());
+
+    act(() => { useTransportStore.getState().armTrack('track-1'); });
+
+    await act(async () => { await result.current.toggleRecord(); });
+
+    expect(mockRequestPermission).toHaveBeenCalled();
+  });
+
+  it('toggleRecord does not start recording when permission denied', async () => {
+    mockRequestPermission.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => useRecording());
+
+    act(() => { useTransportStore.getState().armTrack('track-1'); });
+
+    await act(async () => { await result.current.toggleRecord(); });
+
+    expect(result.current.isRecording).toBe(false);
+    expect(mockStartRecording).not.toHaveBeenCalled();
+  });
+
+  it('toggleRecord starts recording for each armed track', async () => {
+    const { result } = renderHook(() => useRecording());
+
+    act(() => {
+      useTransportStore.getState().armTrack('track-1');
+      useTransportStore.getState().armTrack('track-2');
+    });
+
+    await act(async () => { await result.current.toggleRecord(); });
+
+    expect(mockStartRecording).toHaveBeenCalledTimes(2);
+    expect(result.current.isRecording).toBe(true);
+  });
+
+  it('toggleRecord stops recording when already recording', async () => {
+    const { result } = renderHook(() => useRecording());
+
+    act(() => {
+      useTransportStore.getState().setIsRecording(true);
+      useTransportStore.getState().armTrack('track-1');
+    });
+
+    await act(async () => { await result.current.toggleRecord(); });
+
+    expect(mockStopAllRecordings).toHaveBeenCalled();
+    expect(result.current.isRecording).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add record arm button (red circle) to TrackHeader for non-group tracks, wired to `useRecording.toggleArmTrack`
- Armed state shows bright red (`bg-red-500`), non-armed shows muted zinc style
- Add 6 unit tests for TrackHeader arm button (renders, toggles, visual states, container placement)
- Add 9 unit tests for `useRecording` hook (permission flow, arm/disarm, start/stop recording, error handling)
- All quality gates pass: `tsc --noEmit` (0 errors), 23 tests pass, `vite build` succeeds

## What was already wired
- Toolbar record button (line 711 in Toolbar.tsx) — already connected to `useRecording.toggleRecord`
- `useRecording` hook — already fully implemented with mic permissions, count-in, punch recording, loop recording
- Transport store `armedTrackIds` and arm/disarm actions — already existed

## What was missing (now fixed)
- TrackHeader imported `armedTrackIds` and `toggleArmTrack` but never rendered an arm button in JSX
- No unit tests existed for the `useRecording` hook

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] All 23 unit tests pass (14 TrackHeader + 9 useRecording)
- [x] `npx vite build` succeeds
- [ ] Visual verification: arm button appears as small red circle next to FX button
- [ ] Click arm button toggles red armed state
- [ ] Click record in toolbar after arming a track triggers mic permission prompt

Closes #1104

https://claude.ai/code/session_01KYEjWp985CYRCcSm9J46ps