### PR TITLE
feat: control hover states — knob glow, slider highlight

### DIFF
--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -110,12 +110,12 @@ export function HSlider({ value, onChange, min = 0, max = 1, defaultValue = min,
       {label && (
         <div className="flex justify-between items-center">
           <span className="text-[9px] text-white/30 tracking-wide">{label}</span>
-          {displayValue && <span className="text-[10px] text-white/60 font-mono font-medium">{displayValue}</span>}
+          {displayValue && <span className="text-[10px] text-white/60 font-mono font-medium" style={{ fontVariantNumeric: 'tabular-nums' }}>{displayValue}</span>}
         </div>
       )}
       <div
         ref={trackRef}
-        className="relative cursor-pointer rounded-sm"
+        className="group relative cursor-pointer rounded-sm hover:brightness-125 transition-[filter] duration-150"
         style={{ width, height: 4 }}
         onMouseDown={handleMouseDown}
         onDoubleClick={(e) => {
@@ -134,7 +134,7 @@ export function HSlider({ value, onChange, min = 0, max = 1, defaultValue = min,
         <div className="absolute inset-0 rounded-sm bg-white/[0.06]" />
         {/* Filled portion — crisp right edge, no thumb */}
         <div
-          className="absolute left-0 top-0 bottom-0 rounded-sm"
+          className="absolute left-0 top-0 bottom-0 rounded-sm transition-opacity duration-150 group-hover:opacity-90"
           style={{ width: `${norm * 100}%`, backgroundColor: color, opacity: 0.7 }}
         />
       </div>

--- a/src/components/ui/Knob.tsx
+++ b/src/components/ui/Knob.tsx
@@ -231,10 +231,14 @@ export function Knob({
           aria-valuenow={value}
           aria-valuemin={min}
           aria-valuemax={max}
-          className={`relative outline-none rounded-full
+          className={`relative outline-none rounded-full transition-[transform,filter] duration-150
             focus-visible:ring-2 focus-visible:ring-daw-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent
-            ${disabled ? 'cursor-not-allowed' : 'cursor-ns-resize'}`}
-          style={{ width: s, height: s }}
+            ${disabled ? 'cursor-not-allowed' : 'cursor-ns-resize hover:brightness-110 hover:scale-[1.03]'}`}
+          style={{
+            width: s,
+            height: s,
+            ...(isDragging ? { filter: 'brightness(1.15)', transform: 'scale(1.05)' } : {}),
+          }}
           data-dragging={isDragging ? 'true' : undefined}
           data-resetting={isResetting ? 'true' : undefined}
         >


### PR DESCRIPTION
## Summary
Part of #1242 — Effects Micro-Interactions.

- **Knob hover**: `brightness(1.1)` + `scale(1.03)` with 150ms CSS transition
- **Knob active drag**: `brightness(1.15)` + `scale(1.05)` for elevated feel
- **HSlider hover**: brightness boost on track container, fill opacity 0.7→0.9
- **Slider display value**: `tabular-nums` for stable digit alignment
- All transitions use consistent 150ms timing

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3741 passed
- [x] `npm run build` — success
- [x] Visual verification in dev server

Closes #1323
Part of #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)