### PR TITLE
fix: force thinking=false for lego (stems) generation requests

### DIFF
--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -674,7 +674,7 @@ async function generateClipInternal(
       shift: options.shiftOverride ?? project.generationDefaults.shift,
       batch_size: 1,
       audio_format: 'wav',
-      thinking: options.thinkingOverride ?? project.generationDefaults.thinking,
+      thinking: false, // lego is a pure DiT task — LM audio codes are out-of-distribution
       model: project.generationDefaults.model,
     } as LegoTaskParams;
 


### PR DESCRIPTION
## Summary
- Force `thinking: false` for all lego task type requests, regardless of global setting
- Lego is a pure DiT task — the model was never trained with LM audio codes. Passing LM-generated codes is out-of-distribution input that degrades stems generation quality.

## Change
One line in `generationPipeline.ts:677`:
```diff
-      thinking: options.thinkingOverride ?? project.generationDefaults.thinking,
+      thinking: false, // lego is a pure DiT task — LM audio codes are out-of-distribution
```

## Test plan
- [x] TypeScript check passes
- [x] All 3279 unit tests pass
- [x] Mix (text2music) requests still respect global thinking setting

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)