### PR TITLE
fix: resolve type error and 2 failing tests on main

### DIFF
--- a/src/engine/InstrumentFactory.ts
+++ b/src/engine/InstrumentFactory.ts
@@ -131,6 +131,9 @@ export function getEngineForInstrument(instrument: TrackInstrument): InstrumentE
       return samplerAdapter;
     case 'fm':
       return fmAdapter;
+    case 'wavetable':
+      // Wavetable falls back to subtractive adapter for now
+      return subtractiveAdapter;
   }
 }
 

--- a/src/engine/__tests__/TrackNodeSend.test.ts
+++ b/src/engine/__tests__/TrackNodeSend.test.ts
@@ -82,7 +82,7 @@ describe('TrackNode send routing', () => {
 
   it('connectSend creates a gain node and connects to destination', () => {
     const sendDest = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
-    trackNode.connectSend('send-1', sendDest, 0.5, 'post');
+    trackNode.connectSend('send-1', sendDest, 0.5, false);
 
     // Should have created a gain node for the send
     expect(ctx.createGain).toHaveBeenCalled();
@@ -90,30 +90,30 @@ describe('TrackNode send routing', () => {
 
   it('disconnectSend removes the send connection', () => {
     const sendDest = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
-    trackNode.connectSend('send-1', sendDest, 0.7, 'post');
+    trackNode.connectSend('send-1', sendDest, 0.7, false);
     trackNode.disconnectSend('send-1');
 
     // After disconnect, reconnecting with same ID should work without error
-    trackNode.connectSend('send-1', sendDest, 0.3, 'pre');
+    trackNode.connectSend('send-1', sendDest, 0.3, true);
   });
 
   it('updateSendAmount changes the gain of an existing send', () => {
     const sendDest = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
-    trackNode.connectSend('send-1', sendDest, 0.5, 'post');
-    trackNode.updateSendAmount('send-1', 0.8);
+    trackNode.connectSend('send-1', sendDest, 0.5, false);
+    trackNode.updateSendAmount('send-1', 0.8, false);
     // No throw = success; gain value update happens internally
   });
 
-  it('updateSendPrePost switches send tap point', () => {
+  it('updateSendAmount switches send to pre-fader', () => {
     const sendDest = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
-    trackNode.connectSend('send-1', sendDest, 0.5, 'post');
-    trackNode.updateSendPrePost('send-1', 'pre');
-    // No throw = success; reconnection happens internally
+    trackNode.connectSend('send-1', sendDest, 0.5, false);
+    trackNode.updateSendAmount('send-1', 0.5, true);
+    // No throw = success; pre/post gain swap happens internally
   });
 
   it('pre-fader send taps before volumeGain', () => {
     const sendDest = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
-    trackNode.connectSend('send-1', sendDest, 0.5, 'pre');
+    trackNode.connectSend('send-1', sendDest, 0.5, true);
 
     // The pre-fader tap point should be the sumGain (before volumeGain)
     // Verify by checking that sumGain.connect was called (for the send gain node)
@@ -122,8 +122,8 @@ describe('TrackNode send routing', () => {
 
   it('disconnect cleans up all sends', () => {
     const sendDest = { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode;
-    trackNode.connectSend('send-1', sendDest, 0.5, 'post');
-    trackNode.connectSend('send-2', sendDest, 0.3, 'pre');
+    trackNode.connectSend('send-1', sendDest, 0.5, false);
+    trackNode.connectSend('send-2', sendDest, 0.3, true);
 
     // Full disconnect should not throw
     trackNode.disconnect();

--- a/src/utils/__tests__/cqt.test.ts
+++ b/src/utils/__tests__/cqt.test.ts
@@ -33,7 +33,7 @@ describe('computeCQT', () => {
     }
   });
 
-  it('440Hz tone has energy in the correct frequency range', () => {
+  it('440Hz tone has energy in the correct frequency range', { timeout: 30_000 }, () => {
     // A4 = 440Hz. C1 = 32.7Hz. 440/32.7 = 13.46 octaves? No —
     // log2(440/32.7) ≈ 3.75 octaves. At 24 bins/octave: bin ~90
     const sr = 22050;


### PR DESCRIPTION
## Summary
- **InstrumentFactory.ts**: Add `'wavetable'` case to exhaustive switch, fixing TS2366 type error
- **TrackNodeSend.test.ts**: Fix API mismatch — use `boolean` instead of `string` for `preFader` param, replace non-existent `updateSendPrePost` with correct `updateSendAmount` call
- **cqt.test.ts**: Increase timeout for 440Hz tone CQT computation (2s audio exceeds default 5s limit)

## Verification
- `npx tsc --noEmit` — 0 errors
- `npx vitest run src/engine/__tests__/TrackNodeSend.test.ts` — 6/6 pass
- `npx vitest run src/utils/__tests__/cqt.test.ts` — 6/6 pass

Closes #1243