### PR TITLE
feat: lightweight DAW CLI for token-efficient Claude Code interaction

### DIFF
--- a/.claude/commands/daw/add-track.md
+++ b/.claude/commands/daw/add-track.md
@@ -6,5 +6,5 @@ Ask the user what kind of track they want if not specified:
 - **sequencer**: Step sequencer for drum patterns
 - **pianoroll**: MIDI track with piano roll editor
 
-Use the daw_add_track tool with the chosen type.
+Use the CLI: `npx tsx server/daw-cli.ts add-track <type> [name]`
 If the user describes a musical purpose (e.g. "drums", "bass", "vocals"), suggest the appropriate track type and set a matching name.

--- a/.claude/commands/daw/arrange.md
+++ b/.claude/commands/daw/arrange.md
@@ -1,6 +1,6 @@
 Analyze the current arrangement and suggest improvements.
 
-1. Read all tracks and clips with daw_get_tracks
+1. Read all tracks and clips: `npx tsx server/daw-cli.ts tracks`
 2. Analyze the arrangement structure:
    - Identify empty tracks that need content
    - Find gaps between clips
@@ -10,6 +10,8 @@ Analyze the current arrangement and suggest improvements.
    - Add transitions between sections
    - Suggest variations for repetitive parts
    - Recommend where to add builds or drops
-4. Execute approved changes via daw_add_track, daw_add_midi_note, etc.
+4. Execute approved changes via CLI:
+   - `npx tsx server/daw-cli.ts add-track <type> [name]`
+   - `npx tsx server/daw-cli.ts midi <clipId> <pitch> <start> <dur> [vel]`
 
 Always confirm with the user before making changes.

--- a/.claude/commands/daw/daw-status.md
+++ b/.claude/commands/daw/daw-status.md
@@ -1,8 +1,10 @@
-Read the current project state using daw_get_project and daw_get_transport MCP tools.
+Read the current project state using the DAW CLI.
 
-Display a concise summary:
-- Project name, BPM, time signature
-- Track count, playing/stopped, current position
-- For each track: name, type, clip count, mute/solo state, volume level
+Run these commands via Bash:
+```bash
+npx tsx server/daw-cli.ts status
+npx tsx server/daw-cli.ts transport
+```
 
-Format as a clean table for readability.
+The CLI outputs a compact summary with project name, BPM, tracks, and transport state.
+If the dev server is not running, start it first with `npm run dev`.

--- a/.claude/commands/daw/generate.md
+++ b/.claude/commands/daw/generate.md
@@ -1,8 +1,9 @@
 Help the user generate AI music in the DAW.
 
-1. Read current project state with daw_get_project
+1. Read current project state: `npx tsx server/daw-cli.ts status`
 2. Ask the user for a text prompt describing the music they want
-3. Determine the best track to generate on, or create a new stems track with daw_add_track
+3. Determine the best track to generate on, or create a new stems track:
+   `npx tsx server/daw-cli.ts add-track stems "Track Name"`
 4. Use concrete prompt guidance: genre, mood, instruments, energy level
 5. Report when the generation is set up
 

--- a/.claude/commands/daw/jam.md
+++ b/.claude/commands/daw/jam.md
@@ -1,7 +1,7 @@
 Interactive jam mode — build up a track collaboratively.
 
-1. Start playback with daw_play
-2. Read current project state
+1. Start playback: `npx tsx server/daw-cli.ts play`
+2. Read current project state: `npx tsx server/daw-cli.ts status`
 3. Enter an interactive loop:
    - Suggest musical additions based on what's playing
    - Propose new MIDI patterns, drum fills, or arrangement changes

--- a/.claude/commands/daw/mix.md
+++ b/.claude/commands/daw/mix.md
@@ -1,6 +1,7 @@
 Analyze the current mix and suggest improvements.
 
