### PR TITLE
fix: resolve pluginSystem test timeout with beforeAll module warm-up

### DIFF
--- a/tests/unit/pluginSystem.test.ts
+++ b/tests/unit/pluginSystem.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { describe, expect, it, beforeAll, beforeEach, vi } from 'vitest';
 import type {
   WAPPlugin,
   PluginAudioNode,
@@ -434,6 +434,12 @@ describe('FM Synth plugin', () => {
 // ─── Plugin Store Integration Tests ──────────────────────────────────────────
 
 describe('Plugin store actions', () => {
+  // Pre-load projectStore so the first test doesn't timeout waiting for
+  // Tone.js and other heavy modules to initialise.
+  beforeAll(async () => {
+    await import('../../src/store/projectStore');
+  }, 15_000);
+
   it('adds and removes plugins on tracks', async () => {
     const { useProjectStore } = await import('../../src/store/projectStore');
 


### PR DESCRIPTION
## Summary
- Add a `beforeAll` hook with 15s timeout to pre-import `projectStore`, warming the Tone.js module cache before tests run
- Root cause: first dynamic import of projectStore triggers Tone.js initialization (~5.2s), exceeding Vitest's default 5s timeout

## Test plan
- [x] All 30 tests in pluginSystem.test.ts pass
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] No production code changed

Closes #1344

https://claude.ai/code/session_01HjYXWHQbfBLh47emoCLfNz