### PR TITLE
feat: distortion waveshaping transfer curve visualization

### DIFF
--- a/src/components/mixer/DistortionCurve.tsx
+++ b/src/components/mixer/DistortionCurve.tsx
@@ -1,0 +1,147 @@
+/**
+ * DistortionCurve — Waveshaping transfer function visualization.
+ * Shows input vs output amplitude with the characteristic shape for each type.
+ */
+import { useRef, useEffect } from 'react';
+import { generateDistortionCurve, type DistortionType } from '../../utils/distortionCurve';
+
+interface DistortionCurveProps {
+  drive: number;
+  distortionType: DistortionType;
+  width?: number;
+  height?: number;
+  /** Accent color for the curve */
+  color?: string;
+}
+
+export function DistortionCurve({
+  drive,
+  distortionType,
+  width = 160,
+  height = 120,
+  color = '#c46454',
+}: DistortionCurveProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    if (canvas.width !== width * dpr || canvas.height !== height * dpr) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.scale(dpr, dpr);
+    }
+
+    // Map amplitude (-1..1) to canvas coordinates
+    const xForAmp = (a: number) => ((a + 1) / 2) * width;
+    const yForAmp = (a: number) => height - ((a + 1) / 2) * height;
+
+    // Clear
+    ctx.clearRect(0, 0, width, height);
+
+    // Background
+    ctx.fillStyle = 'rgba(8, 12, 24, 0.85)';
+    ctx.fillRect(0, 0, width, height);
+
+    // Grid lines at -1, -0.5, 0, +0.5, +1
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
+    ctx.lineWidth = 0.5;
+    ctx.font = '8px monospace';
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.2)';
+
+    for (const amp of [-1, -0.5, 0, 0.5, 1]) {
+      const x = xForAmp(amp);
+      const y = yForAmp(amp);
+      // Vertical
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
+      ctx.stroke();
+      // Horizontal
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+    }
+
+    // Clip boundary markers (±1 dashed lines)
+    ctx.setLineDash([2, 2]);
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
+    ctx.lineWidth = 0.5;
+    [xForAmp(-1), xForAmp(1)].forEach((x) => {
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, height); ctx.stroke();
+    });
+    [yForAmp(-1), yForAmp(1)].forEach((y) => {
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(width, y); ctx.stroke();
+    });
+    ctx.setLineDash([]);
+
+    // Unity line (45° dashed)
+    ctx.setLineDash([3, 3]);
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(xForAmp(-1), yForAmp(-1));
+    ctx.lineTo(xForAmp(1), yForAmp(1));
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Transfer curve
+    const points = generateDistortionCurve(drive, distortionType, 200);
+
+    // Fill area between curve and unity line
+    ctx.beginPath();
+    for (let i = 0; i < points.length; i++) {
+      const px = xForAmp(points[i].x);
+      const py = yForAmp(points[i].y);
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    // Close back along unity line
+    for (let i = points.length - 1; i >= 0; i--) {
+      ctx.lineTo(xForAmp(points[i].x), yForAmp(points[i].x));
+    }
+    ctx.closePath();
+    ctx.fillStyle = `${color}18`;
+    ctx.fill();
+
+    // Curve stroke
+    ctx.beginPath();
+    for (let i = 0; i < points.length; i++) {
+      const px = xForAmp(points[i].x);
+      const py = yForAmp(points[i].y);
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // Center crosshair dot
+    ctx.beginPath();
+    ctx.arc(xForAmp(0), yForAmp(0), 2, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(255,255,255,0.25)';
+    ctx.fill();
+
+    // Type label
+    const label = distortionType.toUpperCase();
+    ctx.font = '8px monospace';
+    ctx.fillStyle = `${color}80`;
+    ctx.textAlign = 'right';
+    ctx.fillText(label, width - 3, height - 3);
+  }, [drive, distortionType, width, height, color]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ width, height }}
+      className="rounded"
+      data-testid="distortion-curve"
+    />
+  );
+}

--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -8,6 +8,7 @@ import { PrecisionInput, clampValue, roundToStep } from '../ui/PrecisionInput';
 import { ContextMenuWrapper, ContextMenuItem } from '../ui/ContextMenu';
 import { EffectCardLayout } from './EffectCardLayout';
 import { CompressorCurve } from './CompressorCurve';
+import { DistortionCurve } from './DistortionCurve';
 import { useProjectStore } from '../../store/projectStore';
 import { effectsEngine } from '../../engine/EffectsEngine';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
