### PR TITLE
fix: strengthen 43 weak assertions in top 3 offender test files

### DIFF
--- a/src/store/__tests__/projectStore.test.ts
+++ b/src/store/__tests__/projectStore.test.ts
@@ -47,7 +47,6 @@ describe('projectStore', () => {
     it('assigns a unique id', () => {
       useProjectStore.getState().createProject();
       const project = useProjectStore.getState().project;
-      expect(project!.id).toBeDefined();
       expect(typeof project!.id).toBe('string');
       expect(project!.id.length).toBeGreaterThan(0);
     });
@@ -138,16 +137,14 @@ describe('projectStore', () => {
 
     it('adds a stems track', () => {
       const track = useProjectStore.getState().addTrack('drums');
-      expect(track).toBeDefined();
-      expect(track.trackName).toBe('drums');
-      expect(track.trackType).toBe('stems');
+      expect(track).toMatchObject({ trackName: 'drums', trackType: 'stems' });
       expect(useProjectStore.getState().project!.tracks).toHaveLength(1);
     });
 
     it('adds a sequencer track with pattern initialized', () => {
       const track = useProjectStore.getState().addTrack('drums', 'sequencer');
       expect(track.trackType).toBe('sequencer');
-      expect(track.sequencerPattern).toBeDefined();
+      expect(track.sequencerPattern).toMatchObject({ stepsPerBar: 16 });
       expect(track.sequencerPattern!.rows.length).toBeGreaterThan(0);
       expect(track.sequencerPattern!.stepsPerBar).toBe(16);
     });
@@ -245,9 +242,7 @@ describe('projectStore', () => {
         rootNote: 57,
       });
 
-      expect(track).toBeDefined();
-      expect(track?.trackType).toBe('pianoRoll');
-      expect(track?.synthPreset).toBe('sampler');
+      expect(track).toMatchObject({ trackType: 'pianoRoll', synthPreset: 'sampler' });
       expect(track?.instrument).toMatchObject({
         kind: 'sampler',
         settings: {
@@ -373,7 +368,7 @@ describe('projectStore', () => {
       });
 
       const asset = useProjectStore.getState().project!.assets?.[0];
-      expect(asset).toBeDefined();
+      expect(asset).toMatchObject({ source: 'generated', isolatedAudioKey: 'audio:isolated:bass' });
       expect(asset?.originTrackSnapshot).toMatchObject({
         trackName: 'bass',
         trackType: 'stems',
@@ -402,16 +397,17 @@ describe('projectStore', () => {
     it('restores a generated asset as a new AI track after the source track is deleted', () => {
       const store = useProjectStore.getState();
       const { track, asset } = createReadyGeneratedAsset();
-      expect(asset).toBeDefined();
+      expect(asset).toMatchObject({ source: 'generated', isolatedAudioKey: 'audio:isolated:lead' });
 
       store.removeTrack(track.id);
       const restoredTrack = store.restoreAssetToNewTrack(asset!.id, 8);
 
-      expect(restoredTrack).toBeDefined();
-      expect(restoredTrack?.trackType).toBe('stems');
-      expect(restoredTrack?.trackName).toBe('synth');
-      expect(restoredTrack?.displayName).toBe(track.displayName);
-      expect(restoredTrack?.localCaption).toBe('Glass lead');
+      expect(restoredTrack).toMatchObject({
+        trackType: 'stems',
+        trackName: 'synth',
+        displayName: track.displayName,
+        localCaption: 'Glass lead',
+      });
 
       const liveTrack = useProjectStore.getState().project!.tracks.find((candidate) => candidate.id === restoredTrack?.id);
       const restoredClip = liveTrack?.clips[0];
@@ -745,14 +741,14 @@ describe('projectStore', () => {
       store.setTrackReverb(track.id, 0.33, 0.72);
 
       const effectId = store.addTrackEffect(track.id, 'reverb');
-      expect(effectId).toBeDefined();
+      expect(typeof effectId).toBe('string');
       store.updateTrackEffect(track.id, effectId!, {
         enabled: false,
         params: { decay: 8.4, preDelay: 0.2, wet: 0.61 },
       });
 
       const midiEffectId = store.addMidiEffect(track.id, 'arpeggiator');
-      expect(midiEffectId).toBeDefined();
+      expect(typeof midiEffectId).toBe('string');
       store.updateMidiEffect(track.id, midiEffectId!, {
         params: { rate: '1/16', pattern: 'up-down', octaves: 2 },
       });
@@ -871,7 +867,7 @@ describe('projectStore', () => {
         compressorRatio: 8,
       });
       const effectId = store.addTrackEffect(sourceTrack.id, 'compressor');
-      expect(effectId).toBeDefined();
+      expect(typeof effectId).toBe('string');
       store.updateTrackEffect(sourceTrack.id, effectId!, {
         params: {
           threshold: -10,
@@ -883,12 +879,12 @@ describe('projectStore', () => {
         },
       });
       const midiEffectId = store.addMidiEffect(sourceTrack.id, 'scale-lock');
-      expect(midiEffectId).toBeDefined();
+      expect(typeof midiEffectId).toBe('string');
 
       const preset = store.saveTrackPreset(sourceTrack.id, 'Dusty Drums');
       const appliedTrack = useProjectStore.getState().applyTrackPreset(preset.id);
 
-      expect(appliedTrack).toBeDefined();
+      expect(appliedTrack).toMatchObject({ trackName: 'drums', trackType: 'sequencer' });
       expect(appliedTrack!.id).not.toBe(sourceTrack.id);
       expect(appliedTrack!.trackName).toBe('drums');
       expect(appliedTrack!.trackType).toBe('sequencer');
@@ -907,7 +903,7 @@ describe('projectStore', () => {
       expect(appliedTrack!.effects?.[0].id).not.toBe(effectId);
       expect(appliedTrack!.midiEffects).toHaveLength(1);
       expect(appliedTrack!.midiEffects?.[0].id).not.toBe(midiEffectId);
-      expect(appliedTrack!.sequencerPattern).toBeDefined();
+      expect(appliedTrack!.sequencerPattern).toMatchObject({ stepsPerBar: 16 });
       expect(appliedTrack!.sequencerPattern?.id).not.toBe(sourceTrack.sequencerPattern?.id);
     });
   });
@@ -940,9 +936,7 @@ describe('projectStore', () => {
         prompt: 'energetic drums',
         lyrics: '',
       });
-      expect(clip).toBeDefined();
-      expect(clip.trackId).toBe(trackId);
-      expect(clip.prompt).toBe('energetic drums');
+      expect(clip).toMatchObject({ trackId, prompt: 'energetic drums' });
       expect(useProjectStore.getState().project!.tracks[0].clips).toHaveLength(1);
     });
 
@@ -1052,7 +1046,7 @@ describe('projectStore', () => {
         durationBeats: 1,
         velocity: 0.8,
       });
-      expect(noteId).toBeDefined();
+      expect(typeof noteId).toBe('string');
       const clip = useProjectStore.getState().getClipById(clipId);
       expect(clip!.midiData!.notes).toHaveLength(1);
       expect(clip!.midiData!.notes[0].pitch).toBe(60);
@@ -1175,7 +1169,7 @@ describe('projectStore', () => {
 
     it('adds an effect to a track', () => {
       const effectId = useProjectStore.getState().addTrackEffect(trackId, 'reverb');
-      expect(effectId).toBeDefined();
+      expect(typeof effectId).toBe('string');
       const track = useProjectStore.getState().project!.tracks[0];
       expect(track.effects).toHaveLength(1);
       expect(track.effects![0].type).toBe('reverb');

--- a/tests/unit/QuickSamplerEditor.test.tsx
+++ b/tests/unit/QuickSamplerEditor.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
 import { QuickSamplerEditor } from '../../src/components/pianoroll/QuickSamplerEditor';
 import type { SamplerConfig, Track } from '../../src/types/project';
 
@@ -69,25 +70,25 @@ describe('QuickSamplerEditor', () => {
 
   it('renders the Quick Sampler heading', () => {
     renderEditor();
-    expect(screen.getByText('Quick Sampler')).toBeDefined();
+    expect(screen.getByText('Quick Sampler')).toBeInTheDocument();
   });
 
   it('shows sample name when loaded', () => {
     renderEditor();
-    expect(screen.getByText('Test Sound')).toBeDefined();
+    expect(screen.getByText('Test Sound')).toBeInTheDocument();
   });
 
   it('shows root note input', () => {
     renderEditor();
     const rootInput = screen.getByLabelText('Sampler root note');
-    expect(rootInput).toBeDefined();
+    expect(rootInput).toBeInTheDocument();
     expect((rootInput as HTMLInputElement).value).toBe('60');
   });
 
   it('shows playback mode selector', () => {
     renderEditor();
     const modeSelect = screen.getByLabelText('Quick Sampler playback mode');
-    expect(modeSelect).toBeDefined();
+    expect(modeSelect).toBeInTheDocument();
     expect((modeSelect as HTMLSelectElement).value).toBe('classic');
   });
 
@@ -107,34 +108,34 @@ describe('QuickSamplerEditor', () => {
 
   it('shows ADSR controls', () => {
     renderEditor();
-    expect(screen.getByLabelText('Attack')).toBeDefined();
-    expect(screen.getByLabelText('Decay')).toBeDefined();
-    expect(screen.getByLabelText('Sustain')).toBeDefined();
-    expect(screen.getByLabelText('Release')).toBeDefined();
+    expect(screen.getByLabelText('Attack')).toBeInTheDocument();
+    expect(screen.getByLabelText('Decay')).toBeInTheDocument();
+    expect(screen.getByLabelText('Sustain')).toBeInTheDocument();
+    expect(screen.getByLabelText('Release')).toBeInTheDocument();
   });
 
   it('shows preview button', () => {
     renderEditor();
-    expect(screen.getByLabelText('Preview quick sampler root note')).toBeDefined();
+    expect(screen.getByLabelText('Preview quick sampler root note')).toBeInTheDocument();
   });
 
   it('shows audition keyboard keys', () => {
     renderEditor();
-    expect(screen.getByTestId('audition-keyboard')).toBeDefined();
+    expect(screen.getByTestId('audition-keyboard')).toBeInTheDocument();
   });
 
   it('shows trim controls', () => {
     renderEditor();
-    expect(screen.getByLabelText('Quick Sampler trim start')).toBeDefined();
-    expect(screen.getByLabelText('Quick Sampler trim end')).toBeDefined();
+    expect(screen.getByLabelText('Quick Sampler trim start')).toBeInTheDocument();
+    expect(screen.getByLabelText('Quick Sampler trim end')).toBeInTheDocument();
   });
 
   it('shows loop controls when mode is loop', () => {
     const track = makeTrack();
     track.samplerConfig!.playbackMode = 'loop';
     renderEditor(track);
-    expect(screen.getByLabelText('Quick Sampler loop start')).toBeDefined();
-    expect(screen.getByLabelText('Quick Sampler loop end')).toBeDefined();
+    expect(screen.getByLabelText('Quick Sampler loop start')).toBeInTheDocument();
+    expect(screen.getByLabelText('Quick Sampler loop end')).toBeInTheDocument();
   });
 
   it('hides loop controls when mode is classic', () => {
@@ -149,7 +150,7 @@ describe('QuickSamplerEditor', () => {
       samplerConfig: undefined,
     });
     renderEditor(track);
-    expect(screen.getByText(/Drop audio here/i)).toBeDefined();
+    expect(screen.getByText(/Drop audio here/i)).toBeInTheDocument();
   });
 
   it('shows Load Sample button', () => {

--- a/tests/unit/dawActions.test.ts
+++ b/tests/unit/dawActions.test.ts
@@ -14,7 +14,7 @@ describe('Typed DAW Action API', () => {
   it('exports DAWActions interface from types/dawActions', async () => {
     const mod = await import('../../src/types/dawActions');
     // The module should export the type (we verify the module exists and is importable)
-    expect(mod).toBeDefined();
+    expect(typeof mod).toBe('object');
   });
 
   it('exports ProjectActions type that matches projectStore action methods', async () => {
@@ -64,12 +64,13 @@ describe('Typed DAW Action API', () => {
     const mod = await import('../../src/types/dawActions');
     // Module should be importable and provide type-level constructs
     // At runtime we verify the module shape
-    expect(mod).toBeDefined();
+    expect(typeof mod).toBe('object');
   });
 
   it('re-exports action types from the stable api barrel', async () => {
     const mod = await import('../../src/api/dawApi');
-    expect(mod).toBeDefined();
+    expect(typeof mod).toBe('object');
+    expect(typeof mod.getDAWApi).toBe('function');
     // The barrel should re-export the types (verified at compile time)
     // At runtime we verify the module is importable
   });
@@ -79,15 +80,24 @@ describe('Typed DAW Action API', () => {
     expect(typeof getDAWApi).toBe('function');
 
     const api = getDAWApi();
-    expect(api).toBeDefined();
-    expect(api.project).toBeDefined();
-    expect(api.transport).toBeDefined();
-    expect(api.ui).toBeDefined();
-    expect(api.generation).toBeDefined();
-    expect(api.collaboration).toBeDefined();
-    expect(api.session).toBeDefined();
-    expect(api.shortcuts).toBeDefined();
-    expect(api.commands).toBeDefined();
+    expect(api).toMatchObject({
+      project: expect.any(Function),
+      transport: expect.any(Function),
+      ui: expect.any(Function),
+      generation: expect.any(Function),
+      collaboration: expect.any(Function),
+      session: expect.any(Function),
+      shortcuts: expect.any(Function),
+      commands: expect.objectContaining({ executeCoreShortcut: expect.any(Function) }),
+    });
+    expect(typeof api.project.getState).toBe('function');
+    expect(typeof api.transport.getState).toBe('function');
+    expect(typeof api.ui.getState).toBe('function');
+    expect(typeof api.generation.getState).toBe('function');
+    expect(typeof api.collaboration.getState).toBe('function');
+    expect(typeof api.session.getState).toBe('function');
+    expect(typeof api.shortcuts.getState).toBe('function');
+    expect(typeof api.commands.executeCoreShortcut).toBe('function');
   });
 
   it('getDAWApi().project exposes store actions', async () => {


### PR DESCRIPTION
## Summary

Replaces `toBeDefined()`/`toBeTruthy()` with specific assertions in the 3 files with most weak assertions:

- **projectStore.test.ts** (16): `toMatchObject`, `typeof` for IDs
- **QuickSamplerEditor.test.tsx** (15): `toBeInTheDocument()`
- **dawActions.test.ts** (12): `typeof`, `toMatchObject` for API shape

43/282 weak assertions fixed (15% of total). Remaining files can be done incrementally.

Partial progress on #1078

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3736 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)