### PR TITLE
feat: add Ctrl+C/V/X clipboard shortcuts for copy/paste/cut

### DIFF
--- a/src/constants/shortcutDefaults.ts
+++ b/src/constants/shortcutDefaults.ts
@@ -23,6 +23,9 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   { id: 'clips.generate',        category: 'clips',     label: 'Generate Selected Clip',      defaultCombo: { code: 'Enter', mod: true }, contexts: ['timeline'] },
   { id: 'clips.toggleMute',      category: 'clips',     label: 'Toggle Clip Mute',            defaultCombo: { code: 'Digit0' }, contexts: ['timeline'] },
   { id: 'clips.enhance',         category: 'clips',     label: 'Enhance Selected Clip',       defaultCombo: { code: 'KeyE', shift: true }, contexts: ['timeline'] },
+  { id: 'clips.copy',            category: 'clips',     label: 'Copy',                        defaultCombo: { code: 'KeyC', mod: true }, contexts: ['timeline', 'pianoRoll'] },
+  { id: 'clips.cut',             category: 'clips',     label: 'Cut',                         defaultCombo: { code: 'KeyX', mod: true }, contexts: ['timeline', 'pianoRoll'] },
+  { id: 'clips.paste',           category: 'clips',     label: 'Paste',                       defaultCombo: { code: 'KeyV', mod: true }, contexts: ['timeline', 'pianoRoll'] },
 
   { id: 'tracks.mute',           category: 'tracks',    label: 'Toggle Focused Track Mute',   defaultCombo: { code: 'KeyM' }, contexts: ['timeline', 'mixer', 'pianoRoll'] },
   { id: 'tracks.solo',           category: 'tracks',    label: 'Toggle Focused Track Solo',   defaultCombo: { code: 'KeyS', shift: true }, contexts: ['timeline', 'mixer', 'pianoRoll'] },

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -19,6 +19,12 @@ import {
   navigateTimelineByArrow,
 } from '../services/arrowKeyNavigation';
 import { resolveFocusedTrackId } from '../services/focusResolution';
+import {
+  copyClips,
+  copyNotes,
+  preparePasteClips,
+  preparePasteNotes,
+} from '../services/clipboardService';
 import type { KeyCombo } from '../types/shortcuts';
 import { DEFAULT_TIMELINE_PIXELS_PER_SECOND } from '../utils/timelineZoom';
 import { getSessionClips } from '../utils/sessionClips';