-1. Read mixer state with daw_get_mixer and project state with daw_get_project
+1. Read mixer state: `npx tsx server/daw-cli.ts mix`
+   Also read project: `npx tsx server/daw-cli.ts status`
 2. Analyze:
    - Volume balance across tracks
    - Panning spread (are things centered or spread out?)
@@ -10,6 +11,9 @@ Analyze the current mix and suggest improvements.
    - Kick and bass typically louder, centered
    - Pads and atmospheres quieter, wider stereo
    - Lead elements forward in the mix
-4. Apply approved changes via daw_set_volume, daw_set_pan, daw_toggle_mute
+4. Apply approved changes via CLI:
+   - `npx tsx server/daw-cli.ts volume <trackId> <0-1>`
+   - `npx tsx server/daw-cli.ts pan <trackId> <-1 to 1>`
+   - `npx tsx server/daw-cli.ts mute <trackId>`
 
 Display the current and proposed mix as a table for easy comparison.

--- a/.claude/daw-system-prompt.md
+++ b/.claude/daw-system-prompt.md
@@ -1,5 +1,5 @@
 You are an AI music production assistant embedded in ACE-Step DAW.
-You have access to DAW tools (prefixed with daw_) via MCP.
+You interact with the DAW via a lightweight CLI: `npx tsx server/daw-cli.ts <command>`.
 
 ## Your Capabilities
 
@@ -8,6 +8,22 @@ You have access to DAW tools (prefixed with daw_) via MCP.
 - Control transport (play, stop, seek)
 - Adjust mix (volume, pan, mute, solo)
 - Trigger AI music generation with text prompts
+
+## CLI Quick Reference
+
+```bash
+npx tsx server/daw-cli.ts status          # Project overview
+npx tsx server/daw-cli.ts tracks          # Track list with clips
+npx tsx server/daw-cli.ts transport       # Playback state
+npx tsx server/daw-cli.ts mix             # Volume/pan table
+npx tsx server/daw-cli.ts play / stop     # Transport control
+npx tsx server/daw-cli.ts set-bpm <bpm>   # Set BPM
+npx tsx server/daw-cli.ts add-track <type> [name]  # Add track
+npx tsx server/daw-cli.ts volume <trackId> <0-1>   # Set volume
+npx tsx server/daw-cli.ts pan <trackId> <-1 to 1>  # Set pan
+npx tsx server/daw-cli.ts mute <trackId>  # Toggle mute
+npx tsx server/daw-cli.ts generate <trackId> <prompt>  # AI generation
+```
 
 ## Interaction Style
 

