### PR TITLE
fix: improve Playback Latency settings layout alignment

### DIFF
--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -428,39 +428,18 @@ export function SettingsDialog() {
                 ? `Detected ${playbackLatency.detectedLatencyMs?.toFixed(1) ?? '0.0'} ms from Web Audio (${playbackLatency.detectedBaseLatencyMs?.toFixed(1) ?? '0.0'} ms base + ${playbackLatency.detectedOutputLatencyMs?.toFixed(1) ?? '0.0'} ms output).`
                 : 'Browser latency unavailable. Enter a manual playback compensation value if timing feels late.'}
             </p>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-[1fr_1fr_auto] items-end gap-3">
               <div>
                 <label className="block text-xs text-zinc-400 mb-1">Detected Latency</label>
-                <div className="flex items-center gap-1.5">
-                  <div className="flex-1 rounded border border-daw-border bg-black/20 px-3 py-1.5 text-sm text-zinc-200">
-                    {playbackLatency.detectedLatencyMs !== null
-                      ? `${playbackLatency.detectedLatencyMs.toFixed(1)} ms (${latencyMsToSamples(playbackLatency.detectedLatencyMs, getAudioEngine().sampleRate)} smp)`
-                      : 'Unavailable'}
-                  </div>
-                  <button
-                    type="button"
-                    data-testid="auto-detect-latency"
-                    onClick={() => {
-                      const engine = getAudioEngine();
-                      const latency = engine.refreshPlaybackLatencyCompensation();
-                      const store = useProjectStore.getState();
-                      store.detectPlaybackLatency(latency);
-                      engine.setPlaybackLatencyCompensation(
-                        store.project?.playbackLatency?.compensationMs
-                          ? store.project.playbackLatency.compensationMs / 1000
-                          : 0,
-                      );
-                    }}
-                    className="shrink-0 px-2 py-1.5 text-[10px] font-medium text-zinc-300 bg-daw-surface-2 border border-daw-border rounded hover:border-daw-accent hover:text-white transition-colors"
-                    title="Re-measure audio output latency from Web Audio API"
-                  >
-                    Re-detect
-                  </button>
+                <div className="rounded border border-daw-border bg-black/20 px-3 py-1.5 text-sm text-zinc-200 whitespace-nowrap">
+                  {playbackLatency.detectedLatencyMs !== null
+                    ? `${playbackLatency.detectedLatencyMs.toFixed(1)} ms (${latencyMsToSamples(playbackLatency.detectedLatencyMs, getAudioEngine().sampleRate)} smp)`
+                    : 'Unavailable'}
                 </div>
               </div>
               <div>
-                <label className="block text-xs text-zinc-400 mb-1" htmlFor="manual-playback-latency">
-                  Manual Override (ms)
+                <label className="block text-xs text-zinc-400 mb-1 whitespace-nowrap" htmlFor="manual-playback-latency">
+                  Override (ms)
                 </label>
                 <input
                   id="manual-playback-latency"
@@ -475,6 +454,25 @@ export function SettingsDialog() {
                   className="w-full px-3 py-1.5 text-sm text-zinc-200 bg-daw-bg border border-daw-border rounded focus:outline-none focus:border-daw-accent placeholder:text-zinc-600"
                 />
               </div>
+              <button
+                type="button"
+                data-testid="auto-detect-latency"
+                onClick={() => {
+                  const engine = getAudioEngine();
+                  const latency = engine.refreshPlaybackLatencyCompensation();
+                  const store = useProjectStore.getState();
+                  store.detectPlaybackLatency(latency);
+                  engine.setPlaybackLatencyCompensation(
+                    store.project?.playbackLatency?.compensationMs
+                      ? store.project.playbackLatency.compensationMs / 1000
+                      : 0,
+                  );
+                }}
+                className="px-3 py-1.5 text-xs font-medium text-zinc-300 bg-daw-surface-2 border border-daw-border rounded hover:border-daw-accent hover:text-white transition-colors whitespace-nowrap"
+                title="Re-measure audio output latency from Web Audio API"
+              >
+                Re-detect
+              </button>
             </div>
              <p className="text-[10px] text-zinc-400">
                Active compensation: {playbackLatency.compensationMs.toFixed(1)} ms ({latencyMsToSamples(playbackLatency.compensationMs, getAudioEngine().sampleRate)} samples @ {getAudioEngine().sampleRate} Hz)


### PR DESCRIPTION
## Summary
- Restructured Playback Latency section from a 2-column grid to a 3-column layout (`grid-cols-[1fr_1fr_auto]`)
- Detected latency value now displays on a single line with `whitespace-nowrap` instead of wrapping to 3 lines
- Re-detect button moved from inside the detected value column to its own column, properly aligned
- Shortened label from "Manual Override (ms)" to "Override (ms)" to prevent label wrapping

## Before
The detected value "29.3 ms (1406 smp)" wrapped across 3 lines in a narrow box, making the section visually unbalanced with the Re-detect button floating awkwardly next to it.

## After
All three elements (detected value, override input, Re-detect button) sit on one row with consistent height and alignment.

Closes #1167

## Test plan
- [ ] Open Settings dialog and scroll to Playback Latency section
- [ ] Verify detected latency displays on a single line
- [ ] Verify Override input and Re-detect button are properly aligned
- [ ] Verify layout works at different dialog widths
- [ ] Verify Re-detect button still functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)