### PR TITLE
feat: enable proactive research and brainstorm exploration in agent workflow

### DIFF
--- a/.claude/agents/do-todo.md
+++ b/.claude/agents/do-todo.md
@@ -8,6 +8,8 @@ tools:
   - Bash
   - Grep
   - Glob
+  - WebSearch
+  - WebFetch
 ---
 
 # Task Executor Agent
@@ -35,6 +37,18 @@ You are a TDD-driven developer agent. Your job is to pick up ONE task from the t
     git add -A
     git commit -m "feat: <description of what was implemented>"
     ```
+
+## Proactive Research Triggers
+
+Before coding, check if any of these apply. If so, **research first** using WebSearch/WebFetch:
+
+1. **Unfamiliar API or library** — You encounter a Tone.js, Web Audio, or third-party API you haven't used before → Search for docs, examples, and known pitfalls
+2. **Complex algorithm** — The task involves DSP, scheduling, or non-trivial logic → Search for established approaches and edge cases
+3. **UI pattern you haven't built** — Drag-and-drop, virtualized lists, canvas rendering → Search for best practices in React + the specific pattern
+4. **Competitor reference needed** — The task mentions matching Ableton/Logic/FL Studio behavior → Search for how they handle it at interaction-detail level
+5. **Error you can't resolve in 2 attempts** — Stop guessing, search for the error message + context
+
+**Research format**: Keep it lightweight. 2-3 searches max. Extract the key insight and move on. Don't turn every task into a research project.
 
 ## Rules
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -6,6 +6,8 @@ tools:
   - Grep
   - Glob
   - Bash
+  - WebSearch
+  - WebFetch
 ---
 
 # Code Reviewer Agent
@@ -71,6 +73,15 @@ If ANY design check fails, request changes — design quality is as important as
 - [ ] Feature accessible via `window.__store.getState().actionName()`
 - [ ] Error messages are actionable (not generic)
 - [ ] State changes go through Zustand (no local DOM state for shared data)
+
+### Best Practice Verification (use WebSearch when needed)
+When reviewing code that uses:
+- **Web Audio / Tone.js APIs**: Search for known gotchas, deprecations, or better patterns
+- **Complex CSS layout**: Search for cross-browser issues with the specific technique
+- **Security-sensitive patterns**: Search for OWASP guidance on the specific pattern
+- **Performance-critical code**: Search for benchmarks or known optimization techniques
+
+Keep searches targeted — verify specific concerns, don't research everything.
 
 ## Output Format
 ```

