### PR TITLE
fix: add proper spacing between Loop Browser tab label and count

### DIFF
--- a/src/components/assets/LoopBrowser.tsx
+++ b/src/components/assets/LoopBrowser.tsx
@@ -291,7 +291,7 @@ export function LoopBrowser() {
         >
           My Loops
           {allAssets.length > 0 && (
-            <span className="ml-1 text-[10px] text-white/20">{allAssets.length}</span>
+            <span className="ml-1 text-[10px] text-white/20">({allAssets.length})</span>
           )}
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Wraps the loop count number in parentheses in the "My Loops" tab label, changing display from "My Loops3" to "My Loops (3)"
- The `ml-1` margin class was already present but insufficient for clear visual separation between text and number

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [ ] Visually verify "My Loops" tab shows count as "(3)" with proper spacing

Closes #854

https://claude.ai/code/session_01MQEBVdio11FAETYijX7Bxi