### PR TITLE
refactor: replace raw console statements with debugLogger

### DIFF
--- a/src/components/assets/LoopBrowser.tsx
+++ b/src/components/assets/LoopBrowser.tsx
@@ -13,7 +13,10 @@ import { loadAudioBlobByKey } from '../../services/audioFileManager';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
 import type { AssetClip } from '../../types/project';
 import { setDragPayload, clearDragPayload } from '../../utils/dragPayload';
+import { createDebugLogger } from '../../utils/debugLogger';
 import * as Tone from 'tone';
+
+const logger = createDebugLogger('ace-step:loop-browser');
 
 /** 1x1 transparent GIF used to hide the native drag ghost. */
 const TRANSPARENT_IMG = new Image();
@@ -137,7 +140,7 @@ export function LoopBrowser() {
       setPreviewWaveform(waveformData);
       addRecentlyUsed(def.id);
     } catch (err) {
-      console.error('Failed to preview loop:', err);
+      logger.error('Failed to preview loop:', err);
     }
   }, [previewingId, setPreviewingId, addRecentlyUsed]);
 
@@ -161,7 +164,7 @@ export function LoopBrowser() {
       setPreviewingId(asset.id);
       setPreviewWaveform(asset.waveformPeaks);
     } catch (err) {
-      console.error('Failed to preview asset:', err);
+      logger.error('Failed to preview asset:', err);
     }
   }, [previewingId, setPreviewingId]);
 

--- a/src/components/dialogs/BounceInPlaceDialog.tsx
+++ b/src/components/dialogs/BounceInPlaceDialog.tsx
@@ -5,6 +5,9 @@ import { projectActionApi } from '../../services/actionApi';
 import { DEFAULT_BOUNCE_IN_PLACE_OPTIONS } from '../../services/bounceInPlace';
 import type { BounceInPlaceOptions } from '../../types/project';
 import { toastError } from '../../hooks/useToast';
+import { createDebugLogger } from '../../utils/debugLogger';
+
+const logger = createDebugLogger('ace-step:bounce-in-place');
 
 const checkboxClass = 'h-4 w-4 rounded border border-daw-border bg-daw-surface-2 text-daw-accent focus:ring-1 focus:ring-daw-accent';
 
