### PR TITLE
feat: filter frequency response Bode plot visualization

### DIFF
--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -11,6 +11,7 @@ import { CompressorCurve } from './CompressorCurve';
 import { DistortionCurve } from './DistortionCurve';
 import { ReverbDecayCurve } from './ReverbDecayCurve';
 import { DelayTapTimeline } from './DelayTapTimeline';
+import { FilterResponseCurve } from './FilterResponseCurve';
 import { useProjectStore } from '../../store/projectStore';
 import { effectsEngine } from '../../engine/EffectsEngine';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
@@ -929,6 +930,16 @@ export function FilterCard({ effect, trackId }: { effect: TrackEffect & { type: 
   return (
     <EffectCardLayout
       color={EFFECT_COLORS.filter}
+      visualization={
+        <FilterResponseCurve
+          frequency={p.frequency}
+          resonance={Math.max(0.1, p.resonance)}
+          filterType={p.filterType}
+          width={160}
+          height={100}
+          color={EFFECT_COLORS.filter}
+        />
+      }
       mode={
         <>
           {(['lowpass', 'highpass', 'bandpass'] as FilterParams['filterType'][]).map((ft) => (

--- a/src/components/mixer/FilterResponseCurve.tsx
+++ b/src/components/mixer/FilterResponseCurve.tsx
@@ -1,0 +1,223 @@
+/**
+ * FilterResponseCurve — Bode plot (magnitude response) for LP/HP/BP filters.
+ * Shows frequency response on a log scale with resonance peak and cutoff marker.
+ * Inspired by FabFilter Volcano and Ableton Auto Filter.
+ */
+import { useRef, useEffect } from 'react';
+import { generateFilterResponse, type FilterType } from '../../utils/filterResponse';
+
+interface FilterResponseCurveProps {
+  frequency: number;   // Cutoff frequency in Hz
+  resonance: number;   // Q factor
+  filterType: FilterType;
+  width?: number;
+  height?: number;
+  color?: string;
+}
+
+const FREQ_LABELS = [
+  { freq: 100, label: '100' },
+  { freq: 1000, label: '1k' },
+  { freq: 10000, label: '10k' },
+];
+
+const LOG_MIN = Math.log10(20);
+const LOG_MAX = Math.log10(20000);
+
+export function FilterResponseCurve({
+  frequency,
+  resonance,
+  filterType,
+  width = 160,
+  height = 100,
+  color = '#10b981',
+}: FilterResponseCurveProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    if (canvas.width !== width * dpr || canvas.height !== height * dpr) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.scale(dpr, dpr);
+    }
+
+    const labelH = 13;
+    const drawH = height - labelH;
+    // dB range: -48 to +18
+    const DB_MIN = -48;
+    const DB_MAX = 18;
+    const DB_RANGE = DB_MAX - DB_MIN;
+
+    const xForFreq = (f: number) => {
+      const logF = Math.log10(f);
+      return ((logF - LOG_MIN) / (LOG_MAX - LOG_MIN)) * width;
+    };
+    const yForDb = (db: number) => {
+      const clamped = Math.max(DB_MIN, Math.min(DB_MAX, db));
+      return drawH - ((clamped - DB_MIN) / DB_RANGE) * (drawH - 4);
+    };
+
+    // ── Background ──────────────────────────────────────────────────────────
+    ctx.clearRect(0, 0, width, height);
+
+    // Subtle horizontal gradient hinting at the passband zone
+    const bgGrad = ctx.createLinearGradient(0, 0, 0, drawH);
+    bgGrad.addColorStop(0, 'rgba(8, 12, 24, 0.95)');
+    bgGrad.addColorStop(1, 'rgba(6, 10, 20, 0.95)');
+    ctx.fillStyle = bgGrad;
+    ctx.fillRect(0, 0, width, height);
+
+    // Label area
+    ctx.fillStyle = 'rgba(0,0,0,0.2)';
+    ctx.fillRect(0, drawH, width, labelH);
+
+    // ── dB grid ─────────────────────────────────────────────────────────────
+    ctx.font = '7px monospace';
+    for (const db of [0, -12, -24, -36]) {
+      const y = yForDb(db);
+      ctx.strokeStyle = db === 0 ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.04)';
+      ctx.lineWidth = 0.5;
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+      if (db <= 0) {
+        ctx.fillStyle = 'rgba(255,255,255,0.18)';
+        ctx.textAlign = 'left';
+        ctx.fillText(`${db}`, 2, y - 1);
+      }
+    }
+
+    // ── Frequency grid + labels ──────────────────────────────────────────────
+    for (const { freq, label } of FREQ_LABELS) {
+      const x = xForFreq(freq);
+      ctx.strokeStyle = 'rgba(255,255,255,0.05)';
+      ctx.lineWidth = 0.5;
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, drawH);
+      ctx.stroke();
+      // Tick
+      ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(x, drawH);
+      ctx.lineTo(x, drawH + 3);
+      ctx.stroke();
+      ctx.fillStyle = 'rgba(255,255,255,0.22)';
+      ctx.textAlign = 'center';
+      ctx.fillText(label, x, height - 2);
+    }
+
+    // ── Generate and draw response curve ────────────────────────────────────
+    const pts = generateFilterResponse(frequency, resonance, filterType, 200);
+
+    // Fill area under the curve (toward 0dB line for visual clarity)
+    const zeroY = yForDb(0);
+    ctx.beginPath();
+    for (let i = 0; i < pts.length; i++) {
+      const x = xForFreq(pts[i].freq);
+      const y = yForDb(pts[i].db);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    // Close toward 0dB line
+    ctx.lineTo(xForFreq(pts[pts.length - 1].freq), zeroY);
+    ctx.lineTo(xForFreq(pts[0].freq), zeroY);
+    ctx.closePath();
+
+    const fillGrad = ctx.createLinearGradient(0, 0, 0, drawH);
+    fillGrad.addColorStop(0, `${color}40`);
+    fillGrad.addColorStop(0.5, `${color}20`);
+    fillGrad.addColorStop(1, `${color}05`);
+    ctx.fillStyle = fillGrad;
+    ctx.fill();
+
+    // Curve stroke with glow
+    ctx.save();
+    ctx.shadowBlur = 5;
+    ctx.shadowColor = `${color}70`;
+    ctx.beginPath();
+    for (let i = 0; i < pts.length; i++) {
+      const x = xForFreq(pts[i].freq);
+      const y = yForDb(pts[i].db);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+    ctx.restore();
+
+    // ── Cutoff frequency marker ──────────────────────────────────────────────
+    const fcX = xForFreq(Math.max(20, Math.min(20000, frequency)));
+
+    // Dashed vertical line
+    ctx.strokeStyle = `${color}55`;
+    ctx.lineWidth = 0.75;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(fcX, 4);
+    ctx.lineTo(fcX, drawH - 2);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Cutoff frequency label
+    const freqLabel = frequency >= 1000
+      ? `${(frequency / 1000).toFixed(frequency >= 10000 ? 0 : 1)}k`
+      : `${Math.round(frequency)}`;
+    ctx.font = '7px monospace';
+    ctx.fillStyle = `${color}cc`;
+    // Avoid edges
+    const labelX = Math.max(10, Math.min(fcX, width - 18));
+    ctx.textAlign = fcX > width * 0.7 ? 'right' : 'center';
+    ctx.fillText(freqLabel, labelX, 10);
+
+    // Dot at the curve's cutoff point
+    const fcDb = pts.reduce((closest, p) => {
+      return Math.abs(p.freq - frequency) < Math.abs(closest.freq - frequency) ? p : closest;
+    }, pts[0]);
+    const dotY = yForDb(fcDb.db);
+    ctx.save();
+    ctx.shadowBlur = 6;
+    ctx.shadowColor = color;
+    ctx.beginPath();
+    ctx.arc(fcX, dotY, 2.5, 0, Math.PI * 2);
+    ctx.fillStyle = color;
+    ctx.fill();
+    ctx.restore();
+    // White highlight on dot
+    ctx.beginPath();
+    ctx.arc(fcX - 0.5, dotY - 0.5, 0.8, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(255,255,255,0.5)';
+    ctx.fill();
+
+    // ── Filter type badge ────────────────────────────────────────────────────
+    const typeLabels: Record<FilterType, string> = { lowpass: 'LP', highpass: 'HP', bandpass: 'BP' };
+    const badge = typeLabels[filterType];
+    ctx.font = '7px monospace';
+    const bw = ctx.measureText(badge).width + 6;
+    ctx.fillStyle = `${color}20`;
+    ctx.beginPath();
+    ctx.roundRect(width - bw - 2, height - 12, bw, 10, 2);
+    ctx.fill();
+    ctx.fillStyle = `${color}cc`;
+    ctx.textAlign = 'center';
+    ctx.fillText(badge, width - bw / 2 - 2, height - 4);
+  }, [frequency, resonance, filterType, width, height, color]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ width, height }}
+      className="rounded"
+      data-testid="filter-response-curve"
+    />
+  );
+}

--- a/src/utils/__tests__/filterResponse.test.ts
+++ b/src/utils/__tests__/filterResponse.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { filterMagnitudeDb, generateFilterResponse } from '../filterResponse';
+
+describe('filterResponse', () => {
+  describe('filterMagnitudeDb', () => {
+    describe('lowpass', () => {
+      it('has 0dB gain at very low frequencies (well below cutoff)', () => {
+        // 100Hz cutoff, check at 1Hz — should be near 0dB
+        const db = filterMagnitudeDb(1, 100, 0.707, 'lowpass');
+        expect(db).toBeCloseTo(0, 0);
+      });
+
+      it('rolls off well above cutoff', () => {
+        // 1kHz cutoff, check at 10kHz (1 decade above)
+        const db = filterMagnitudeDb(10000, 1000, 0.707, 'lowpass');
+        expect(db).toBeLessThan(-20);
+      });
+
+      it('resonance creates a peak near cutoff', () => {
+        // With high Q, there should be a peak near the cutoff frequency
+        const atCutoff = filterMagnitudeDb(1000, 1000, 8, 'lowpass');
+        const belowCutoff = filterMagnitudeDb(500, 1000, 8, 'lowpass');
+        expect(atCutoff).toBeGreaterThan(belowCutoff);
+      });
+
+      it('at cutoff with Q=0.707 (Butterworth), gain is ~-3dB', () => {
+        const db = filterMagnitudeDb(1000, 1000, 0.707, 'lowpass');
+        expect(db).toBeCloseTo(-3, 0);
+      });
+    });
+
+    describe('highpass', () => {
+      it('has 0dB gain at very high frequencies (well above cutoff)', () => {
+        const db = filterMagnitudeDb(20000, 1000, 0.707, 'highpass');
+        expect(db).toBeCloseTo(0, 0);
+      });
+
+      it('rolls off well below cutoff', () => {
+        const db = filterMagnitudeDb(10, 1000, 0.707, 'highpass');
+        expect(db).toBeLessThan(-20);
+      });
+
+      it('at cutoff with Q=0.707, gain is ~-3dB', () => {
+        const db = filterMagnitudeDb(1000, 1000, 0.707, 'highpass');
+        expect(db).toBeCloseTo(-3, 0);
+      });
+    });
+
+    describe('bandpass', () => {
+      it('passes signal at center frequency', () => {
+        const db = filterMagnitudeDb(1000, 1000, 2, 'bandpass');
+        expect(db).toBeGreaterThan(-6);
+      });
+
+      it('attenuates well above and below center', () => {
+        const dbLow = filterMagnitudeDb(50, 1000, 2, 'bandpass');
+        const dbHigh = filterMagnitudeDb(20000, 1000, 2, 'bandpass');
+        expect(dbLow).toBeLessThan(-12);
+        expect(dbHigh).toBeLessThan(-12);
+      });
+
+      it('higher Q gives higher peak gain at center frequency', () => {
+        // Web Audio BPF: higher Q → narrower bandwidth, higher center gain
+        const lowQ = filterMagnitudeDb(1000, 1000, 1, 'bandpass');
+        const highQ = filterMagnitudeDb(1000, 1000, 8, 'bandpass');
+        expect(highQ).toBeGreaterThan(lowQ);
+      });
+    });
+
+    it('returns finite numbers for all filter types and frequencies', () => {
+      const types = ['lowpass', 'highpass', 'bandpass'] as const;
+      const freqs = [20, 100, 500, 1000, 5000, 10000, 20000];
+      for (const type of types) {
+        for (const f of freqs) {
+          const db = filterMagnitudeDb(f, 1000, 2, type);
+          expect(isFinite(db)).toBe(true);
+          expect(db).toBeGreaterThan(-120); // not below noise floor
+          expect(db).toBeLessThan(30);      // not unreasonably large
+        }
+      }
+    });
+  });
+
+  describe('generateFilterResponse', () => {
+    it('generates correct number of points', () => {
+      const pts = generateFilterResponse(1000, 2, 'lowpass', 100);
+      expect(pts).toHaveLength(101);
+    });
+
+    it('first point is at 20Hz', () => {
+      const pts = generateFilterResponse(1000, 2, 'lowpass');
+      expect(pts[0].freq).toBeCloseTo(20, 0);
+    });
+
+    it('last point is at 20000Hz', () => {
+      const pts = generateFilterResponse(1000, 2, 'lowpass');
+      expect(pts[pts.length - 1].freq).toBeCloseTo(20000, 0);
+    });
+
+    it('frequencies are monotonically increasing', () => {
+      const pts = generateFilterResponse(1000, 2, 'lowpass');
+      for (let i = 1; i < pts.length; i++) {
+        expect(pts[i].freq).toBeGreaterThan(pts[i - 1].freq);
+      }
+    });
+
+    it('all dB values are finite', () => {
+      const pts = generateFilterResponse(1000, 4, 'bandpass');
+      for (const p of pts) {
+        expect(isFinite(p.db)).toBe(true);
+      }
+    });
+  });
+});

--- a/src/utils/filterResponse.ts
+++ b/src/utils/filterResponse.ts
@@ -1,0 +1,118 @@
+/**
+ * filterResponse.ts — Pure math for biquad filter frequency response visualization.
+ *
+ * Computes magnitude response in dB for lowpass/highpass/bandpass filters
+ * using the standard biquad transfer function evaluated on the unit circle.
+ *
+ * Reference: Audio EQ Cookbook (Robert Bristow-Johnson)
+ */
+
+export type FilterType = 'lowpass' | 'highpass' | 'bandpass';
+
+const SAMPLE_RATE = 44100;
+const TWO_PI = 2 * Math.PI;
+
+/**
+ * Compute biquad filter magnitude in dB at the given frequency.
+ * @param freq       Evaluation frequency in Hz
+ * @param cutoff     Filter cutoff frequency in Hz
+ * @param Q          Resonance / quality factor
+ * @param filterType Filter type
+ */
+export function filterMagnitudeDb(
+  freq: number,
+  cutoff: number,
+  Q: number,
+  filterType: FilterType,
+): number {
+  // Normalize cutoff to [0, 1] in terms of Nyquist
+  const w0 = (TWO_PI * cutoff) / SAMPLE_RATE;
+  const cosW0 = Math.cos(w0);
+  const sinW0 = Math.sin(w0);
+  const alpha = sinW0 / (2 * Math.max(Q, 0.1));
+
+  // Biquad coefficients (b0, b1, b2, a0, a1, a2)
+  let b0: number, b1: number, b2: number, a0: number, a1: number, a2: number;
+
+  switch (filterType) {
+    case 'lowpass':
+      b0 = (1 - cosW0) / 2;
+      b1 = 1 - cosW0;
+      b2 = (1 - cosW0) / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha;
+      break;
+    case 'highpass':
+      b0 = (1 + cosW0) / 2;
+      b1 = -(1 + cosW0);
+      b2 = (1 + cosW0) / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha;
+      break;
+    case 'bandpass':
+      // BPF (peak gain = Q)
+      b0 = sinW0 / 2;
+      b1 = 0;
+      b2 = -sinW0 / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosW0;
+      a2 = 1 - alpha;
+      break;
+  }
+
+  // Normalize by a0
+  const B0 = b0 / a0, B1 = b1 / a0, B2 = b2 / a0;
+  const A1 = a1 / a0, A2 = a2 / a0;
+
+  // Evaluate H(e^jw) where w = 2π * freq / sampleRate
+  const w = (TWO_PI * freq) / SAMPLE_RATE;
+  const cosW = Math.cos(w);
+  const sinW = Math.sin(w);
+  const cos2W = Math.cos(2 * w);
+  const sin2W = Math.sin(2 * w);
+
+  // H(z) = (B0 + B1*z^-1 + B2*z^-2) / (1 + A1*z^-1 + A2*z^-2)
+  // At z = e^jw: z^-1 = e^-jw = cosW - j*sinW, z^-2 = cos2W - j*sin2W
+  const numRe = B0 + B1 * cosW + B2 * cos2W;
+  const numIm = -(B1 * sinW + B2 * sin2W);
+  const denRe = 1 + A1 * cosW + A2 * cos2W;
+  const denIm = -(A1 * sinW + A2 * sin2W);
+
+  const numMag2 = numRe * numRe + numIm * numIm;
+  const denMag2 = denRe * denRe + denIm * denIm;
+
+  if (denMag2 < 1e-30) return -120;
+
+  const magnitude = Math.sqrt(numMag2 / denMag2);
+  return 20 * Math.log10(Math.max(magnitude, 1e-6));
+}
+
+export interface FilterResponsePoint {
+  freq: number;  // Hz (log-spaced 20–20000)
+  db: number;    // Magnitude in dB
+}
+
+/**
+ * Generate frequency response curve on a log scale 20Hz–20kHz.
+ */
+export function generateFilterResponse(
+  cutoff: number,
+  Q: number,
+  filterType: FilterType,
+  steps: number = 120,
+): FilterResponsePoint[] {
+  const points: FilterResponsePoint[] = [];
+  const logMin = Math.log10(20);
+  const logMax = Math.log10(20000);
+
+  for (let i = 0; i <= steps; i++) {
+    const logF = logMin + ((logMax - logMin) * i) / steps;
+    const freq = Math.pow(10, logF);
+    const db = filterMagnitudeDb(freq, cutoff, Q, filterType);
+    points.push({ freq, db: Math.max(-60, Math.min(24, db)) });
+  }
+
+  return points;
+}


### PR DESCRIPTION
## Summary
- Adds `FilterResponseCurve` canvas component (160×100px) for Filter effect card
- Biquad magnitude response using Web Audio EQ Cookbook formulas (exact same math as Web Audio API)
- Log-frequency X axis (20Hz–20kHz), dB Y axis with grid lines
- LP/HP/BP curves — lowpass rolloff, highpass rolloff, bandpass peak all correctly shaped
- Resonance peak visible as Q increases
- Cutoff frequency marker: dashed vertical line + Hz label + glowing dot on curve
- Filter type badge (LP/HP/BP) in bottom-right pill
- Gradient fill + glow on curve stroke

## Test plan
- [x] 16 unit tests for `filterMagnitudeDb` and `generateFilterResponse`
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3701 passed
- [x] `npm run build` — success
- [x] Visual verification: LP curve at 1.8kHz clearly visible

Closes #1292
Part of #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)