### PR TITLE
feat: delay tap timeline visualization with decay envelope

### DIFF
--- a/src/components/mixer/DelayTapTimeline.tsx
+++ b/src/components/mixer/DelayTapTimeline.tsx
@@ -1,0 +1,227 @@
+/**
+ * DelayTapTimeline — Tap echo timeline visualization for the Delay effect.
+ * Shows repeating echoes as vertical bars decaying by the feedback amount.
+ * Inspired by FabFilter Timeless and Soundtoys EchoBoy.
+ */
+import { useRef, useEffect } from 'react';
+import { generateDelayTaps } from '../../utils/delayTaps';
+
+interface DelayTapTimelineProps {
+  time: number;       // Delay time in seconds
+  feedback: number;   // Feedback amount 0–0.95
+  width?: number;
+  height?: number;
+  color?: string;
+}
+
+export function DelayTapTimeline({
+  time,
+  feedback,
+  width = 160,
+  height = 100,
+  color = '#38bdf8',
+}: DelayTapTimelineProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    if (canvas.width !== width * dpr || canvas.height !== height * dpr) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.scale(dpr, dpr);
+    }
+
+    const labelH = 13;
+    const drawH = height - labelH;
+    const PAD = 4;
+    const displayEnd = Math.max(time * 6, 0.5); // show at least 6 taps worth of space
+
+    const xForT = (t: number) => PAD + (t / displayEnd) * (width - PAD * 2);
+    const yForLevel = (l: number) => drawH - l * (drawH - 4) - 2;
+
+    // ── Background ──────────────────────────────────────────────────────────
+    ctx.clearRect(0, 0, width, height);
+
+    const bgGrad = ctx.createLinearGradient(0, 0, 0, height);
+    bgGrad.addColorStop(0, 'rgba(8, 12, 24, 0.95)');
+    bgGrad.addColorStop(1, 'rgba(4, 8, 18, 0.95)');
+    ctx.fillStyle = bgGrad;
+    ctx.fillRect(0, 0, width, height);
+
+    // Label area separator
+    ctx.fillStyle = 'rgba(0,0,0,0.2)';
+    ctx.fillRect(0, drawH, width, labelH);
+
+    // ── Ruler: horizontal baseline ──────────────────────────────────────────
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+    ctx.lineWidth = 0.5;
+    ctx.beginPath();
+    ctx.moveTo(PAD, drawH - 1);
+    ctx.lineTo(width - PAD, drawH - 1);
+    ctx.stroke();
+
+    // Horizontal amplitude guides (very faint)
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.035)';
+    ctx.lineWidth = 0.5;
+    for (const lvl of [0.5, 0.25]) {
+      const y = yForLevel(lvl);
+      ctx.beginPath();
+      ctx.moveTo(PAD, y);
+      ctx.lineTo(width - PAD, y);
+      ctx.stroke();
+    }
+
+    // ── Dry signal marker at t=0 ─────────────────────────────────────────────
+    {
+      const x0 = PAD;
+      const topY0 = yForLevel(1);
+      ctx.strokeStyle = `${color}40`;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([1, 2]);
+      ctx.beginPath();
+      ctx.moveTo(x0, drawH);
+      ctx.lineTo(x0, topY0);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.fillStyle = `${color}50`;
+      ctx.fillRect(x0 - 0.5, topY0, 1.5, 2);
+    }
+
+    // ── Decay envelope reference curve ───────────────────────────────────────
+    if (feedback > 0.05) {
+      ctx.beginPath();
+      const steps = 80;
+      for (let i = 0; i <= steps; i++) {
+        const t = (displayEnd * i) / steps;
+        const level = Math.pow(feedback, t / time);
+        const x = xForT(t);
+        const y = yForLevel(level);
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.strokeStyle = `${color}28`;
+      ctx.lineWidth = 0.75;
+      ctx.setLineDash([2, 4]);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // ── Tap bars ─────────────────────────────────────────────────────────────
+    const taps = generateDelayTaps(time, feedback, displayEnd);
+    const isHighFeedback = feedback > 0.9;
+    // Adaptive bar width: wide for few taps, narrow for many
+    const barW = Math.max(4, Math.min(18, (width - PAD * 2) / Math.max(taps.length + 1, 3)));
+
+    for (const tap of taps) {
+      const x = xForT(tap.time);
+      const topY = yForLevel(tap.level);
+      const tapColor = isHighFeedback ? '#f97316' : color;
+      const bx = x - barW / 2;
+
+      // Outer glow (only for first 2 taps)
+      if (tap.repeat < 2) {
+        ctx.save();
+        ctx.shadowBlur = tap.repeat === 0 ? 10 : 5;
+        ctx.shadowColor = `${tapColor}80`;
+        ctx.fillStyle = `${tapColor}${Math.round(tap.level * 60).toString(16).padStart(2, '0')}`;
+        ctx.beginPath();
+        ctx.roundRect(bx - 2, topY, barW + 4, drawH - topY, [3, 3, 0, 0]);
+        ctx.fill();
+        ctx.restore();
+      }
+
+      // Filled bar with vertical gradient
+      const alpha = Math.round(tap.level * 255);
+      const alphaHex = alpha.toString(16).padStart(2, '0');
+      const midAlphaHex = Math.round(tap.level * 130).toString(16).padStart(2, '0');
+
+      const barGrad = ctx.createLinearGradient(x, drawH, x, topY);
+      barGrad.addColorStop(0, `${tapColor}00`);
+      barGrad.addColorStop(0.3, `${tapColor}${midAlphaHex}`);
+      barGrad.addColorStop(1, `${tapColor}${alphaHex}`);
+
+      ctx.fillStyle = barGrad;
+      ctx.beginPath();
+      ctx.roundRect(bx, topY, barW, drawH - topY, [2, 2, 0, 0]);
+      ctx.fill();
+
+      // Bright top cap line
+      ctx.fillStyle = `${tapColor}${alphaHex}`;
+      ctx.fillRect(bx, topY, barW, 1.5);
+
+      // Highlight stripe on first tap
+      if (tap.repeat === 0) {
+        ctx.save();
+        ctx.shadowBlur = 8;
+        ctx.shadowColor = tapColor;
+        ctx.fillStyle = tapColor;
+        ctx.fillRect(bx, topY, barW, 2);
+        ctx.restore();
+        // White specular highlight
+        ctx.fillStyle = 'rgba(255,255,255,0.4)';
+        ctx.fillRect(bx + 1, topY + 1, Math.max(1, barW * 0.4), 1);
+      }
+    }
+
+    // ── Time axis labels (first + second tap) ───────────────────────────────
+    ctx.font = '7px monospace';
+    const formatT = (t: number) => t >= 1 ? `${t.toFixed(2)}s` : `${Math.round(t * 1000)}ms`;
+
+    if (taps.length > 0) {
+      // First tap: colored, prominent
+      const x1 = xForT(taps[0].time);
+      ctx.fillStyle = `${color}dd`;
+      ctx.textAlign = 'center';
+      ctx.fillText(formatT(taps[0].time), Math.min(Math.max(x1, 20), width - 22), height - 2);
+
+      // Second tap: muted
+      if (taps.length > 1) {
+        const x2 = xForT(taps[1].time);
+        if (Math.abs(x2 - x1) > 24) { // don't overlap
+          ctx.fillStyle = 'rgba(255,255,255,0.22)';
+          ctx.fillText(formatT(taps[1].time), Math.min(x2, width - 20), height - 2);
+        }
+      }
+    }
+
+    // ── High-feedback warning ────────────────────────────────────────────────
+    if (isHighFeedback) {
+      ctx.font = '7px monospace';
+      ctx.fillStyle = '#f97316cc';
+      ctx.textAlign = 'right';
+      ctx.fillText('∞ REPEAT', width - 4, 10);
+      // Warning badge
+      const badgeW = 52;
+      ctx.fillStyle = 'rgba(249, 115, 22, 0.12)';
+      ctx.beginPath();
+      ctx.roundRect(width - badgeW - 2, 0, badgeW, 13, 2);
+      ctx.fill();
+    } else {
+      // Feedback % label
+      ctx.font = '7px monospace';
+      ctx.fillStyle = `${color}66`;
+      ctx.textAlign = 'right';
+      ctx.fillText(`fb ${Math.round(feedback * 100)}%`, width - 4, 10);
+    }
+
+    // ── Tap count label ──────────────────────────────────────────────────────
+    ctx.font = '7px monospace';
+    ctx.fillStyle = 'rgba(255,255,255,0.18)';
+    ctx.textAlign = 'left';
+    ctx.fillText(`${taps.length} echo${taps.length !== 1 ? 's' : ''}`, PAD + 1, 10);
+  }, [time, feedback, width, height, color]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ width, height }}
+      className="rounded"
+      data-testid="delay-tap-timeline"
+    />
+  );
+}

