### PR TITLE
fix: rename invalid hook event names in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,7 @@
     ]
   },
   "hooks": {
-    "PreToolCall": [
+    "PreToolUse": [
       {
         "matcher": "Bash(git commit*)",
         "hooks": [
@@ -45,7 +45,7 @@
         ]
       }
     ],
-    "PostToolCall": [
+    "PostToolUse": [
       {
         "matcher": "Write|Edit",
         "hooks": [


### PR DESCRIPTION
## Summary
- Rename `PreToolCall` → `PreToolUse` and `PostToolCall` → `PostToolUse` in `.claude/settings.json`
- These invalid event names caused Claude Code to skip the entire settings file on startup

Closes #1255

## Test plan
- [ ] Restart Claude Code — no settings error on startup
- [ ] Edit a file — post-edit reminder hook fires
- [ ] Attempt `git commit` — pre-commit type-check hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)