### PR TITLE
fix: guard Enhance with model inventory & readiness checks

### DIFF
--- a/src/components/generation/EnhancePanel.tsx
+++ b/src/components/generation/EnhancePanel.tsx
@@ -4,7 +4,7 @@ import { useGenerationStore } from '../../store/generationStore';
 import { useUIStore, getBottomPanelHeight } from '../../store/uiStore';
 import { generateCoverClip } from '../../services/generationPipeline';
 import { generateRepaintClip } from '../../services/generationPipeline';
-import { modelSupportsTaskType } from '../../services/aceStepApi';
+import { modelSupportsTaskType, isModelInventoryLoaded, isModelReady } from '../../services/aceStepApi';
 import { DualRangeSlider } from '../ui/DualRangeSlider';
 import { Z } from '../../utils/zIndex';
 import { WaveformPreview } from './WaveformPreview';
@@ -490,6 +490,8 @@ export function EnhancePanel() {
   }
 
   const hasAudio = !!(clip?.isolatedAudioKey || clip?.cumulativeMixKey);
+  const inventoryLoaded = isModelInventoryLoaded();
+  const modelReady = isModelReady();
   const coverSupported = modelSupportsTaskType('cover');
   const repaintSupported = modelSupportsTaskType('repaint');
   const modeSupported = mode === 'cover' ? coverSupported : repaintSupported;
@@ -689,7 +691,17 @@ export function EnhancePanel() {
                 No audio generated yet — generate the clip first before enhancing.
               </p>
             )}
-            {!modeSupported && (
+            {!inventoryLoaded && (
+              <p className="text-[10px] text-amber-400 mt-2">
+                Connecting to server...
+              </p>
+            )}
+            {inventoryLoaded && !modelReady && (
+              <p className="text-[10px] text-amber-400 mt-2">
+                No model loaded on server. Load a model in Settings before enhancing.
+              </p>
+            )}
+            {inventoryLoaded && modelReady && !modeSupported && (
               <p className="text-[10px] text-amber-400 mt-2">
                 The currently loaded model does not support {mode} generation.
               </p>

--- a/src/components/generation/__tests__/EnhancePanel.test.tsx
+++ b/src/components/generation/__tests__/EnhancePanel.test.tsx
@@ -17,6 +17,8 @@ vi.mock('../../../services/projectStorage', () => ({
 
 vi.mock('../../../services/aceStepApi', () => ({
   modelSupportsTaskType: vi.fn(() => true),
+  isModelInventoryLoaded: vi.fn(() => true),
+  isModelReady: vi.fn(() => true),
 }));
 
 const mockPlayback = {

--- a/src/services/__tests__/aceStepApi.test.ts
+++ b/src/services/__tests__/aceStepApi.test.ts
@@ -128,3 +128,88 @@ describe('healthCheck', () => {
     expect(fetchMock).toHaveBeenLastCalledWith('http://127.0.0.1:9000/health');
   });
 });
+
+describe('modelSupportsTaskType / isModelInventoryLoaded / isModelReady', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('fetch', vi.fn());
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('returns false when no inventory is cached', async () => {
+    const { modelSupportsTaskType, isModelInventoryLoaded, isModelReady } = await import('../aceStepApi');
+    expect(isModelInventoryLoaded()).toBe(false);
+    expect(isModelReady()).toBe(false);
+    expect(modelSupportsTaskType('cover')).toBe(false);
+    expect(modelSupportsTaskType('repaint')).toBe(false);
+  });
+
+  it('returns false when inventory exists but no model is loaded', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        data: {
+          models: [{ name: 'test-model', is_loaded: false, supported_task_types: ['cover'] }],
+          default_model: null,
+          lm_models: [],
+        },
+      }),
+    } as Response);
+
+    const { listModels, modelSupportsTaskType, isModelInventoryLoaded, isModelReady } = await import('../aceStepApi');
+    await listModels();
+
+    expect(isModelInventoryLoaded()).toBe(true);
+    expect(isModelReady()).toBe(false);
+    expect(modelSupportsTaskType('cover')).toBe(false);
+  });
+
+  it('returns true for supported task types when model is loaded', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        data: {
+          models: [{ name: 'test-model', is_loaded: true, supported_task_types: ['cover', 'repaint'] }],
+          default_model: 'test-model',
+          lm_models: [],
+        },
+      }),
+    } as Response);
+
+    const { listModels, modelSupportsTaskType, isModelReady } = await import('../aceStepApi');
+    await listModels();
+
+    expect(isModelReady()).toBe(true);
+    expect(modelSupportsTaskType('cover')).toBe(true);
+    expect(modelSupportsTaskType('repaint')).toBe(true);
+    expect(modelSupportsTaskType('unknown')).toBe(false);
+  });
+
+  it('returns true for any task when model has no supported_task_types metadata', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        data: {
+          models: [{ name: 'old-model', is_loaded: true }],
+          default_model: 'old-model',
+          lm_models: [],
+        },
+      }),
+    } as Response);
+
+    const { listModels, modelSupportsTaskType } = await import('../aceStepApi');
+    await listModels();
+
+    // Backward compat: no task type metadata → assume all supported
+    expect(modelSupportsTaskType('cover')).toBe(true);
+    expect(modelSupportsTaskType('repaint')).toBe(true);
+  });
+});

--- a/src/services/aceStepApi.ts
+++ b/src/services/aceStepApi.ts
@@ -169,14 +169,31 @@ export async function listModels(): Promise<ModelsListResponse> {
 let _cachedInventory: ModelsListResponse | null = null;
 
 /**
+ * Check whether the model inventory has been fetched from the server.
+ */
+export function isModelInventoryLoaded(): boolean {
+  return _cachedInventory !== null;
+}
+
+/**
+ * Check whether any model is currently loaded on the server.
+ */
+export function isModelReady(): boolean {
+  if (!_cachedInventory) return false;
+  return _cachedInventory.models.some((m) => m.is_loaded);
+}
+
+/**
  * Check whether the currently loaded (or default) model supports a given task type.
  * Uses the cached model inventory from the last `listModels()` call.
- * Returns true if the information is unavailable (optimistic fallback).
+ * Returns false if no inventory is cached or no model is loaded — callers should
+ * show appropriate guidance instead of silently enabling unsupported actions.
  */
 export function modelSupportsTaskType(taskType: string): boolean {
-  if (!_cachedInventory) return true;
+  if (!_cachedInventory) return false;
   const loaded = _cachedInventory.models.find((m) => m.is_loaded);
-  if (!loaded) return true;
+  if (!loaded) return false;
+  // If model has no task type metadata, assume it supports everything (backward compat)
   if (!loaded.supported_task_types || loaded.supported_task_types.length === 0) return true;
   return loaded.supported_task_types.includes(taskType);
 }


### PR DESCRIPTION
## Summary
- `modelSupportsTaskType()` previously returned `true` when no inventory was cached, potentially sending requests to an unloaded model
- Expose `isModelInventoryLoaded()` and `isModelReady()` from `aceStepApi`
- Display three distinct warning messages in the Enhancer: inventory not loaded, model not ready, or task type unsupported

## Test plan
- [x] Unit tests: no inventory → false, inventory with no loaded model → false, loaded model with/without task type metadata
- [x] EnhancePanel mock updated with new API functions
- [ ] Manual: start app without backend, open Enhancer — verify "inventory not loaded" message; start backend without model loaded — verify "model not ready" message

Closes #1199

https://claude.ai/code/session_01CzJuSwLHvtiJfKFfcXbXhC