### PR TITLE
feat: compressor transfer curve visualization with threshold/ratio/knee

### DIFF
--- a/src/components/mixer/CompressorCurve.tsx
+++ b/src/components/mixer/CompressorCurve.tsx
@@ -1,0 +1,162 @@
+/**
+ * CompressorCurve — Transfer curve visualization for the compressor effect.
+ * Shows input vs output dB with threshold, ratio, and knee.
+ */
+import { useRef, useEffect } from 'react';
+import { generateTransferCurve } from '../../utils/compressorCurve';
+
+const MIN_DB = -60;
+const MAX_DB = 0;
+const DB_LABELS = [-48, -36, -24, -12, 0];
+
+interface CompressorCurveProps {
+  threshold: number;
+  ratio: number;
+  kneeDb: number;
+  /** Current gain reduction in dB (negative) for the animated dot */
+  reduction?: number;
+  width?: number;
+  height?: number;
+  /** Accent color for the curve */
+  color?: string;
+}
+
+export function CompressorCurve({
+  threshold,
+  ratio,
+  kneeDb,
+  reduction = 0,
+  width = 160,
+  height = 120,
+  color = '#f59e0b',
+}: CompressorCurveProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    if (canvas.width !== width * dpr || canvas.height !== height * dpr) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.scale(dpr, dpr);
+    }
+
+    // Coordinate helpers
+    const xForDb = (db: number) => ((db - MIN_DB) / (MAX_DB - MIN_DB)) * width;
+    const yForDb = (db: number) => height - ((db - MIN_DB) / (MAX_DB - MIN_DB)) * height;
+
+    // Clear
+    ctx.clearRect(0, 0, width, height);
+
+    // Background
+    ctx.fillStyle = 'rgba(8, 12, 24, 0.85)';
+    ctx.fillRect(0, 0, width, height);
+
+    // Grid lines
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
+    ctx.lineWidth = 0.5;
+    ctx.font = '8px monospace';
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.2)';
+
+    for (const db of DB_LABELS) {
+      const x = xForDb(db);
+      const y = yForDb(db);
+      // Vertical
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.stroke();
+      // Horizontal
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+      // Label
+      ctx.textAlign = 'left';
+      ctx.fillText(`${db}`, 2, y - 2);
+    }
+
+    // Unity line (45° dashed)
+    ctx.setLineDash([3, 3]);
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(xForDb(MIN_DB), yForDb(MIN_DB));
+    ctx.lineTo(xForDb(MAX_DB), yForDb(MAX_DB));
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Threshold marker (vertical)
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.2)';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([2, 2]);
+    ctx.beginPath();
+    const threshX = xForDb(threshold);
+    ctx.moveTo(threshX, 0);
+    ctx.lineTo(threshX, height);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Transfer curve
+    const points = generateTransferCurve(threshold, ratio, kneeDb, MIN_DB, MAX_DB, 200);
+
+    ctx.beginPath();
+    for (let i = 0; i < points.length; i++) {
+      const x = xForDb(points[i].x);
+      const y = yForDb(points[i].y);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // Fill area between curve and unity line (compression region)
+    ctx.beginPath();
+    for (let i = 0; i < points.length; i++) {
+      const x = xForDb(points[i].x);
+      const y = yForDb(points[i].y);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    // Close back along unity line
+    for (let i = points.length - 1; i >= 0; i--) {
+      const x = xForDb(points[i].x);
+      const y = yForDb(points[i].x); // unity line: output = input
+      ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.fillStyle = `${color}15`; // ~8% opacity
+    ctx.fill();
+
+    // GR indicator dot (shows current operating point)
+    if (Math.abs(reduction) > 0.1) {
+      // Estimate input level from reduction: input ≈ threshold - reduction * ratio / (ratio - 1)
+      // Simplified: just show the dot at threshold position moving down
+      const dotInputDb = Math.max(MIN_DB, threshold - reduction);
+      const dotOutputDb = dotInputDb + reduction;
+      const dotX = xForDb(dotInputDb);
+      const dotY = yForDb(dotOutputDb);
+      ctx.beginPath();
+      ctx.arc(dotX, dotY, 3, 0, Math.PI * 2);
+      ctx.fillStyle = color;
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.5)';
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+  }, [threshold, ratio, kneeDb, reduction, width, height, color]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ width, height }}
+      className="rounded"
+      data-testid="compressor-curve"
+    />
+  );
+}

