### PR TITLE
fix: auto-scroll starts immediately instead of playhead walking to center

### DIFF
--- a/src/components/timeline/useTimelineScroll.ts
+++ b/src/components/timeline/useTimelineScroll.ts
@@ -6,6 +6,7 @@ import { toastInfo } from '../../hooks/useToast';
 import {
   clampTimelineScrollLeft,
   clampTimelinePixelsPerSecond,
+  computeAutoScrollAnchor,
   DEFAULT_TIMELINE_PIXELS_PER_SECOND,
   getNextTimelineZoomLevel,
   getTimelineContentWidth,
@@ -46,6 +47,7 @@ export function useTimelineScroll(scrollRef: React.RefObject<HTMLDivElement | nu
   const zoomAnchorRef = useRef<{ time: number; viewportX: number } | null>(null);
   const zoomFrameTimeRef = useRef<number | null>(null);
   const handledTimelineZoomRequestIdRef = useRef<number | null>(null);
+  const autoScrollAnchorRef = useRef<number | null>(null);
 
   const totalWidth = hasProject
     ? getTimelineContentWidth(totalDuration, pixelsPerSecond, viewportWidth)
@@ -143,18 +145,32 @@ export function useTimelineScroll(scrollRef: React.RefObject<HTMLDivElement | nu
     scrollRef,
   ]);
 
+  // Reset auto-scroll anchor when playback stops or auto-scroll is disabled
+  useEffect(() => {
+    if (!isPlaying || !autoScrollEnabled) {
+      autoScrollAnchorRef.current = null;
+    }
+  }, [isPlaying, autoScrollEnabled]);
+
   // --- Auto-scroll during playback ---
   useEffect(() => {
     const container = scrollRef.current;
     if (!container || !hasProject || !isPlaying || !autoScrollEnabled) return;
 
     const timelineViewportWidth = Math.max(1, (container.clientWidth - trackListWidth) || window.innerWidth || 1);
-    const fixedPlayheadViewportX = Math.min(
-      Math.max(120, timelineViewportWidth * 0.35),
-      Math.max(120, timelineViewportWidth - 96),
+
+    // Compute the viewport-x anchor for the playhead. On the first frame
+    // this captures where the playhead currently sits so the view scrolls
+    // immediately instead of waiting for the playhead to walk to 35 %.
+    const playheadViewportX = currentTime * pixelsPerSecond - container.scrollLeft;
+    autoScrollAnchorRef.current = computeAutoScrollAnchor(
+      playheadViewportX,
+      autoScrollAnchorRef.current,
+      timelineViewportWidth,
     );
+
     const nextScrollLeft = clampTimelineScrollLeft(
-      currentTime * pixelsPerSecond - fixedPlayheadViewportX,
+      currentTime * pixelsPerSecond - autoScrollAnchorRef.current,
       totalDuration,
       pixelsPerSecond,
       timelineViewportWidth,

--- a/src/utils/__tests__/timelineZoom.test.ts
+++ b/src/utils/__tests__/timelineZoom.test.ts
@@ -6,6 +6,7 @@ import {
   getTimelineZoomAnchor,
   TIMELINE_ZOOM_LEVELS,
   getZoomedTimelineViewport,
+  computeAutoScrollAnchor,
 } from '../timelineZoom';
 
 describe('timelineZoom', () => {
@@ -86,5 +87,38 @@ describe('timelineZoom', () => {
     const maxPps = TIMELINE_ZOOM_LEVELS[TIMELINE_ZOOM_LEVELS.length - 1];
     const beatPxAt120 = maxPps * (60 / 120);
     expect(beatPxAt120).toBeGreaterThanOrEqual(640);
+  });
+});
+
+describe('computeAutoScrollAnchor', () => {
+  const viewportWidth = 1200;
+
+  it('uses playhead current viewport position when left of target (avoids walking-to-center)', () => {
+    const anchor = computeAutoScrollAnchor(100, null, viewportWidth);
+    expect(anchor).toBe(100);
+  });
+
+  it('caps anchor at target position when playhead is right of target', () => {
+    const anchor = computeAutoScrollAnchor(800, null, viewportWidth);
+    const targetX = Math.min(
+      Math.max(120, viewportWidth * 0.35),
+      Math.max(120, viewportWidth - 96),
+    );
+    expect(anchor).toBe(targetX);
+  });
+
+  it('returns existing anchor unchanged when already set (stable during playback)', () => {
+    const anchor = computeAutoScrollAnchor(100, 200, viewportWidth);
+    expect(anchor).toBe(200);
+  });
+
+  it('clamps anchor to 0 minimum when playhead is at negative viewport position', () => {
+    const anchor = computeAutoScrollAnchor(-50, null, viewportWidth);
+    expect(anchor).toBe(0);
+  });
+
+  it('uses small anchor at timeline start so scrolling begins immediately', () => {
+    const anchor = computeAutoScrollAnchor(0, null, viewportWidth);
+    expect(anchor).toBe(0);
   });
 });

--- a/src/utils/timelineZoom.ts
+++ b/src/utils/timelineZoom.ts
@@ -157,6 +157,32 @@ export function getZoomedTimelineViewport(
   };
 }
 
+/**
+ * Compute the auto-scroll viewport anchor for the playhead.
+ *
+ * On the first frame of auto-scrolling (previousAnchor === null), uses the
+ * playhead's *current* viewport position (capped at the 35 % target) so
+ * scrolling starts immediately instead of waiting for the playhead to walk
+ * to the centre of the viewport.
+ *
+ * Once an anchor is established it is returned unchanged — it stays stable
+ * for the entire playback session.
+ */
+export function computeAutoScrollAnchor(
+  playheadViewportX: number,
+  previousAnchor: number | null,
+  viewportWidth: number,
+): number {
+  // Stable: return existing anchor once set
+  if (previousAnchor !== null) return previousAnchor;
+
+  const targetX = Math.min(
+    Math.max(120, viewportWidth * 0.35),
+    Math.max(120, viewportWidth - 96),
+  );
+  return clamp(playheadViewportX, 0, targetX);
+}
+
 export function getTimelineFitViewport(
   range: TimelineZoomRange,
   viewportWidth: number,


### PR DESCRIPTION
## Summary
- Fixed auto-scroll "walking to center" bug where the playhead would visually walk to 35% of the viewport before background scrolling began
- Added `computeAutoScrollAnchor()` utility that captures the playhead's current viewport position on the first frame of auto-scrolling, using it as the scroll anchor instead of a fixed 35% offset
- Anchor resets when playback stops or auto-scroll is toggled off

## Root Cause
The auto-scroll effect calculated `nextScrollLeft = currentTime * pps - fixedPlayheadViewportX` where `fixedPlayheadViewportX` was always ~35% of viewport width. When the playhead was to the left of that 35% mark, `nextScrollLeft` clamped to 0, causing the playhead to walk rightward across the viewport before any scrolling occurred.

## Test plan
- [x] Unit tests for `computeAutoScrollAnchor()` cover all cases (initial anchor, existing anchor, edge clamping)
- [x] All 3199 existing tests pass
- [x] TypeScript type-check passes with 0 errors
- [x] Production build succeeds
- [ ] Manual: enable auto-scroll → play from beginning → background scrolls immediately
- [ ] Manual: enable auto-scroll → play from mid-timeline → no jarring jump, smooth scroll

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)