@@ -326,6 +332,117 @@ export function useKeyboardShortcuts() {
           if (track) {
             const clip = getSessionClips(track)[slot.sceneIndex];
             if (clip) project.duplicateClip(clip.id);
+          }
+        }
+        return;
+      }
+
+      // ── Clipboard: Copy / Cut / Paste ───────────────────────────
+      // Must be before the `if (mod) return` guard since these use Cmd/Ctrl.
+      if (matches('clips.copy') && !anyModalOpen) {
+        event.preventDefault();
+        if (ui.keyboardContext.scope === 'pianoRoll') {
+          // Copy selected piano roll notes
+          const clipId = ui.openPianoRollClipId;
+          if (clipId && ui.selectedPianoRollNoteIds.length > 0) {
+            const clip = project.getClipById?.(clipId);
+            if (clip?.midiData) {
+              const noteIdSet = new Set(ui.selectedPianoRollNoteIds);
+              const selectedNotes = clip.midiData.notes.filter((n) => noteIdSet.has(n.id));
+              const data = copyNotes(selectedNotes, clipId);
+              if (data) ui.setClipboard(data);
+            }
+          }
+        } else {
+          // Copy selected clips
+          if (ui.selectedClipIds.size > 0 && project.project) {
+            const entries = [...ui.selectedClipIds]
+              .map((clipId) => {
+                for (const track of project.project!.tracks) {
+                  const clip = track.clips.find((c) => c.id === clipId);
+                  if (clip) return { clip, trackId: track.id };
+                }
+                return null;
+              })
+              .filter((e): e is NonNullable<typeof e> => e !== null);
+            const data = copyClips(entries);
+            if (data) ui.setClipboard(data);
+          }
+        }
+        return;
+      }
+
+      if (matches('clips.cut') && !anyModalOpen) {
+        event.preventDefault();
+        if (ui.keyboardContext.scope === 'pianoRoll') {
+          // Cut selected piano roll notes (copy then delete)
+          const clipId = ui.openPianoRollClipId;
+          if (clipId && ui.selectedPianoRollNoteIds.length > 0) {
+            const clip = project.getClipById?.(clipId);
+            if (clip?.midiData) {
+              const noteIdSet = new Set(ui.selectedPianoRollNoteIds);
+              const selectedNotes = clip.midiData.notes.filter((n) => noteIdSet.has(n.id));
+              const data = copyNotes(selectedNotes, clipId);
+              if (data) {
+                ui.setClipboard(data);
+                // Delete the original notes
+                for (const noteId of ui.selectedPianoRollNoteIds) {
+                  project.removeMidiNote(clipId, noteId);
+                }
+                ui.setSelectedPianoRollNoteIds([]);
+              }
+            }
+          }
+        } else {
+          // Cut selected clips (copy then delete)
+          if (ui.selectedClipIds.size > 0 && project.project) {
+            const entries = [...ui.selectedClipIds]
+              .map((clipId) => {
+                for (const track of project.project!.tracks) {
+                  const clip = track.clips.find((c) => c.id === clipId);
+                  if (clip) return { clip, trackId: track.id };
+                }
+                return null;
+              })
+              .filter((e): e is NonNullable<typeof e> => e !== null);
+            const data = copyClips(entries);
+            if (data) {
+              ui.setClipboard(data);
+              const ids = [...ui.selectedClipIds];
+              ui.deselectAll();
+              ids.forEach((id) => project.removeClip(id));
+            }
+          }
+        }
+        return;
+      }
+
+      if (matches('clips.paste') && !anyModalOpen) {
+        event.preventDefault();
+        const clipboard = ui.clipboard;
+        if (!clipboard) return;
+
+        if (clipboard.type === 'notes' && ui.keyboardContext.scope === 'pianoRoll') {
+          // Paste notes into the active piano roll clip at playhead
+          const clipId = ui.openPianoRollClipId;
+          if (clipId) {
+            const clip = project.getClipById?.(clipId);
+            if (clip) {
+              const bpm = project.project?.bpm ?? 120;
+              const pasteBeat = (transport.currentTime - clip.startTime) * (bpm / 60);
+              const newNotes = preparePasteNotes(clipboard, Math.max(0, pasteBeat));
+              for (const note of newNotes) {
+                project.addMidiNote(clipId, note);
+              }
+              ui.setSelectedPianoRollNoteIds(newNotes.map((n) => n.id));
+            }
+          }
+        } else if (clipboard.type === 'clips') {
+          // Paste clips at playhead position
+          const pastedClips = preparePasteClips(clipboard, transport.currentTime);
+          const newIds = project.pasteClipsToTracks(pastedClips);
+          if (newIds.length > 0) {
+            ui.selectClips(newIds);
           }
         }
         return;

--- a/src/services/__tests__/clipboardService.test.ts
+++ b/src/services/__tests__/clipboardService.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from 'vitest';
+import {
+  copyClips,
+  copyNotes,
+  preparePasteClips,
+  preparePasteNotes,
+  deepCloneClip,
+  deepCloneMidiNote,
+  type ClipboardClipData,
+  type ClipboardNoteData,
+} from '../clipboardService';
+import type { Clip, MidiNote } from '../../types/project';
+
+// ── Fixtures ──────────────────────────────────────────────────────
+
+function makeClip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: 'clip-1',
+    trackId: 'track-1',
+    startTime: 4,
+    duration: 8,
+    prompt: 'test prompt',
+    lyrics: '',
+    generationStatus: 'ready',
+    generationJobId: null,
+    cumulativeMixKey: 'cum-key',
+    isolatedAudioKey: 'iso-key',
+    waveformPeaks: [0.1, 0.5, 0.8],
+    ...overrides,
+  };
+}
+
+function makeNote(overrides: Partial<MidiNote> = {}): MidiNote {
+  return {
+    id: 'note-1',
+    pitch: 60,
+    startBeat: 0,
+    durationBeats: 1,
+    velocity: 100,
+    ...overrides,
+  };
+}
+
+// ── deepCloneClip ─────────────────────────────────────────────────
+
+describe('deepCloneClip', () => {
+  it('creates an independent copy of a clip', () => {
+    const original = makeClip({ waveformPeaks: [0.1, 0.2] });
+    const clone = deepCloneClip(original);
+
+    expect(clone).toEqual(original);
+    expect(clone).not.toBe(original);
+    // Mutating clone must not affect original
+    clone.startTime = 999;
+    expect(original.startTime).toBe(4);
+  });
+
+  it('deep clones midiData notes', () => {
+    const original = makeClip({
+      midiData: { notes: [makeNote()], grid: '1/16' },
+    });
+    const clone = deepCloneClip(original);
+
+    expect(clone.midiData!.notes).toEqual(original.midiData!.notes);
+    clone.midiData!.notes[0].pitch = 999;
+    expect(original.midiData!.notes[0].pitch).toBe(60);
+  });
+});
+
+// ── deepCloneMidiNote ─────────────────────────────────────────────
+
+describe('deepCloneMidiNote', () => {
+  it('creates an independent copy of a note', () => {
+    const original = makeNote();
+    const clone = deepCloneMidiNote(original);
+
+    expect(clone).toEqual(original);
+    clone.pitch = 999;
+    expect(original.pitch).toBe(60);
+  });
+});
+
+// ── copyClips ─────────────────────────────────────────────────────
+
+describe('copyClips', () => {
+  it('returns null for empty array', () => {
+    expect(copyClips([])).toBeNull();
+  });
+
+  it('builds clipboard data from a single clip', () => {
+    const clip = makeClip({ startTime: 4 });
+    const result = copyClips([{ clip, trackId: 'track-1' }]);
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('clips');
+    expect(result!.entries).toHaveLength(1);
+    expect(result!.entries[0].sourceTrackId).toBe('track-1');
+    expect(result!.anchorTime).toBe(4);
+    // Should be a deep clone, not the same reference
+    expect(result!.entries[0].clip).not.toBe(clip);
+    expect(result!.entries[0].clip).toEqual(clip);
+  });
+
+  it('computes anchorTime as earliest startTime among multiple clips', () => {
+    const clip1 = makeClip({ id: 'c1', startTime: 8 });
+    const clip2 = makeClip({ id: 'c2', startTime: 2 });
+    const clip3 = makeClip({ id: 'c3', startTime: 12 });
+
+    const result = copyClips([
+      { clip: clip1, trackId: 'track-1' },
+      { clip: clip2, trackId: 'track-2' },
+      { clip: clip3, trackId: 'track-1' },
+    ]);
+
+    expect(result!.anchorTime).toBe(2);
+    expect(result!.entries).toHaveLength(3);
+  });
+});
+
+// ── copyNotes ─────────────────────────────────────────────────────
+
+describe('copyNotes', () => {
+  it('returns null for empty array', () => {
+    expect(copyNotes([], 'clip-1')).toBeNull();
+  });
+
+  it('builds clipboard data from notes', () => {
+    const notes = [
+      makeNote({ id: 'n1', startBeat: 4 }),
+      makeNote({ id: 'n2', startBeat: 2 }),
+    ];
+    const result = copyNotes(notes, 'clip-1');
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('notes');
+    expect(result!.notes).toHaveLength(2);
+    expect(result!.sourceClipId).toBe('clip-1');
+    expect(result!.anchorBeat).toBe(2);
+    // Deep clones
+    expect(result!.notes[0]).not.toBe(notes[0]);
+  });
+});
+
+// ── preparePasteClips ─────────────────────────────────────────────
+
+describe('preparePasteClips', () => {
+  it('offsets clips to paste at the given time', () => {
+    const data: ClipboardClipData = {
+      type: 'clips',
+      entries: [
+        { clip: makeClip({ startTime: 4, duration: 4 }), sourceTrackId: 'track-1' },
+        { clip: makeClip({ id: 'c2', startTime: 8, duration: 4 }), sourceTrackId: 'track-2' },
+      ],
+      anchorTime: 4,
+    };
+
+    const result = preparePasteClips(data, 16);
+    expect(result).toHaveLength(2);
+
+    // Offset = 16 - 4 = 12
+    expect(result[0].clip.startTime).toBe(16); // 4 + 12
+    expect(result[1].clip.startTime).toBe(20); // 8 + 12
+    expect(result[0].targetTrackId).toBe('track-1');
+    expect(result[1].targetTrackId).toBe('track-2');
+  });
+
+  it('generates new IDs for pasted clips', () => {
+    const data: ClipboardClipData = {
+      type: 'clips',
+      entries: [{ clip: makeClip(), sourceTrackId: 'track-1' }],
+      anchorTime: 4,
+    };
+
+    const result = preparePasteClips(data, 4);
+    expect(result[0].clip.id).not.toBe('clip-1');
+    expect(result[0].clip.id).toBeTruthy();
+  });
+
+  it('generates new IDs for MIDI notes inside pasted clips', () => {
+    const clip = makeClip({
+      midiData: { notes: [makeNote({ id: 'original-note' })], grid: '1/16' },
+    });
+    const data: ClipboardClipData = {
+      type: 'clips',
+      entries: [{ clip, sourceTrackId: 'track-1' }],
+      anchorTime: 4,
+    };
+
+    const result = preparePasteClips(data, 4);
+    expect(result[0].clip.midiData!.notes[0].id).not.toBe('original-note');
+  });
+
+  it('preserves audio state for ready clips', () => {
+    const clip = makeClip({
+      generationStatus: 'ready',
+      isolatedAudioKey: 'audio-key',
+      cumulativeMixKey: 'mix-key',
+      waveformPeaks: [0.1, 0.5],
+    });
+    const data: ClipboardClipData = {
+      type: 'clips',
+      entries: [{ clip, sourceTrackId: 'track-1' }],
+      anchorTime: 4,
+    };
+
+    const result = preparePasteClips(data, 10);
+    expect(result[0].clip.generationStatus).toBe('ready');
+    expect(result[0].clip.isolatedAudioKey).toBe('audio-key');
+    expect(result[0].clip.cumulativeMixKey).toBe('mix-key');
+    expect(result[0].clip.waveformPeaks).toEqual([0.1, 0.5]);
+  });
+
+  it('clears generationJobId on pasted clips', () => {
+    const clip = makeClip({ generationJobId: 'running-job' });
+    const data: ClipboardClipData = {
+      type: 'clips',
+      entries: [{ clip, sourceTrackId: 'track-1' }],
+      anchorTime: 4,
+    };
+
+    const result = preparePasteClips(data, 4);
+    expect(result[0].clip.generationJobId).toBeNull();
+  });
+});
+
+// ── preparePasteNotes ─────────────────────────────────────────────
+
+describe('preparePasteNotes', () => {
+  it('offsets notes to paste at the given beat', () => {
+    const data: ClipboardNoteData = {
+      type: 'notes',
+      notes: [
+        makeNote({ startBeat: 2 }),
+        makeNote({ id: 'n2', startBeat: 6 }),
+      ],
+      sourceClipId: 'clip-1',
+      anchorBeat: 2,
+    };
+
+    const result = preparePasteNotes(data, 8);
+    // Offset = 8 - 2 = 6
+    expect(result[0].startBeat).toBe(8); // 2 + 6
+    expect(result[1].startBeat).toBe(12); // 6 + 6
+  });
+
+  it('generates new IDs for pasted notes', () => {
+    const data: ClipboardNoteData = {
+      type: 'notes',
+      notes: [makeNote({ id: 'original' })],
+      sourceClipId: 'clip-1',
+      anchorBeat: 0,
+    };
+
+    const result = preparePasteNotes(data, 0);
+    expect(result[0].id).not.toBe('original');
+    expect(result[0].id).toBeTruthy();
+  });
+
+  it('preserves pitch, duration, and velocity', () => {
+    const data: ClipboardNoteData = {
+      type: 'notes',
+      notes: [makeNote({ pitch: 72, durationBeats: 2, velocity: 64 })],
+      sourceClipId: 'clip-1',
+      anchorBeat: 0,
+    };
+
+    const result = preparePasteNotes(data, 4);
+    expect(result[0].pitch).toBe(72);
+    expect(result[0].durationBeats).toBe(2);
+    expect(result[0].velocity).toBe(64);
+  });
+});