--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -7,6 +7,7 @@ import { Knob } from '../ui/Knob';
 import { PrecisionInput, clampValue, roundToStep } from '../ui/PrecisionInput';
 import { ContextMenuWrapper, ContextMenuItem } from '../ui/ContextMenu';
 import { EffectCardLayout } from './EffectCardLayout';
+import { CompressorCurve } from './CompressorCurve';
 import { useProjectStore } from '../../store/projectStore';
 import { effectsEngine } from '../../engine/EffectsEngine';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
@@ -713,6 +714,17 @@ export function CompressorCard({ effect, trackId }: { effect: TrackEffect & { ty
   return (
     <EffectCardLayout
       color={EFFECT_COLORS.compressor}
+      visualization={
+        <CompressorCurve
+          threshold={p.threshold}
+          ratio={p.ratio}
+          kneeDb={p.knee}
+          reduction={reduction}
+          width={220}
+          height={120}
+          color={EFFECT_COLORS.compressor}
+        />
+      }
       footer={
         <div className="flex flex-col gap-2">
           {/* Sidechain source */}

--- a/src/utils/__tests__/compressorCurve.test.ts
+++ b/src/utils/__tests__/compressorCurve.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { compressorTransfer, generateTransferCurve } from '../compressorCurve';
+
+describe('compressorCurve', () => {
+  describe('compressorTransfer', () => {
+    it('passes through signal below threshold with no knee', () => {
+      // Input -40dB, threshold -20dB, ratio 4:1, no knee
+      expect(compressorTransfer(-40, -20, 4, 0)).toBe(-40);
+      expect(compressorTransfer(-30, -20, 4, 0)).toBe(-30);
+    });
+
+    it('compresses signal above threshold at given ratio', () => {
+      // Input -10dB, threshold -20dB, ratio 4:1 → excess = 10dB, compressed excess = 2.5dB
+      // Output = -20 + 10/4 = -17.5
+      expect(compressorTransfer(-10, -20, 4, 0)).toBe(-17.5);
+    });
+
+    it('handles infinite ratio (limiter)', () => {
+      // ratio = Infinity → output at threshold
+      expect(compressorTransfer(-10, -20, Infinity, 0)).toBe(-20);
+      expect(compressorTransfer(0, -20, Infinity, 0)).toBe(-20);
+    });
+
+    it('handles ratio of 1 (no compression)', () => {
+      expect(compressorTransfer(-10, -20, 1, 0)).toBe(-10);
+      expect(compressorTransfer(0, -20, 1, 0)).toBe(0);
+    });
+
+    it('applies soft knee smoothly around threshold', () => {
+      const threshold = -20;
+      const ratio = 4;
+      const knee = 12; // 12dB knee
+
+      // At threshold with soft knee, output is below unity (some compression applied)
+      const atThreshold = compressorTransfer(threshold, threshold, ratio, knee);
+      expect(atThreshold).toBeLessThan(threshold); // some compression happening
+      // But more than what full compression at threshold would give (which is just threshold)
+      // The soft knee applies partial compression, so output is between full-compress and unity
+      expect(atThreshold).toBeGreaterThan(threshold - knee); // not extreme
+
+      // Below knee start (threshold - knee/2), should be unity
+      const belowKnee = compressorTransfer(threshold - knee / 2 - 1, threshold, ratio, knee);
+      expect(belowKnee).toBe(threshold - knee / 2 - 1);
+
+      // Above knee end (threshold + knee/2), should follow compressed line
+      const aboveKnee = compressorTransfer(threshold + knee / 2 + 1, threshold, ratio, knee);
+      const excess = knee / 2 + 1;
+      const expectedCompressed = threshold + excess / ratio;
+      expect(aboveKnee).toBeCloseTo(expectedCompressed, 1);
+    });
+
+    it('soft knee curve is monotonically increasing', () => {
+      const threshold = -24;
+      const ratio = 4;
+      const knee = 12;
+      let prev = -Infinity;
+      for (let db = -60; db <= 0; db += 0.5) {
+        const out = compressorTransfer(db, threshold, ratio, knee);
+        expect(out).toBeGreaterThanOrEqual(prev);
+        prev = out;
+      }
+    });
+  });
+
+  describe('generateTransferCurve', () => {
+    it('generates correct number of points', () => {
+      const points = generateTransferCurve(-20, 4, 6, -60, 0, 100);
+      expect(points).toHaveLength(101); // steps + 1
+    });
+
+    it('first point starts at minDb', () => {
+      const points = generateTransferCurve(-20, 4, 0, -60, 0);
+      expect(points[0].x).toBe(-60);
+      expect(points[0].y).toBe(-60); // below threshold = unity
+    });
+
+    it('last point is at maxDb', () => {
+      const points = generateTransferCurve(-20, 4, 0, -60, 0);
+      const last = points[points.length - 1];
+      expect(last.x).toBe(0);
+      // 0dB input, -20 threshold, 4:1 ratio → -20 + 20/4 = -15
+      expect(last.y).toBe(-15);
+    });
+
+    it('curve follows unity below threshold', () => {
+      const points = generateTransferCurve(-20, 4, 0, -60, 0);
+      // All points below -20 should be on the unity line
+      for (const p of points) {
+        if (p.x <= -20) {
+          expect(p.y).toBeCloseTo(p.x, 5);
+        }
+      }
+    });
+  });
+});

--- a/src/utils/compressorCurve.ts
+++ b/src/utils/compressorCurve.ts
@@ -1,0 +1,48 @@
+/**
+ * compressorCurve.ts — Pure math for compressor transfer curve visualization.
+ *
+ * Calculates output dB from input dB given threshold, ratio, and knee width.
+ * Based on the standard soft-knee compressor formula.
+ */
+
+/** Compute output dB for a given input dB */
+export function compressorTransfer(
+  inputDb: number,
+  threshold: number,
+  ratio: number,
+  kneeDb: number,
+): number {
+  const halfKnee = kneeDb / 2;
+
+  if (inputDb <= threshold - halfKnee) {
+    // Below knee region — no compression
+    return inputDb;
+  }
+
+  if (kneeDb > 0 && inputDb < threshold + halfKnee) {
+    // Soft knee region — quadratic interpolation
+    const x = inputDb - threshold + halfKnee;
+    return inputDb + ((1 / ratio - 1) * x * x) / (2 * kneeDb);
+  }
+
+  // Above threshold — full compression
+  return threshold + (inputDb - threshold) / ratio;
+}
+
+/** Generate an array of {x, y} points for the transfer curve */
+export function generateTransferCurve(
+  threshold: number,
+  ratio: number,
+  kneeDb: number,
+  minDb: number = -60,
+  maxDb: number = 0,
+  steps: number = 120,
+): Array<{ x: number; y: number }> {
+  const points: Array<{ x: number; y: number }> = [];
+  for (let i = 0; i <= steps; i++) {
+    const inputDb = minDb + (maxDb - minDb) * (i / steps);
+    const outputDb = compressorTransfer(inputDb, threshold, ratio, kneeDb);
+    points.push({ x: inputDb, y: outputDb });
+  }
+  return points;
+}


### PR DESCRIPTION
## Summary
- New `compressorCurve.ts` — pure math for soft-knee compressor transfer function
- New `CompressorCurve.tsx` — 220x120px canvas rendering transfer curve with:
  - dB grid, 45 degree unity line (dashed), threshold marker
  - Golden compression curve with soft knee rendering
  - Filled compression region (subtle amber)
  - GR indicator dot showing current operating point
- Integrated into CompressorCard via EffectCardLayout `visualization` slot
- 10 unit tests for transfer function math

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 3654 tests pass (10 new for compressor math)
- [x] `npm run build` — succeeds
- [x] Visual: transfer curve renders above compressor knobs
- [x] Visual: threshold line, unity line, knee curve all visible
- [x] Visual: curve updates when threshold/ratio/knee params change

Part of #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)