--- a/.claude/skills/brainstorm/SKILL.md
+++ b/.claude/skills/brainstorm/SKILL.md
@@ -1,0 +1,97 @@
+# Brainstorm Skill
+
+> Multi-approach exploration protocol. Use when there are multiple valid ways to solve
+> a problem and you need to pick the best one — not just the first one that comes to mind.
+>
+> **Use this when**: The task has 2+ viable approaches and the wrong choice would be
+> expensive to reverse (architecture, data model, complex UI pattern).
+>
+> **Don't use this when**: There's an obvious approach, or the task is small enough
+> that any approach works. Don't brainstorm how to add a CSS class.
+
+## When to Trigger
+
+1. **Architecture decision**: New store shape, new service, new component hierarchy
+2. **Algorithm choice**: Multiple valid approaches with different tradeoffs
+3. **UI pattern decision**: Modal vs. panel vs. inline? Drag vs. click? Canvas vs. DOM?
+4. **Integration approach**: How to connect a new feature with existing systems
+5. **Performance tradeoff**: Eager vs. lazy, cache vs. recompute, sync vs. async
+
+## Protocol (4 steps, under 5 minutes)
+
+### Step 1: Define the Decision
+
+Write in this format:
+```
+DECISION: [What specifically needs to be decided]
+CONSTRAINTS: [Non-negotiable requirements]
+CONTEXT: [What already exists that this must work with]
+```
+
+Example:
+```
+DECISION: How to implement undo/redo for track operations
+CONSTRAINTS: Must handle 100+ operations, must work with Zustand, must support grouped operations
+CONTEXT: Existing projectStore with track/clip actions, no current undo system
+```
+
+### Step 2: Generate 2-3 Approaches
+
+For each approach, write exactly:
+- **Name**: Short descriptive name
+- **How it works**: 2-3 sentences
+- **Pros**: What's good about it
+- **Cons**: What's risky or costly
+- **Effort**: S / M / L
+
+Use WebSearch if you need to verify feasibility of an approach.
+
+**Rules**:
+- Minimum 2 approaches, maximum 4. Don't pad with bad options.
+- At least one approach should be the "simple/boring" option.
+- At least one approach should be the "ideal if we had unlimited time" option.
+- Don't include approaches that violate the constraints.
+
+### Step 3: Score and Select
+
+Score each approach on:
+| Criterion | Weight | Description |
+|-----------|--------|-------------|
+| Correctness | 3x | Does it actually solve the problem fully? |
+| Simplicity | 2x | How easy to implement and maintain? |
+| Compatibility | 2x | How well does it fit with existing code? |
+| Extensibility | 1x | How easy to extend later? |
+
+Pick the highest-scoring approach. If two are tied, pick the simpler one.
+
+### Step 4: Document the Decision (brief)
+
+Add a comment at the top of the primary file:
+```typescript
+// Architecture decision: [approach name]
+// Alternatives considered: [other names]
+// Rationale: [1 sentence why this one won]
+```
+
+For significant decisions (new store, new service, new data model), also record in
+`.llm/decisions.md` with the full scoring table.
+
+## Anti-Patterns
+
+- **Analysis paralysis**: Spending 20 minutes comparing approaches for a 10-minute task.
+  If the task is small, skip brainstorming and just do it.
+- **Phantom options**: Including an approach you'd never actually pick just to have 3 options.
+  Two genuine options is better than three with one filler.
+- **Ignoring the codebase**: Proposing an approach that conflicts with existing patterns.
+  Always check what patterns the codebase already uses.
+- **Premature optimization**: Picking the "fastest" approach when any approach is fast enough.
+  Optimize for maintainability first.
+- **Committee of one**: Brainstorming without constraints leads to scope creep.
+  Always define constraints first.
+
+## Integration with Other Skills
+
+- If an approach requires research: use `/quick-research` inline
+- If the decision involves UI: check `.claude/references/design-patterns.md`
+- If the decision involves store shape: check `.claude/references/store-api.md`
+- After deciding, proceed with TDD implementation per `do-todo` workflow

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -166,6 +166,30 @@ Check: Do hardcoded colors bleed through? Is hierarchy still visible?
 
 For entirely new UI features (not modifications to existing ones):
 
+### 5.1 Proactive Competitive Research
+
+**Before evaluating**, use WebSearch to find how competitors handle this specific UI pattern:
+
+```
+Search: "[feature name] UI [Ableton / Logic Pro / FL Studio / Bitwig] 2025"
+Search: "[feature name] best practices DAW UI design"
+```
+
+Look for:
+- **Screenshots or videos** of how competitors implement this exact feature
+- **User complaints** about competitor implementations (what to avoid)
+- **Innovative approaches** from newer DAWs (Bitwig, BandLab) that break conventions
+
+Document findings briefly:
+```
+Competitor research for [feature]:
+- Ableton: [1 sentence on their approach]
+- Logic: [1 sentence on their approach]
+- Best insight: [the one thing we should learn from]
+```
+
+### 5.2 Reference Points
+
 ### How would Ableton approach this?
 Ableton = brutalist minimalism. Functional color only. Maximum density. Strict grid.
 

