### PR TITLE
refactor: replace as any casts in test files with proper mock types

### DIFF
--- a/src/components/timeline/__tests__/simplifyEnhanceMenu.test.tsx
+++ b/src/components/timeline/__tests__/simplifyEnhanceMenu.test.tsx
@@ -4,6 +4,7 @@ import { ClipContextMenu } from '../ClipContextMenu';
 import { AIToolsSubmenu, type ClipAIContext } from '../AIToolsSubmenu';
 import { SHORTCUT_ACTIONS } from '../../../constants/shortcutDefaults';
 import { buildCommandPaletteCommands, type CommandPaletteContext } from '../../../services/commandPalette';
+import type { Clip, Track, Project } from '../../../types/project';
 
 // ── shortcutDefaults ──────────────────────────────────────────
 describe('shortcutDefaults — clips.enhance', () => {
@@ -93,50 +94,57 @@ describe('AIToolsSubmenu — no longer contains Enhance', () => {
       isReady: true,
     };
     expect(ctx).toBeDefined();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((ctx as any).onEnhance).toBeUndefined();
+    expect((ctx as Record<string, unknown>).onEnhance).toBeUndefined();
   });
 });
 
 // ── commandPalette ──────────────────────────────────────────────
 describe('commandPalette — Enhance Selected Clip command', () => {
   function makeContext(overrides: Partial<CommandPaletteContext> = {}): CommandPaletteContext {
+    const mockClip: Partial<Clip> = {
+      id: 'c1',
+      trackId: 't1',
+      startTime: 0,
+      duration: 10,
+      generationStatus: 'ready',
+      prompt: 'test',
+    };
+
+    const mockTrack: Partial<Track> = {
+      id: 't1',
+      displayName: 'Track 1',
+      trackName: 'vocals',
+      trackType: 'stems',
+      color: '#fff',
+      volume: 1,
+      pan: 0,
+      muted: false,
+      soloed: false,
+      order: 0,
+      clips: [mockClip as Clip],
+      effects: [],
+    };
+
+    const mockProject: Partial<Project> = {
+      id: 'p1',
+      name: 'Test',
+      bpm: 120,
+      timeSignature: 4,
+      totalDuration: 60,
+      tracks: [mockTrack as Track],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      generationDefaults: {
+        inferenceSteps: 50,
+        guidanceScale: 7,
+        shift: 0,
+        thinking: false,
+        model: 'default',
+      },
+    };
+
     return {
-      project: {
-        id: 'p1',
-        name: 'Test',
-        bpm: 120,
-        timeSignature: { numerator: 4, denominator: 4 },
-        totalDuration: 60,
-        tracks: [
-          {
-            id: 't1',
-            displayName: 'Track 1',
-            trackName: 'vocals' as any,
-            trackType: 'stems' as any,
-            color: '#fff',
-            volume: 1,
-            pan: 0,
-            muted: false,
-            soloed: false,
-            order: 0,
-            clips: [
-              {
-                id: 'c1',
-                trackId: 't1',
-                startTime: 0,
-                duration: 10,
-                generationStatus: 'ready' as any,
-                prompt: 'test',
-              } as any,
-            ],
-            effects: [],
-          } as any,
-        ],
-        sampleRate: 44100,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      } as any,
+      project: mockProject as Project,
       selectedClipIds: ['c1'],
       currentTime: 5,
       isPlaying: false,
@@ -172,15 +180,15 @@ describe('commandPalette — Enhance Selected Clip command', () => {
         zoomTimelineToSelection: vi.fn(),
         zoomTimelineToProject: vi.fn(),
         setBatchGenerateMode: vi.fn(),
-        addTrack: vi.fn() as any,
-        addTrackEffect: vi.fn() as any,
+        addTrack: vi.fn() as CommandPaletteContext['actions']['addTrack'],
+        addTrackEffect: vi.fn() as unknown as CommandPaletteContext['actions']['addTrackEffect'],
         updateProject: vi.fn(),
         updateTrack: vi.fn(),
         updateTrackMixer: vi.fn(),
         updateTrackEffect: vi.fn(),
         duplicateClip: vi.fn(),
         splitClip: vi.fn(),
-        splitClipAtZeroCrossing: vi.fn() as any,
+        splitClipAtZeroCrossing: vi.fn() as unknown as CommandPaletteContext['actions']['splitClipAtZeroCrossing'],
         removeClip: vi.fn(),
         setEditingClip: vi.fn(),
         deselectAll: vi.fn(),

--- a/src/engine/__tests__/ReturnTrackNode.test.ts
+++ b/src/engine/__tests__/ReturnTrackNode.test.ts
@@ -1,32 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ReturnTrackNode } from '../ReturnTrackNode';
+import { type MockAudioParam, type MockNode, makeAudioParam, makeNode } from './mockAudioHelpers';
 
-function makeAudioParam(initial = 0) {
-  let _value = initial;
-  const rampCalls: { value: number; endTime: number }[] = [];
-  return {
-    get value() { return _value; },
-    set value(v: number) { _value = v; },
-    linearRampToValueAtTime(value: number, endTime: number) {
-      rampCalls.push({ value, endTime });
-      _value = value;
-      return this;
-    },
-    setValueAtTime(value: number, _time: number) {
-      _value = value;
-      return this;
-    },
-    cancelScheduledValues() { return this; },
-    rampCalls,
-  };
-}
-
-function makeNode(overrides: Record<string, unknown> = {}) {
-  return {
-    connect: vi.fn().mockReturnThis(),
-    disconnect: vi.fn(),
-    ...overrides,
-  };
+/** Type-safe accessor for private members of ReturnTrackNode used in tests. */
+interface ReturnTrackNodeInternals {
+  volumeGain: MockNode & { gain: MockAudioParam };
+  panNode: MockNode & { pan: MockAudioParam };
+  analyserNode: MockNode;
 }
 
 function makeAudioContext(): AudioContext {
@@ -51,25 +31,28 @@ function makeAudioContext(): AudioContext {
 
 describe('ReturnTrackNode', () => {
   let ctx: AudioContext;
-  let destination: ReturnType<typeof makeNode>;
+  let destination: MockNode;
   let node: ReturnTrackNode;
+  /** Type-safe accessor for private members. */
+  let internals: ReturnTrackNodeInternals;
 
   beforeEach(() => {
     ctx = makeAudioContext();
     destination = makeNode();
     node = new ReturnTrackNode(ctx, destination as unknown as AudioNode);
+    internals = node as unknown as ReturnTrackNodeInternals;
   });
 
   it('connects signal chain: inputGain → volumeGain → panNode → analyser → destination', () => {
     // inputGain connects to volumeGain
-    expect((node.inputGain as any).connect).toHaveBeenCalled();
+    const inputGain = node.inputGain as unknown as MockNode;
+    expect(inputGain.connect).toHaveBeenCalled();
   });
 
   it('applies volume with 5ms click-free ramp', () => {
     node.volume = 0.5;
     // Volume gain should have been ramped
-    const volumeGain = (node as any).volumeGain;
-    const param = volumeGain.gain;
+    const param = internals.volumeGain.gain;
     expect(param.rampCalls.length).toBeGreaterThan(0);
     expect(param.rampCalls[param.rampCalls.length - 1].value).toBe(0.5);
   });
@@ -77,7 +60,7 @@ describe('ReturnTrackNode', () => {
   it('mutes to 0 with ramp', () => {
     node.volume = 0.8;
     node.muted = true;
-    const param = (node as any).volumeGain.gain;
+    const param = internals.volumeGain.gain;
     expect(param.rampCalls[param.rampCalls.length - 1].value).toBe(0);
   });
 
@@ -85,15 +68,15 @@ describe('ReturnTrackNode', () => {
     node.volume = 0.7;
     node.muted = true;
     node.muted = false;
-    const param = (node as any).volumeGain.gain;
+    const param = internals.volumeGain.gain;
     expect(param.rampCalls[param.rampCalls.length - 1].value).toBe(0.7);
   });
 
   it('sets pan value clamped to [-1, 1]', () => {
     node.pan = 2;
-    expect((node as any).panNode.pan.value).toBe(1);
+    expect(internals.panNode.pan.value).toBe(1);
     node.pan = -5;
-    expect((node as any).panNode.pan.value).toBe(-1);
+    expect(internals.panNode.pan.value).toBe(-1);
   });
 
   it('spliceEffects inserts chain between input and volume', () => {
@@ -101,7 +84,8 @@ describe('ReturnTrackNode', () => {
     const effectOutput = makeNode();
     node.spliceEffects(effectInput as unknown as AudioNode, effectOutput as unknown as AudioNode);
     // inputGain should connect to effectInput
-    expect((node.inputGain as any).connect).toHaveBeenCalledWith(effectInput);
+    const inputGain = node.inputGain as unknown as MockNode;
+    expect(inputGain.connect).toHaveBeenCalledWith(effectInput);
     // effectOutput should connect to volumeGain
     expect(effectOutput.connect).toHaveBeenCalled();
   });
@@ -112,17 +96,19 @@ describe('ReturnTrackNode', () => {
     node.spliceEffects(effectInput as unknown as AudioNode, effectOutput as unknown as AudioNode);
     node.spliceEffects(null, null);
     // inputGain should reconnect directly to volumeGain
-    const connectCalls = (node.inputGain as any).connect.mock.calls;
+    const inputGain = node.inputGain as unknown as MockNode;
+    const connectCalls = inputGain.connect.mock.calls;
     const lastCall = connectCalls[connectCalls.length - 1];
-    expect(lastCall[0]).toBe((node as any).volumeGain);
+    expect(lastCall[0]).toBe(internals.volumeGain);
   });
 
   it('disconnect() disconnects all nodes', () => {
     node.disconnect();
-    expect((node.inputGain as any).disconnect).toHaveBeenCalled();
-    expect((node as any).volumeGain.disconnect).toHaveBeenCalled();
-    expect((node as any).panNode.disconnect).toHaveBeenCalled();
-    expect((node as any).analyserNode.disconnect).toHaveBeenCalled();
+    const inputGain = node.inputGain as unknown as MockNode;
+    expect(inputGain.disconnect).toHaveBeenCalled();
+    expect(internals.volumeGain.disconnect).toHaveBeenCalled();
+    expect(internals.panNode.disconnect).toHaveBeenCalled();
+    expect(internals.analyserNode.disconnect).toHaveBeenCalled();
   });
 
   it('getMeter returns level data', () => {

--- a/src/engine/__tests__/TrackNode.sends.test.ts
+++ b/src/engine/__tests__/TrackNode.sends.test.ts
@@ -1,32 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TrackNode } from '../TrackNode';
+import { type MockAudioParam, type MockNode, makeAudioParam, makeNode } from './mockAudioHelpers';
 
-function makeAudioParam(initial = 0) {
-  let _value = initial;
-  const rampCalls: { value: number; endTime: number }[] = [];
-  return {
-    get value() { return _value; },
-    set value(v: number) { _value = v; },
-    linearRampToValueAtTime(value: number, endTime: number) {
-      rampCalls.push({ value, endTime });
-      _value = value;
-      return this;
-    },
-    setValueAtTime(value: number, _time: number) {
-      _value = value;
-      return this;
-    },
-    cancelScheduledValues() { return this; },
-    rampCalls,
-  };
-}
-
-function makeNode(overrides: Record<string, unknown> = {}) {
-  return {
-    connect: vi.fn().mockReturnThis(),
-    disconnect: vi.fn(),
-    ...overrides,
-  };
+/** Type-safe accessor for private TrackNode members used in tests. */
+interface TrackNodeInternals {
+  volumeGain: MockNode & { gain: MockAudioParam };
+  sendGains: Map<string, { pre: MockNode & { gain: MockAudioParam }; post: MockNode & { gain: MockAudioParam } }>;
+  compressor: MockNode;
+  latencyCompNode: MockNode | null;
 }
 
 function makeAudioContext(): AudioContext {
@@ -74,38 +55,41 @@ function makeAudioContext(): AudioContext {
 
 describe('TrackNode sends', () => {
   let ctx: AudioContext;
-  let destination: ReturnType<typeof makeNode>;
+  let destination: MockNode;
   let node: TrackNode;
-  let returnInput: ReturnType<typeof makeNode>;
+  let returnInput: MockNode;
+  /** Type-safe accessor for private members. */
+  let internals: TrackNodeInternals;
 
   beforeEach(() => {
     ctx = makeAudioContext();
     destination = makeNode();
     node = new TrackNode(ctx, destination as unknown as AudioNode);
     returnInput = makeNode({ gain: makeAudioParam(1) });
+    internals = node as unknown as TrackNodeInternals;
   });
 
   describe('connectSend', () => {
     it('creates pre and post gain nodes connected to destination', () => {
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.6, false);
       // Post-fader: volumeGain should connect to a post gain node
-      const volumeGainConnects = (node.volumeGain as any).connect.mock.calls;
+      const volumeGain = node.volumeGain as unknown as MockNode;
+      const volumeGainConnects = volumeGain.connect.mock.calls;
       // volumeGain connects to: analyserNode, splitter, and now a post-fader send gain
       expect(volumeGainConnects.length).toBeGreaterThanOrEqual(3);
     });
 
     it('post-fader send: pre gain = 0, post gain = amount', () => {
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.7, false);
-      const sends = (node as any).sendGains;
-      const send = sends.get('ret1');
+      const send = internals.sendGains.get('ret1');
       expect(send).toBeDefined();
-      expect(send.pre.gain.value).toBe(0);
-      expect(send.post.gain.value).toBe(0.7);
+      expect(send!.pre.gain.value).toBe(0);
+      expect(send!.post.gain.value).toBe(0.7);
     });
 
     it('pre-fader send: pre gain = amount, post gain = 0', () => {
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.5, true);
-      const send = (node as any).sendGains.get('ret1');
+      const send = internals.sendGains.get('ret1')!;
       expect(send.pre.gain.value).toBe(0.5);
       expect(send.post.gain.value).toBe(0);
     });
@@ -113,7 +97,7 @@ describe('TrackNode sends', () => {
     it('overwrites existing send on same returnTrackId', () => {
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.3, false);
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.9, true);
-      const send = (node as any).sendGains.get('ret1');
+      const send = internals.sendGains.get('ret1')!;
       expect(send.pre.gain.value).toBe(0.9);
       expect(send.post.gain.value).toBe(0);
     });
@@ -123,7 +107,7 @@ describe('TrackNode sends', () => {
     it('ramps gain values for click-free transition', () => {
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.5, false);
       node.updateSendAmount('ret1', 0.8, false);
-      const send = (node as any).sendGains.get('ret1');
+      const send = internals.sendGains.get('ret1')!;
       // Post gain should be ramped to 0.8
       expect(send.post.gain.rampCalls.length).toBeGreaterThan(0);
       expect(send.post.gain.value).toBe(0.8);
@@ -132,7 +116,7 @@ describe('TrackNode sends', () => {
     it('switches from post to pre-fader', () => {
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.6, false);
       node.updateSendAmount('ret1', 0.6, true);
-      const send = (node as any).sendGains.get('ret1');
+      const send = internals.sendGains.get('ret1')!;
       // Pre should now have the amount, post should be 0
       expect(send.pre.gain.value).toBe(0.6);
       expect(send.post.gain.value).toBe(0);
@@ -148,7 +132,7 @@ describe('TrackNode sends', () => {
     it('removes send gains and disconnects', () => {
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.5, false);
       node.disconnectSend('ret1');
-      expect((node as any).sendGains.has('ret1')).toBe(false);
+      expect(internals.sendGains.has('ret1')).toBe(false);
     });
 
     it('no-op for unknown returnTrackId', () => {
@@ -162,7 +146,7 @@ describe('TrackNode sends', () => {
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.5, false);
       node.connectSend('ret2', returnInput as unknown as AudioNode, 0.3, true);
       node.disconnectAllSends();
-      expect((node as any).sendGains.size).toBe(0);
+      expect(internals.sendGains.size).toBe(0);
     });
   });
 
@@ -170,24 +154,24 @@ describe('TrackNode sends', () => {
     it('disconnect() also disconnects all sends', () => {
       node.connectSend('ret1', returnInput as unknown as AudioNode, 0.5, false);
       node.disconnect();
-      expect((node as any).sendGains.size).toBe(0);
+      expect(internals.sendGains.size).toBe(0);
     });
   });
 
   describe('preFaderOutput', () => {
     it('returns compressor by default', () => {
-      expect(node.preFaderOutput).toBe((node as any).compressor);
+      expect(node.preFaderOutput).toBe(internals.compressor);
     });
 
     it('returns latencyCompNode when set', () => {
       node.setLatencyCompensation(512, 44100);
-      expect(node.preFaderOutput).toBe((node as any).latencyCompNode);
+      expect(node.preFaderOutput).toBe(internals.latencyCompNode);
     });
 
     it('returns compressor after removing latency compensation', () => {
       node.setLatencyCompensation(512, 44100);
       node.setLatencyCompensation(0, 44100);
-      expect(node.preFaderOutput).toBe((node as any).compressor);
+      expect(node.preFaderOutput).toBe(internals.compressor);
     });
   });
 });

--- a/src/engine/__tests__/effectsEngineSidechain.test.ts
+++ b/src/engine/__tests__/effectsEngineSidechain.test.ts
@@ -42,7 +42,7 @@ vi.mock('../sidechainFollower', () => {
 });
 
 import { effectsEngine } from '../EffectsEngine';
-import type { TrackEffect } from '../../types/project';
+import type { CompressorParams, TrackEffect } from '../../types/project';
 
 describe('EffectsEngine sidechain management', () => {
   const compressorEffect: TrackEffect = {
@@ -59,14 +59,14 @@ describe('EffectsEngine sidechain management', () => {
   it('connectSidechain creates a sidechain follower', () => {
     effectsEngine.rebuildChain('bass-track', [compressorEffect]);
     const mockSource = { context: {} } as unknown as AudioNode;
-    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as any);
+    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as CompressorParams);
     expect(effectsEngine.getSidechainReduction('bass-track', 'fx-1')).toBe(-6);
   });
 
   it('disconnectSidechain cleans up the follower', () => {
     effectsEngine.rebuildChain('bass-track', [compressorEffect]);
     const mockSource = { context: {} } as unknown as AudioNode;
-    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as any);
+    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as CompressorParams);
     effectsEngine.disconnectSidechain('bass-track', 'fx-1');
     expect(effectsEngine.getSidechainReduction('bass-track', 'fx-1')).toBe(0);
   });
@@ -78,7 +78,7 @@ describe('EffectsEngine sidechain management', () => {
   it('dispose cleans up all sidechains', () => {
     effectsEngine.rebuildChain('bass-track', [compressorEffect]);
     const mockSource = { context: {} } as unknown as AudioNode;
-    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as any);
+    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as CompressorParams);
     effectsEngine.dispose();
     expect(effectsEngine.getSidechainReduction('bass-track', 'fx-1')).toBe(0);
   });
@@ -86,7 +86,7 @@ describe('EffectsEngine sidechain management', () => {
   it('getOutputNode returns follower gainNode when compressor has sidechain', () => {
     effectsEngine.rebuildChain('bass-track', [compressorEffect]);
     const mockSource = { context: {} } as unknown as AudioNode;
-    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as any);
+    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as CompressorParams);
     const output = effectsEngine.getOutputNode('bass-track');
     expect(output).toBeDefined();
   });
@@ -101,7 +101,7 @@ describe('EffectsEngine sidechain management', () => {
   it('updateSidechainParams calls updateParams on the follower', () => {
     effectsEngine.rebuildChain('bass-track', [compressorEffect]);
     const mockSource = { context: {} } as unknown as AudioNode;
-    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as any);
+    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as CompressorParams);
     // Should not throw
     effectsEngine.updateSidechainParams('bass-track', 'fx-1', {
       threshold: -30, ratio: 6, attack: 0.01, release: 0.1, knee: 3,
@@ -113,9 +113,9 @@ describe('EffectsEngine sidechain management', () => {
   it('reconnecting sidechain disposes the previous follower', () => {
     effectsEngine.rebuildChain('bass-track', [compressorEffect]);
     const mockSource = { context: {} } as unknown as AudioNode;
-    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as any);
+    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as CompressorParams);
     // Connect again — should dispose old follower first, then create new one
-    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as any);
+    effectsEngine.connectSidechain('bass-track', 'fx-1', mockSource, compressorEffect.params as CompressorParams);
     expect(effectsEngine.getSidechainReduction('bass-track', 'fx-1')).toBe(-6);
   });
 });

--- a/src/engine/__tests__/mockAudioHelpers.ts
+++ b/src/engine/__tests__/mockAudioHelpers.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared mock types and factory functions for Web Audio API testing.
+ *
+ * Used by TrackNode and ReturnTrackNode test suites to avoid `as any` casts
+ * while providing type-safe access to mock internals (e.g. rampCalls).
+ */
+import { vi, type Mock } from 'vitest';
+
+export interface MockAudioParam {
+  value: number;
+  linearRampToValueAtTime(value: number, endTime: number): MockAudioParam;
+  setValueAtTime(value: number, time: number): MockAudioParam;
+  cancelScheduledValues(time?: number): MockAudioParam;
+  rampCalls: { value: number; endTime: number }[];
+}
+
+export interface MockNode {
+  connect: Mock;
+  disconnect: Mock;
+  [key: string]: unknown;
+}
+
+export function makeAudioParam(initial = 0): MockAudioParam {
+  let _value = initial;
+  const rampCalls: { value: number; endTime: number }[] = [];
+  const param: MockAudioParam = {
+    get value() { return _value; },
+    set value(v: number) { _value = v; },
+    linearRampToValueAtTime(value: number, endTime: number) {
+      rampCalls.push({ value, endTime });
+      _value = value;
+      return param;
+    },
+    setValueAtTime(value: number, _time: number) {
+      _value = value;
+      return param;
+    },
+    cancelScheduledValues() { return param; },
+    rampCalls,
+  };
+  return param;
+}
+
+export function makeNode(overrides: Record<string, unknown> = {}): MockNode {
+  return {
+    connect: vi.fn().mockReturnThis(),
+    disconnect: vi.fn(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- Extracted shared `MockAudioParam`/`MockNode` interfaces and `makeAudioParam`/`makeNode` factory functions to `src/engine/__tests__/mockAudioHelpers.ts`
- Replaced all 42 `as any` occurrences across 4 test files with proper typed alternatives
- Used typed `Internals` interfaces for accessing private class members in engine tests
- Used `Partial<Clip>`/`Partial<Track>`/`Partial<Project>` pattern for mock data in component tests
- Used `as CompressorParams` instead of `as any` for sidechain test params

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] All 40 tests in the 4 modified files pass
- [x] Full test suite passes

https://claude.ai/code/session_01HjYXWHQbfBLh47emoCLfNz