### PR TITLE
fix: add beforeAll warm-up for pluginSystem test to prevent timeout

### DIFF
--- a/tests/unit/pluginSystem.test.ts
+++ b/tests/unit/pluginSystem.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { describe, expect, it, beforeAll, beforeEach, vi } from 'vitest';
 import type {
   WAPPlugin,
   PluginAudioNode,
@@ -434,6 +434,11 @@ describe('FM Synth plugin', () => {
 // ─── Plugin Store Integration Tests ──────────────────────────────────────────
 
 describe('Plugin store actions', () => {
+  // Pre-import projectStore to warm the module cache (Tone.js init takes ~5s)
+  beforeAll(async () => {
+    await import('../../src/store/projectStore');
+  }, 15_000);
+
   it('adds and removes plugins on tracks', async () => {
     const { useProjectStore } = await import('../../src/store/projectStore');
 


### PR DESCRIPTION
## Summary
- Adds a `beforeAll` hook with 15s timeout to pre-import `projectStore` in the "Plugin store actions" describe block
- This warms the Tone.js module cache before individual tests run, preventing the ~5.2s initialization from exceeding Vitest's 5s default timeout

Closes #1344

## Test plan
- [x] All 30 pluginSystem tests pass consistently
- [x] `npx tsc --noEmit` passes
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)