--- a/src/services/clipboardService.ts
+++ b/src/services/clipboardService.ts
@@ -1,0 +1,137 @@
+/**
+ * Clipboard service for copy/cut/paste of clips and MIDI notes.
+ *
+ * Uses an internal app clipboard (not the system clipboard) to store
+ * rich structured data that can't be serialized to plain text.
+ */
+import { v4 as uuidv4 } from 'uuid';
+import type { Clip, MidiNote } from '../types/project';
+
+// ── Clipboard data types ──────────────────────────────────────────
+
+export interface ClipboardClipEntry {
+  /** Deep clone of the source clip (original IDs preserved for reference). */
+  clip: Clip;
+  /** Track ID the clip was copied from, used for same-track paste. */
+  sourceTrackId: string;
+}
+
+export interface ClipboardClipData {
+  type: 'clips';
+  entries: ClipboardClipEntry[];
+  /** Earliest startTime among copied clips — used as the paste anchor. */
+  anchorTime: number;
+}
+
+export interface ClipboardNoteData {
+  type: 'notes';
+  notes: MidiNote[];
+  /** Clip ID the notes were copied from. */
+  sourceClipId: string;
+  /** Earliest startBeat among copied notes — used as the paste anchor. */
+  anchorBeat: number;
+}
+
+export type ClipboardData = ClipboardClipData | ClipboardNoteData;
+
+// ── Deep clone helpers ────────────────────────────────────────────
+
+/** Deep clone a clip, preserving all fields exactly. */
+export function deepCloneClip(clip: Clip): Clip {
+  return structuredClone(clip);
+}
+
+/** Deep clone a MIDI note. */
+export function deepCloneMidiNote(note: MidiNote): MidiNote {
+  return { ...note };
+}
+
+// ── Copy operations ───────────────────────────────────────────────
+
+/**
+ * Build clipboard data from selected clips.
+ * Returns null if no clips are provided.
+ */
+export function copyClips(
+  clips: { clip: Clip; trackId: string }[],
+): ClipboardClipData | null {
+  if (clips.length === 0) return null;
+
+  const entries: ClipboardClipEntry[] = clips.map(({ clip, trackId }) => ({
+    clip: deepCloneClip(clip),
+    sourceTrackId: trackId,
+  }));
+
+  const anchorTime = Math.min(...entries.map((e) => e.clip.startTime));
+  return { type: 'clips', entries, anchorTime };
+}
+
+/**
+ * Build clipboard data from selected MIDI notes.
+ * Returns null if no notes are provided.
+ */
+export function copyNotes(
+  notes: MidiNote[],
+  sourceClipId: string,
+): ClipboardNoteData | null {
+  if (notes.length === 0) return null;
+
+  const cloned = notes.map(deepCloneMidiNote);
+  const anchorBeat = Math.min(...cloned.map((n) => n.startBeat));
+  return { type: 'notes', notes: cloned, sourceClipId, anchorBeat };
+}
+
+// ── Paste operations ──────────────────────────────────────────────
+
+export interface PastedClip {
+  /** New clip with fresh ID, repositioned to pasteTime. */
+  clip: Clip;
+  /** Target track ID for this clip. */
+  targetTrackId: string;
+}
+
+/**
+ * Prepare clips from clipboard for pasting at a given time.
+ * Each clip gets a new UUID and is offset so the anchor aligns to pasteTime.
+ */
+export function preparePasteClips(
+  data: ClipboardClipData,
+  pasteTime: number,
+): PastedClip[] {
+  const timeOffset = pasteTime - data.anchorTime;
+
+  return data.entries.map((entry) => {
+    const newClip: Clip = {
+      ...deepCloneClip(entry.clip),
+      id: uuidv4(),
+      startTime: entry.clip.startTime + timeOffset,
+      // Preserve audio state for ready clips
+      generationJobId: null,
+    };
+    // Give MIDI notes fresh IDs
+    if (newClip.midiData) {
+      newClip.midiData = {
+        ...newClip.midiData,
+        notes: newClip.midiData.notes.map((n) => ({ ...n, id: uuidv4() })),
+      };
+    }
+    return { clip: newClip, targetTrackId: entry.sourceTrackId };
+  });
+}
+
+/**
+ * Prepare MIDI notes from clipboard for pasting at a given beat position.
+ * Each note gets a new UUID and is offset so the anchor aligns to pasteBeat.
+ */
+export function preparePasteNotes(
+  data: ClipboardNoteData,
+  pasteBeat: number,
+): MidiNote[] {
+  const beatOffset = pasteBeat - data.anchorBeat;
+
+  return data.notes.map((note) => ({
+    ...deepCloneMidiNote(note),
+    id: uuidv4(),
+    startBeat: note.startBeat + beatOffset,
+  }));
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -742,6 +742,8 @@ export interface ProjectState extends MidiSliceActions {
   duplicateClipToTrack: (clipId: string, targetTrackId: string, startTime?: number) => Clip | undefined;
   batchDuplicateClips: (clipIds: string[], timeOffset: number) => void;
   batchMoveClips: (clipIds: string[], timeOffset: number) => void;
+  /** Paste pre-built clips into their target tracks. Returns IDs of newly created clips. */
+  pasteClipsToTracks: (clips: { clip: Clip; targetTrackId: string }[]) => string[];
 
   // Session View / clip launcher
   createSessionScene: (name?: string) => SessionScene | undefined;
@@ -4980,6 +4982,40 @@ export const useProjectStore = create<ProjectState>()(
       updated.totalDuration = computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.timeSignatureDenominator, state.project.tempoMap, state.project.timeSignatureMap);
     }
     set({ project: updated });
+  },
+
+  pasteClipsToTracks: (clips) => {
+    const state = get();
+    if (_isViewerMode()) return [];
+    if (!state.project || clips.length === 0) return [];
+    _pushHistory(state.project);
+
+    const trackIdSet = new Set(state.project.tracks.map((t) => t.id));
+    const newClipIds: string[] = [];
+    let newTracks = state.project.tracks;
+    let session = ensureProjectSession(state.project).session!;
+
+    for (const { clip, targetTrackId } of clips) {
+      if (!trackIdSet.has(targetTrackId)) continue;
+      const newClip: Clip = { ...clip, trackId: targetTrackId };
+      newTracks = newTracks.map((t) =>
+        t.id === targetTrackId ? { ...t, clips: [...t.clips, newClip] } : t,
+      );
+      session = autoAssignClipToSession(session, targetTrackId, newClip.id);
+      newClipIds.push(newClip.id);
+    }
+
+    set({
+      project: {
+        ...state.project,
+        updatedAt: Date.now(),
+        totalDuration: computeTotalDuration(newTracks, state.project.measures, state.project.bpm, state.project.timeSignature, state.project.timeSignatureDenominator, state.project.tempoMap, state.project.timeSignatureMap),
+        tracks: newTracks,
+        session: ensureProjectSession({ ...state.project, tracks: newTracks, session }).session!,
+      },
+    });
+
+    return newClipIds;
   },
 
   createSessionScene: (name) => {

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -8,6 +8,7 @@ import { useTransportStore } from './transportStore';
 import type { ShortcutContext } from '../types/shortcuts';
 import type { ThemeId } from '../themes/themeTokens';
 import type { EnhancementNode, EnhancementSession } from '../types/enhance';
+import type { ClipboardData } from '../services/clipboardService';
 import type { SynthPresetDefinition, SynthPresetCategory } from '../data/synthPresets';
 import type { InstrumentPreset } from '../data/instrumentPresets';
 import type { LoopCategory } from '../engine/LoopLibrary';
@@ -54,6 +55,8 @@ export interface UIState {
   selectedTrackIds: Set<string>;
   /** Tracks whether the user's last selection was on clips or tracks, for context-aware Cmd+A and Delete. */
   lastSelectionContext: 'tracks' | 'clips' | null;
+  /** Internal clipboard for copy/cut/paste of clips or MIDI notes. */
+  clipboard: ClipboardData | null;
   editingClipId: string | null;
   editingText2MusicClipId: string | null;
   showNewProjectDialog: boolean;
@@ -260,6 +263,7 @@ export interface UIState {
   selectTracks: (trackIds: string[]) => void;
   deselectAllTracks: () => void;
   deselectAll: () => void;
+  setClipboard: (data: ClipboardData | null) => void;
   setEditingClip: (clipId: string | null) => void;
   setEditingText2MusicClipId: (clipId: string | null) => void;
   setShowNewProjectDialog: (v: boolean) => void;
@@ -589,6 +593,7 @@ export const useUIStore = create<UIState>()(
   selectedClipIds: new Set(),
   selectedTrackIds: new Set(),
   lastSelectionContext: null,
+  clipboard: null,
   editingClipId: null,
   editingText2MusicClipId: null,
   showNewProjectDialog: false,
@@ -830,6 +835,8 @@ export const useUIStore = create<UIState>()(
   deselectAllTracks: () => set({ selectedTrackIds: new Set() }),
 
   deselectAll: () => set({ selectedClipIds: new Set(), selectedTrackIds: new Set(), lastSelectionContext: null }),
+
+  setClipboard: (data) => set({ clipboard: data }),
 
   setEditingClip: (clipId) => set({ editingClipId: clipId }),
   setEditingText2MusicClipId: (clipId: string | null) => set({ editingText2MusicClipId: clipId }),


### PR DESCRIPTION
## Summary
- Add standard Cmd+C / Cmd+V / Cmd+X clipboard shortcuts for clips (timeline) and MIDI notes (piano roll)
- Internal app clipboard preserves rich structured data (audio state, MIDI notes, generation params)
- Paste positions clips/notes at playhead with fresh UUIDs
- Cut = copy + delete, integrating with undo/redo system

## Changes
- `src/services/clipboardService.ts` — Pure clipboard logic (copy/paste data prep, deep cloning)
- `src/services/__tests__/clipboardService.test.ts` — 16 unit tests
- `src/constants/shortcutDefaults.ts` — 3 new shortcut definitions
- `src/hooks/useKeyboardShortcuts.ts` — Copy/cut/paste handlers for timeline + piano roll contexts
- `src/store/uiStore.ts` — Clipboard state field + setter
- `src/store/projectStore.ts` — `pasteClipsToTracks()` method

## Test plan
- [x] 16 unit tests for clipboard service (clone, copy, paste offset, ID generation)
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 3802 tests pass
- [x] `npx tsc -b && npx vite build` — builds successfully
- [ ] Manual: select clips → Cmd+C → move playhead → Cmd+V → clips appear at playhead
- [ ] Manual: Cmd+X cuts clips (disappear from original, appear on paste)
- [ ] Manual: piano roll note copy/paste works

Closes #1377

🤖 Generated with [Claude Code](https://claude.com/claude-code)