### PR TITLE
fix: set demo project MIDI clips to idle status to prevent error state display

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -188,6 +188,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
 
   const statusStyles: Record<string, string> = {
     empty: 'opacity-60',
+    idle: '',
     queued: 'opacity-70',
     generating: 'opacity-80 animate-pulse',
     processing: 'opacity-80 animate-pulse',

--- a/src/data/onboardingCatalog.ts
+++ b/src/data/onboardingCatalog.ts
@@ -66,7 +66,7 @@ function createMidiClip(trackId: string, startTime: number, duration: number, pr
     duration,
     prompt,
     lyrics: '',
-    generationStatus: 'empty',
+    generationStatus: 'idle',
     generationJobId: null,
     cumulativeMixKey: null,
     isolatedAudioKey: null,

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -408,7 +408,7 @@ export interface DrumMachineConfig {
 }
 
 export type ClipGenerationStatus =
-  | 'empty' | 'queued' | 'generating' | 'processing' | 'ready' | 'error' | 'stale';
+  | 'empty' | 'idle' | 'queued' | 'generating' | 'processing' | 'ready' | 'error' | 'stale';
 
 export interface MidiNote {
   id: string;


### PR DESCRIPTION
## Summary
- Change `generationStatus` from `'empty'` to `'idle'` for demo project MIDI clips in `onboardingCatalog.ts`
- Prevents the default seed project from showing clips in a visible error state on first load

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Load default project — clips should display normally, not in error state
- [ ] Verify demo MIDI clips still play correctly

Closes #852

https://claude.ai/code/session_01MQEBVdio11FAETYijX7Bxi