### PR TITLE
fix: invert consistency→strength mapping in AI Enhancer

### DIFF
--- a/src/components/generation/EnhancePanel.tsx
+++ b/src/components/generation/EnhancePanel.tsx
@@ -19,9 +19,9 @@ const ENHANCER_BASE_BOTTOM = 60;
 
 type ConsistencyLevel = 'low' | 'medium' | 'high';
 const CONSISTENCY_VALUES: Record<ConsistencyLevel, number> = {
-  low: 0.25,
+  low: 0.75,
   medium: 0.5,
-  high: 0.75,
+  high: 0.25,
 };
 
 function fmt(s: number) {

--- a/src/components/generation/__tests__/EnhancePanel.test.tsx
+++ b/src/components/generation/__tests__/EnhancePanel.test.tsx
@@ -616,6 +616,42 @@ describe('EnhancePanel version tree UI', () => {
     expect(screen.getByText(/Jazz cover/)).toBeInTheDocument();
   });
 
+  it('passes correct coverStrength for each consistency level (high=0.25, medium=0.5, low=0.75)', async () => {
+    const { generateCoverClip } = await import('../../../services/generationPipeline');
+    const { track, clip } = setupProjectWithClip();
+    useUIStore.setState({
+      enhancerOpen: true,
+      enhancerTarget: { clipId: clip.id, trackId: track.id, range: null, mode: 'cover' },
+      enhancementSession: null,
+    });
+    const { unmount } = render(<EnhancePanel />);
+
+    // Default is 'medium' — click Enhance
+    const enhanceBtn = screen.getByTestId('enhance-btn');
+    fireEvent.click(enhanceBtn);
+    expect(generateCoverClip).toHaveBeenLastCalledWith(
+      expect.objectContaining({ coverStrength: 0.5 }),
+    );
+
+    // Switch to 'high' consistency — should map to LOW deviation (0.25)
+    const highBtn = screen.getByText('high');
+    fireEvent.click(highBtn);
+    fireEvent.click(enhanceBtn);
+    expect(generateCoverClip).toHaveBeenLastCalledWith(
+      expect.objectContaining({ coverStrength: 0.25 }),
+    );
+
+    // Switch to 'low' consistency — should map to HIGH deviation (0.75)
+    const lowBtn = screen.getByText('low');
+    fireEvent.click(lowBtn);
+    fireEvent.click(enhanceBtn);
+    expect(generateCoverClip).toHaveBeenLastCalledWith(
+      expect.objectContaining({ coverStrength: 0.75 }),
+    );
+
+    unmount();
+  });
+
   it('shows chained source indicator when chainedSourceAudioKey is set', () => {
     // This tests the UI indicator — we can't directly set React state,
     // but we can verify the version tree renders. The chained indicator


### PR DESCRIPTION
## Summary
- Fix semantic inversion in `CONSISTENCY_VALUES` mapping: "High consistency" now correctly maps to `audio_cover_strength: 0.25` (low deviation), and "Low consistency" maps to `0.75` (high deviation)
- Previously the mapping was backwards — selecting "High consistency" actually sent `0.75` to the API, causing maximum deviation from the source audio

## Test plan
- [x] Regression test verifying `coverStrength` values: high→0.25, medium→0.5, low→0.75
- [ ] Manual: open AI Enhancer Cover mode, select each consistency level, verify the generated output matches expectations

Closes #1194

https://claude.ai/code/session_01CzJuSwLHvtiJfKFfcXbXhC