### PR TITLE
feat: smooth effect bypass transition with grayscale + watermark

### DIFF
--- a/src/components/mixer/EffectChain.tsx
+++ b/src/components/mixer/EffectChain.tsx
@@ -668,7 +668,7 @@ export function EffectChain() {
       />
 
       {/* ── Full-width selected effect view ── */}
-      <div className={`flex-1 overflow-y-auto transition-opacity ${track.effectsBypassed ? 'opacity-45' : 'opacity-100'}`}>
+      <div className={`flex-1 overflow-y-auto relative transition-all duration-200 ease-in-out ${track.effectsBypassed ? 'opacity-45 grayscale' : 'opacity-100 grayscale-0'}`}>
         {selectedEffect ? (
           <div className="h-full">
             {/* Device header — integrated into the full-width view */}
@@ -685,6 +685,14 @@ export function EffectChain() {
         ) : (
           <div className="flex items-center justify-center h-full text-white/20 text-sm">
             No effects — click + to add one
+          </div>
+        )}
+        {/* Bypass watermark overlay */}
+        {track.effectsBypassed && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none transition-opacity duration-200">
+            <span className="text-white/[0.06] text-4xl font-bold uppercase tracking-[0.3em] select-none">
+              Bypass
+            </span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Change bypass transition from instant opacity to 200ms ease-in-out with `transition-all duration-200`
- Add `grayscale` CSS filter when effects chain is bypassed (desaturates the entire effect view)
- Add subtle "BYPASS" watermark overlay centered on the effect view
- Audio bypass remains instant — only visual transition is animated

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 3601 tests pass
- [x] `npm run build` — succeeds
- [ ] Visual: bypass toggle shows smooth 200ms dim + grayscale transition
- [ ] Visual: "BYPASS" watermark visible but subtle (6% opacity)
- [ ] Audio: bypass is still instant (no fade in audio)

Part of #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)