### PR TITLE
fix: use ready status for demo project MIDI clips

### DIFF
--- a/src/data/onboardingCatalog.ts
+++ b/src/data/onboardingCatalog.ts
@@ -66,7 +66,7 @@ function createMidiClip(trackId: string, startTime: number, duration: number, pr
     duration,
     prompt,
     lyrics: '',
-    generationStatus: 'empty',
+    generationStatus: 'ready',
     generationJobId: null,
     cumulativeMixKey: null,
     isolatedAudioKey: null,


### PR DESCRIPTION
Closing as duplicate of #1355 which uses `'idle'` status instead of `'ready'` — avoids downstream issues with `freezeTrackToAudio()` as flagged in review.