--- a/server/daw-cli-format.ts
+++ b/server/daw-cli-format.ts
@@ -1,0 +1,198 @@
+/**
+ * daw-cli-format.ts — Pure formatting functions for DAW CLI output.
+ * Separated from the WebSocket client for testability.
+ */
+
+export interface ParsedCommand {
+  tool: string;
+  params: Record<string, unknown>;
+}
+
+/** Map CLI subcommands to tool names and extract params */
+export function parseCommand(args: string[]): ParsedCommand | { error: string } {
+  const [cmd, ...rest] = args;
+
+  switch (cmd) {
+    case 'status':
+      return { tool: 'daw_get_project', params: {} };
+    case 'tracks':
+      return { tool: 'daw_get_tracks', params: {} };
+    case 'transport':
+      return { tool: 'daw_get_transport', params: {} };
+    case 'mix':
+      return { tool: 'daw_get_mixer', params: {} };
+    case 'play':
+      return { tool: 'daw_play', params: {} };
+    case 'stop':
+      return { tool: 'daw_stop', params: {} };
+    case 'loop':
+      return { tool: 'daw_toggle_loop', params: {} };
+    case 'set-bpm': {
+      const bpm = Number(rest[0]);
+      if (!rest[0] || isNaN(bpm) || bpm < 20 || bpm > 999)
+        return { error: 'Usage: daw set-bpm <20-999>' };
+      return { tool: 'daw_set_bpm', params: { bpm } };
+    }
+    case 'add-track': {
+      const type = rest[0];
+      const validTypes = ['stems', 'sample', 'sequencer', 'pianoroll'];
+      if (!type || !validTypes.includes(type))
+        return { error: `Usage: daw add-track <${validTypes.join('|')}> [name]` };
+      const params: Record<string, unknown> = { type };
+      if (rest[1]) params.name = rest.slice(1).join(' ');
+      return { tool: 'daw_add_track', params };
+    }
+    case 'delete-track': {
+      if (!rest[0]) return { error: 'Usage: daw delete-track <trackId>' };
+      return { tool: 'daw_delete_track', params: { trackId: rest[0] } };
+    }
+    case 'volume': {
+      const vol = Number(rest[1]);
+      if (!rest[0] || isNaN(vol))
+        return { error: 'Usage: daw volume <trackId> <0-1>' };
+      return { tool: 'daw_set_volume', params: { trackId: rest[0], volume: vol } };
+    }
+    case 'pan': {
+      const pan = Number(rest[1]);
+      if (!rest[0] || isNaN(pan))
+        return { error: 'Usage: daw pan <trackId> <-1 to 1>' };
+      return { tool: 'daw_set_pan', params: { trackId: rest[0], pan } };
+    }
+    case 'mute':
+      if (!rest[0]) return { error: 'Usage: daw mute <trackId>' };
+      return { tool: 'daw_toggle_mute', params: { trackId: rest[0] } };
+    case 'solo':
+      if (!rest[0]) return { error: 'Usage: daw solo <trackId>' };
+      return { tool: 'daw_toggle_solo', params: { trackId: rest[0] } };
+    case 'generate': {
+      if (!rest[0]) return { error: 'Usage: daw generate <trackId> <prompt>' };
+      const trackId = rest[0];
+      const prompt = rest.slice(1).join(' ');
+      if (!prompt) return { error: 'Usage: daw generate <trackId> <prompt>' };
+      return { tool: 'daw_generate', params: { trackId, prompt } };
+    }
+    case 'midi': {
+      if (rest.length < 4)
+        return { error: 'Usage: daw midi <clipId> <pitch> <start> <dur> [vel]' };
+      return {
+        tool: 'daw_add_midi_note',
+        params: {
+          clipId: rest[0],
+          pitch: Number(rest[1]),
+          startBeat: Number(rest[2]),
+          durationBeats: Number(rest[3]),
+          ...(rest[4] ? { velocity: Number(rest[4]) } : {}),
+        },
+      };
+    }
+    case 'step': {
+      if (rest.length < 3)
+        return { error: 'Usage: daw step <trackId> <rowId> <stepIndex>' };
+      return {
+        tool: 'daw_toggle_step',
+        params: {
+          trackId: rest[0],
+          rowId: rest[1],
+          stepIndex: Number(rest[2]),
+        },
+      };
+    }
+    default:
+      return {
+        error: `Unknown command: ${cmd ?? '(none)'}\nCommands: status tracks transport mix play stop loop set-bpm add-track delete-track volume pan mute solo generate midi step`,
+      };
+  }
+}
+
+/** Format pan value compactly: C, L.3, R.7 */
+export function formatPan(pan: number): string {
+  if (Math.abs(pan) < 0.05) return 'C';
+  return pan < 0 ? `L${Math.abs(pan).toFixed(1).replace('0.', '.')}` : `R${pan.toFixed(1).replace('0.', '.')}`;
+}
+
+/** Format time as M:SS */
+export function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/** Format project status output */
+export function formatStatus(data: Record<string, unknown>): string {
+  const name = data.name ?? 'Untitled';
+  const bpm = data.bpm ?? 120;
+  const ts = data.timeSignature ?? '4/4';
+  const tracks = data.tracks as Array<Record<string, unknown>> | undefined;
+  const trackCount = tracks?.length ?? data.trackCount ?? 0;
+
+  const lines: string[] = [];
+  lines.push(`${name} | ${bpm}bpm ${ts} | ${trackCount} tracks`);
+  lines.push('─'.repeat(40));
+
+  if (tracks) {
+    for (const t of tracks) {
+      const type = `[${(t.type as string)?.slice(0, 5) ?? '?'}]`;
+      const clipCount = (t.clips as unknown[])?.length ?? t.clipCount ?? 0;
+      const vol = `V:${(t.volume as number)?.toFixed(2) ?? '?'}`;
+      const pan = formatPan((t.pan as number) ?? 0);
+      const flags = [
+        t.muted ? 'MUTED' : '',
+        t.soloed ? 'SOLO' : '',
+      ].filter(Boolean).join(' ');
+      lines.push(`  ${(t.name as string)?.padEnd(12) ?? 'Track'} ${type.padEnd(7)} ${clipCount}clip${clipCount !== 1 ? 's' : ''} ${vol} ${pan} ${flags}`.trimEnd());
+    }
+  }
+  return lines.join('\n');
+}
+
+/** Format mixer table */
+export function formatMixer(data: Record<string, unknown>): string {
+  const tracks = data.tracks as Array<Record<string, unknown>> | undefined;
+  if (!tracks?.length) return 'No tracks';
+
+  const lines: string[] = [];
+  lines.push('Track        Vol  Pan  M S');
+  for (const t of tracks) {
+    const name = ((t.name as string) ?? 'Track').padEnd(12);
+    const vol = ((t.volume as number) ?? 0).toFixed(2);
+    const pan = formatPan((t.pan as number) ?? 0).padEnd(4);
+    const m = t.muted ? 'M' : '.';
+    const s = t.soloed ? 'S' : '.';
+    lines.push(`${name} ${vol} ${pan} ${m} ${s}`);
+  }
+  return lines.join('\n');
+}
+
+/** Format transport state */
+export function formatTransport(data: Record<string, unknown>): string {
+  const playing = data.isPlaying ? '▶ playing' : '■ stopped';
+  const time = formatTime((data.currentTime as number) ?? 0);
+  const loop = data.loopEnabled ? 'loop on' : 'loop off';
+  return `${playing} ${time} | ${loop}`;
+}
+
+/** Generic format for command results */
+export function formatResult(tool: string, result: unknown): string {
+  if (typeof result === 'string') return result;
+
+  const data = result as Record<string, unknown>;
+
+  switch (tool) {
+    case 'daw_get_project':
+      return formatStatus(data);
+    case 'daw_get_mixer':
+      return formatMixer(data);
+    case 'daw_get_transport':
+      return formatTransport(data);
+    case 'daw_get_tracks':
+      return formatStatus({ ...data, name: 'Tracks' });
+    default: {
+      // For write operations, show success message
+      if (data.success) {
+        const msg = data.message ?? data.trackId ?? 'OK';
+        return `✓ ${msg}`;
+      }
+      return JSON.stringify(result, null, 2);
+    }
+  }
+}

