### PR TITLE
fix: preserve stems form state when switching between Mix/Stems tabs

### DIFF
--- a/src/components/generation/MultiTrackGenerateSection.tsx
+++ b/src/components/generation/MultiTrackGenerateSection.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useGenerationStore } from '../../store/generationStore';
 import { useUIStore } from '../../store/uiStore';
 import { generateBatch, type BatchTrackEntry } from '../../services/generationPipeline';
 import { TRACK_CATALOG, TRACK_NAMES } from '../../constants/tracks';
 import type { Track } from '../../types/project';
+import type { StemsFormDraft } from '../../store/generationStore';
 
 const VOCAL_TRACKS = new Set(['vocals', 'backing_vocals']);
 const DEFAULT_MULTI_TRACK_NAMES = ['drums', 'bass', 'keyboard', 'vocals'] as const;
@@ -89,19 +90,45 @@ function buildInitialRows(project: NonNullable<ReturnType<typeof useProjectStore
 export function MultiTrackGenerateSection({ mode, onModeChange, onFooterChange }: Props) {
   const project = useProjectStore((s) => s.project);
   const isGenerating = useGenerationStore((s) => s.isGenerating);
+  const stemsFormDraft = useGenerationStore((s) => s.stemsFormDraft);
+  const setStemsFormDraft = useGenerationStore((s) => s.setStemsFormDraft);
   const initialRange = useUIStore((s) => s.batchGenerateInitialRange);
 
-  const [globalCaption, setGlobalCaption] = useState(() => project?.globalCaption ?? '');
-  const [rows, setRows] = useState<TrackRow[]>([]);
-  const [sharedSeed, setSharedSeed] = useState<number>(randomSeed);
-  const [audioDuration, setAudioDuration] = useState(30);
-  const [durationAuto, setDurationAuto] = useState(false);
-  const [useRandomSeed, setUseRandomSeed] = useState(true);
+  const [globalCaption, setGlobalCaption] = useState(() => stemsFormDraft?.globalCaption ?? project?.globalCaption ?? '');
+  const [rows, setRows] = useState<TrackRow[]>(() => stemsFormDraft?.rows as TrackRow[] ?? []);
+  const [sharedSeed, setSharedSeed] = useState<number>(() => stemsFormDraft?.sharedSeed ?? randomSeed());
+  const [audioDuration, setAudioDuration] = useState(() => stemsFormDraft?.audioDuration ?? 30);
+  const [durationAuto, setDurationAuto] = useState(() => stemsFormDraft?.durationAuto ?? false);
+  const [useRandomSeed, setUseRandomSeed] = useState(() => stemsFormDraft?.useRandomSeed ?? true);
+
+  // Refs to capture latest state for the unmount effect
+  const stateRef = useRef({ globalCaption, rows, sharedSeed, audioDuration, durationAuto, useRandomSeed });
+  stateRef.current = { globalCaption, rows, sharedSeed, audioDuration, durationAuto, useRandomSeed };
+
+  // Save draft to store on unmount
+  useEffect(() => {
+    return () => {
+      const s = stateRef.current;
+      if (s.rows.length > 0) {
+        setStemsFormDraft({
+          globalCaption: s.globalCaption,
+          rows: s.rows,
+          sharedSeed: s.sharedSeed,
+          audioDuration: s.audioDuration,
+          durationAuto: s.durationAuto,
+          useRandomSeed: s.useRandomSeed,
+        });
+      }
+    };
+  }, [setStemsFormDraft]);
 
   useEffect(() => {
     if (!project) return;
-    setGlobalCaption((prev) => prev || project.globalCaption || '');
-    setRows(buildInitialRows(project));
+    // Only build from project if we don't have a saved draft
+    if (rows.length === 0) {
+      setGlobalCaption((prev) => prev || project.globalCaption || '');
+      setRows(buildInitialRows(project));
+    }
   }, [project?.id]);
 
   const toggleRow = useCallback((rowId: string) => {

--- a/src/store/generationStore.ts
+++ b/src/store/generationStore.ts
@@ -423,6 +423,29 @@ export function getGenerationValidationError(input: GenerationValidationInput): 
   return null;
 }
 
+/** Draft state for the multi-track (Stems) generation form.
+ *  Stored in the generation store so it survives component unmount/remount
+ *  when switching between Mix and Stems tabs. */
+export interface StemsFormDraft {
+  globalCaption: string;
+  rows: StemsFormDraftRow[];
+  sharedSeed: number;
+  audioDuration: number;
+  durationAuto: boolean;
+  useRandomSeed: boolean;
+}
+
+export interface StemsFormDraftRow {
+  rowId: string;
+  linkedTrackId: string | null;
+  trackName: string;
+  localDescription: string;
+  lyrics: string;
+  checked: boolean;
+  firstClipId: string | null;
+  hasExistingAudio: boolean;
+}
+
 export interface GenerationState {
   jobs: GenerationJob[];
   isGenerating: boolean;
@@ -432,6 +455,7 @@ export interface GenerationState {
   variationSession: VariationSession | null;
   generationForm: GenerationFormState;
   lastSubmittedRequest: SubmittedGenerationRequest | null;
+  stemsFormDraft: StemsFormDraft | null;
 
   addJob: (job: GenerationJob) => void;
   updateJob: (jobId: string, updates: Partial<GenerationJob>) => void;
@@ -470,6 +494,9 @@ export interface GenerationState {
   getGenerationValidationError: () => string | null;
   canSubmitGeneration: () => boolean;
   submitGenerationRequest: (context?: { globalCaption?: string | null }) => VariationSessionParams | null;
+
+  setStemsFormDraft: (draft: StemsFormDraft) => void;
+  clearStemsFormDraft: () => void;
 
   setCompareModelsEnabled: (enabled: boolean) => void;
   setCompareModelOverrides: (overrides: ModelOverride[]) => void;
@@ -526,6 +553,7 @@ export const useGenerationStore = create<GenerationState>()(
       variationSession: null,
       generationForm: createDefaultGenerationFormState(),
       lastSubmittedRequest: null,
+      stemsFormDraft: null,
 
       addJob: (job) => set((s) => ({
         jobs: [
@@ -829,6 +857,9 @@ export const useGenerationStore = create<GenerationState>()(
       setGenerationUseRandomSeed: (useRandom) => set((s) => ({
         generationForm: { ...s.generationForm, useRandomSeed: useRandom, requestError: null },
       })),
+
+      setStemsFormDraft: (draft) => set({ stemsFormDraft: draft }),
+      clearStemsFormDraft: () => set({ stemsFormDraft: null }),
 
       setCompareModelsEnabled: (enabled) => set((s) => ({
         generationForm: { ...s.generationForm, compareModelsEnabled: enabled, requestError: null },


### PR DESCRIPTION
## Summary
- Add `stemsFormDraft` field to `generationStore` to persist multi-track form state across tab switches
- On unmount, `MultiTrackGenerateSection` saves its state (global caption, per-track descriptions, seed, duration) to the store
- On remount, it restores from the saved draft instead of rebuilding from scratch

## Root Cause
`MultiTrackGenerateSection` used only local `useState` for all form state. When switching tabs (Mix ↔ Stems), the component is unmounted/remounted via conditional rendering, discarding all user input.

## Test plan
- [x] Type stems descriptions → switch to Mix → switch back to Stems → descriptions preserved (verified with screenshot)
- [x] Global caption preserved across tab switches
- [x] Per-track descriptions preserved across tab switches  
- [x] Seed and duration preserved
- [x] All 3279 unit tests pass
- [x] TypeScript check passes

Closes #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)