### PR TITLE
feat: bypass watermark overlay on effect chain

### DIFF
--- a/src/components/mixer/EffectChain.tsx
+++ b/src/components/mixer/EffectChain.tsx
@@ -669,6 +669,14 @@ export function EffectChain() {
 
       {/* ── Full-width selected effect view ── */}
       <div className={`flex-1 overflow-y-auto relative transition-all duration-200 ease-in-out ${track.effectsBypassed ? 'opacity-45 grayscale' : 'opacity-100 grayscale-0'}`}>
+        {/* Bypass watermark overlay */}
+        {track.effectsBypassed && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
+            <span className="text-white/[0.08] text-4xl font-bold tracking-[0.3em] uppercase select-none rotate-[-12deg]">
+              BYPASSED
+            </span>
+          </div>
+        )}
         {selectedEffect ? (
           <div className="h-full">
             {/* Device header — integrated into the full-width view */}


### PR DESCRIPTION
## Summary
Part of #1242 — Effects Micro-Interactions.

Adds a diagonal "BYPASSED" watermark overlay when the full effect chain is bypassed. Complements the existing `opacity-45 grayscale` transition with a clear text indicator.

- Rotated -12deg, 8% white opacity, wide letter-spacing (0.3em)
- `pointer-events-none` so it doesn't block interaction
- z-10 overlay above the dimmed effect content

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3741 passed
- [x] `npm run build` — success
- [x] Visual verification: watermark visible when bypass active, disappears when off

Part of #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)