### PR TITLE
feat: knob magnetic snap near default + reset brightness pulse + detent marker

### DIFF
--- a/src/components/ui/Knob.tsx
+++ b/src/components/ui/Knob.tsx
@@ -80,9 +80,22 @@ export function Knob({
       if (!dragStart.current) return;
       const range = max - min;
       const fine = mv.altKey;
-      const sensitivity = fine ? range / 2000 : range / 200;
+      let sensitivity = fine ? range / 2000 : range / 200;
+
+      // Magnetic snap: reduce sensitivity near default value
+      const snapZone = range * 0.03; // 3% of range
+      if (Math.abs(dragStart.current.value - defaultValue) < snapZone) {
+        sensitivity *= 0.5;
+      }
+
       const delta = mv.movementY * sensitivity;
-      const newVal = applyStep(dragStart.current.value + delta);
+      let newVal = applyStep(dragStart.current.value + delta);
+
+      // Snap to exact default if within snap zone
+      if (Math.abs(newVal - defaultValue) < snapZone * 0.3) {
+        newVal = defaultValue;
+      }
+
       dragStart.current = { y: mv.clientY, value: newVal };
       setIsFineMode(fine);
       onChange(newVal);
@@ -250,6 +263,36 @@ export function Knob({
               filter={isDragging ? 'url(#knob-glow)' : undefined}
               style={isResetting ? { transition: 'd 200ms ease-out' } : undefined}
             />
+
+            {/* Default value detent marker — tiny tick on the track */}
+            {(() => {
+              const defAngle = valueToAngle(defaultValue, min, max, arc);
+              const defPos = polarToXY(defAngle - 90, trackR);
+              return (
+                <circle
+                  cx={defPos.x}
+                  cy={defPos.y}
+                  r={1}
+                  fill="rgba(255,255,255,0.15)"
+                />
+              );
+            })()}
+
+            {/* Reset brightness pulse */}
+            {isResetting && (
+              <circle
+                cx={radius}
+                cy={radius}
+                r={trackR + strokeWidth}
+                fill="none"
+                stroke={color}
+                strokeWidth={1}
+                opacity={0.6}
+                style={{
+                  animation: 'knob-pulse 200ms ease-out forwards',
+                }}
+              />
+            )}
 
             {/* Minimal center anchor */}
             <circle

--- a/src/index.css
+++ b/src/index.css
@@ -148,6 +148,11 @@ select:focus-visible,
   100% { transform: translate(-50%, -50%) scale(2.5); opacity: 0; }
 }
 
+@keyframes knob-pulse {
+  0% { opacity: 0.6; }
+  100% { opacity: 0; }
+}
+
 /* ═══════════════════════════════════════════════════════════════
    THEME STRUCTURAL OVERRIDES
    Each DAW theme changes: border-radius, shadows, borders,


### PR DESCRIPTION
## Summary

- **Magnetic snap**: Drag sensitivity halves within 3% of default value, snaps to exact default within 1%
- **Default detent marker**: Tiny dot on arc track at default position
- **Reset brightness pulse**: Colored ring fades out on double-click reset
- No audio parameter lag — only visual smoothing

Closes #1320

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3744 passed
- [x] Visual: compressor knobs show detent markers in dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)