--- a/.claude/skills/quick-research/SKILL.md
+++ b/.claude/skills/quick-research/SKILL.md
@@ -1,0 +1,68 @@
+# Quick Research Skill
+
+> Lightweight inline research protocol for agents who need to look something up
+> mid-task without derailing into a full research cycle.
+>
+> **Use this when**: You hit an unknown API, unfamiliar pattern, or need to verify
+> a technical approach — and the answer is findable in 2-3 searches.
+>
+> **Don't use this when**: You need to compare 5+ competitors, analyze a market,
+> or produce a research document. Use `@researcher` or `/research-cycle` instead.
+
+## When to Trigger
+
+1. **Unknown API**: You're about to call a function you haven't used before
+2. **Error loop**: You've failed the same thing twice — stop guessing, search
+3. **Best practice question**: "Is there a better way to do X in React/Tone.js?"
+4. **Competitor behavior**: "How does Ableton handle this specific interaction?"
+5. **Edge case uncertainty**: "What happens when the sample rate changes mid-playback?"
+
+## Protocol (3 steps, under 2 minutes)
+
+### Step 1: Frame the Question (10 seconds)
+
+Write a single sentence: "I need to know [X] because [Y]."
+
+Bad: "Research Web Audio API"
+Good: "I need to know if AudioContext.resume() is needed after tab visibility change because our playback breaks when users switch tabs"
+
+### Step 2: Search (2-3 queries max)
+
+Use WebSearch with targeted queries:
+- Include the specific API/library name
+- Include the specific problem or behavior
+- Add "2024" or "2025" for recent results if the API may have changed
+
+Example queries:
+```
+"AudioContext resume tab visibility change 2025"
+"Tone.js Transport sync drift workaround"
+"React 19 useEffect cleanup race condition"
+```
+
+If the first result answers your question, stop. Don't search for confirmation.
+
+### Step 3: Extract and Apply (30 seconds)
+
+From the search results, extract:
+- **The answer** (1-2 sentences)
+- **The source** (URL for reference)
+- **Any gotcha** (common mistake to avoid)
+
+Then immediately return to your task. Don't write a research document.
+
+## Anti-Patterns
+
+- **Research rabbit hole**: 5+ searches on a tangent. If 3 searches don't answer it, escalate to `@researcher`.
+- **Confirmation searching**: You already know the answer but keep searching to "make sure." Trust the first credible source.
+- **Over-documenting**: Writing a research summary for a simple API lookup. Just use the knowledge and move on.
+- **Searching for things in the codebase**: If the answer is in the project files, use Grep/Read, not WebSearch.
+
+## Output (inline, not a separate document)
+
+No formal output. The research result gets applied directly to your current task.
+If the finding is surprising or non-obvious, add a brief code comment:
+```typescript
+// Note: AudioContext must be resumed after tab visibility change (Chrome policy)
+await Tone.context.resume();
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,40 @@ Every plan (`docs/plans/*.md`) must contain: Problem → Root Cause → Solution
 
 ---
 
+## Proactive Research & Exploration
+
+### Principle: Precision + Breadth = Global Optimum
+
+Deep focus alone finds local maxima. Exploration alone finds nothing. Agents must combine both:
+- **Research before coding**: When facing unfamiliar APIs, patterns, or competitor behavior, search first
+- **Explore multiple approaches**: For architecture decisions, generate 2-3 options before committing
+- **Verify assumptions**: Don't code based on guesses — a 30-second search beats a 30-minute debug
+
+### Research Triggers (any agent)
+
+| Trigger | Action |
+|---------|--------|
+| Unfamiliar API or library | `/quick-research` — search docs + examples |
+| 2+ viable approaches | `/brainstorm` — score and select |
+| Competitor behavior needed | WebSearch for interaction-detail level info |
+| Error after 2 failed attempts | Stop guessing, search the error |
+| New UI pattern | Search for best practices + competitor screenshots |
+
+### Skills
+
+- **`/quick-research`**: Lightweight inline research (2-3 searches, extract key insight, move on)
+- **`/brainstorm`**: Multi-approach exploration (generate options, score, select, document decision)
+- **`@researcher`**: Full competitive research cycle (for epics and new feature areas)
+
+### Anti-Patterns
+
+- **Coding blind**: Implementing an unfamiliar API without reading docs first
+- **First-solution lock**: Committing to the first approach without considering alternatives
+- **Research rabbit hole**: Spending 20 minutes researching a 5-minute task
+- **Confirmation bias**: Searching only for evidence that supports your current approach
+
+---
+
 ## Red Lines (absolute prohibitions)
 
 - Never push directly to main


### PR DESCRIPTION
## Summary
- Add WebSearch/WebFetch tools to `do-todo` and `reviewer` agents with defined research triggers
- Create `/quick-research` skill for lightweight inline research (2-3 searches, extract key insight)
- Create `/brainstorm` skill for multi-approach exploration (generate options, score, select)
- Update `design-review` skill Phase 5 with proactive competitive research via WebSearch
- Add "Proactive Research & Exploration" section to AGENTS.md with triggers, skills, and anti-patterns

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 3500 tests passed
- [x] `npm run build` — succeeds
- [ ] Verify `/quick-research` skill is registered and invocable
- [ ] Verify `/brainstorm` skill is registered and invocable
- [ ] Verify `do-todo` agent can use WebSearch during task execution
- [ ] Verify `reviewer` agent can use WebSearch during code review

Closes #1248

🤖 Generated with [Claude Code](https://claude.com/claude-code)