### PR TITLE
fix: close generation panel immediately when stems generation starts

### DIFF
--- a/src/components/generation/MultiTrackGenerateSection.tsx
+++ b/src/components/generation/MultiTrackGenerateSection.tsx
@@ -241,11 +241,17 @@ export function MultiTrackGenerateSection({ mode, onModeChange, onFooterChange }
       )));
     }
 
-    await generateBatch({
+    // Close panel before generation starts (match Mix mode behavior)
+    useUIStore.getState().setShowGenerationPanel(false);
+
+    // Fire-and-forget — generation runs in the background
+    generateBatch({
       mode,
       globalCaption,
       tracks,
       sharedSeed,
+    }).catch(() => {
+      // errors are handled inside generateBatch via toast
     });
   }, [canGenerate, globalCaption, initialRange?.duration, initialRange?.startTime, mode, selectedRows, sharedSeed]);
 


### PR DESCRIPTION
## Summary
- Close the generation panel before calling `generateBatch()`, matching Mix mode behavior
- Run `generateBatch` as fire-and-forget instead of awaiting it
- User can continue editing while stems generate in the background

## Root Cause
`MultiTrackGenerateSection.handleGenerate` used `await generateBatch(...)` without closing the panel, causing the UI to show "Generating..." and block all interaction until completion. Mix mode (`FullSongForm`) correctly closes the panel first and doesn't await.

## Test plan
- [x] Click "Generate" in Stems mode → panel closes immediately
- [x] Generation continues in background (visible in status bar)
- [x] All 3279 unit tests pass
- [x] TypeScript check passes

Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)