### PR TITLE
feat: categorize AI generation errors with actionable recovery suggestions

### DIFF
--- a/src/components/generation/GenerationPanel.tsx
+++ b/src/components/generation/GenerationPanel.tsx
@@ -43,6 +43,11 @@ export function GenerationPanel() {
                       <span className="text-red-400">✕</span>
                     )}
                     <span className="uppercase">{job.trackName}</span>
+                    {job.status === 'error' && job.errorCategory && (
+                      <span className="px-1 py-px rounded text-[9px] bg-red-800/60 text-red-200 uppercase">
+                        {job.errorCategory}
+                      </span>
+                    )}
                     <span className="text-[10px] opacity-70">
                       {job.status === 'error'
                         ? (job.actionableMessage ?? job.error ?? 'Failed')

--- a/src/components/timeline/ClipStatusOverlay.tsx
+++ b/src/components/timeline/ClipStatusOverlay.tsx
@@ -18,8 +18,11 @@ export function ClipStatusOverlay({ clip, generatingProgress, isMidiClip }: Clip
         </div>
       )}
       {clip.generationStatus === 'error' && (
-        <div className="absolute bottom-0 left-1.5 text-[8px] text-red-300 truncate pointer-events-none">
-          Error
+        <div
+          className="absolute bottom-0 left-1.5 right-1.5 text-[8px] text-red-300 truncate pointer-events-none"
+          title={clip.errorMessage}
+        >
+          {clip.errorMessage ? clip.errorMessage : 'Error'}
         </div>
       )}
       {clip.generationStatus === 'ready' && clip.inferredMetas && (

--- a/src/services/__tests__/generationErrorClassifier.test.ts
+++ b/src/services/__tests__/generationErrorClassifier.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { classifyGenerationError, type GenerationErrorCategory } from '../generationErrorClassifier';
+
+describe('classifyGenerationError', () => {
+  describe('network errors', () => {
+    it.each([
+      'Failed to fetch',
+      'NetworkError when attempting to fetch resource',
+      'Network request failed',
+      'net::ERR_CONNECTION_REFUSED',
+      'ERR_INTERNET_DISCONNECTED',
+      'The Internet connection appears to be offline',
+      'ECONNREFUSED',
+      'ENOTFOUND',
+      'Load failed',
+    ])('classifies "%s" as network', (message) => {
+      const result = classifyGenerationError(message);
+      expect(result.category).toBe('network' satisfies GenerationErrorCategory);
+      expect(result.suggestion).toBeTruthy();
+      expect(result.retryable).toBe(true);
+    });
+  });
+
+  describe('timeout errors', () => {
+    it.each([
+      'Generation timed out',
+      'Request timed out after 120000ms',
+      'Generation timed out — the server did not return a result within the time limit.',
+      'Cover generation timed out — the server did not return a result',
+      'AbortError: The operation was aborted',
+      'The operation timed out',
+      'timeout of 60000ms exceeded',
+    ])('classifies "%s" as timeout', (message) => {
+      const result = classifyGenerationError(message);
+      expect(result.category).toBe('timeout' satisfies GenerationErrorCategory);
+      expect(result.retryable).toBe(true);
+    });
+  });
+
+  describe('rate limit errors', () => {
+    it.each([
+      'Rate limit exceeded',
+      '429 Too Many Requests',
+      'rate_limit_exceeded',
+      'You have exceeded the rate limit',
+      'Too many requests, please slow down',
+      'throttled',
+    ])('classifies "%s" as rate-limited', (message) => {
+      const result = classifyGenerationError(message);
+      expect(result.category).toBe('rate-limited' satisfies GenerationErrorCategory);
+      expect(result.retryable).toBe(true);
+      expect(result.retryDelaySeconds).toBeGreaterThan(0);
+    });
+  });
+
+  describe('model errors', () => {
+    it.each([
+      'Generation failed: CUDA out of memory',
+      'Generation failed: Model inference error',
+      'Generation failed: Internal server error',
+      'Model switch failed: Model not found',
+      '500 Internal Server Error',
+      '503 Service Unavailable',
+      'Generation failed: invalid parameter',
+    ])('classifies "%s" as model-error', (message) => {
+      const result = classifyGenerationError(message);
+      expect(result.category).toBe('model-error' satisfies GenerationErrorCategory);
+    });
+  });
+
+  describe('unknown errors', () => {
+    it('classifies empty message as unknown', () => {
+      const result = classifyGenerationError('');
+      expect(result.category).toBe('unknown' satisfies GenerationErrorCategory);
+      expect(result.retryable).toBe(true);
+    });
+
+    it('classifies undefined message as unknown', () => {
+      const result = classifyGenerationError(undefined);
+      expect(result.category).toBe('unknown');
+    });
+
+    it('classifies unrecognized error as unknown', () => {
+      const result = classifyGenerationError('Something completely unexpected happened');
+      expect(result.category).toBe('unknown');
+    });
+  });
+
+  describe('suggestion quality', () => {
+    it('network suggestion mentions checking connection', () => {
+      const result = classifyGenerationError('Failed to fetch');
+      expect(result.suggestion).toMatch(/network|connection|backend/i);
+    });
+
+    it('timeout suggestion mentions retry or duration', () => {
+      const result = classifyGenerationError('Generation timed out');
+      expect(result.suggestion).toMatch(/retry|duration|shorter/i);
+    });
+
+    it('rate limit suggestion mentions waiting', () => {
+      const result = classifyGenerationError('Rate limit exceeded');
+      expect(result.suggestion).toMatch(/wait|moment|seconds/i);
+    });
+
+    it('model error suggestion mentions settings or backend', () => {
+      const result = classifyGenerationError('Generation failed: CUDA out of memory');
+      expect(result.suggestion).toMatch(/setting|parameter|backend|steps/i);
+    });
+  });
+});

--- a/src/services/generationErrorClassifier.ts
+++ b/src/services/generationErrorClassifier.ts
@@ -1,0 +1,119 @@
+/**
+ * Generation Error Classifier
+ *
+ * Categorizes AI generation errors with actionable recovery suggestions.
+ * Used by generationStore to provide meaningful feedback to users.
+ */
+
+export type GenerationErrorCategory =
+  | 'network'
+  | 'timeout'
+  | 'rate-limited'
+  | 'model-error'
+  | 'unknown';
+
+export interface ClassifiedError {
+  category: GenerationErrorCategory;
+  suggestion: string;
+  retryable: boolean;
+  /** Suggested delay before retrying (seconds). Only set for rate-limited errors. */
+  retryDelaySeconds?: number;
+}
+
+const NETWORK_PATTERNS = [
+  'failed to fetch',
+  'networkerror',
+  'network request failed',
+  'net::err_',
+  'err_internet',
+  'err_connection',
+  'econnrefused',
+  'enotfound',
+  'econnreset',
+  'connection appears to be offline',
+  'load failed',
+];
+
+const TIMEOUT_PATTERNS = [
+  'timed out',
+  'timeout',
+  'the operation was aborted',
+  'aborterror',
+];
+
+const RATE_LIMIT_PATTERNS = [
+  'rate limit',
+  'rate_limit',
+  '429',
+  'too many requests',
+  'throttle',
+];
+
+const MODEL_ERROR_PATTERNS = [
+  'cuda out of memory',
+  'model inference',
+  'internal server error',
+  'model switch failed',
+  'model not found',
+  '500 ',
+  '503 ',
+  'generation failed:',
+  'invalid parameter',
+  'server error',
+];
+
+function matchesAny(lower: string, patterns: string[]): boolean {
+  return patterns.some((p) => lower.includes(p));
+}
+
+export function classifyGenerationError(message?: string): ClassifiedError {
+  const trimmed = message?.trim() ?? '';
+  if (!trimmed) {
+    return {
+      category: 'unknown',
+      suggestion: 'Generation failed. Retry the request. If it keeps failing, verify the backend is healthy.',
+      retryable: true,
+    };
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  if (matchesAny(lower, NETWORK_PATTERNS)) {
+    return {
+      category: 'network',
+      suggestion: 'Check your network connection and verify the backend server is running, then retry.',
+      retryable: true,
+    };
+  }
+
+  if (matchesAny(lower, TIMEOUT_PATTERNS)) {
+    return {
+      category: 'timeout',
+      suggestion: 'The server took too long to respond. Retry with a shorter duration or fewer inference steps.',
+      retryable: true,
+    };
+  }
+
+  if (matchesAny(lower, RATE_LIMIT_PATTERNS)) {
+    return {
+      category: 'rate-limited',
+      suggestion: 'Too many requests. Wait a moment before retrying — the server needs time to process.',
+      retryable: true,
+      retryDelaySeconds: 30,
+    };
+  }
+
+  if (matchesAny(lower, MODEL_ERROR_PATTERNS)) {
+    return {
+      category: 'model-error',
+      suggestion: 'The AI model encountered an error. Try reducing inference steps or check the backend logs.',
+      retryable: lower.includes('cuda') || lower.includes('500') || lower.includes('503'),
+    };
+  }
+
+  return {
+    category: 'unknown',
+    suggestion: `${trimmed}. Retry the request. If it keeps failing, check the backend logs.`,
+    retryable: true,
+  };
+}

--- a/src/store/generationStore.ts
+++ b/src/store/generationStore.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import { DEFAULT_BPM, DEFAULT_DURATION, DEFAULT_KEY_SCALE, DEFAULT_GENERATION, MAX_BPM, MAX_DURATION, MIN_BPM, MIN_DURATION } from '../constants/defaults';
 import type { GenerationPreset } from '../constants/generationPresets';
 import { useProjectStore } from './projectStore';
+import { classifyGenerationError, type GenerationErrorCategory } from '../services/generationErrorClassifier';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import {
   applyPromptAutocompleteSuggestion as applyPromptAutocompleteSuggestionToPrompt,
@@ -25,6 +26,7 @@ export interface GenerationJob {
   completedAt?: number;
   lastUpdatedAt?: number;
   actionableMessage?: string;
+  errorCategory?: GenerationErrorCategory;
   error?: string;
   taskId?: string;
 }
@@ -80,20 +82,13 @@ function normalizeProgressPercent(
   return Math.max(0, Math.min(100, parsed));
 }
 
-function buildActionableGenerationMessage(status: GenerationJob['status'], error?: string): string | undefined {
-  if (status !== 'error') return undefined;
-  const message = error?.trim();
-  if (!message) {
-    return 'Generation failed. Retry the request. If it keeps failing, verify the backend is healthy.';
-  }
-  const lower = message.toLowerCase();
-  if (lower.includes('timed out')) {
-    return 'Generation timed out while waiting for the backend. Retry the request or check the backend status before trying again.';
-  }
-  if (lower.includes('failed to fetch') || lower.includes('network') || lower.includes('abort')) {
-    return 'Generation lost connection to the backend. Check the backend URL or health, then retry.';
-  }
-  return `${message} Retry the request. If it keeps failing, try a shorter duration or check the backend logs.`;
+function buildClassifiedError(status: GenerationJob['status'], error?: string): { actionableMessage?: string; errorCategory?: GenerationErrorCategory } {
+  if (status !== 'error') return {};
+  const classified = classifyGenerationError(error);
+  return {
+    actionableMessage: classified.suggestion,
+    errorCategory: classified.category,
+  };
 }
 
 export function deriveGenerationJobProgress(
@@ -146,7 +141,7 @@ export function deriveGenerationJobProgress(
     startedAt,
     lastUpdatedAt: now,
     completedAt: input.status === 'done' ? now : previous?.completedAt,
-    actionableMessage: buildActionableGenerationMessage(input.status, input.error),
+    ...buildClassifiedError(input.status, input.error),
     error: input.error,
   };
 }

--- a/tests/unit/generationStore.test.ts
+++ b/tests/unit/generationStore.test.ts
@@ -88,8 +88,8 @@ describe('generationStore', () => {
         now: 12_000,
       });
 
-      expect(updates.actionableMessage).toContain('timed out');
-      expect(updates.actionableMessage).toContain('Retry');
+      expect(updates.actionableMessage).toMatch(/retry|duration|shorter/i);
+      expect(updates.errorCategory).toBe('timeout');
       expect(updates.etaConfidence).toBe('none');
     });
 


### PR DESCRIPTION
## Summary
- Adds `generationErrorClassifier` service that categorizes errors into 5 categories: network, timeout, rate-limited, model-error, unknown
- Each category includes actionable recovery suggestions (e.g., "Check your network connection", "Wait 30s before retrying")
- `errorCategory` field added to `GenerationJob` interface
- GenerationPanel shows error category badge alongside the actionable message
- ClipStatusOverlay shows error message with tooltip for details
- 36 test cases covering all categories and edge cases

Closes #1360

## Test plan
- [x] 36 new classifier tests pass
- [x] All 3838 existing tests pass
- [x] `npx tsc --noEmit` passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)