--- a/server/daw-cli.ts
+++ b/server/daw-cli.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env npx tsx
+/**
+ * daw-cli.ts — Lightweight DAW CLI for token-efficient Claude Code interaction.
+ *
+ * Usage: node server/daw-cli.ts <command> [args...]
+ *
+ * Connects to the DAW's WebSocket bridge, sends one command, prints compact
+ * text output, and exits. Replaces the heavy MCP server pipeline.
+ */
+import { WebSocket } from 'ws';
+import { parseCommand, formatResult } from './daw-cli-format';
+
+const BRIDGE_URL = process.env.DAW_MCP_BRIDGE_URL ?? 'ws://127.0.0.1:5174/ws/mcp-bridge';
+const TIMEOUT_MS = 5000;
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const parsed = parseCommand(args);
+
+  if ('error' in parsed) {
+    process.stderr.write(parsed.error + '\n');
+    process.exit(1);
+  }
+
+  const { tool, params } = parsed;
+  const id = `cli-${Date.now()}`;
+
+  try {
+    const result = await sendToolCall(id, tool, params);
+    const output = formatResult(tool, result);
+    process.stdout.write(output + '\n');
+  } catch (err) {
+    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+}
+
+function sendToolCall(
+  id: string,
+  tool: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error(`Timeout after ${TIMEOUT_MS}ms — is the DAW dev server running?`));
+    }, TIMEOUT_MS);
+
+    const ws = new WebSocket(BRIDGE_URL);
+
+    ws.on('open', () => {
+      ws.send(JSON.stringify({ id, tool, params }));
+    });
+
+    ws.on('message', (data: Buffer) => {
+      try {
+        const msg = JSON.parse(data.toString()) as { id: string; result?: unknown; error?: string };
+        if (msg.id !== id) return;
+        clearTimeout(timer);
+        ws.close();
+        if (msg.error) {
+          reject(new Error(msg.error));
+        } else {
+          resolve(msg.result);
+        }
+      } catch {
+        // Ignore non-JSON messages
+      }
+    });
+
+    ws.on('error', (err: Error) => {
+      clearTimeout(timer);
+      reject(new Error(`WebSocket error: ${err.message}. Is the DAW running at ${BRIDGE_URL}?`));
+    });
+
+    ws.on('close', () => {
+      clearTimeout(timer);
+    });
+  });
+}
+
+main();

