### PR TITLE
feat: modulation visualizations for Chorus, Flanger, and Phaser effects

### DIFF
--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -12,6 +12,7 @@ import { DistortionCurve } from './DistortionCurve';
 import { ReverbDecayCurve } from './ReverbDecayCurve';
 import { DelayTapTimeline } from './DelayTapTimeline';
 import { FilterResponseCurve } from './FilterResponseCurve';
+import { ModulationDisplay } from './ModulationDisplay';
 import { useProjectStore } from '../../store/projectStore';
 import { effectsEngine } from '../../engine/EffectsEngine';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
@@ -1003,6 +1004,9 @@ export function ChorusCard({ effect, trackId }: { effect: TrackEffect & { type: 
   return (
     <EffectCardLayout
       color={EFFECT_COLORS.chorus}
+      visualization={
+        <ModulationDisplay type="chorus" rate={p.frequency} depth={p.depth} color={EFFECT_COLORS.chorus} />
+      }
       footer={
         <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'chorus', param: 'wet' }} normalizedValue={normalizeEffectParamValue('chorus', 'wet', p.wet) ?? 0.5}>
           <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color={EFFECT_COLORS.chorus} />
@@ -1038,6 +1042,9 @@ export function FlangerCard({ effect, trackId }: { effect: TrackEffect & { type:
   return (
     <EffectCardLayout
       color={EFFECT_COLORS.flanger}
+      visualization={
+        <ModulationDisplay type="flanger" rate={p.frequency} depth={p.depth} centerDelay={p.delayTime} feedback={p.feedback} color={EFFECT_COLORS.flanger} />
+      }
       footer={
         <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'flanger', param: 'wet' }} normalizedValue={normalizeEffectParamValue('flanger', 'wet', p.wet) ?? 0.5}>
           <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color={EFFECT_COLORS.flanger} />
@@ -1073,6 +1080,9 @@ export function PhaserCard({ effect, trackId }: { effect: TrackEffect & { type: 
   return (
     <EffectCardLayout
       color={EFFECT_COLORS.phaser}
+      visualization={
+        <ModulationDisplay type="phaser" rate={p.frequency} depth={p.octaves / 6} baseFreq={p.baseFrequency} stages={p.stages ?? 4} color={EFFECT_COLORS.phaser} />
+      }
       footer={
         <AutomationControlShell trackId={trackId} effect={effect} target={{ effectType: 'phaser', param: 'wet' }} normalizedValue={normalizeEffectParamValue('phaser', 'wet', p.wet) ?? 0.5}>
           <HSlider value={p.wet} onChange={(v) => update({ wet: v })} label="Dry/Wet" displayValue={`${Math.round(p.wet * 100)}%`} color={EFFECT_COLORS.phaser} />

--- a/src/components/mixer/ModulationDisplay.tsx
+++ b/src/components/mixer/ModulationDisplay.tsx
@@ -1,0 +1,277 @@
+/**
+ * ModulationDisplay — Shared LFO waveform visualization for Chorus, Flanger, and Phaser.
+ *
+ * Shows animated modulation waveforms:
+ * - Chorus: stereo LFO pair with phase offset
+ * - Flanger: delay sweep with feedback indicator
+ * - Phaser: frequency sweep arcs with notch indicators
+ */
+import { useRef, useEffect } from 'react';
+import {
+  generateStereoLfo,
+  generateCombSweep,
+  generatePhaserSweep,
+} from '../../utils/modulationWave';
+
+type ModulationType = 'chorus' | 'flanger' | 'phaser';
+
+interface ModulationDisplayProps {
+  type: ModulationType;
+  /** LFO rate in Hz */
+  rate: number;
+  /** Modulation depth (0–1) */
+  depth: number;
+  /** Additional params depending on type */
+  centerDelay?: number;  // Flanger: center delay ms
+  feedback?: number;     // Flanger: feedback amount
+  baseFreq?: number;     // Phaser: base frequency Hz
+  stages?: number;       // Phaser: allpass stages
+  width?: number;
+  height?: number;
+  /** Effect accent color */
+  color?: string;
+}
+
+export function ModulationDisplay({
+  type,
+  rate,
+  depth,
+  centerDelay = 3,
+  feedback = 0.5,
+  baseFreq = 1000,
+  stages = 4,
+  width = 160,
+  height = 100,
+  color = '#06b6d4',
+}: ModulationDisplayProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animRef = useRef<number>(0);
+  const phaseRef = useRef(0);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    if (canvas.width !== width * dpr || canvas.height !== height * dpr) {
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.scale(dpr, dpr);
+    }
+
+    let lastTime = 0;
+
+    function draw(timestamp: number) {
+      if (!ctx) return;
+      const dt = lastTime > 0 ? (timestamp - lastTime) / 1000 : 0;
+      lastTime = timestamp;
+
+      // Advance phase based on rate
+      phaseRef.current = (phaseRef.current + rate * dt) % 1.0;
+      const phase = phaseRef.current;
+
+      // Background
+      ctx.clearRect(0, 0, width, height);
+      const bg = ctx.createLinearGradient(0, 0, 0, height);
+      bg.addColorStop(0, 'rgba(8, 12, 24, 0.92)');
+      bg.addColorStop(1, 'rgba(4, 8, 18, 0.95)');
+      ctx.fillStyle = bg;
+      ctx.fillRect(0, 0, width, height);
+
+      // Center line
+      const cy = height / 2;
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
+      ctx.lineWidth = 0.5;
+      ctx.beginPath();
+      ctx.moveTo(0, cy);
+      ctx.lineTo(width, cy);
+      ctx.stroke();
+
+      switch (type) {
+        case 'chorus':
+          drawChorus(ctx, width, height, depth, phase, color);
+          break;
+        case 'flanger':
+          drawFlanger(ctx, width, height, centerDelay, depth, feedback, phase, color);
+          break;
+        case 'phaser':
+          drawPhaser(ctx, width, height, baseFreq, depth, stages, phase, color);
+          break;
+      }
+
+      animRef.current = requestAnimationFrame(draw);
+    }
+
+    animRef.current = requestAnimationFrame(draw);
+
+    return () => {
+      if (animRef.current) cancelAnimationFrame(animRef.current);
+    };
+  }, [type, rate, depth, centerDelay, feedback, baseFreq, stages, width, height, color]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ width, height }}
+      className="rounded"
+      data-testid="modulation-display"
+    />
+  );
+}
+
+function drawChorus(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  depth: number,
+  phase: number,
+  color: string,
+) {
+  const { left, right } = generateStereoLfo(depth, 0.25, 150);
+  const cy = h / 2;
+  const amp = (h / 2) * 0.8;
+
+  // Left channel (solid)
+  ctx.save();
+  ctx.shadowBlur = 4;
+  ctx.shadowColor = `${color}60`;
+  ctx.beginPath();
+  for (let i = 0; i < left.length; i++) {
+    const x = (left[i].x + phase) % 1.0;
+    const px = x * w;
+    const py = cy - left[i].y * amp;
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+  }
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+  ctx.restore();
+
+  // Right channel (dashed, dimmer)
+  ctx.beginPath();
+  for (let i = 0; i < right.length; i++) {
+    const x = (right[i].x + phase) % 1.0;
+    const px = x * w;
+    const py = cy - right[i].y * amp;
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+  }
+  ctx.strokeStyle = `${color}60`;
+  ctx.lineWidth = 1;
+  ctx.setLineDash([4, 3]);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Labels
+  ctx.font = '7px monospace';
+  ctx.fillStyle = `${color}bb`;
+  ctx.textAlign = 'left';
+  ctx.fillText('L', 3, 10);
+  ctx.fillStyle = `${color}55`;
+  ctx.fillText('R', 3, 20);
+}
+
+function drawFlanger(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  centerDelay: number,
+  depth: number,
+  feedback: number,
+  phase: number,
+  color: string,
+) {
+  const { delayLine } = generateCombSweep(centerDelay, depth, feedback, 150);
+  const margin = 10;
+  const drawH = h - margin;
+
+  // Delay sweep line
+  ctx.save();
+  ctx.shadowBlur = 4;
+  ctx.shadowColor = `${color}60`;
+  ctx.beginPath();
+  for (let i = 0; i < delayLine.length; i++) {
+    const x = ((delayLine[i].x + phase) % 1.0) * w;
+    const y = margin + (1 - delayLine[i].y) * (drawH - margin);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+  ctx.restore();
+
+  // Feedback indicator bar
+  const fbHeight = Math.abs(feedback) * (drawH * 0.3);
+  const fbY = h - fbHeight - 2;
+  ctx.fillStyle = feedback >= 0 ? `${color}25` : `#ef444425`;
+  ctx.fillRect(w - 12, fbY, 8, fbHeight);
+  ctx.strokeStyle = feedback >= 0 ? `${color}55` : '#ef444455';
+  ctx.lineWidth = 0.5;
+  ctx.strokeRect(w - 12, fbY, 8, fbHeight);
+
+  // Labels
+  ctx.font = '7px monospace';
+  ctx.fillStyle = `${color}bb`;
+  ctx.textAlign = 'left';
+  ctx.fillText(`${centerDelay.toFixed(1)}ms`, 3, 10);
+  ctx.fillStyle = `${color}66`;
+  ctx.textAlign = 'right';
+  ctx.fillText(`fb:${(feedback * 100).toFixed(0)}%`, w - 15, 10);
+}
+
+function drawPhaser(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  baseFreq: number,
+  depth: number,
+  stages: number,
+  phase: number,
+  color: string,
+) {
+  const { sweep, notchCount } = generatePhaserSweep(baseFreq, depth, stages, 150);
+  const margin = 12;
+  const drawH = h - margin;
+
+  // Frequency sweep line
+  ctx.save();
+  ctx.shadowBlur = 4;
+  ctx.shadowColor = `${color}60`;
+  ctx.beginPath();
+  for (let i = 0; i < sweep.length; i++) {
+    const x = ((sweep[i].x + phase) % 1.0) * w;
+    const y = margin + (1 - sweep[i].y) * (drawH - margin);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+  ctx.restore();
+
+  // Notch indicators (horizontal dashes at current sweep position)
+  const currentY = sweep[Math.floor(phase * sweep.length) % sweep.length]?.y ?? 0.5;
+  for (let n = 0; n < notchCount; n++) {
+    const notchY = margin + (1 - currentY) * (drawH - margin) + (n - notchCount / 2) * 8;
+    ctx.strokeStyle = `${color}40`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(w * 0.3, notchY);
+    ctx.lineTo(w * 0.7, notchY);
+    ctx.stroke();
+  }
+
+  // Labels
+  ctx.font = '7px monospace';
+  ctx.fillStyle = `${color}bb`;
+  ctx.textAlign = 'left';
+  const freqLabel = baseFreq >= 1000 ? `${(baseFreq / 1000).toFixed(1)}k` : `${Math.round(baseFreq)}`;
+  ctx.fillText(`${freqLabel}Hz`, 3, 10);
+  ctx.fillStyle = `${color}66`;
+  ctx.textAlign = 'right';
+  ctx.fillText(`${notchCount} notch`, w - 3, 10);
+}

--- a/src/utils/__tests__/modulationWave.test.ts
+++ b/src/utils/__tests__/modulationWave.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateLfoWave,
+  generateStereoLfo,
+  generateCombSweep,
+  generatePhaserSweep,
+} from '../modulationWave';
+
+describe('modulationWave', () => {
+  describe('generateLfoWave', () => {
+    it('sine wave has correct range (-1 to +1)', () => {
+      const pts = generateLfoWave('sine', 200);
+      const min = Math.min(...pts.map((p) => p.y));
+      const max = Math.max(...pts.map((p) => p.y));
+      expect(min).toBeGreaterThanOrEqual(-1.01);
+      expect(max).toBeLessThanOrEqual(1.01);
+      expect(min).toBeLessThan(-0.95);
+      expect(max).toBeGreaterThan(0.95);
+    });
+
+    it('triangle wave has correct range', () => {
+      const pts = generateLfoWave('triangle', 200);
+      const min = Math.min(...pts.map((p) => p.y));
+      const max = Math.max(...pts.map((p) => p.y));
+      expect(min).toBeGreaterThanOrEqual(-1.01);
+      expect(max).toBeLessThanOrEqual(1.01);
+    });
+
+    it('generates correct number of points', () => {
+      const pts = generateLfoWave('sine', 50);
+      expect(pts).toHaveLength(51); // 0..50 inclusive
+    });
+
+    it('x values span 0 to 1', () => {
+      const pts = generateLfoWave('sine', 100);
+      expect(pts[0].x).toBe(0);
+      expect(pts[pts.length - 1].x).toBe(1);
+    });
+
+    it('phase offset shifts the waveform', () => {
+      const noPhase = generateLfoWave('sine', 100, 0);
+      const withPhase = generateLfoWave('sine', 100, 0.25);
+      // At x=0, sine with 0 phase should be ~0, with 0.25 phase should be ~1
+      expect(Math.abs(noPhase[0].y)).toBeLessThan(0.1);
+      expect(withPhase[0].y).toBeGreaterThan(0.9);
+    });
+  });
+
+  describe('generateStereoLfo', () => {
+    it('returns left and right channels', () => {
+      const { left, right } = generateStereoLfo(0.5);
+      expect(left.length).toBeGreaterThan(0);
+      expect(right.length).toBeGreaterThan(0);
+      expect(left.length).toBe(right.length);
+    });
+
+    it('depth scales amplitude', () => {
+      const full = generateStereoLfo(1.0);
+      const half = generateStereoLfo(0.5);
+      const fullMax = Math.max(...full.left.map((p) => Math.abs(p.y)));
+      const halfMax = Math.max(...half.left.map((p) => Math.abs(p.y)));
+      expect(fullMax).toBeGreaterThan(halfMax * 1.5);
+    });
+
+    it('stereo channels are different (phase offset)', () => {
+      const { left, right } = generateStereoLfo(1.0, 0.25);
+      // At the first sample, L and R should differ
+      expect(Math.abs(left[0].y - right[0].y)).toBeGreaterThan(0.5);
+    });
+  });
+
+  describe('generateCombSweep', () => {
+    it('returns delay and feedback lines', () => {
+      const { delayLine, feedbackLine } = generateCombSweep(3, 0.7, 0.5);
+      expect(delayLine.length).toBeGreaterThan(0);
+      expect(feedbackLine.length).toBeGreaterThan(0);
+    });
+
+    it('delay line oscillates around center', () => {
+      const { delayLine } = generateCombSweep(5, 0.8, 0);
+      const values = delayLine.map((p) => p.y);
+      const min = Math.min(...values);
+      const max = Math.max(...values);
+      expect(max).toBeGreaterThan(min);
+    });
+  });
+
+  describe('generatePhaserSweep', () => {
+    it('returns sweep and notch count', () => {
+      const { sweep, notchCount } = generatePhaserSweep(1000, 0.7, 4);
+      expect(sweep.length).toBeGreaterThan(0);
+      expect(notchCount).toBe(2); // 4 stages / 2
+    });
+
+    it('sweep values are in 0–1 range (normalized log frequency)', () => {
+      const { sweep } = generatePhaserSweep(1000, 1.0, 6);
+      for (const p of sweep) {
+        expect(p.y).toBeGreaterThanOrEqual(0);
+        expect(p.y).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('higher depth gives wider sweep', () => {
+      const narrow = generatePhaserSweep(1000, 0.2, 4);
+      const wide = generatePhaserSweep(1000, 1.0, 4);
+      const narrowRange = Math.max(...narrow.sweep.map((p) => p.y)) - Math.min(...narrow.sweep.map((p) => p.y));
+      const wideRange = Math.max(...wide.sweep.map((p) => p.y)) - Math.min(...wide.sweep.map((p) => p.y));
+      expect(wideRange).toBeGreaterThan(narrowRange);
+    });
+  });
+});

--- a/src/utils/modulationWave.ts
+++ b/src/utils/modulationWave.ts
@@ -1,0 +1,148 @@
+/**
+ * modulationWave.ts — Pure math for LFO waveform visualization.
+ *
+ * Generates waveform data for the modulation effects (chorus, flanger, phaser)
+ * to display animated LFO curves in their effect cards.
+ */
+
+export type LfoShape = 'sine' | 'triangle';
+
+export interface ModulationWavePoint {
+  /** Normalized X position (0–1) */
+  x: number;
+  /** Waveform value (-1 to +1) */
+  y: number;
+}
+
+/**
+ * Generate one cycle of an LFO waveform.
+ *
+ * @param shape    Waveform shape
+ * @param steps    Number of points to generate
+ * @param phase    Phase offset (0–1, where 0.25 = 90°)
+ * @returns        Array of (x, y) points where y is -1..+1
+ */
+export function generateLfoWave(
+  shape: LfoShape,
+  steps: number = 100,
+  phase: number = 0,
+): ModulationWavePoint[] {
+  const points: ModulationWavePoint[] = [];
+
+  for (let i = 0; i <= steps; i++) {
+    const x = i / steps;
+    const t = (x + phase) % 1.0;
+    let y: number;
+
+    switch (shape) {
+      case 'sine':
+        y = Math.sin(t * 2 * Math.PI);
+        break;
+      case 'triangle':
+        if (t < 0.25) y = t * 4;
+        else if (t < 0.75) y = 2 - t * 4;
+        else y = t * 4 - 4;
+        break;
+    }
+
+    points.push({ x, y });
+  }
+
+  return points;
+}
+
+/**
+ * Generate stereo LFO pair with phase offset for chorus visualization.
+ *
+ * @param rate       LFO rate in Hz (visual only — determines label)
+ * @param depth      Modulation depth (0–1, scales the amplitude)
+ * @param stereoOffset Phase offset between L and R (0–0.5, default 0.25 = 90°)
+ * @param steps      Number of points
+ */
+export function generateStereoLfo(
+  depth: number,
+  stereoOffset: number = 0.25,
+  steps: number = 100,
+): { left: ModulationWavePoint[]; right: ModulationWavePoint[] } {
+  const left = generateLfoWave('sine', steps, 0).map((p) => ({
+    ...p,
+    y: p.y * depth,
+  }));
+  const right = generateLfoWave('sine', steps, stereoOffset).map((p) => ({
+    ...p,
+    y: p.y * depth,
+  }));
+
+  return { left, right };
+}
+
+/**
+ * Generate comb filter frequency sweep path for flanger visualization.
+ *
+ * @param centerDelay Center delay in ms
+ * @param depth       Modulation depth (0–1)
+ * @param feedback    Feedback amount (-1..+1)
+ * @param steps       Number of points
+ */
+export function generateCombSweep(
+  centerDelay: number,
+  depth: number,
+  feedback: number,
+  steps: number = 100,
+): { delayLine: ModulationWavePoint[]; feedbackLine: ModulationWavePoint[] } {
+  const delayLine: ModulationWavePoint[] = [];
+  const feedbackLine: ModulationWavePoint[] = [];
+
+  for (let i = 0; i <= steps; i++) {
+    const x = i / steps;
+    const t = x * 2 * Math.PI;
+    const lfo = Math.sin(t);
+    const delay = centerDelay + lfo * centerDelay * depth;
+
+    delayLine.push({
+      x,
+      y: delay / (centerDelay * 2), // Normalize to 0–1 range
+    });
+
+    feedbackLine.push({
+      x,
+      y: Math.abs(feedback), // Constant line showing feedback amount
+    });
+  }
+
+  return { delayLine, feedbackLine };
+}
+
+/**
+ * Generate frequency sweep arcs for phaser visualization.
+ *
+ * @param baseFreq   Base frequency in Hz
+ * @param depth      Sweep depth (0–1, maps to octave range)
+ * @param stages     Number of allpass stages (notch count = stages/2)
+ * @param steps      Number of points
+ */
+export function generatePhaserSweep(
+  baseFreq: number,
+  depth: number,
+  stages: number,
+  steps: number = 100,
+): { sweep: ModulationWavePoint[]; notchCount: number } {
+  const sweep: ModulationWavePoint[] = [];
+  const octaveRange = 3; // 3 octave sweep range
+
+  for (let i = 0; i <= steps; i++) {
+    const x = i / steps;
+    const t = x * 2 * Math.PI;
+    const lfo = Math.sin(t);
+    // Frequency modulation in octave space
+    const freqMod = baseFreq * Math.pow(2, lfo * depth * octaveRange);
+    // Normalize to log scale for display (20Hz–20kHz → 0–1)
+    const logMin = Math.log10(20);
+    const logMax = Math.log10(20000);
+    const normalized = (Math.log10(Math.max(20, Math.min(20000, freqMod))) - logMin) / (logMax - logMin);
+
+    sweep.push({ x, y: normalized });
+  }
+
+  return { sweep, notchCount: Math.floor(stages / 2) };
+}


### PR DESCRIPTION
## Summary

- Animated LFO waveform displays for all three modulation effect cards
- **Chorus**: stereo LFO pair (solid L + dashed R with 90° phase offset)
- **Flanger**: delay sweep line + feedback indicator bar
- **Phaser**: frequency sweep arc with notch position indicators
- All animate at 60fps synced to the Rate parameter
- 13 unit tests for modulation math utilities

Closes #1307

## Test plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 3736 passed, 0 failed
- [x] Visual: Chorus stereo waveform confirmed in dev server
- [x] Visual: Flanger delay sweep + feedback bar confirmed
- [x] Visual: Phaser frequency arc + notch indicators confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)