### PR TITLE
refactor: replace `any` types in LoopLibrary.ts and dawStateSummary.ts

### DIFF
--- a/src/engine/LoopLibrary.ts
+++ b/src/engine/LoopLibrary.ts
@@ -5,10 +5,11 @@
 import * as Tone from 'tone';
 
 // Tone.Offline returns ToneAudioBuffer; extract the underlying AudioBuffer
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function toAudioBuffer(buf: any): AudioBuffer {
-  if (typeof buf.get === 'function') return buf.get();
-  return buf as AudioBuffer;
+function toAudioBuffer(buf: Tone.ToneAudioBuffer | AudioBuffer): AudioBuffer {
+  if (buf instanceof AudioBuffer) return buf;
+  const inner = buf.get();
+  if (!inner) throw new Error('ToneAudioBuffer has no underlying AudioBuffer');
+  return inner;
 }
 
 // ─── Types ──────────────────────────────────────────────────────────────────

--- a/src/utils/dawStateSummary.ts
+++ b/src/utils/dawStateSummary.ts
@@ -75,7 +75,7 @@ function formatTrackLine(track: Track): string {
 
   // Effects
   if (track.effects && track.effects.length > 0) {
-    const fx = track.effects.map((e) => `${e.type}${(e as any).bypass ? '(off)' : ''}`).join(', ');
+    const fx = track.effects.map((e) => `${e.type}${!e.enabled ? '(off)' : ''}`).join(', ');
     parts.push(`    FX: ${fx}`);
   }
 


### PR DESCRIPTION
## Summary
- **LoopLibrary.ts**: Type `buf` parameter as `Tone.ToneAudioBuffer | AudioBuffer` with `instanceof` check and null guard on `buf.get()`
- **dawStateSummary.ts**: Use `e.enabled` from `EffectBase` type instead of casting to `any` for nonexistent `bypass` property

Closes #1350

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] All 14 related tests pass (dawStateSummary + LoopLibrary)
- [x] No `any` types remain in either file

🤖 Generated with [Claude Code](https://claude.com/claude-code)