### PR TITLE
feat: wire FM and Wavetable synth engines into playback pipeline

### DIFF
--- a/src/components/midi/VirtualKeyboard.tsx
+++ b/src/components/midi/VirtualKeyboard.tsx
@@ -1,11 +1,48 @@
 import { useEffect, useRef } from 'react';
+import * as Tone from 'tone';
 import { synthEngine } from '../../engine/SynthEngine';
+import { wavetableEngine } from '../../engine/WavetableEngine';
 import { getMidiCaptureService } from '../../services/midiCaptureService';
 import { isEditableShortcutTarget } from '../../services/coreDawShortcuts';
 import { useProjectStore } from '../../store/projectStore';
 import { useTransportStore } from '../../store/transportStore';
 import { useUIStore } from '../../store/uiStore';
 import type { Track } from '../../types/project';
+
+/** Start a note on the appropriate engine based on the track's instrument kind. */
+function instrumentNoteOn(track: Track, pitch: number, velocity: number): void {
+  const instrument = track.instrument;
+  if (instrument?.kind === 'fm') {
+    synthEngine.ensureFmSynth(track.id, instrument.settings);
+    const fmSynth = synthEngine.getFmSynth(track.id);
+    if (fmSynth) {
+      const freq = Tone.Frequency(pitch, 'midi').toFrequency();
+      fmSynth.triggerAttack(freq, undefined, velocity / 127);
+    }
+  } else if (instrument?.kind === 'wavetable') {
+    wavetableEngine.ensureTrackSynth(track.id, instrument.settings);
+    wavetableEngine.noteOn(track.id, pitch, velocity);
+  } else {
+    synthEngine.ensureTrackSynth(track.id, track.synthPreset ?? 'piano');
+    synthEngine.noteOn(track.id, pitch, velocity);
+  }
+}
+
+/** Stop a note on the appropriate engine based on the track's instrument kind. */
+function instrumentNoteOff(track: Track | undefined, trackId: string, pitch: number): void {
+  const instrument = track?.instrument;
+  if (instrument?.kind === 'fm') {
+    const fmSynth = synthEngine.getFmSynth(trackId);
+    if (fmSynth) {
+      const freq = Tone.Frequency(pitch, 'midi').toFrequency();
+      fmSynth.triggerRelease(freq);
+    }
+  } else if (instrument?.kind === 'wavetable') {
+    wavetableEngine.noteOff(trackId, pitch);
+  } else {
+    synthEngine.noteOff(trackId, pitch);
+  }
+}
 
 const WHITE_KEY_BINDINGS = [
   { code: 'KeyA', semitone: 0, label: 'A' },
@@ -103,9 +140,11 @@ export function VirtualKeyboard() {
     const releaseHeldNotes = () => {
       const transport = useTransportStore.getState();
       const captureService = getMidiCaptureService();
+      const project = useProjectStore.getState().project;
       for (const [code, note] of heldNotesRef.current.entries()) {
         if (note.trackId) {
-          synthEngine.noteOff(note.trackId, note.pitch);
+          const track = project?.tracks.find((t) => t.id === note.trackId);
+          instrumentNoteOff(track, note.trackId, note.pitch);
           captureService.noteOff(note.trackId, note.pitch, transport.currentTime);
         }
         useUIStore.getState().releaseVirtualKeyboardPitch(note.pitch);
@@ -158,8 +197,7 @@ export function VirtualKeyboard() {
       let clipStartTime = 0;
 
       if (targetTrack) {
-        synthEngine.ensureTrackSynth(targetTrack.id, targetTrack.synthPreset ?? 'piano');
-        synthEngine.noteOn(targetTrack.id, pitch, nextVelocity);
+        instrumentNoteOn(targetTrack, pitch, nextVelocity);
         captureService.noteOn(targetTrack.id, pitch, velocityNormalized, startTime);
 
         if (shouldRecordIntoPianoRoll(targetTrack)) {
@@ -193,7 +231,8 @@ export function VirtualKeyboard() {
       const captureService = getMidiCaptureService();
 
       if (held.trackId) {
-        synthEngine.noteOff(held.trackId, held.pitch);
+        const heldTrack = project.project?.tracks.find((t) => t.id === held.trackId);
+        instrumentNoteOff(heldTrack, held.trackId, held.pitch);
         captureService.noteOff(held.trackId, held.pitch, transport.currentTime);
       }
 

--- a/src/data/__tests__/fmPresets.test.ts
+++ b/src/data/__tests__/fmPresets.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { FACTORY_FM_PRESETS, getFmPresetById } from '../fmPresets';
+
+describe('FM Presets', () => {
+  it('has at least 10 factory presets', () => {
+    expect(FACTORY_FM_PRESETS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('all presets have unique ids', () => {
+    const ids = FACTORY_FM_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('all presets have valid settings', () => {
+    for (const preset of FACTORY_FM_PRESETS) {
+      expect(preset.settings.carrier.waveform).toBeTruthy();
+      expect(preset.settings.modulator.waveform).toBeTruthy();
+      expect(preset.settings.modulationIndex).toBeGreaterThanOrEqual(0);
+      expect(preset.settings.harmonicity).toBeGreaterThan(0);
+      expect(['serial', 'parallel', 'stack', 'feedback']).toContain(preset.settings.algorithm);
+      expect(preset.settings.ampEnvelope.attack).toBeGreaterThanOrEqual(0);
+      expect(preset.settings.outputGain).toBeGreaterThan(0);
+    }
+  });
+
+  it('getFmPresetById finds a preset', () => {
+    const preset = getFmPresetById('fm-electric-piano');
+    expect(preset).toBeDefined();
+    expect(preset!.name).toBe('FM Electric Piano');
+  });
+
+  it('getFmPresetById returns undefined for unknown id', () => {
+    expect(getFmPresetById('nonexistent')).toBeUndefined();
+  });
+
+  it('covers all categories', () => {
+    const categories = new Set(FACTORY_FM_PRESETS.map((p) => p.category));
+    expect(categories.has('Keys')).toBe(true);
+    expect(categories.has('Bell')).toBe(true);
+    expect(categories.has('Bass')).toBe(true);
+    expect(categories.has('Lead')).toBe(true);
+  });
+});

--- a/src/data/fmPresets.ts
+++ b/src/data/fmPresets.ts
@@ -1,0 +1,130 @@
+/**
+ * Factory presets for FM synthesis.
+ *
+ * Each preset provides a complete FmInstrumentSettings configuration
+ * that can be applied to a track's FmTrackInstrument.
+ */
+
+import type { FmInstrumentSettings, FmAlgorithm, InstrumentWaveform } from '../types/project';
+
+export interface FmPresetDefinition {
+  id: string;
+  name: string;
+  category: 'Bass' | 'Lead' | 'Keys' | 'Pad' | 'Bell' | 'FX';
+  isFactory: boolean;
+  settings: FmInstrumentSettings;
+}
+
+function fmPreset(
+  id: string,
+  name: string,
+  category: FmPresetDefinition['category'],
+  overrides: Partial<FmInstrumentSettings> & {
+    carrierWaveform?: InstrumentWaveform;
+    modulatorWaveform?: InstrumentWaveform;
+    algorithm?: FmAlgorithm;
+  },
+): FmPresetDefinition {
+  const {
+    carrierWaveform = 'sine',
+    modulatorWaveform = 'sine',
+    algorithm = 'serial',
+    ...rest
+  } = overrides;
+
+  return {
+    id,
+    name,
+    category,
+    isFactory: true,
+    settings: {
+      carrier: { waveform: carrierWaveform, ratio: 1, level: 1 },
+      modulator: { waveform: modulatorWaveform, ratio: 1, level: 1 },
+      modulationIndex: 5,
+      harmonicity: 1,
+      feedback: 0,
+      algorithm,
+      ampEnvelope: { attack: 0.01, decay: 0.3, sustain: 0.5, release: 0.5 },
+      outputGain: 0.55,
+      ...rest,
+    },
+  };
+}
+
+export const FACTORY_FM_PRESETS: readonly FmPresetDefinition[] = [
+  // ── Keys ──────────────────────────────────────────────────────────────
+  fmPreset('fm-electric-piano', 'FM Electric Piano', 'Keys', {
+    modulationIndex: 3.5,
+    harmonicity: 2,
+    ampEnvelope: { attack: 0.005, decay: 0.4, sustain: 0.15, release: 1.0 },
+  }),
+  fmPreset('fm-dx-keys', 'DX Keys', 'Keys', {
+    modulationIndex: 5,
+    harmonicity: 1,
+    ampEnvelope: { attack: 0.001, decay: 0.5, sustain: 0.1, release: 0.8 },
+  }),
+
+  // ── Bell ──────────────────────────────────────────────────────────────
+  fmPreset('fm-bell', 'FM Bell', 'Bell', {
+    modulationIndex: 10,
+    harmonicity: 3.5,
+    ampEnvelope: { attack: 0.001, decay: 1.5, sustain: 0.0, release: 2.0 },
+  }),
+  fmPreset('fm-glass-bell', 'Glass Bell', 'Bell', {
+    modulationIndex: 8,
+    harmonicity: 5.07,
+    ampEnvelope: { attack: 0.001, decay: 2.0, sustain: 0.0, release: 3.0 },
+    outputGain: 0.4,
+  }),
+
+  // ── Bass ──────────────────────────────────────────────────────────────
+  fmPreset('fm-bass', 'FM Bass', 'Bass', {
+    modulationIndex: 8,
+    harmonicity: 0.5,
+    ampEnvelope: { attack: 0.005, decay: 0.2, sustain: 0.4, release: 0.3 },
+  }),
+  fmPreset('fm-growl-bass', 'Growl Bass', 'Bass', {
+    modulationIndex: 12,
+    harmonicity: 1,
+    feedback: 0.3,
+    algorithm: 'feedback',
+    ampEnvelope: { attack: 0.01, decay: 0.15, sustain: 0.5, release: 0.4 },
+  }),
+
+  // ── Lead ──────────────────────────────────────────────────────────────
+  fmPreset('fm-brass', 'FM Brass', 'Lead', {
+    modulationIndex: 6,
+    harmonicity: 1,
+    carrierWaveform: 'sawtooth',
+    ampEnvelope: { attack: 0.05, decay: 0.2, sustain: 0.7, release: 0.3 },
+  }),
+  fmPreset('fm-screech', 'Screech Lead', 'Lead', {
+    modulationIndex: 15,
+    harmonicity: 3,
+    algorithm: 'stack',
+    ampEnvelope: { attack: 0.01, decay: 0.1, sustain: 0.6, release: 0.3 },
+    outputGain: 0.4,
+  }),
+
+  // ── Pad ───────────────────────────────────────────────────────────────
+  fmPreset('fm-ethereal-pad', 'Ethereal Pad', 'Pad', {
+    modulationIndex: 2,
+    harmonicity: 2,
+    algorithm: 'parallel',
+    ampEnvelope: { attack: 1.0, decay: 0.5, sustain: 0.8, release: 2.0 },
+  }),
+
+  // ── FX ────────────────────────────────────────────────────────────────
+  fmPreset('fm-metallic', 'Metallic', 'FX', {
+    modulationIndex: 20,
+    harmonicity: 7.07,
+    feedback: 0.5,
+    algorithm: 'feedback',
+    ampEnvelope: { attack: 0.001, decay: 0.8, sustain: 0.0, release: 1.5 },
+    outputGain: 0.35,
+  }),
+] as const;
+
+export function getFmPresetById(id: string): FmPresetDefinition | undefined {
+  return FACTORY_FM_PRESETS.find((p) => p.id === id);
+}

--- a/src/engine/SynthEngine.ts
+++ b/src/engine/SynthEngine.ts
@@ -446,7 +446,7 @@ class SynthEngine {
     }
   }
 
-  /** Release all currently sounding notes on all track synths. */
+  /** Release all currently sounding notes on all track synths (subtractive + FM). */
   releaseAll() {
     for (const instance of this.synths.values()) {
       instance.filterEnvelope?.triggerRelease();
@@ -456,6 +456,9 @@ class SynthEngine {
       for (const voice of voices) {
         voice.synth.releaseAll();
       }
+    }
+    for (const instance of this.fmSynths.values()) {
+      instance.synth.triggerRelease();
     }
   }
 

--- a/src/engine/__tests__/WavetableEngine.test.ts
+++ b/src/engine/__tests__/WavetableEngine.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockSynthSet = vi.fn();
+const mockSynthConnect = vi.fn();
+const mockSynthDispose = vi.fn();
+const mockSynthTriggerAttackRelease = vi.fn();
+const mockSynthTriggerAttack = vi.fn();
+const mockSynthTriggerRelease = vi.fn();
+const mockSynthReleaseAll = vi.fn();
+
+const mockGainConnect = vi.fn();
+const mockGainToDestination = vi.fn();
+const mockGainDispose = vi.fn();
+const mockGainValue = { value: 0 };
+
+vi.mock('tone', () => {
+  return {
+    PolySynth: class MockPolySynth {
+      set = mockSynthSet;
+      connect = mockSynthConnect;
+      dispose = mockSynthDispose;
+      triggerAttackRelease = mockSynthTriggerAttackRelease;
+      triggerAttack = mockSynthTriggerAttack;
+      triggerRelease = mockSynthTriggerRelease;
+      releaseAll = mockSynthReleaseAll;
+    },
+    Synth: class MockSynth {},
+    Gain: class MockGain {
+      gain = mockGainValue;
+      connect = mockGainConnect;
+      toDestination = mockGainToDestination;
+      dispose = mockGainDispose;
+    },
+    Frequency: vi.fn().mockReturnValue({ toFrequency: () => 440 }),
+    getContext: vi.fn().mockReturnValue({ state: 'running' }),
+    start: vi.fn(),
+  };
+});
+
+import { wavetableEngine } from '../WavetableEngine';
+import type { WavetableSettings } from '../../types/project';
+import { WAVEFORM_SINE, WAVEFORM_SAW, WAVEFORM_SQUARE } from '../wavetablePresets';
+
+const makeSettings = (overrides?: Partial<WavetableSettings>): WavetableSettings => ({
+  waveforms: [WAVEFORM_SINE, WAVEFORM_SAW],
+  position: 0,
+  morphSpeed: 0,
+  ampEnvelope: { attack: 0.01, decay: 0.2, sustain: 0.8, release: 0.3 },
+  outputGain: 0.55,
+  ...overrides,
+});
+
+describe('WavetableEngine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wavetableEngine.removeTrackSynth('test-track');
+  });
+
+  describe('ensureTrackSynth', () => {
+    it('creates a synth with custom partials', () => {
+      const settings = makeSettings();
+      const synth = wavetableEngine.ensureTrackSynth('test-track', settings);
+      expect(synth).toBeDefined();
+      expect(mockSynthSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          oscillator: expect.objectContaining({ type: 'custom' }),
+        }),
+      );
+    });
+
+    it('returns existing synth on second call', () => {
+      const settings = makeSettings();
+      const synth1 = wavetableEngine.ensureTrackSynth('test-track', settings);
+      const synth2 = wavetableEngine.ensureTrackSynth('test-track', settings);
+      expect(synth1).toBe(synth2);
+    });
+
+    it('connects to provided output node', () => {
+      const settings = makeSettings();
+      const mockOutput = {} as unknown as import('tone').InputNode;
+      wavetableEngine.ensureTrackSynth('test-track', settings, mockOutput);
+      expect(mockGainConnect).toHaveBeenCalledWith(mockOutput);
+    });
+  });
+
+  describe('setPosition', () => {
+    it('updates partials when position changes', () => {
+      const settings = makeSettings({ waveforms: [WAVEFORM_SINE, WAVEFORM_SAW, WAVEFORM_SQUARE] });
+      wavetableEngine.ensureTrackSynth('test-track', settings);
+      vi.clearAllMocks();
+
+      wavetableEngine.setPosition('test-track', 0.5);
+      expect(mockSynthSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          oscillator: expect.objectContaining({ type: 'custom' }),
+        }),
+      );
+      expect(wavetableEngine.getPosition('test-track')).toBe(0.5);
+    });
+
+    it('clamps position to 0-1 range', () => {
+      wavetableEngine.ensureTrackSynth('test-track', makeSettings());
+      wavetableEngine.setPosition('test-track', 1.5);
+      expect(wavetableEngine.getPosition('test-track')).toBe(1);
+
+      wavetableEngine.setPosition('test-track', -0.5);
+      expect(wavetableEngine.getPosition('test-track')).toBe(0);
+    });
+
+    it('is a no-op for unknown track', () => {
+      wavetableEngine.setPosition('nonexistent', 0.5);
+      expect(mockSynthSet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('noteOn / noteOff', () => {
+    it('triggers attack on note-on', () => {
+      wavetableEngine.ensureTrackSynth('test-track', makeSettings());
+      wavetableEngine.noteOn('test-track', 60, 100);
+      expect(mockSynthTriggerAttack).toHaveBeenCalled();
+    });
+
+    it('triggers release on note-off', () => {
+      wavetableEngine.ensureTrackSynth('test-track', makeSettings());
+      wavetableEngine.noteOff('test-track', 60);
+      expect(mockSynthTriggerRelease).toHaveBeenCalled();
+    });
+
+    it('is a no-op for unknown track', () => {
+      wavetableEngine.noteOn('nonexistent', 60);
+      wavetableEngine.noteOff('nonexistent', 60);
+      expect(mockSynthTriggerAttack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeTrackSynth', () => {
+    it('disposes synth and gain', () => {
+      wavetableEngine.ensureTrackSynth('test-track', makeSettings());
+      wavetableEngine.removeTrackSynth('test-track');
+      expect(mockSynthReleaseAll).toHaveBeenCalled();
+      expect(mockSynthDispose).toHaveBeenCalled();
+      expect(mockGainDispose).toHaveBeenCalled();
+    });
+
+    it('makes getSynth return null after removal', () => {
+      wavetableEngine.ensureTrackSynth('test-track', makeSettings());
+      wavetableEngine.removeTrackSynth('test-track');
+      expect(wavetableEngine.getSynth('test-track')).toBeNull();
+    });
+  });
+
+  describe('getSynth', () => {
+    it('returns null for unregistered track', () => {
+      expect(wavetableEngine.getSynth('nonexistent')).toBeNull();
+    });
+
+    it('returns synth for registered track', () => {
+      const synth = wavetableEngine.ensureTrackSynth('test-track', makeSettings());
+      expect(wavetableEngine.getSynth('test-track')).toBe(synth);
+    });
+  });
+});

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -9,6 +9,7 @@ import { synthEngine } from '../engine/SynthEngine';
 import { subtractiveEngine } from '../engine/SubtractiveEngine';
 import { createSamplerConfig, samplerEngine } from '../engine/SamplerEngine';
 import { drumEngine } from '../engine/DrumEngine';
+import { wavetableEngine } from '../engine/WavetableEngine';
 import { automationEngine } from '../engine/AutomationEngine';
 import {
   stopAllStrudelTracks,
@@ -379,7 +380,9 @@ export function useTransport() {
         const useSampler = !vst3Instrument && !!samplerConfig;
 
         synthEngine.removeTrackSynth(track.id);
+        synthEngine.removeFmSynth(track.id);
         subtractiveEngine.removeTrackSynth(track.id);
+        wavetableEngine.removeTrackSynth(track.id);
         samplerEngine.removeTrackSampler(track.id);
 
         if (useSampler && samplerConfig) {
@@ -397,6 +400,18 @@ export function useTransport() {
           subtractiveEngine.ensureTrackSynth(
             track.id,
             track.instrument.settings,
+            trackNode.inputGain as unknown as Tone.InputNode,
+          );
+        } else if (!vst3Instrument && track.instrument?.kind === 'fm') {
+          const trackNode = engine.getOrCreateTrackNode(track.id);
+          synthEngine.ensureFmSynth(
+            track.id, track.instrument.settings,
+            trackNode.inputGain as unknown as Tone.InputNode,
+          );
+        } else if (!vst3Instrument && track.instrument?.kind === 'wavetable') {
+          const trackNode = engine.getOrCreateTrackNode(track.id);
+          wavetableEngine.ensureTrackSynth(
+            track.id, track.instrument.settings,
             trackNode.inputGain as unknown as Tone.InputNode,
           );
         } else if (preset !== 'sampler') {
@@ -489,6 +504,22 @@ export function useTransport() {
                     return;
                   }
                   subtractiveEngine.triggerAttackRelease(trackId, note.pitch, scheduledDuration, velocity);
+                });
+              } else if (track.instrument?.kind === 'fm') {
+                const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
+                engine.scheduleMidiEvent(scheduledStart, () => {
+                  const fmSynth = synthEngine.getFmSynth(trackId);
+                  if (fmSynth) {
+                    fmSynth.triggerAttackRelease(freq, scheduledDuration, undefined, velocity);
+                  }
+                });
+              } else if (track.instrument?.kind === 'wavetable') {
+                const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
+                engine.scheduleMidiEvent(scheduledStart, () => {
+                  const wtSynth = wavetableEngine.getSynth(trackId);
+                  if (wtSynth) {
+                    wtSynth.triggerAttackRelease(freq, scheduledDuration, undefined, velocity);
+                  }
                 });
               } else {
                 const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
@@ -650,6 +681,7 @@ export function useTransport() {
     engine.stop();
     synthEngine.releaseAll();
     subtractiveEngine.releaseAll();
+    wavetableEngine.releaseAll();
     samplerEngine.stopAll();
     automationEngine.stop();
     useTransportStore.getState().pause();
@@ -668,6 +700,7 @@ export function useTransport() {
     engine.stop();
     synthEngine.releaseAll();
     subtractiveEngine.releaseAll();
+    wavetableEngine.releaseAll();
     samplerEngine.stopAll();
     automationEngine.stop();
     stopAllStrudelTracks();
@@ -681,6 +714,8 @@ export function useTransport() {
     if (engine.playing) {
       engine.stop();
       synthEngine.releaseAll();
+      subtractiveEngine.releaseAll();
+      wavetableEngine.releaseAll();
       samplerEngine.stopAll();
       useTransportStore.getState().seek(time);
       play(time);


### PR DESCRIPTION
## Summary
- Wire FM synthesis (`SynthEngine.ensureFmSynth`) into the playback pipeline — FM tracks now produce actual FM synthesis audio
- Wire `WavetableEngine` into the playback pipeline — wavetable tracks now use partials interpolation synthesis
- Update `VirtualKeyboard` to dispatch noteOn/noteOff to the correct engine based on `track.instrument.kind`
- Add 10 FM factory presets across 6 categories (Keys, Bell, Bass, Lead, Pad, FX)
- Ensure FM and wavetable synths release on stop/pause/seek
- Clean rebase onto current main (supersedes #1260)

Closes #1231
Closes #1232

## Test plan
- [x] All 3519 unit tests pass (19 new)
- [x] `npx tsc --noEmit` — 0 new type errors
- [x] FM engine creates `Tone.FMSynth` with correct algorithm parameters
- [x] Wavetable engine creates `Tone.PolySynth` with interpolated partials
- [x] VirtualKeyboard dispatches to correct engine for FM/wavetable tracks
- [x] All synth types release notes on stop/pause/seek

🤖 Generated with [Claude Code](https://claude.com/claude-code)