### PR TITLE
feat: UI aesthetic polish — tighter spacing, glass menus, tabular-nums, canvas theme

### DIFF
--- a/src/components/mixer/EffectCardLayout.tsx
+++ b/src/components/mixer/EffectCardLayout.tsx
@@ -21,22 +21,40 @@ interface EffectCardLayoutProps {
 
 export function EffectCardLayout({ mode, visualization, children, footer, color }: EffectCardLayoutProps) {
   return (
-    <div className="flex flex-col items-center w-full px-6 py-5">
+    <div className="flex flex-col items-center w-full px-4 py-4">
       {/* Constrained content — prevents full-width stretching */}
-      <div className="w-full max-w-[800px] flex flex-col items-center gap-6">
+      <div className="w-full max-w-[800px] flex flex-col items-center gap-3">
         {mode && (
-          <div className="flex items-center gap-0.5 rounded-md bg-white/[0.04] p-1">{mode}</div>
+          <div
+            className="flex items-center gap-0.5 rounded-md p-1"
+            style={{
+              background: 'rgba(255,255,255,0.03)',
+              backdropFilter: 'blur(8px)',
+              WebkitBackdropFilter: 'blur(8px)',
+              border: '1px solid rgba(255,255,255,0.06)',
+            }}
+          >
+            {mode}
+          </div>
         )}
         {visualization && (
           <div
-            className="w-full min-h-[60px] rounded-md overflow-hidden border border-white/[0.04]"
-            style={{ borderColor: color ? `${color}18` : undefined }}
+            className="w-full min-h-[60px] rounded-md overflow-hidden"
+            style={{
+              borderColor: color ? `${color}18` : 'rgba(255,255,255,0.04)',
+              border: `1px solid ${color ? `${color}18` : 'rgba(255,255,255,0.04)'}`,
+              boxShadow: `
+                0 1px 3px rgba(0,0,0,0.3),
+                0 4px 12px rgba(0,0,0,0.2),
+                inset 0 1px 0 rgba(255,255,255,0.04)
+              `,
+            }}
           >
             {visualization}
           </div>
         )}
         {/* Parameters — evenly spaced horizontal row */}
-        <div className="flex flex-wrap items-start justify-center gap-x-10 gap-y-5">
+        <div className="flex flex-wrap items-start justify-center gap-x-8 gap-y-4">
           {children}
         </div>
         {footer && (

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -2,18 +2,19 @@ import type { ReactNode } from 'react';
 
 /* ─── Shared context-menu design tokens ──────────────────────────────────── */
 export const CONTEXT_MENU = {
-  bg: '#2a2a2a',
-  border: '#444',
+  bg: 'rgba(32, 32, 36, 0.85)',
+  border: 'rgba(255, 255, 255, 0.08)',
   hoverBg: 'rgba(74, 95, 255, 0.25)', // daw-accent at 25%
   dangerColor: '#e74c3c',
   dangerHoverBg: 'rgba(231, 76, 60, 0.15)',
   textColor: '#d4d4d8', // zinc-300
   textDim: '#a1a1aa',   // zinc-400
-  separatorColor: '#444',
+  separatorColor: 'rgba(255, 255, 255, 0.06)',
   fontSize: 11,
   borderRadius: 8,
   minWidth: 160,
-  shadow: '0 4px 16px rgba(0,0,0,0.5)',
+  shadow: '0 2px 8px rgba(0,0,0,0.4), 0 8px 24px rgba(0,0,0,0.3)',
+  backdropFilter: 'blur(16px) saturate(1.2)',
 } as const;
 
 /* ─── Overlay + positioned wrapper ───────────────────────────────────────── */
@@ -62,6 +63,8 @@ export function ContextMenuWrapper({
           border: `1px solid ${CONTEXT_MENU.border}`,
           borderRadius: CONTEXT_MENU.borderRadius,
           boxShadow: CONTEXT_MENU.shadow,
+          backdropFilter: CONTEXT_MENU.backdropFilter,
+          WebkitBackdropFilter: CONTEXT_MENU.backdropFilter,
           padding: '4px 0',
           minWidth,
         }}
@@ -169,6 +172,8 @@ export function ContextMenuSubmenu({ children }: ContextMenuSubmenuProps) {
         border: `1px solid ${CONTEXT_MENU.border}`,
         borderRadius: CONTEXT_MENU.borderRadius,
         boxShadow: CONTEXT_MENU.shadow,
+        backdropFilter: CONTEXT_MENU.backdropFilter,
+        WebkitBackdropFilter: CONTEXT_MENU.backdropFilter,
         padding: '4px 0',
         minWidth: 130,
       }}

--- a/src/components/ui/Knob.tsx
+++ b/src/components/ui/Knob.tsx
@@ -305,8 +305,8 @@ export function Knob({
           {label}
         </span>
       )}
-      {/* Value */}
-      <span className="text-xs text-white/75 leading-tight font-mono font-medium">
+      {/* Value — tabular-nums prevents digit jitter during parameter changes */}
+      <span className="text-xs text-white/75 leading-tight font-mono font-medium" style={{ fontVariantNumeric: 'tabular-nums' }}>
         {displayValue}{unit && !formatValue ? unit : ''}
       </span>
     </div>

--- a/src/utils/__tests__/canvasTheme.test.ts
+++ b/src/utils/__tests__/canvasTheme.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { CANVAS_GRID } from '../canvasTheme';
+
+describe('canvasTheme', () => {
+  it('exports grid constants', () => {
+    expect(CANVAS_GRID.lineColor).toContain('rgba');
+    expect(CANVAS_GRID.labelColor).toContain('rgba');
+    expect(CANVAS_GRID.labelFont).toContain('monospace');
+    expect(CANVAS_GRID.zeroLineColor).toContain('rgba');
+  });
+
+  it('grid line color is subtle (low opacity)', () => {
+    // Verify the grid is not too bright
+    const match = CANVAS_GRID.lineColor.match(/[\d.]+\)$/);
+    expect(match).toBeTruthy();
+    const opacity = parseFloat(match![0]);
+    expect(opacity).toBeLessThan(0.15);
+  });
+});

--- a/src/utils/canvasTheme.ts
+++ b/src/utils/canvasTheme.ts
@@ -1,0 +1,74 @@
+/**
+ * canvasTheme — Shared visual constants for all canvas-based effect visualizations.
+ *
+ * Provides consistent background, grid, and accent styling across
+ * CompressorCurve, DistortionCurve, FilterResponseCurve, ReverbDecayCurve,
+ * DelayTapTimeline, and SpectrumAnalyzer.
+ */
+
+/** Standard canvas background with subtle vignette gradient. */
+export function drawCanvasBackground(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  accentColor?: string,
+) {
+  // Base gradient: dark center, darker edges (vignette)
+  const grad = ctx.createRadialGradient(
+    width / 2, height / 2, 0,
+    width / 2, height / 2, Math.max(width, height) * 0.7,
+  );
+  grad.addColorStop(0, 'rgba(12, 16, 28, 0.92)');
+  grad.addColorStop(1, 'rgba(4, 6, 14, 0.98)');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, width, height);
+
+  // Optional accent tint at center
+  if (accentColor) {
+    const tint = ctx.createRadialGradient(
+      width / 2, height * 0.6, 0,
+      width / 2, height * 0.6, width * 0.5,
+    );
+    tint.addColorStop(0, `${accentColor}08`);
+    tint.addColorStop(1, 'transparent');
+    ctx.fillStyle = tint;
+    ctx.fillRect(0, 0, width, height);
+  }
+}
+
+/** Standard grid lines for dB/frequency axes. */
+export const CANVAS_GRID = {
+  lineColor: 'rgba(255, 255, 255, 0.06)',
+  labelColor: 'rgba(255, 255, 255, 0.25)',
+  labelFont: '9px ui-monospace, monospace',
+  zeroLineColor: 'rgba(255, 255, 255, 0.12)',
+} as const;
+
+/** Draw a horizontal grid line. */
+export function drawHGridLine(
+  ctx: CanvasRenderingContext2D,
+  y: number,
+  width: number,
+  isZero = false,
+) {
+  ctx.strokeStyle = isZero ? CANVAS_GRID.zeroLineColor : CANVAS_GRID.lineColor;
+  ctx.lineWidth = isZero ? 0.75 : 0.5;
+  ctx.beginPath();
+  ctx.moveTo(0, y);
+  ctx.lineTo(width, y);
+  ctx.stroke();
+}
+
+/** Draw a vertical grid line. */
+export function drawVGridLine(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  height: number,
+) {
+  ctx.strokeStyle = CANVAS_GRID.lineColor;
+  ctx.lineWidth = 0.5;
+  ctx.beginPath();
+  ctx.moveTo(x, 0);
+  ctx.lineTo(x, height);
+  ctx.stroke();
+}

--- a/tests/unit/contextMenu.test.tsx
+++ b/tests/unit/contextMenu.test.tsx
@@ -8,9 +8,8 @@ import {
   CONTEXT_MENU,
 } from '../../src/components/ui/ContextMenu';
 
-// jsdom normalizes hex colors to rgb(), so we compare against that
-const RGB_BG = 'rgb(42, 42, 42)';        // #2a2a2a
-const RGB_BORDER = 'rgb(68, 68, 68)';     // #444
+// jsdom preserves rgba() strings as-is when set via style prop
+const EXPECTED_BG = CONTEXT_MENU.bg;
 const RGB_DANGER = 'rgb(231, 76, 60)';    // #e74c3c
 
 describe('ContextMenuWrapper', () => {
@@ -55,7 +54,7 @@ describe('ContextMenuWrapper', () => {
       </ContextMenuWrapper>,
     );
     const menu = screen.getByTestId('test-menu');
-    expect(menu.style.background).toBe(RGB_BG);
+    expect(menu.style.background).toBe(EXPECTED_BG);
     expect(menu.style.border).toContain('1px solid');
     expect(menu.style.borderRadius).toBe(`${CONTEXT_MENU.borderRadius}px`);
   });
@@ -157,7 +156,7 @@ describe('ContextMenuSeparator', () => {
   it('renders a separator line with consistent color', () => {
     const { container } = render(<ContextMenuSeparator />);
     const sep = container.firstChild as HTMLElement;
-    expect(sep.style.background).toBe(RGB_BORDER); // separatorColor = #444
+    expect(sep.style.background).toBe(CONTEXT_MENU.separatorColor);
     expect(sep.style.height).toBe('1px');
   });
 });
@@ -171,7 +170,7 @@ describe('ContextMenuSubmenu', () => {
     );
     expect(screen.getByText('Sub item')).toBeInTheDocument();
     const submenu = container.firstChild as HTMLElement;
-    expect(submenu.style.background).toBe(RGB_BG);
+    expect(submenu.style.background).toBe(EXPECTED_BG);
     expect(submenu.style.border).toContain('1px solid');
     expect(submenu.style.borderRadius).toBe(`${CONTEXT_MENU.borderRadius}px`);
   });


### PR DESCRIPTION
## Summary

- Tighter effect card spacing (px-6→px-4, gap-6→gap-3) for denser, more professional layout
- Frosted glass context menus with `backdrop-blur(16px)` and semi-transparent background
- Mode selector glass effect with `backdrop-blur(8px)` and subtle border
- Multi-layer box-shadow on visualization containers (outer shadow + inset highlight)
- `tabular-nums` on knob value displays to prevent digit jitter during parameter changes
- New `canvasTheme.ts` with shared vignette background and grid drawing helpers

Closes #1315

## Test plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 3723 passed, 0 failed
- [x] `npm run build` — success
- [x] Visual verification: compressor card, filter card, context menu confirmed working in dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)