### PR TITLE
refactor: replace `any` types in LoopLibrary.ts and dawStateSummary.ts

### DIFF
--- a/src/engine/LoopLibrary.ts
+++ b/src/engine/LoopLibrary.ts
@@ -3,12 +3,14 @@
  * No external audio files needed.
  */
 import * as Tone from 'tone';
+import type { ToneAudioBuffer } from 'tone';
 
 // Tone.Offline returns ToneAudioBuffer; extract the underlying AudioBuffer
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function toAudioBuffer(buf: any): AudioBuffer {
-  if (typeof buf.get === 'function') return buf.get();
-  return buf as AudioBuffer;
+function toAudioBuffer(buf: ToneAudioBuffer | AudioBuffer): AudioBuffer {
+  if (buf instanceof AudioBuffer) return buf;
+  const nativeBuffer = buf.get();
+  if (!nativeBuffer) throw new Error('Offline render returned no AudioBuffer');
+  return nativeBuffer;
 }
 
 // ─── Types ──────────────────────────────────────────────────────────────────

--- a/src/utils/dawStateSummary.ts
+++ b/src/utils/dawStateSummary.ts
@@ -75,7 +75,7 @@ function formatTrackLine(track: Track): string {
 
   // Effects
   if (track.effects && track.effects.length > 0) {
-    const fx = track.effects.map((e) => `${e.type}${(e as any).bypass ? '(off)' : ''}`).join(', ');
+    const fx = track.effects.map((e) => `${e.type}${!e.enabled ? '(off)' : ''}`).join(', ');
     parts.push(`    FX: ${fx}`);
   }
 


### PR DESCRIPTION
## Summary
- Type `toAudioBuffer` param as `ToneAudioBuffer | AudioBuffer` with `instanceof` check and null guard (matching `offlineRender.ts` pattern)
- Use existing `e.enabled` property instead of `(e as any).bypass` in `dawStateSummary.ts`

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] No `any` types remain in these files

Closes #1350

https://claude.ai/code/session_01HjYXWHQbfBLh47emoCLfNz