### PR TITLE
feat: knob micro-interactions — fine mode, reset animation, drag state

### DIFF
--- a/src/components/ui/Knob.tsx
+++ b/src/components/ui/Knob.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { PrecisionInput, clampValue, roundToStep } from './PrecisionInput';
 import { useNonPassiveWheel } from '../../hooks/useNonPassiveWheel';
 
@@ -54,6 +54,16 @@ export function Knob({
   const knobRef = useRef<HTMLDivElement>(null);
   const [showPrecisionInput, setShowPrecisionInput] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [isFineMode, setIsFineMode] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up reset timer on unmount
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    };
+  }, []);
 
   const clamp = (v: number) => clampValue(v, min, max);
   const applyStep = useCallback((nextValue: number) => clamp(roundToStep(nextValue, step)), [clamp, step]);
@@ -69,16 +79,19 @@ export function Knob({
     const onMove = (mv: MouseEvent) => {
       if (!dragStart.current) return;
       const range = max - min;
-      const sensitivity = mv.altKey ? range / 2000 : range / 200;
+      const fine = mv.altKey;
+      const sensitivity = fine ? range / 2000 : range / 200;
       const delta = mv.movementY * sensitivity;
       const newVal = applyStep(dragStart.current.value + delta);
       dragStart.current = { y: mv.clientY, value: newVal };
+      setIsFineMode(fine);
       onChange(newVal);
     };
 
     const onUp = () => {
       dragStart.current = null;
       setIsDragging(false);
+      setIsFineMode(false);
       document.exitPointerLock?.();
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
@@ -92,6 +105,10 @@ export function Knob({
     if (disabled) return;
     e.preventDefault();
     onChange(defaultValue);
+    // Trigger reset animation
+    setIsResetting(true);
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    resetTimerRef.current = setTimeout(() => setIsResetting(false), 200);
   }, [defaultValue, onChange, disabled]);
 
   const onWheelHandler = useCallback((e: WheelEvent) => {
@@ -165,6 +182,8 @@ export function Knob({
           aria-label={`${label ?? 'Control'} knob`}
           className={`relative ${disabled ? 'cursor-not-allowed' : 'cursor-ns-resize'}`}
           style={{ width: s, height: s }}
+          data-dragging={isDragging ? 'true' : undefined}
+          data-resetting={isResetting ? 'true' : undefined}
         >
           <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} overflow="visible">
             <defs>
@@ -187,11 +206,12 @@ export function Knob({
             <path
               d={fillPath}
               fill="none"
-              stroke={color}
+              stroke={isFineMode ? '#22d3ee' : color}
               strokeWidth={strokeWidth}
               strokeLinecap="round"
               opacity={isDragging ? 1 : 0.8}
               filter={isDragging ? 'url(#knob-glow)' : undefined}
+              style={isResetting ? { transition: 'd 200ms ease-out' } : undefined}
             />
 
             {/* Minimal center anchor */}
@@ -213,6 +233,17 @@ export function Knob({
             style={{ bottom: s + 4 }}
           >
             {displayValue}{unit && !formatValue ? unit : ''}
+          </div>
+        )}
+
+        {/* Fine mode indicator */}
+        {isDragging && isFineMode && (
+          <div
+            className="absolute left-1/2 -translate-x-1/2 pointer-events-none z-50 whitespace-nowrap
+                        rounded bg-cyan-500/90 px-1 py-0.5 text-[10px] font-mono text-white shadow-lg"
+            style={{ bottom: s + (showTooltip ? 22 : 4) }}
+          >
+            Fine
           </div>
         )}
       </div>

--- a/src/components/ui/__tests__/Knob.test.tsx
+++ b/src/components/ui/__tests__/Knob.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { Knob } from '../Knob';
 
 describe('Knob component', () => {
@@ -123,6 +123,66 @@ describe('Knob component', () => {
       const { container } = render(<Knob {...defaultProps} disabled />);
       const wrapper = container.firstElementChild as HTMLElement;
       expect(wrapper.className).toContain('opacity-40');
+    });
+  });
+
+  describe('micro-interactions', () => {
+    it('shows fine mode indicator when Alt is held during drag', () => {
+      const onChange = vi.fn();
+      render(<Knob {...defaultProps} onChange={onChange} />);
+      const knob = screen.getByLabelText('Control knob');
+
+      // Start drag
+      fireEvent.mouseDown(knob, { clientY: 100 });
+
+      // Simulate Alt+move
+      fireEvent(window, new MouseEvent('mousemove', {
+        clientY: 90,
+        movementY: -10,
+        altKey: true,
+        bubbles: true,
+      }));
+
+      // Should show fine mode indicator
+      expect(screen.getByText('Fine')).toBeDefined();
+
+      // Release
+      fireEvent(window, new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    it('applies data-dragging attribute during drag', () => {
+      render(<Knob {...defaultProps} />);
+      const knob = screen.getByLabelText('Control knob');
+
+      // Before drag
+      expect(knob.getAttribute('data-dragging')).toBeNull();
+
+      // Start drag
+      fireEvent.mouseDown(knob, { clientY: 100 });
+      expect(knob.getAttribute('data-dragging')).toBe('true');
+
+      // Release
+      fireEvent(window, new MouseEvent('mouseup', { bubbles: true }));
+      expect(knob.getAttribute('data-dragging')).toBeNull();
+    });
+
+    it('animates reset on double-click by setting data-resetting', () => {
+      vi.useFakeTimers();
+      const onChange = vi.fn();
+      render(<Knob {...defaultProps} value={75} defaultValue={50} onChange={onChange} />);
+      const knob = screen.getByLabelText('Control knob');
+
+      fireEvent.doubleClick(knob);
+      expect(onChange).toHaveBeenCalledWith(50);
+
+      // data-resetting should be set during animation
+      expect(knob.getAttribute('data-resetting')).toBe('true');
+
+      // After animation duration (200ms), data-resetting should clear
+      act(() => { vi.advanceTimersByTime(250); });
+      expect(knob.getAttribute('data-resetting')).toBeNull();
+
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
## Summary
- Add fine mode visual indicator (cyan "Fine" badge + arc color change) during Alt+drag
- Add animated reset on double-click with `data-resetting` attribute (200ms transition)
- Add `data-dragging` attribute for drag state tracking/styling

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 3604 tests pass (3 new tests for micro-interactions)
- [x] `npm run build` — succeeds
- [ ] Visual verification: Alt+drag shows cyan "Fine" badge above knob
- [ ] Visual verification: double-click animates arc sweep to default
- [ ] Accessibility: text-[10px] minimum font size maintained

Part of #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)