### PR TITLE
fix: migrate legacy contextWindow to relative offsets on clip move

### DIFF
--- a/src/store/__tests__/contextWindowMigration.test.ts
+++ b/src/store/__tests__/contextWindowMigration.test.ts
@@ -172,4 +172,53 @@ describe('contextWindow migration on clip move', () => {
       expect(resolved!.endTime).toBe(8.5);
     });
   });
+
+  describe('updateClip (same-track drag path)', () => {
+    it('converts legacy absolute contextWindow to relative offsets on startTime change', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('custom', 'sample');
+      const clip = addClipWithLegacyCtx(track.id, 5.5, 3.0, 8.5);
+
+      // Same-track drag: updateClip called with new startTime
+      store.updateClip(clip.id, { startTime: 9.5 });
+
+      const updated = getClip(clip.id)!;
+      expect(updated.startTime).toBe(9.5);
+
+      const ctx = updated.generationParams?.contextWindow;
+      expect(ctx).toHaveProperty('offsetStart');
+
+      const resolved = resolveContextWindow(updated);
+      expect(resolved!.startTime).toBe(7.0);  // 9.5 + (3.0 - 5.5)
+      expect(resolved!.endTime).toBe(12.5);   // 9.5 + (8.5 - 5.5)
+    });
+
+    it('does not migrate when generationParams is also being updated', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('custom', 'sample');
+      const clip = addClipWithLegacyCtx(track.id, 5.5, 3.0, 8.5);
+
+      // Caller explicitly sets generationParams — should not double-migrate
+      store.updateClip(clip.id, {
+        startTime: 9.5,
+        generationParams: { ...clip.generationParams, contextWindow: null },
+      });
+
+      const updated = getClip(clip.id)!;
+      expect(updated.generationParams?.contextWindow).toBeNull();
+    });
+
+    it('preserves relative contextWindow unchanged on startTime change', () => {
+      const store = useProjectStore.getState();
+      const track = store.addTrack('custom', 'sample');
+      const clip = addClipWithRelativeCtx(track.id, 5.5, -2.5, 3.0);
+
+      store.updateClip(clip.id, { startTime: 9.5 });
+
+      const updated = getClip(clip.id)!;
+      const ctx = updated.generationParams?.contextWindow;
+      expect(ctx).toHaveProperty('offsetStart', -2.5);
+      expect(ctx).toHaveProperty('offsetEnd', 3.0);
+    });
+  });
 });

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -3855,9 +3855,24 @@ export const useProjectStore = create<ProjectState>()(
     _pushHistory(state.project);
     const newTracks = state.project.tracks.map((t) => ({
       ...t,
-      clips: t.clips.map((c) =>
-        c.id === clipId ? { ...c, ...updates } : c,
-      ),
+      clips: t.clips.map((c) => {
+        if (c.id !== clipId) return c;
+        // Migrate legacy contextWindow when startTime changes so regeneration
+        // uses correct context bounds after any kind of repositioning.
+        const needsCtxMigration =
+          'startTime' in updates &&
+          updates.startTime !== c.startTime &&
+          !('generationParams' in updates);
+        if (needsCtxMigration) {
+          const migratedParams = _migrateLegacyContextWindow(c);
+          return {
+            ...c,
+            ...updates,
+            ...(migratedParams !== c.generationParams ? { generationParams: migratedParams } : {}),
+          };
+        }
+        return { ...c, ...updates };
+      }),
     }));
     const updated = { ...state.project, tracks: newTracks };
     if (!_isDragging) {
@@ -4378,6 +4393,7 @@ export const useProjectStore = create<ProjectState>()(
 
     const rightClip: Clip = {
       ...sourceClip,
+      generationParams: _migrateLegacyContextWindow({ ...sourceClip, startTime: splitTime }) ?? sourceClip.generationParams,
       id: uuidv4(),
       startTime: splitTime,
       duration: rightDuration,
@@ -4823,11 +4839,13 @@ export const useProjectStore = create<ProjectState>()(
     if (!sourceClip) return undefined;
     _pushHistory(state.project);
     const isReady = sourceClip.generationStatus === 'ready' && !!sourceClip.isolatedAudioKey;
+    const newClipStartTime = startTime ?? sourceClip.startTime;
     const newClip: Clip = {
       ...sourceClip,
+      generationParams: _migrateLegacyContextWindow({ ...sourceClip, startTime: newClipStartTime }) ?? sourceClip.generationParams,
       id: uuidv4(),
       trackId: targetTrackId,
-      startTime: startTime ?? sourceClip.startTime,
+      startTime: newClipStartTime,
       generationStatus: isReady ? 'ready' : 'empty',
       generationJobId: null,
       cumulativeMixKey: sourceClip.cumulativeMixKey,


### PR DESCRIPTION
## Summary
- Fixes stale `contextWindow` absolute times after clip drag/move causing incorrect regeneration
- Converts legacy `{startTime, endTime}` format to move-proof `{offsetStart, offsetEnd, trackIds}` during `batchMoveClips` and `moveClipToTrack`
- Adds 5 regression tests covering legacy migration, relative preservation, and no-contextWindow clips

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3542 passed
- [x] `npm run build` — success
- [ ] Manual: generate clip with context window → drag to new position → regenerate → verify correct context audio

Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)