@@ -32,7 +35,7 @@ export function BounceInPlaceDialog() {
       if (result.ok) {
         close();
       } else {
-        console.error('Bounce in place failed', result.error);
+        logger.error('Bounce in place failed', result.error);
         toastError(result.error.message);
       }
     } finally {

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -12,6 +12,7 @@ import {
   type StemExportScope,
 } from '../../engine/exportMix';
 import { toastError, toastSuccess } from '../../hooks/useToast';
+import { createDebugLogger } from '../../utils/debugLogger';
 import {
   type ExportFormat,
   type ExportMetadata,
@@ -24,6 +25,8 @@ import {
   formatFileSize,
 } from '../../utils/audioEncoders';
 import { Button } from '../ui/Button';
+
+const logger = createDebugLogger('ace-step:export');
 
 const FORMAT_OPTIONS: { value: ExportFormat; label: string }[] = [
   { value: 'wav', label: 'WAV' },
@@ -141,7 +144,7 @@ export function ExportDialog() {
       }
       setShow(false);
     } catch (error) {
-      console.error('Export failed:', error);
+      logger.error('Export failed:', error);
       toastError('Export failed');
     } finally {
       setExporting(false);

--- a/src/components/strudel/StrudelEditor.tsx
+++ b/src/components/strudel/StrudelEditor.tsx
@@ -10,6 +10,9 @@ import { useProjectStore } from '../../store/projectStore';
 import { Z } from '../../utils/zIndex';
 import type { StrudelFromMidiOptions } from '../../types/project';
 import { registerStrudelEditorPlaybackStop, registerStrudelEditorAudioContext, resumeStrudelAudio } from '../../engine/strudelEditorPlayback';
+import { createDebugLogger } from '../../utils/debugLogger';
+
+const logger = createDebugLogger('ace-step:strudel-editor');
 const DEFAULT_CODE = `s("[bd <hh oh>]*2, [~ cp]*2")`;
 
 // Inject CSS to constrain the autocomplete info panel
@@ -238,7 +241,7 @@ export function StrudelEditor() {
         setIsLoading(false);
         setConsoleMessages(['🌀 Strudel ready']);
       } catch (err) {
-        console.error('[StrudelEditor] init failed:', err);
+        logger.error('init failed:', err);
         setIsLoading(false);
         setError(err instanceof Error ? err.message : 'Failed to load editor');
       }
@@ -310,7 +313,7 @@ export function StrudelEditor() {
         setConsoleMessages((prev) => [...prev.slice(-50), `✓ sent ${bounceBars} bars to track`]);
       }
     } catch (err: any) {
-      console.error('Strudel bounce failed:', err);
+      logger.error('Strudel bounce failed:', err);
       setError(err?.message ?? 'Bounce failed');
       setConsoleMessages((prev) => [...prev.slice(-50), `! bounce failed: ${err?.message}`]);
     } finally {

--- a/src/engine/RecordingEngine.ts
+++ b/src/engine/RecordingEngine.ts
@@ -4,6 +4,9 @@
  */
 
 import * as Tone from 'tone';
+import { createDebugLogger } from '../utils/debugLogger';
+
+const logger = createDebugLogger('ace-step:recording');
 
 export interface AudioInputDevice {
   deviceId: string;
@@ -105,7 +108,7 @@ class RecordingEngine {
 
       return true;
     } catch (err) {
-      console.error('Microphone permission denied:', err);
+      logger.error('Microphone permission denied:', err);
       this.permissionGranted = false;
       this.permissionDenied = true;
       return false;
@@ -343,7 +346,7 @@ class RecordingEngine {
         duration: audioBuffer.duration,
       };
     } catch (err) {
-      console.error('Failed to decode recorded audio:', err);
+      logger.error('Failed to decode recorded audio:', err);
       audioCtx.close();
       return null;
     }

--- a/src/hooks/useAudioImport.ts
+++ b/src/hooks/useAudioImport.ts
@@ -9,6 +9,9 @@ import { audioBufferToWavBlob } from '../utils/wav';
 import { parseMidiFile } from '../utils/midi';
 import { toastError, toastInfo, toastSuccess } from './useToast';
 import { LOOP_DEFINITIONS, loadLoop } from '../engine/LoopLibrary';
+import { createDebugLogger } from '../utils/debugLogger';
+
+const logger = createDebugLogger('ace-step:audio-import');
 
 function trimAudioBuffer(
   engine: ReturnType<typeof getAudioEngine>,
@@ -278,7 +281,7 @@ export function useAudioImport() {
 
       toastSuccess(`Imported MIDI into ${parsed.tracks.length} piano roll track${parsed.tracks.length === 1 ? '' : 's'}`);
     } catch (error) {
-      console.error(error);
+      logger.error('Failed to import MIDI file:', error);
       toastError(`Failed to import MIDI file: ${file.name}`);
     }
   }, [addClip, addTrack, maybeApplyImportedMidiMetadata, updateTrack]);

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -746,7 +746,7 @@ async function generateClipInternal(
     } as LegoTaskParams;
 
     // Always log critical generation params for debugging
-    console.log(
+    logger.info(
       `[generateClip] audio_duration=${audioDuration}`,
       `repainting=[${repaintStart.toFixed(2)}, ${repaintEnd.toFixed(2)}]`,
       `isChunk=${isChunkMode}`,
@@ -1440,7 +1440,7 @@ export async function generateFromAddLayer(opts: AddLayerOptions): Promise<void>
         // trimToContext: blob spans [0, ctxDuration], no leading silence
         contextBlob = await extractContextAudioLazy(effectiveCtxWindow, { trimToContext: true });
         const ctxDur = effectiveCtxWindow.endTime - effectiveCtxWindow.startTime;
-        console.log(
+        logger.info(
           `[AddLayer] contextBlob: size=${contextBlob?.size ?? 0}`,
           `expectedDur=${ctxDur.toFixed(1)}s`,
           `ctx=[${effectiveCtxWindow.startTime}, ${effectiveCtxWindow.endTime}]`,
@@ -1448,7 +1448,7 @@ export async function generateFromAddLayer(opts: AddLayerOptions): Promise<void>
           `chunkMaskMode=${opts.chunkMaskMode}`,
         );
       } else {
-        console.log(`[AddLayer] NO contextWindow, forceSilence=true`);
+        logger.info(`[AddLayer] NO contextWindow, forceSilence=true`);
       }
 
       const outcome = await generateClipInternal(clipId, contextBlob, {
@@ -1749,7 +1749,7 @@ export async function generateCoverClip(opts: GenerateCoverOptions): Promise<str
     if (sourceAudioOverride) {
       sourceAudioBlob = (await loadAudioBlobByKey(sourceAudioOverride)) ?? null;
       if (!sourceAudioBlob) {
-        console.warn(`[EnhancePipeline] Chained source audio key "${sourceAudioOverride}" not found in storage, falling back to clip audio`);
+        logger.warn(`[EnhancePipeline] Chained source audio key "${sourceAudioOverride}" not found in storage, falling back to clip audio`);
       }
     }
     if (!sourceAudioBlob && sourceClip.isolatedAudioKey) {
@@ -2148,7 +2148,7 @@ export async function generateRepaintClip(opts: GenerateRepaintOptions): Promise
       if (opts.sourceAudioOverride) {
         srcBlob = (await loadAudioBlobByKey(opts.sourceAudioOverride)) ?? null;
         if (!srcBlob) {
-          console.warn(`[EnhancePipeline] Chained source audio key "${opts.sourceAudioOverride}" not found in storage, falling back to clip audio`);
+          logger.warn(`[EnhancePipeline] Chained source audio key "${opts.sourceAudioOverride}" not found in storage, falling back to clip audio`);
         }
       }
       if (!srcBlob && clip.cumulativeMixKey) {

--- a/src/services/mcpBridge.ts
+++ b/src/services/mcpBridge.ts
@@ -13,6 +13,9 @@ import { useProjectStore } from '../store/projectStore';
 import { useTransportStore } from '../store/transportStore';
 import { useGenerationStore } from '../store/generationStore';
 import { useUIStore } from '../store/uiStore';
+import { createDebugLogger } from '../utils/debugLogger';
+
+const logger = createDebugLogger('ace-step:mcp-bridge');
 
 const WS_URL = `ws://${window.location.hostname}:${window.location.port}/ws/mcp-bridge`;
 const RECONNECT_DELAY_MS = 3000;
@@ -39,7 +42,7 @@ function connect() {
   ws = new WebSocket(WS_URL);
 
   ws.onopen = () => {
-    console.log('[MCP Bridge] Connected');
+    logger.info('Connected');
   };
 
   ws.onmessage = (event) => {
@@ -49,7 +52,7 @@ function connect() {
         const response = await handleToolCall(request);
         ws?.send(JSON.stringify(response));
       } catch (err) {
-        console.error('[MCP Bridge] Failed to handle message:', err);
+        logger.error('Failed to handle message:', err);
       }
     })();
   };

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -152,6 +152,9 @@ import { bounceTrackToAudioAsset } from '../services/bounceInPlace';
 import {
   ensurePlaybackLatencySettings,
 } from '../utils/playbackLatency';
+import { createDebugLogger } from '../utils/debugLogger';
+
+const logger = createDebugLogger('ace-step:project-store');
 
 function _isViewerMode(): boolean {
   return useCollaborationStore.getState().isViewerMode;
@@ -6799,7 +6802,7 @@ export const useProjectStore = create<ProjectState>()(
       };
       return convertParsedMidiFileToStrudelCode(parsed, file.name.replace(/\.(mid|midi)$/i, ''), options);
     } catch (error) {
-      console.error(error);
+      logger.error('Failed to convert MIDI to Strudel code:', error);
       return null;
     }
   },
@@ -8731,7 +8734,7 @@ export const useProjectStore = create<ProjectState>()(
       toastSuccess(`Imported MIDI into ${parsed.tracks.length} piano roll track${parsed.tracks.length === 1 ? '' : 's'}`);
       return trackIds;
     } catch (error) {
-      console.error(error);
+      logger.error('Failed to import MIDI file:', error);
       toastError(`Failed to import MIDI file: ${file.name}`);
       return [];
     }


### PR DESCRIPTION
## Summary
- Replace 18 raw `console.log/warn/error` calls across 9 production files with the project's `createDebugLogger` utility
- Each file gets a scoped logger (e.g., `ace-step:mcp-bridge`, `ace-step:recording`) for consistent, filterable logging
- Errors always log (no scope gate); info/warn are scope-gated per the debugLogger design

## Files modified
1. `src/services/generationPipeline.ts` — 5 replacements (already had logger import)
2. `src/services/mcpBridge.ts` — 2 replacements
3. `src/hooks/useAudioImport.ts` — 1 replacement
4. `src/components/assets/LoopBrowser.tsx` — 2 replacements
5. `src/components/strudel/StrudelEditor.tsx` — 2 replacements
6. `src/components/dialogs/BounceInPlaceDialog.tsx` — 1 replacement
7. `src/components/dialogs/ExportDialog.tsx` — 1 replacement
8. `src/engine/RecordingEngine.ts` — 2 replacements
9. `src/store/projectStore.ts` — 2 replacements

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npm test` (vitest) — all unit tests pass
- [ ] Build passes (wasm-pack not available in CI env, but TS + Vite stages pass)

Closes #1329

https://claude.ai/code/session_01HjYXWHQbfBLh47emoCLfNz