### PR TITLE
feat: double-click/right-click edit clip opens AddLayerPanel with restored state

### DIFF
--- a/src/components/generation/AddLayerPanel.tsx
+++ b/src/components/generation/AddLayerPanel.tsx
@@ -109,6 +109,7 @@ function keepPositionIfUnchanged(currentPosition: PanelPosition | null, nextPosi
 export function AddLayerPanel() {
   const isOpen = useUIStore((s) => s.addLayerOpen);
   const setAddLayerOpen = useUIStore((s) => s.setAddLayerOpen);
+  const editingClipId = useUIStore((s) => s.editingLegoClipId);
   const selectWindow = useUIStore((s) => s.selectWindow);
   const contextWindow = useUIStore((s) => s.contextWindow);
 
@@ -116,6 +117,17 @@ export function AddLayerPanel() {
   const addTrack = useProjectStore((s) => s.addTrack);
   const setTrackLocalCaption = useProjectStore((s) => s.setTrackLocalCaption);
   const isGenerating = useGenerationStore((s) => s.isGenerating);
+
+  // Resolve editing clip and its track
+  const editingClip = useMemo(() => {
+    if (!editingClipId || !project) return null;
+    for (const track of project.tracks) {
+      const clip = track.clips.find((c) => c.id === editingClipId);
+      if (clip) return { clip, track };
+    }
+    return null;
+  }, [editingClipId, project]);
+  const isEditMode = editingClip !== null;
 
   const [targetTrackName, setTargetTrackName] = useState<TrackName>('drums');
   const [style, setStyle] = useState('');
@@ -277,21 +289,50 @@ export function AddLayerPanel() {
     return () => window.removeEventListener('keydown', handleEsc);
   }, [isOpen, handleClose]);
 
-  // Reset form when panel opens
+  // Reset form when panel opens — restore from clip in edit mode
   useEffect(() => {
     if (isOpen && !wasOpenRef.current) {
-      setTargetTrackName(project ? getDefaultTargetTrackName(project, selectWindow) : 'drums');
-      setStyle('');
-      setLyrics('');
-      setGlobalCaption(project?.globalCaption ?? '');
-      setSeedValue('');
-      setUseRandomSeed(true);
-      setChunkMaskMode('auto');
+      if (editingClip) {
+        // Edit mode: restore from clip's generation params
+        const { clip, track } = editingClip;
+        const params = clip.generationParams;
+        setTargetTrackName(track.trackName);
+        setStyle(params?.prompt ?? clip.prompt ?? '');
+        setLyrics(params?.lyrics ?? clip.lyrics ?? '');
+        setGlobalCaption(params?.globalCaption ?? clip.globalCaption ?? project?.globalCaption ?? '');
+        setSeedValue(params?.seed !== undefined ? String(params.seed) : '');
+        setUseRandomSeed(params?.useRandomSeed ?? true);
+        setChunkMaskMode('auto');
+        // Restore context window from saved generation params
+        if (params?.contextWindow) {
+          useUIStore.getState().setContextWindow({
+            startTime: params.contextWindow.startTime,
+            endTime: params.contextWindow.endTime,
+            trackIds: [track.id],
+          });
+        }
+        // Set select window to match clip range
+        useUIStore.getState().setSelectWindow({
+          startTime: clip.startTime,
+          endTime: clip.startTime + clip.duration,
+          trackIds: [track.id],
+          primaryTrackId: track.id,
+        });
+      } else {
+        // New layer mode: fresh form
+        setTargetTrackName(project ? getDefaultTargetTrackName(project, selectWindow) : 'drums');
+        setStyle('');
+        setLyrics('');
+        setGlobalCaption(project?.globalCaption ?? '');
+        setSeedValue('');
+        setUseRandomSeed(true);
+        setChunkMaskMode('auto');
+      }
       setSavedSelectionBeforeWholeSong(null);
       setPanelPosition(null);
     }
     wasOpenRef.current = isOpen;
-  }, [isOpen, project, selectWindow]);
+  }, [isOpen, project, selectWindow, editingClip]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -557,17 +598,37 @@ export function AddLayerPanel() {
   const handleGenerate = async () => {
     stopPreview();
 
-    let targetTrack = selectedWindowTrack;
-    if (!targetTrack) {
-      targetTrack = addTrack(
-        targetTrackName,
-        'stems',
-        selectedEmptyTrackOrder !== null ? { order: selectedEmptyTrackOrder } : undefined,
-      );
-    }
+    let trackId: string;
 
-    if (style) {
-      setTrackLocalCaption(targetTrack.id, style);
+    if (isEditMode && editingClip) {
+      // Edit mode: reuse existing track, update clip params
+      trackId = editingClip.track.id;
+      if (style) setTrackLocalCaption(trackId, style);
+      // Update clip with new params before regenerating
+      useProjectStore.getState().updateClip(editingClip.clip.id, {
+        prompt: style,
+        globalCaption,
+        lyrics: showLyrics ? lyrics : '',
+        generationParams: {
+          type: 'lego',
+          prompt: style,
+          lyrics: showLyrics ? lyrics : '',
+          globalCaption,
+          contextWindow: hasContext ? { startTime: contextWindow!.startTime, endTime: contextWindow!.endTime } : null,
+        },
+      });
+    } else {
+      // New layer mode: create or find target track
+      let targetTrack = selectedWindowTrack;
+      if (!targetTrack) {
+        targetTrack = addTrack(
+          targetTrackName,
+          'stems',
+          selectedEmptyTrackOrder !== null ? { order: selectedEmptyTrackOrder } : undefined,
+        );
+      }
+      trackId = targetTrack.id;
+      if (style) setTrackLocalCaption(trackId, style);
     }
 
     useUIStore.getState().setSelectWindow(null);
@@ -575,7 +636,7 @@ export function AddLayerPanel() {
     handleClose();
 
     await generateFromAddLayer({
-      trackId: targetTrack.id,
+      trackId,
       startTime,
       duration,
       localDescription: style,
@@ -583,6 +644,7 @@ export function AddLayerPanel() {
       lyrics: showLyrics ? lyrics : '',
       contextWindow: hasContext ? contextWindow : null,
       chunkMaskMode,
+      clipId: isEditMode ? editingClipId ?? undefined : undefined,
     });
   };
 
@@ -622,7 +684,7 @@ export function AddLayerPanel() {
             <span className="block h-1 w-5 rounded-full bg-current/40" />
           </div>
           <div className="min-w-0">
-            <span className="block text-sm font-semibold text-white">Add a Layer</span>
+            <span className="block text-sm font-semibold text-white">{isEditMode ? 'Edit Layer' : 'Add a Layer'}</span>
             <div className="flex items-center gap-2 text-[11px]">
               <span className="text-zinc-500">{fmt(startTime)} - {fmt(endTime)}</span>
               {!selectionCoversWholeSong && (
@@ -894,7 +956,7 @@ export function AddLayerPanel() {
               : 'bg-teal-600 hover:bg-teal-500 text-white'
           }`}
         >
-          {isGenerating ? 'Generating\u2026' : 'Generate'}
+          {isGenerating ? 'Generating\u2026' : isEditMode ? 'Regenerate' : 'Generate'}
         </button>
       </div>
     </div>

--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -156,16 +156,17 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
       setOpenPianoRoll(track.id, clip.id);
       return;
     }
-    // Text2music clips (explicit params OR mix track type) → open GenerationSidePanel
+    // Text2music clips (explicit params AND mix track type) → open GenerationSidePanel
     if (clip.generationParams?.type === 'text2music' || (clip.source === 'generated' && track.trackType === 'mix')) {
       const ui = useUIStore.getState();
       ui.setEditingText2MusicClipId(clip.id);
       ui.openGenerationPanelView('textToMusic');
       return;
     }
-    // Lego (add layer / stems) clips → open AddLayerModal
-    if (clip.source === 'generated') {
-      setEditModalOpen(true);
+    // Any other generated clip (lego / stems / add layer) → open AddLayerPanel
+    // Also handle stems-track clips that may not have source set
+    if (clip.source === 'generated' || track.trackType === 'stems') {
+      useUIStore.getState().openAddLayerForClip(clip.id);
       return;
     }
     setCtxMenu({ x: e.clientX, y: e.clientY });

--- a/src/components/timeline/ClipContextMenu.tsx
+++ b/src/components/timeline/ClipContextMenu.tsx
@@ -73,6 +73,9 @@ export function ClipContextMenu({
 
   return (
     <ContextMenuWrapper x={x} y={y} onClose={onClose} minWidth={190}>
+      {/* Edit Clip — first item for quick access */}
+      <ContextMenuItem label="Edit Clip" onClick={onEdit} />
+
       {/* Top-level Enhance entry */}
       {onEnhance && (
         <ContextMenuItem label="Enhance..." onClick={onEnhance} color="#6ee7b7" shortcut="⇧E" />
@@ -109,10 +112,6 @@ export function ClipContextMenu({
       <ContextMenuSeparator />
       <ContextMenuItem label="Split" onClick={onSplitAtPlayhead} shortcut="⌘E" />
       <ContextMenuItem label="Consolidate" onClick={onConsolidate} shortcut="⌘J" disabled={!canConsolidate} />
-
-      {/* Edit */}
-      <ContextMenuSeparator />
-      <ContextMenuItem label="Edit Clip" onClick={onEdit} />
 
       {/* Delete */}
       <ContextMenuSeparator />

--- a/src/components/timeline/ClipContextMenuContainer.tsx
+++ b/src/components/timeline/ClipContextMenuContainer.tsx
@@ -123,7 +123,7 @@ export function ClipContextMenuContainer({
           ui.setEditingText2MusicClipId(clip.id);
           ui.openGenerationPanelView('textToMusic');
         } else {
-          onEditModalOpen();
+          useUIStore.getState().openAddLayerForClip(clip.id);
         }
       }}
       onDuplicate={() => { onClose(); duplicateClip(clip.id); }}

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -1248,6 +1248,8 @@ export interface AddLayerOptions {
   contextWindow: { startTime: number; endTime: number } | null;
   /** Chunk mask mode for this single-track generation */
   chunkMaskMode?: 'explicit' | 'auto';
+  /** When set, regenerate into this existing clip instead of creating a new one. */
+  clipId?: string;
 }
 
 export async function generateFromAddLayer(opts: AddLayerOptions): Promise<void> {
@@ -1260,23 +1262,45 @@ export async function generateFromAddLayer(opts: AddLayerOptions): Promise<void>
     try {
       const store = useProjectStore.getState();
 
-      const clip = store.addClip(opts.trackId, {
-        startTime: opts.startTime,
-        duration: opts.duration,
-        prompt: opts.localDescription,
-        globalCaption: opts.globalCaption,
-        lyrics: opts.lyrics,
-      });
+      let clipId: string;
 
-      // Persist generation params for edit/regenerate
-      store.updateClip(clip.id, {
-        generationParams: {
-          type: 'lego',
+      if (opts.clipId) {
+        // Edit mode: reuse existing clip, update its params
+        clipId = opts.clipId;
+        store.updateClip(clipId, {
           prompt: opts.localDescription,
-          lyrics: opts.lyrics,
           globalCaption: opts.globalCaption,
-        },
-      });
+          lyrics: opts.lyrics,
+          generationParams: {
+            type: 'lego',
+            prompt: opts.localDescription,
+            lyrics: opts.lyrics,
+            globalCaption: opts.globalCaption,
+            contextWindow: opts.contextWindow,
+          },
+        });
+      } else {
+        // New layer: create clip
+        const clip = store.addClip(opts.trackId, {
+          startTime: opts.startTime,
+          duration: opts.duration,
+          prompt: opts.localDescription,
+          globalCaption: opts.globalCaption,
+          lyrics: opts.lyrics,
+        });
+        clipId = clip.id;
+
+        // Persist generation params for edit/regenerate
+        store.updateClip(clipId, {
+          generationParams: {
+            type: 'lego',
+            prompt: opts.localDescription,
+            lyrics: opts.lyrics,
+            globalCaption: opts.globalCaption,
+            contextWindow: opts.contextWindow,
+          },
+        });
+      }
 
       if (opts.localDescription) {
         store.setTrackLocalCaption(opts.trackId, opts.localDescription);
@@ -1288,7 +1312,7 @@ export async function generateFromAddLayer(opts: AddLayerOptions): Promise<void>
         contextBlob = await extractContextAudioLazy(opts.contextWindow);
       }
 
-      const outcome = await generateClipInternal(clip.id, contextBlob, {
+      const outcome = await generateClipInternal(clipId, contextBlob, {
         forceSilence: !contextBlob,
         localDescription: opts.localDescription,
         globalCaptionOverride: opts.globalCaption,
@@ -1297,7 +1321,7 @@ export async function generateFromAddLayer(opts: AddLayerOptions): Promise<void>
       });
 
       if (outcome.succeeded) {
-        useProjectStore.getState().saveClipVersion(clip.id);
+        useProjectStore.getState().saveClipVersion(clipId);
       }
 
       return outcome.succeeded;

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -197,6 +197,7 @@ export interface UIState {
 
   // Add Layer Panel (floating, no backdrop)
   addLayerOpen: boolean;
+  editingLegoClipId: string | null;
 
   // Model Library Panel
   showModelLibrary: boolean;
@@ -385,6 +386,8 @@ export interface UIState {
 
   // Add Layer Panel
   setAddLayerOpen: (v: boolean) => void;
+  setEditingLegoClipId: (id: string | null) => void;
+  openAddLayerForClip: (clipId: string) => void;
 
   // Model Library Panel
   toggleModelLibrary: () => void;
@@ -642,6 +645,7 @@ export const useUIStore = create<UIState>()(
   generatePatternClipId: null,
 
   addLayerOpen: false,
+  editingLegoClipId: null,
 
   showModelLibrary: false,
 
@@ -1124,7 +1128,9 @@ export const useUIStore = create<UIState>()(
   setShowGeneratePatternDialog: (v) => set(v ? { showGeneratePatternDialog: v } : { showGeneratePatternDialog: false, generatePatternClipId: null }),
   openGeneratePatternDialog: (clipId) => set({ showGeneratePatternDialog: true, generatePatternClipId: clipId }),
 
-  setAddLayerOpen: (v) => set({ addLayerOpen: v }),
+  setAddLayerOpen: (v) => set({ addLayerOpen: v, ...(v ? {} : { editingLegoClipId: null }) }),
+  setEditingLegoClipId: (id) => set({ editingLegoClipId: id }),
+  openAddLayerForClip: (clipId) => set({ addLayerOpen: true, editingLegoClipId: clipId }),
 
   toggleModelLibrary: () => set((s) => s.showModelLibrary ? { showModelLibrary: false } : { ...ALL_RIGHT_PANELS_CLOSED, showModelLibrary: true }),
   setShowModelLibrary: (v) => set(v ? { ...ALL_RIGHT_PANELS_CLOSED, showModelLibrary: true } : { showModelLibrary: false }),

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -622,6 +622,8 @@ export interface ClipGenerationParams {
   globalCaption?: string;
   sampleMode?: boolean;
   autoExpandPrompt?: boolean;
+  /** Context window used for lego generation — persisted for edit/regenerate. */
+  contextWindow?: { startTime: number; endTime: number } | null;
 }
 
 export interface Clip {


### PR DESCRIPTION
## Summary
- Double-click a lego-generated clip → opens AddLayerPanel with restored params (prompt, globalCaption, lyrics, target track, selection range)
- Right-click → Edit Clip → same behavior
- Header shows "Edit Layer" in edit mode, button shows "Regenerate"
- Regeneration reuses the existing clip instead of creating a new one
- Closing the panel clears `editingLegoClipId`

## Changes
- `uiStore`: Add `editingLegoClipId`, `setEditingLegoClipId`, `openAddLayerForClip`
- `AddLayerPanel`: Edit mode restores form state from `clip.generationParams`; `handleGenerate` updates existing clip and passes `clipId` to pipeline
- `generationPipeline.ts`: `AddLayerOptions.clipId` — when set, updates existing clip instead of creating new
- `ClipBlock.tsx`: Double-click lego clips → `openAddLayerForClip`
- `ClipContextMenuContainer.tsx`: Edit Clip → `openAddLayerForClip`

## Test plan
- [x] TypeScript check passes
- [x] All 3277 unit tests pass

Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)