--- a/tests/unit/daw-cli-format.test.ts
+++ b/tests/unit/daw-cli-format.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseCommand,
+  formatPan,
+  formatTime,
+  formatStatus,
+  formatMixer,
+  formatTransport,
+  formatResult,
+} from '../../server/daw-cli-format';
+
+describe('daw-cli-format', () => {
+  describe('parseCommand', () => {
+    it('parses status command', () => {
+      expect(parseCommand(['status'])).toEqual({
+        tool: 'daw_get_project',
+        params: {},
+      });
+    });
+
+    it('parses tracks command', () => {
+      expect(parseCommand(['tracks'])).toEqual({
+        tool: 'daw_get_tracks',
+        params: {},
+      });
+    });
+
+    it('parses transport command', () => {
+      expect(parseCommand(['transport'])).toEqual({
+        tool: 'daw_get_transport',
+        params: {},
+      });
+    });
+
+    it('parses mix command', () => {
+      expect(parseCommand(['mix'])).toEqual({
+        tool: 'daw_get_mixer',
+        params: {},
+      });
+    });
+
+    it('parses play/stop/loop', () => {
+      expect(parseCommand(['play'])).toEqual({ tool: 'daw_play', params: {} });
+      expect(parseCommand(['stop'])).toEqual({ tool: 'daw_stop', params: {} });
+      expect(parseCommand(['loop'])).toEqual({ tool: 'daw_toggle_loop', params: {} });
+    });
+
+    it('parses set-bpm with valid value', () => {
+      expect(parseCommand(['set-bpm', '140'])).toEqual({
+        tool: 'daw_set_bpm',
+        params: { bpm: 140 },
+      });
+    });
+
+    it('rejects set-bpm with invalid value', () => {
+      const result = parseCommand(['set-bpm', 'abc']);
+      expect('error' in result).toBe(true);
+    });
+
+    it('rejects set-bpm out of range', () => {
+      expect('error' in parseCommand(['set-bpm', '5'])).toBe(true);
+      expect('error' in parseCommand(['set-bpm', '1000'])).toBe(true);
+    });
+
+    it('parses add-track with type and optional name', () => {
+      expect(parseCommand(['add-track', 'stems'])).toEqual({
+        tool: 'daw_add_track',
+        params: { type: 'stems' },
+      });
+      expect(parseCommand(['add-track', 'pianoroll', 'My', 'Piano'])).toEqual({
+        tool: 'daw_add_track',
+        params: { type: 'pianoroll', name: 'My Piano' },
+      });
+    });
+
+    it('rejects add-track with invalid type', () => {
+      expect('error' in parseCommand(['add-track', 'bogus'])).toBe(true);
+    });
+
+    it('parses delete-track', () => {
+      expect(parseCommand(['delete-track', 'track-1'])).toEqual({
+        tool: 'daw_delete_track',
+        params: { trackId: 'track-1' },
+      });
+    });
+
+    it('parses volume', () => {
+      expect(parseCommand(['volume', 'track-1', '0.8'])).toEqual({
+        tool: 'daw_set_volume',
+        params: { trackId: 'track-1', volume: 0.8 },
+      });
+    });
+
+    it('parses pan', () => {
+      expect(parseCommand(['pan', 'track-1', '-0.5'])).toEqual({
+        tool: 'daw_set_pan',
+        params: { trackId: 'track-1', pan: -0.5 },
+      });
+    });
+
+    it('parses mute/solo', () => {
+      expect(parseCommand(['mute', 'track-1'])).toEqual({
+        tool: 'daw_toggle_mute',
+        params: { trackId: 'track-1' },
+      });
+      expect(parseCommand(['solo', 'track-1'])).toEqual({
+        tool: 'daw_toggle_solo',
+        params: { trackId: 'track-1' },
+      });
+    });
+
+    it('parses generate with trackId and prompt', () => {
+      expect(parseCommand(['generate', 'track-1', 'a', 'lofi', 'beat'])).toEqual({
+        tool: 'daw_generate',
+        params: { trackId: 'track-1', prompt: 'a lofi beat' },
+      });
+    });
+
+    it('rejects generate without prompt', () => {
+      expect('error' in parseCommand(['generate', 'track-1'])).toBe(true);
+    });
+
+    it('parses midi note', () => {
+      expect(parseCommand(['midi', 'clip-1', '60', '0', '1'])).toEqual({
+        tool: 'daw_add_midi_note',
+        params: { clipId: 'clip-1', pitch: 60, startBeat: 0, durationBeats: 1 },
+      });
+    });
+
+    it('parses midi note with velocity', () => {
+      expect(parseCommand(['midi', 'clip-1', '60', '0', '1', '100'])).toEqual({
+        tool: 'daw_add_midi_note',
+        params: { clipId: 'clip-1', pitch: 60, startBeat: 0, durationBeats: 1, velocity: 100 },
+      });
+    });
+
+    it('parses step toggle', () => {
+      expect(parseCommand(['step', 'track-1', 'kick', '3'])).toEqual({
+        tool: 'daw_toggle_step',
+        params: { trackId: 'track-1', rowId: 'kick', stepIndex: 3 },
+      });
+    });
+
+    it('returns error for unknown command', () => {
+      const result = parseCommand(['bogus']);
+      expect('error' in result).toBe(true);
+      expect((result as { error: string }).error).toContain('Unknown command');
+    });
+
+    it('returns error for empty args', () => {
+      const result = parseCommand([]);
+      expect('error' in result).toBe(true);
+    });
+  });
+
+  describe('formatPan', () => {
+    it('formats center', () => {
+      expect(formatPan(0)).toBe('C');
+      expect(formatPan(0.02)).toBe('C');
+      expect(formatPan(-0.03)).toBe('C');
+    });
+
+    it('formats left', () => {
+      expect(formatPan(-0.5)).toBe('L.5');
+      expect(formatPan(-1)).toBe('L1.0');
+    });
+
+    it('formats right', () => {
+      expect(formatPan(0.3)).toBe('R.3');
+      expect(formatPan(1)).toBe('R1.0');
+    });
+  });
+
+  describe('formatTime', () => {
+    it('formats seconds to M:SS', () => {
+      expect(formatTime(0)).toBe('0:00');
+      expect(formatTime(65)).toBe('1:05');
+      expect(formatTime(130)).toBe('2:10');
+    });
+  });
+
+  describe('formatStatus', () => {
+    it('formats project summary', () => {
+      const data = {
+        name: 'My Song',
+        bpm: 128,
+        timeSignature: '4/4',
+        tracks: [
+          { name: 'Drums', type: 'sequencer', clips: [1, 2], volume: 0.8, pan: 0, muted: false, soloed: false },
+          { name: 'Bass', type: 'pianoroll', clips: [1], volume: 0.7, pan: -0.1, muted: true, soloed: false },
+        ],
+      };
+      const output = formatStatus(data);
+      expect(output).toContain('My Song');
+      expect(output).toContain('128bpm');
+      expect(output).toContain('Drums');
+      expect(output).toContain('Bass');
+      expect(output).toContain('MUTED');
+      expect(output).toContain('2clips');
+    });
+  });
+
+  describe('formatMixer', () => {
+    it('formats mixer table', () => {
+      const data = {
+        tracks: [
+          { name: 'Drums', volume: 0.8, pan: 0, muted: false, soloed: false },
+          { name: 'Bass', volume: 0.7, pan: -0.5, muted: true, soloed: false },
+        ],
+      };
+      const output = formatMixer(data);
+      expect(output).toContain('Track');
+      expect(output).toContain('Drums');
+      expect(output).toContain('0.80');
+      expect(output).toContain('Bass');
+      expect(output).toContain('M');
+    });
+
+    it('handles empty tracks', () => {
+      expect(formatMixer({ tracks: [] })).toBe('No tracks');
+    });
+  });
+
+  describe('formatTransport', () => {
+    it('formats playing state', () => {
+      const output = formatTransport({ isPlaying: true, currentTime: 65, loopEnabled: true });
+      expect(output).toContain('▶ playing');
+      expect(output).toContain('1:05');
+      expect(output).toContain('loop on');
+    });
+
+    it('formats stopped state', () => {
+      const output = formatTransport({ isPlaying: false, currentTime: 0, loopEnabled: false });
+      expect(output).toContain('■ stopped');
+      expect(output).toContain('loop off');
+    });
+  });
+
+  describe('formatResult', () => {
+    it('formats project result', () => {
+      const output = formatResult('daw_get_project', { name: 'Test', bpm: 120, timeSignature: '4/4', tracks: [] });
+      expect(output).toContain('Test');
+      expect(output).toContain('120bpm');
+    });
+
+    it('formats write operation success', () => {
+      const output = formatResult('daw_set_bpm', { success: true, message: 'BPM set to 140' });
+      expect(output).toContain('✓');
+      expect(output).toContain('BPM set to 140');
+    });
+
+    it('passes through string results', () => {
+      expect(formatResult('unknown', 'hello')).toBe('hello');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `server/daw-cli.ts` — lightweight CLI that connects to existing WebSocket bridge, sends one command, prints compact text, exits
- New `server/daw-cli-format.ts` — pure arg parser + output formatters for 16 DAW commands
- 33 unit tests for all parsing and formatting logic
- All 6 skill files updated to use CLI instead of MCP tools
- System prompt updated with CLI quick reference

Replaces the heavy MCP server pipeline (stdio JSON-RPC + Content-Length framing) with a direct WebSocket client that costs ~5 tokens per command vs ~50 for MCP.

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 3634 tests pass (33 new for CLI)
- [x] `npm run build` — succeeds
- [ ] `npx tsx server/daw-cli.ts status` prints compact summary (requires running dev server)
- [ ] `npx tsx server/daw-cli.ts add-track stems "Test"` creates track
- [ ] CLI exits with code 1 on invalid args
- [ ] CLI times out after 5s if bridge unavailable

Closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)