@@ -867,6 +868,15 @@ export function DistortionCard({ effect, trackId }: { effect: TrackEffect & { ty
   return (
     <EffectCardLayout
       color={EFFECT_COLORS.distortion}
+      visualization={
+        <DistortionCurve
+          drive={p.amount}
+          distortionType={p.distortionType}
+          width={160}
+          height={100}
+          color={EFFECT_COLORS.distortion}
+        />
+      }
       mode={
         <>
           {(['soft', 'overdrive', 'fuzz'] as DistortionParams['distortionType'][]).map((dt) => (

--- a/src/utils/__tests__/distortionCurve.test.ts
+++ b/src/utils/__tests__/distortionCurve.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { distortionTransfer, generateDistortionCurve } from '../distortionCurve';
+
+describe('distortionCurve', () => {
+  describe('distortionTransfer', () => {
+    describe('zero drive (unity)', () => {
+      it('passes through signal unchanged at drive=0 for soft', () => {
+        expect(distortionTransfer(0.5, 0, 'soft')).toBeCloseTo(0.5, 4);
+        expect(distortionTransfer(-0.5, 0, 'soft')).toBeCloseTo(-0.5, 4);
+        expect(distortionTransfer(0, 0, 'soft')).toBe(0);
+      });
+
+      it('passes through at drive=0 for overdrive', () => {
+        expect(distortionTransfer(0.5, 0, 'overdrive')).toBeCloseTo(0.5, 4);
+        expect(distortionTransfer(-0.3, 0, 'overdrive')).toBeCloseTo(-0.3, 4);
+      });
+
+      it('passes through at drive=0 for fuzz', () => {
+        expect(distortionTransfer(0.5, 0, 'fuzz')).toBeCloseTo(0.5, 4);
+      });
+    });
+
+    describe('all types output in [-1, 1]', () => {
+      const types = ['soft', 'overdrive', 'fuzz'] as const;
+      for (const type of types) {
+        it(`${type} output stays in [-1, 1] for any input`, () => {
+          for (let x = -2; x <= 2; x += 0.1) {
+            const y = distortionTransfer(x, 0.8, type);
+            expect(y).toBeGreaterThanOrEqual(-1 - 1e-9);
+            expect(y).toBeLessThanOrEqual(1 + 1e-9);
+          }
+        });
+      }
+    });
+
+    describe('odd symmetry (f(-x) = -f(x))', () => {
+      it('soft clip is odd-symmetric', () => {
+        for (let x = -1; x <= 1; x += 0.2) {
+          const pos = distortionTransfer(x, 0.5, 'soft');
+          const neg = distortionTransfer(-x, 0.5, 'soft');
+          expect(pos).toBeCloseTo(-neg, 5);
+        }
+      });
+
+      it('fuzz is approximately odd-symmetric', () => {
+        for (let x = -1; x <= 1; x += 0.25) {
+          const pos = distortionTransfer(x, 0.5, 'fuzz');
+          const neg = distortionTransfer(-x, 0.5, 'fuzz');
+          expect(pos).toBeCloseTo(-neg, 4);
+        }
+      });
+    });
+
+    describe('monotonically increasing', () => {
+      const types = ['soft', 'overdrive', 'fuzz'] as const;
+      for (const type of types) {
+        it(`${type} curve is monotonically non-decreasing`, () => {
+          let prev = -Infinity;
+          for (let x = -1; x <= 1; x += 0.02) {
+            const y = distortionTransfer(x, 0.5, type);
+            expect(y).toBeGreaterThanOrEqual(prev - 1e-9);
+            prev = y;
+          }
+        });
+      }
+    });
+
+    describe('fuzz clips hard at high drive', () => {
+      it('fuzz clips to ±1 for large inputs', () => {
+        expect(distortionTransfer(1, 1, 'fuzz')).toBeCloseTo(1, 3);
+        expect(distortionTransfer(-1, 1, 'fuzz')).toBeCloseTo(-1, 3);
+      });
+    });
+
+    describe('drive effect', () => {
+      it('higher drive increases output for soft clip at x=0.3', () => {
+        const low = distortionTransfer(0.3, 0.1, 'soft');
+        const high = distortionTransfer(0.3, 0.9, 'soft');
+        expect(high).toBeGreaterThan(low);
+      });
+    });
+  });
+
+  describe('generateDistortionCurve', () => {
+    it('generates correct number of points', () => {
+      const pts = generateDistortionCurve(0.5, 'soft', 100);
+      expect(pts).toHaveLength(101);
+    });
+
+    it('first point starts at x=-1', () => {
+      const pts = generateDistortionCurve(0.5, 'soft');
+      expect(pts[0].x).toBe(-1);
+    });
+
+    it('last point ends at x=1', () => {
+      const pts = generateDistortionCurve(0.5, 'soft');
+      expect(pts[pts.length - 1].x).toBe(1);
+    });
+
+    it('all y values are in [-1, 1]', () => {
+      for (const type of ['soft', 'overdrive', 'fuzz'] as const) {
+        const pts = generateDistortionCurve(0.7, type);
+        for (const p of pts) {
+          expect(p.y).toBeGreaterThanOrEqual(-1 - 1e-9);
+          expect(p.y).toBeLessThanOrEqual(1 + 1e-9);
+        }
+      }
+    });
+
+    it('at drive=0, curve is approximately linear', () => {
+      const pts = generateDistortionCurve(0, 'soft', 10);
+      for (const p of pts) {
+        expect(p.y).toBeCloseTo(p.x, 4);
+      }
+    });
+  });
+});

--- a/src/utils/distortionCurve.ts
+++ b/src/utils/distortionCurve.ts
@@ -1,0 +1,75 @@
+/**
+ * distortionCurve.ts — Pure math for distortion waveshaping transfer functions.
+ *
+ * Each distortion type has a characteristic curve shape:
+ * - soft:     smooth tanh-based S-curve (gentle saturation)
+ * - overdrive: asymmetric exponential (warm, harmonically rich)
+ * - fuzz:     hard clip (flat top/bottom, aggressive)
+ */
+
+export type DistortionType = 'soft' | 'overdrive' | 'fuzz';
+
+/**
+ * Compute waveshaper output for input x in [-1, 1].
+ * @param x     Input amplitude (-1 to 1)
+ * @param drive Drive amount (0 = unity, 1 = maximum distortion)
+ * @param type  Distortion character
+ * @returns     Clipped output amplitude in [-1, 1]
+ */
+export function distortionTransfer(x: number, drive: number, type: DistortionType): number {
+  // Drive multiplier: 0 at drive=0 (linear passthrough), 9 at drive=1
+  const k = drive * 9;
+
+  // At zero drive, output equals input (no processing)
+  if (k < 0.001) return Math.max(-1, Math.min(1, x));
+
+  let y: number;
+  switch (type) {
+    case 'soft':
+      // Smooth tanh saturation — odd-symmetric, never clips hard
+      y = Math.tanh(k * x) / Math.tanh(k);
+      break;
+
+    case 'overdrive':
+      // Asymmetric exponential — positive half has gentler knee, negative harder
+      if (x >= 0) {
+        y = (1 - Math.exp(-k * x)) / (1 - Math.exp(-k));
+      } else {
+        // Slightly harder on negative half (asymmetric harmonic content)
+        y = -(1 - Math.exp(k * 0.85 * x)) / (1 - Math.exp(-k * 0.85));
+      }
+      break;
+
+    case 'fuzz':
+      // Hard clip with soft transition at edges
+      y = Math.max(-1, Math.min(1, k * x));
+      // Smooth the hard edge slightly with tanh to avoid exact square waves
+      y = Math.tanh(y * 3) / Math.tanh(3);
+      break;
+
+    default:
+      y = x;
+  }
+
+  return Math.max(-1, Math.min(1, y));
+}
+
+/**
+ * Generate an array of {x, y} points for the distortion transfer curve.
+ * @param drive  Drive amount (0–1)
+ * @param type   Distortion type
+ * @param steps  Number of segments (default 120)
+ */
+export function generateDistortionCurve(
+  drive: number,
+  type: DistortionType,
+  steps: number = 120,
+): Array<{ x: number; y: number }> {
+  const points: Array<{ x: number; y: number }> = [];
+  for (let i = 0; i <= steps; i++) {
+    const x = -1 + (2 * i) / steps;
+    const y = distortionTransfer(x, drive, type);
+    points.push({ x, y });
+  }
+  return points;
+}


### PR DESCRIPTION
## Summary
- Adds `DistortionCurve` canvas component (160×100px) with input/output amplitude axes
- Three distinct curve shapes: soft (smooth tanh S), overdrive (asymmetric exponential), fuzz (hard clip with edge softening)
- Curve updates in real-time as drive amount and type change
- Unity reference line (dashed), amplitude grid, fill region showing distortion deviation
- `distortionCurve.ts` utility with 18 unit tests covering symmetry, monotonicity, output bounds, drive effect

## Test plan
- [x] 18 unit tests for `distortionTransfer` and `generateDistortionCurve`
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3672 passed
- [x] `npm run build` — success
- [x] Visual verification: curve visible in Distortion card, correct S-shape at low drive

Closes #1286
Part of #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)