### PR TITLE
feat: enhance auto-save status indicator with timestamps and notifications

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -97,7 +97,7 @@ function EditorShell() {
   }, [project, setShowNewProjectDialog]);
 
   // Auto-save to IndexedDB with dirty detection and beforeunload warning
-  const { status: saveStatus, saveNow } = useAutoSave();
+  const { status: saveStatus, saveNow, lastSavedAt } = useAutoSave();
 
   // Cmd/Ctrl+S — immediate save
   useEffect(() => {
@@ -110,6 +110,13 @@ function EditorShell() {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [saveNow]);
+
+  // Unsaved changes indicator in document title
+  useEffect(() => {
+    const projectName = project?.name ?? 'ACE-Step DAW';
+    document.title = saveStatus === 'unsaved' ? `● ${projectName}` : projectName;
+    return () => { document.title = 'ACE-Step DAW'; };
+  }, [saveStatus, project?.name]);
 
   useKeyboardShortcuts();
   useEffectsSync();
@@ -139,7 +146,7 @@ function EditorShell() {
         {project && <LoopBrowser />}
       </div>
 
-      <StatusBar saveStatus={saveStatus} />
+      <StatusBar saveStatus={saveStatus} lastSavedAt={lastSavedAt} />
 
       {project && showSmartControls && <SmartControlsPanel />}
       {project && openSequencerTrackId && <ErrorBoundary name="Sequencer"><Suspense fallback={null}><SequencerEditor /></Suspense></ErrorBoundary>}

--- a/src/components/layout/SaveStatusIndicator.tsx
+++ b/src/components/layout/SaveStatusIndicator.tsx
@@ -1,14 +1,36 @@
+import { useState, useEffect } from 'react';
 import type { SaveStatus } from '../../hooks/useAutoSave';
 
 interface SaveStatusIndicatorProps {
   status: SaveStatus;
+  lastSavedAt?: number | null;
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const diff = Math.floor((Date.now() - timestamp) / 1000);
+  if (diff < 10) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  const mins = Math.floor(diff / 60);
+  if (mins < 60) return `${mins} min ago`;
+  const hours = Math.floor(mins / 60);
+  return `${hours}h ago`;
 }
 
 /**
  * Minimal save-status indicator for the status bar.
  * Shows a dot + label: green "Saved", amber pulsing "Saving...", red "Unsaved".
+ * Optionally shows relative time since last save.
  */
-export function SaveStatusIndicator({ status }: SaveStatusIndicatorProps) {
+export function SaveStatusIndicator({ status, lastSavedAt }: SaveStatusIndicatorProps) {
+  const [, setTick] = useState(0);
+
+  // Re-render every 30s to update relative time
+  useEffect(() => {
+    if (!lastSavedAt) return;
+    const interval = setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => clearInterval(interval);
+  }, [lastSavedAt]);
+
   const dotColor =
     status === 'saved'
       ? 'bg-emerald-500'
@@ -23,13 +45,17 @@ export function SaveStatusIndicator({ status }: SaveStatusIndicatorProps) {
         ? 'Saving...'
         : 'Unsaved';
 
+  const timeLabel = status === 'saved' && lastSavedAt
+    ? formatRelativeTime(lastSavedAt)
+    : null;
+
   return (
     <span
       className="inline-flex items-center gap-1 text-daw-text-muted"
       data-testid="save-status-indicator"
       title={
         status === 'saved'
-          ? 'All changes saved'
+          ? `All changes saved${timeLabel ? ` (${timeLabel})` : ''}`
           : status === 'saving'
             ? 'Saving changes...'
             : 'Unsaved changes (Ctrl+S to save now)'
@@ -40,6 +66,9 @@ export function SaveStatusIndicator({ status }: SaveStatusIndicatorProps) {
         aria-hidden="true"
       />
       <span>{label}</span>
+      {timeLabel && (
+        <span className="text-daw-text-muted/60" data-testid="save-time-label">{timeLabel}</span>
+      )}
     </span>
   );
 }

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -22,9 +22,10 @@ export function _resetLastKnownConnection() {
 
 interface StatusBarProps {
   saveStatus?: SaveStatus;
+  lastSavedAt?: number | null;
 }
 
-export function StatusBar({ saveStatus }: StatusBarProps) {
+export function StatusBar({ saveStatus, lastSavedAt }: StatusBarProps) {
   const [connected, setConnected] = useState(lastKnownBackendConnection);
   const jobs = useGenerationStore((s) => s.jobs);
   const pixelsPerSecond = useUIStore((s) => s.pixelsPerSecond);
@@ -165,7 +166,7 @@ export function StatusBar({ saveStatus }: StatusBarProps) {
             </a>
           </div>
           {saveStatus && (
-            <SaveStatusIndicator status={saveStatus} />
+            <SaveStatusIndicator status={saveStatus} lastSavedAt={lastSavedAt} />
           )}
           <div className="hidden md:flex items-center gap-1.5 text-daw-text-muted">
             <button

--- a/src/hooks/__tests__/useAutoSave.test.ts
+++ b/src/hooks/__tests__/useAutoSave.test.ts
@@ -269,6 +269,24 @@ describe('useAutoSave', () => {
     expect(result.current.status).toBe('saved');
   });
 
+  it('sets lastSavedAt after manual save', async () => {
+    const project = makeProject({ updatedAt: 1000 });
+
+    const { result } = renderHook(() => useAutoSave());
+
+    act(() => {
+      useProjectStore.setState({ project });
+    });
+
+    expect(result.current.lastSavedAt).toBeNull();
+
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    expect(result.current.lastSavedAt).toBeGreaterThan(0);
+  });
+
   it('accepts custom debounce interval via status transitions', async () => {
     const project = makeProject({ updatedAt: 1000 });
 

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useProjectStore } from '../store/projectStore';
 import { saveProject as saveProjectToIDB } from '../services/projectStorage';
+import { toastError, toastSuccess } from './useToast';
 
 export type SaveStatus = 'saved' | 'saving' | 'unsaved';
 
@@ -16,6 +17,8 @@ interface UseAutoSaveReturn {
   status: SaveStatus;
   /** Trigger an immediate save, bypassing the debounce timer. */
   saveNow: () => Promise<void>;
+  /** Timestamp of last successful save (ms since epoch), or null if never saved. */
+  lastSavedAt: number | null;
 }
 
 /**
@@ -29,24 +32,32 @@ interface UseAutoSaveReturn {
 export function useAutoSave(options?: UseAutoSaveOptions): UseAutoSaveReturn {
   const debounceMs = options?.debounceMs ?? DEFAULT_DEBOUNCE_MS;
   const [status, setStatus] = useState<SaveStatus>('saved');
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSavedUpdatedAtRef = useRef<number>(0);
   const isDirtyRef = useRef(false);
+  const isManualSaveRef = useRef(false);
 
   const saveNow = useCallback(async () => {
     const project = useProjectStore.getState().project;
     if (!project) return;
 
+    isManualSaveRef.current = true;
     setStatus('saving');
     try {
       await saveProjectToIDB(project);
       lastSavedUpdatedAtRef.current = project.updatedAt;
       isDirtyRef.current = false;
       setStatus('saved');
+      setLastSavedAt(Date.now());
+      if (isManualSaveRef.current) {
+        toastSuccess('Project saved');
+      }
     } catch {
-      // On failure, remain unsaved so the next cycle retries
       setStatus('unsaved');
+      toastError('Save failed — will retry automatically');
     }
+    isManualSaveRef.current = false;
 
     // Clear any pending debounce timer since we just saved
     if (timerRef.current) {
@@ -82,6 +93,10 @@ export function useAutoSave(options?: UseAutoSaveOptions): UseAutoSaveReturn {
           lastSavedUpdatedAtRef.current = currentProject.updatedAt;
           isDirtyRef.current = false;
           setStatus('saved');
+          setLastSavedAt(Date.now());
+        }).catch(() => {
+          setStatus('unsaved');
+          toastError('Auto-save failed — will retry');
         });
       }, debounceMs);
     });
@@ -111,5 +126,5 @@ export function useAutoSave(options?: UseAutoSaveOptions): UseAutoSaveReturn {
     };
   }, []);
 
-  return { status, saveNow };
+  return { status, saveNow, lastSavedAt };
 }


### PR DESCRIPTION
## Summary
- **Last save timestamp**: SaveStatusIndicator shows relative time (e.g., "Saved just now", "Saved 2 min ago")
- **Save toast notifications**: Manual save (Ctrl+S) shows success toast; failures show error toast
- **Title bar indicator**: Document title shows ● dot prefix when unsaved changes exist
- **Auto-save failure toast**: Background auto-save failures now surface as error toasts

Closes #1363

## Test plan
- [x] All 12 useAutoSave tests pass (including new `lastSavedAt` test)
- [x] `npx tsc --noEmit` passes
- [x] Full test suite (3803 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)