--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -10,6 +10,7 @@ import { EffectCardLayout } from './EffectCardLayout';
 import { CompressorCurve } from './CompressorCurve';
 import { DistortionCurve } from './DistortionCurve';
 import { ReverbDecayCurve } from './ReverbDecayCurve';
+import { DelayTapTimeline } from './DelayTapTimeline';
 import { useProjectStore } from '../../store/projectStore';
 import { effectsEngine } from '../../engine/EffectsEngine';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
@@ -840,6 +841,15 @@ export function DelayCard({ effect, trackId }: { effect: TrackEffect & { type: '
   return (
     <EffectCardLayout
       color={EFFECT_COLORS.delay}
+      visualization={
+        <DelayTapTimeline
+          time={p.time}
+          feedback={p.feedback}
+          width={160}
+          height={100}
+          color={EFFECT_COLORS.delay}
+        />
+      }
       footer={
         <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'delay', param: 'wet' }} normalizedValue={normalizeEffectParamValue('delay', 'wet', p.wet) ?? 0.5}>
           <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color={EFFECT_COLORS.delay} />

--- a/src/utils/__tests__/delayTaps.test.ts
+++ b/src/utils/__tests__/delayTaps.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { generateDelayTaps, tapLevelAtRepeat } from '../delayTaps';
+
+describe('delayTaps', () => {
+  describe('tapLevelAtRepeat', () => {
+    it('first tap (n=0) is always at full level', () => {
+      expect(tapLevelAtRepeat(0, 0.5)).toBe(1);
+      expect(tapLevelAtRepeat(0, 0.9)).toBe(1);
+      expect(tapLevelAtRepeat(0, 0)).toBe(1);
+    });
+
+    it('level decays by feedback factor each repeat', () => {
+      // n=1 → feedback^1, n=2 → feedback^2
+      expect(tapLevelAtRepeat(1, 0.5)).toBe(0.5);
+      expect(tapLevelAtRepeat(2, 0.5)).toBeCloseTo(0.25, 6);
+      expect(tapLevelAtRepeat(3, 0.5)).toBeCloseTo(0.125, 6);
+    });
+
+    it('at feedback=0, only first tap has level', () => {
+      expect(tapLevelAtRepeat(0, 0)).toBe(1);
+      expect(tapLevelAtRepeat(1, 0)).toBe(0);
+      expect(tapLevelAtRepeat(5, 0)).toBe(0);
+    });
+
+    it('at high feedback, level stays high', () => {
+      expect(tapLevelAtRepeat(3, 0.9)).toBeCloseTo(0.9 ** 3, 6);
+      expect(tapLevelAtRepeat(3, 0.9)).toBeGreaterThan(0.5);
+    });
+
+    it('level is always in [0, 1]', () => {
+      for (let n = 0; n <= 10; n++) {
+        for (let fb = 0; fb <= 1; fb += 0.1) {
+          const v = tapLevelAtRepeat(n, fb);
+          expect(v).toBeGreaterThanOrEqual(0);
+          expect(v).toBeLessThanOrEqual(1 + 1e-9);
+        }
+      }
+    });
+
+    it('level is monotonically non-increasing with repeat index', () => {
+      const fb = 0.7;
+      let prev = 1;
+      for (let n = 0; n <= 10; n++) {
+        const v = tapLevelAtRepeat(n, fb);
+        expect(v).toBeLessThanOrEqual(prev + 1e-9);
+        prev = v;
+      }
+    });
+  });
+
+  describe('generateDelayTaps', () => {
+    it('generates at least one tap for any non-zero time', () => {
+      const taps = generateDelayTaps(0.25, 0.5, 2);
+      expect(taps.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('first tap is at delayTime', () => {
+      const taps = generateDelayTaps(0.25, 0.5, 2);
+      expect(taps[0].time).toBeCloseTo(0.25, 4);
+    });
+
+    it('taps are evenly spaced by delayTime', () => {
+      const taps = generateDelayTaps(0.3, 0.6, 2);
+      if (taps.length >= 2) {
+        expect(taps[1].time).toBeCloseTo(0.6, 4);
+        if (taps.length >= 3) {
+          expect(taps[2].time).toBeCloseTo(0.9, 4);
+        }
+      }
+    });
+
+    it('levels decay correctly', () => {
+      const taps = generateDelayTaps(0.25, 0.5, 2);
+      expect(taps[0].level).toBe(1);
+      if (taps.length >= 2) {
+        expect(taps[1].level).toBeCloseTo(0.5, 4);
+      }
+    });
+
+    it('stops generating taps when level drops below threshold', () => {
+      // With feedback=0, only one tap
+      const taps = generateDelayTaps(0.25, 0, 2);
+      expect(taps).toHaveLength(1);
+    });
+
+    it('stops when time exceeds displayEnd', () => {
+      const taps = generateDelayTaps(0.3, 0.9, 2);
+      for (const t of taps) {
+        expect(t.time).toBeLessThanOrEqual(2 + 1e-9);
+      }
+    });
+
+    it('near-infinite feedback (>0.9) is flagged', () => {
+      const taps = generateDelayTaps(0.25, 0.95, 2);
+      expect(taps.some(t => t.isWarning)).toBe(true);
+    });
+
+    it('normal feedback does not trigger warning', () => {
+      const taps = generateDelayTaps(0.25, 0.5, 2);
+      expect(taps.every(t => !t.isWarning)).toBe(true);
+    });
+  });
+});

--- a/src/utils/delayTaps.ts
+++ b/src/utils/delayTaps.ts
@@ -1,0 +1,57 @@
+/**
+ * delayTaps.ts — Pure math for delay tap timeline visualization.
+ *
+ * Models repeating delay echoes decaying by feedback amount each repeat.
+ */
+
+export interface DelayTap {
+  time: number;    // Time in seconds (position on timeline)
+  level: number;   // Amplitude 0–1
+  repeat: number;  // Repeat index (0 = first tap)
+  isWarning: boolean; // True when feedback is dangerously high
+}
+
+/** Level of tap at repeat index n given feedback factor */
+export function tapLevelAtRepeat(n: number, feedback: number): number {
+  return Math.pow(feedback, n);
+}
+
+/** Minimum audible level (below this we stop generating taps) */
+const MIN_LEVEL = 0.03;
+
+/**
+ * Generate delay tap events for visualization.
+ * @param delayTime  Delay time in seconds (time between taps)
+ * @param feedback   Feedback amount 0–0.95
+ * @param displayEnd Maximum time to show (seconds)
+ */
+export function generateDelayTaps(
+  delayTime: number,
+  feedback: number,
+  displayEnd: number,
+): DelayTap[] {
+  const taps: DelayTap[] = [];
+  const isHighFeedback = feedback > 0.9;
+  let n = 0;
+
+  while (true) {
+    const time = delayTime * (n + 1);
+    if (time > displayEnd) break;
+
+    const level = tapLevelAtRepeat(n, feedback);
+    if (level < MIN_LEVEL && n > 0) break;
+
+    taps.push({
+      time,
+      level,
+      repeat: n,
+      isWarning: isHighFeedback,
+    });
+
+    n++;
+    // Safety: no more than 32 taps
+    if (n >= 32) break;
+  }
+
+  return taps;
+}


### PR DESCRIPTION
## Summary
- Adds `DelayTapTimeline` canvas component (160×100px) for Delay effect card
- Vertical tap bars at each echo position, decaying by feedback factor per repeat
- Adaptive bar width (wide for few taps, narrow for many)
- Glow effect on first (loudest) tap, specular highlight
- Exponential decay reference curve (dashed) connecting tap tops
- Dry signal marker at t=0 (left edge)
- Time axis labels for first two tap positions
- Orange `∞ REPEAT` warning badge when feedback > 0.9
- `delayTaps.ts` utility with 14 unit tests

## Visual Iterations
3 progressive UI refinements: basic bars → glow + wider bars with gradient → ruler baseline + dry signal marker + envelope curve

## Test plan
- [x] 14 unit tests for `tapLevelAtRepeat` and `generateDelayTaps`
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3686 passed
- [x] `npm run build` — success
- [x] Visual verification: 3 iterations confirmed in dev server

Closes #1290
Part of #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)