### PR TITLE
feat: enable WASM DSP as default audio processing path

### DIFF
--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -920,10 +920,44 @@ class EffectsEngine {
   private bypassedTracks = new Map<string, boolean>();
   private sidechains = new Map<string, SidechainFollower>();
 
+  // WASM DSP integration
+  private wasmNodes = new Map<string, import('../wasm/WasmDspEngine').WasmDspNode>();
+  private _useWasm = false;
+  private _wasmEngine: typeof import('../wasm/WasmDspEngine') | null = null;
+  private _wasmMapper: typeof import('./wasmParamMapper') | null = null;
+
+  /** Enable/disable WASM DSP routing. Called after WasmDspEngine.initialize() succeeds. */
+  setUseWasm(enabled: boolean, wasmEngine?: typeof import('../wasm/WasmDspEngine'), mapper?: typeof import('./wasmParamMapper')) {
+    this._useWasm = enabled;
+    if (wasmEngine) this._wasmEngine = wasmEngine;
+    if (mapper) this._wasmMapper = mapper;
+  }
+
   rebuildChain(trackId: string, effects: TrackEffect[], bypassed = false) {
     this.disposeChain(trackId);
     this.bypassedTracks.set(trackId, bypassed);
     const activeEffects = effects.filter((e) => e.enabled);
+    if (activeEffects.length === 0) return;
+
+    // Try WASM path: single AudioWorkletNode per track
+    if (this._useWasm && this._wasmEngine && this._wasmMapper) {
+      const { canUseWasmForChain, applyEffectsToWasmNode } = this._wasmMapper;
+      if (canUseWasmForChain(activeEffects)) {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const eng = this._wasmEngine as any;
+          const ctx = Tone.getContext().rawContext as AudioContext;
+          const wasmNode = eng.createProcessor(ctx, trackId) as import('../wasm/WasmDspEngine').WasmDspNode;
+          applyEffectsToWasmNode(wasmNode, activeEffects);
+          this.wasmNodes.set(trackId, wasmNode);
+          return;
+        } catch (err) {
+          console.warn(`[EffectsEngine] WASM chain failed for ${trackId}, falling back to Tone.js`, err);
+        }
+      }
+    }
+
+    // Tone.js path (unchanged)
     const nodes = activeEffects.map(createNode);
     for (let i = 0; i < nodes.length - 1; i++) {
       getEffectOutput(nodes[i]).connect(getEffectInput(nodes[i + 1]));
@@ -937,6 +971,14 @@ class EffectsEngine {
     params: TrackEffect['params'],
     effectType: TrackEffectType,
   ) {
+    // WASM path: re-map the single changed effect
+    const wasmNode = this.wasmNodes.get(trackId);
+    if (wasmNode && this._wasmMapper) {
+      const msg = this._wasmMapper.mapEffectToWasm(effectType, params as unknown as Record<string, unknown>);
+      if (msg) wasmNode.audioNode.port.postMessage(msg);
+      return;
+    }
+
     const nodes = this.chains.get(trackId);
     if (!nodes) return;
     const effectNode = nodes.find((n) => n.id === effectId);
@@ -1473,6 +1515,9 @@ class EffectsEngine {
 
   getInputNode(trackId: string): AudioNode | null {
     if (this.bypassedTracks.get(trackId)) return null;
+    // WASM path: AudioWorkletNode is both input and output
+    const wasmNode = this.wasmNodes.get(trackId);
+    if (wasmNode) return wasmNode.audioNode;
     const nodes = this.chains.get(trackId);
     if (!nodes?.length) return null;
     return getEffectInput(nodes[0]) ?? null;
@@ -1480,6 +1525,9 @@ class EffectsEngine {
 
   getOutputNode(trackId: string): AudioNode | null {
     if (this.bypassedTracks.get(trackId)) return null;
+    // WASM path
+    const wasmNode = this.wasmNodes.get(trackId);
+    if (wasmNode) return wasmNode.audioNode;
     const nodes = this.chains.get(trackId);
     if (!nodes?.length) return null;
 
@@ -1495,6 +1543,13 @@ class EffectsEngine {
 
   disposeChain(trackId: string) {
     this.bypassedTracks.delete(trackId);
+    // Dispose WASM node if present
+    const wasmNode = this.wasmNodes.get(trackId);
+    if (wasmNode) {
+      try { wasmNode.audioNode.disconnect(); } catch { /* already disconnected */ }
+      try { wasmNode.audioNode.port.close(); } catch { /* already closed */ }
+      this.wasmNodes.delete(trackId);
+    }
     // Dispose all sidechains for this track
     for (const [key, follower] of this.sidechains) {
       if (key.startsWith(`${trackId}:`)) {
@@ -1514,6 +1569,12 @@ class EffectsEngine {
 
   dispose() {
     this.bypassedTracks.clear();
+    // Dispose all WASM nodes
+    for (const wasmNode of this.wasmNodes.values()) {
+      try { wasmNode.audioNode.disconnect(); } catch { /* ok */ }
+      try { wasmNode.audioNode.port.close(); } catch { /* ok */ }
+    }
+    this.wasmNodes.clear();
     for (const follower of this.sidechains.values()) {
       follower.dispose();
     }
@@ -1525,3 +1586,26 @@ class EffectsEngine {
 }
 
 export const effectsEngine = new EffectsEngine();
+
+/**
+ * Initialize WASM DSP and wire it into the effects engine.
+ * Call once after AudioContext is available. Safe to call multiple times (idempotent).
+ * Returns true if WASM is ready, false on fallback to Tone.js.
+ */
+export async function initWasmDsp(): Promise<boolean> {
+  try {
+    const wasmEngine = await import('../wasm/WasmDspEngine');
+    const mapper = await import('./wasmParamMapper');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const eng = wasmEngine as any;
+    const ctx = Tone.getContext().rawContext as AudioContext;
+    await eng.initialize(ctx);
+    effectsEngine.setUseWasm(true, eng, mapper);
+    console.info('[WASM DSP] Initialized — effects will route through WASM when compatible');
+    return true;
+  } catch (err) {
+    console.warn('[WASM DSP] Init failed, using Tone.js fallback:', err);
+    effectsEngine.setUseWasm(false);
+    return false;
+  }
+}

--- a/src/engine/__tests__/wasmParamMapper.test.ts
+++ b/src/engine/__tests__/wasmParamMapper.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { canUseWasmForChain, mapEffectToWasm, WASM_SUPPORTED_EFFECTS } from '../wasmParamMapper';
+import type { TrackEffect } from '../../types/project';
+
+// Minimal effect factory helpers
+function makeEffect(type: string, params: Record<string, unknown> = {}, enabled = true): TrackEffect {
+  return { id: `eff-${type}`, type, params, enabled } as unknown as TrackEffect;
+}
+
+describe('wasmParamMapper', () => {
+  describe('WASM_SUPPORTED_EFFECTS', () => {
+    it('contains the expected 11 effect types', () => {
+      expect(WASM_SUPPORTED_EFFECTS).toContain('compressor');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('parametricEq');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('reverb');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('delay');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('distortion');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('filter');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('chorus');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('phaser');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('gate');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('limiter');
+      expect(WASM_SUPPORTED_EFFECTS).toContain('stereoImager');
+    });
+
+    it('does NOT contain unsupported types', () => {
+      expect(WASM_SUPPORTED_EFFECTS).not.toContain('eq3');
+      expect(WASM_SUPPORTED_EFFECTS).not.toContain('flanger');
+      expect(WASM_SUPPORTED_EFFECTS).not.toContain('convolver');
+      expect(WASM_SUPPORTED_EFFECTS).not.toContain('saturation');
+      expect(WASM_SUPPORTED_EFFECTS).not.toContain('algorithmicReverb');
+    });
+  });
+
+  describe('canUseWasmForChain', () => {
+    it('returns true for empty chain', () => {
+      expect(canUseWasmForChain([])).toBe(true);
+    });
+
+    it('returns true for all-WASM-supported chain', () => {
+      const effects = [
+        makeEffect('compressor', { threshold: -20, ratio: 4, attack: 0.01, release: 0.1, knee: 6 }),
+        makeEffect('reverb', { decay: 2.5, preDelay: 0.02, wet: 0.3 }),
+        makeEffect('delay', { time: 0.25, feedback: 0.3, wet: 0.5 }),
+      ];
+      expect(canUseWasmForChain(effects)).toBe(true);
+    });
+
+    it('returns false when chain contains unsupported effect', () => {
+      const effects = [
+        makeEffect('compressor', { threshold: -20, ratio: 4, attack: 0.01, release: 0.1, knee: 6 }),
+        makeEffect('convolver', { irType: 'plate', wet: 0.5 }),
+      ];
+      expect(canUseWasmForChain(effects)).toBe(false);
+    });
+
+    it('returns false when compressor has sidechain', () => {
+      const effects = [
+        makeEffect('compressor', {
+          threshold: -20, ratio: 4, attack: 0.01, release: 0.1, knee: 6,
+          sidechainSourceTrackId: 'other-track',
+        }),
+      ];
+      expect(canUseWasmForChain(effects)).toBe(false);
+    });
+
+    it('ignores disabled effects for compatibility check', () => {
+      const effects = [
+        makeEffect('compressor', { threshold: -20, ratio: 4, attack: 0.01, release: 0.1, knee: 6 }),
+        makeEffect('convolver', { irType: 'plate', wet: 0.5 }, false), // disabled
+      ];
+      expect(canUseWasmForChain(effects)).toBe(true);
+    });
+  });
+
+  describe('mapEffectToWasm', () => {
+    it('maps compressor params with s→ms conversion', () => {
+      const msg = mapEffectToWasm('compressor', {
+        threshold: -20, ratio: 4, attack: 0.01, release: 0.1, knee: 6,
+      });
+      expect(msg).toEqual({
+        type: 'set-compressor',
+        threshold: -20,
+        ratio: 4,
+        attackMs: 10,   // 0.01s → 10ms
+        releaseMs: 100,  // 0.1s → 100ms
+        kneeDb: 6,
+        makeupDb: 0,
+      });
+    });
+
+    it('maps delay params with s→ms conversion', () => {
+      const msg = mapEffectToWasm('delay', { time: 0.25, feedback: 0.3, wet: 0.5 });
+      expect(msg).toEqual({
+        type: 'set-delay',
+        delayMs: 250,   // 0.25s → 250ms
+        feedback: 0.3,
+        wet: 0.5,
+      });
+    });
+
+    it('maps distortion type string to int', () => {
+      const msg = mapEffectToWasm('distortion', { amount: 0.5, distortionType: 'overdrive', wet: 0.8 });
+      expect(msg.type).toBe('set-distortion');
+      expect(msg.distType).toBe(1); // overdrive = 1
+      expect(msg.drive).toBe(0.5);
+      expect(msg.mix).toBe(0.8);
+    });
+
+    it('maps filter type string to FilterType enum', () => {
+      const msg = mapEffectToWasm('filter', { frequency: 1000, resonance: 2, filterType: 'highpass' });
+      expect(msg.type).toBe('set-filter');
+      expect(msg.filterType).toBe(1); // highpass = 1
+      expect(msg.frequency).toBe(1000);
+      expect(msg.q).toBe(2);
+    });
+
+    it('maps reverb params', () => {
+      const msg = mapEffectToWasm('reverb', { decay: 2.5, preDelay: 0.02, wet: 0.3 });
+      expect(msg.type).toBe('set-reverb');
+      expect(msg.roomSize).toBeCloseTo(0.25, 1); // decay/10
+      expect(msg.wet).toBe(0.3);
+    });
+
+    it('maps chorus params', () => {
+      const msg = mapEffectToWasm('chorus', {
+        frequency: 1.5, depth: 0.7, delayTime: 3.5, feedback: 0, wet: 0.5,
+      });
+      expect(msg.type).toBe('set-chorus');
+      expect(msg.rateHz).toBe(1.5);
+      expect(msg.depthMs).toBeCloseTo(0.7 * 3.5, 2); // depth * delayTime
+      expect(msg.delayMs).toBe(3.5);
+    });
+
+    it('maps phaser params', () => {
+      const msg = mapEffectToWasm('phaser', {
+        frequency: 0.5, octaves: 3, stages: 4, Q: 10, baseFrequency: 350, wet: 0.5,
+      });
+      expect(msg.type).toBe('set-phaser');
+      expect(msg.rateHz).toBe(0.5);
+      expect(msg.stages).toBe(4);
+    });
+
+    it('maps gate params with s→ms conversion', () => {
+      const msg = mapEffectToWasm('gate', {
+        threshold: -40, range: -80, attack: 0.001, hold: 0.05, release: 0.1,
+        hysteresis: 3, mode: 'gate', sidechainHpf: 0, sidechainLpf: 20000,
+      });
+      expect(msg.type).toBe('set-gate');
+      expect(msg.attackMs).toBe(1);
+      expect(msg.holdMs).toBe(50);
+      expect(msg.releaseMs).toBe(100);
+    });
+
+    it('maps limiter params', () => {
+      const msg = mapEffectToWasm('limiter', {
+        ceiling: -1, release: 0.05, lookahead: 0.005, gain: 0, style: 'transparent',
+      });
+      expect(msg.type).toBe('set-limiter');
+      expect(msg.ceilingDb).toBe(-1);
+      expect(msg.releaseMs).toBe(50);
+    });
+
+    it('maps stereoImager params', () => {
+      const msg = mapEffectToWasm('stereoImager', {
+        width: 1.5, midGain: 0, sideGain: 0, monoFreq: 200, pan: 0,
+      });
+      expect(msg.type).toBe('set-stereo-width');
+      expect(msg.width).toBe(1.5);
+    });
+
+    it('returns null for unsupported effect type', () => {
+      const msg = mapEffectToWasm('convolver', { irType: 'plate', wet: 0.5 });
+      expect(msg).toBeNull();
+    });
+  });
+});

--- a/src/engine/wasmParamMapper.ts
+++ b/src/engine/wasmParamMapper.ts
@@ -1,0 +1,199 @@
+/**
+ * wasmParamMapper.ts — Translates TrackEffect parameters to WASM DSP message format.
+ *
+ * Determines which effect chains are WASM-compatible and maps
+ * Tone.js-style params (seconds, strings) to WASM-style params (ms, enums).
+ */
+import type { TrackEffect } from '../types/project';
+import { FilterType } from '../wasm/WasmDspEngine';
+import type { WasmDspNode } from '../wasm/WasmDspEngine';
+
+/** Effect types that have a production-ready WASM implementation. */
+export const WASM_SUPPORTED_EFFECTS = new Set([
+  'compressor',
+  'parametricEq',
+  'reverb',
+  'delay',
+  'distortion',
+  'filter',
+  'chorus',
+  'phaser',
+  'gate',
+  'limiter',
+  'stereoImager',
+] as const);
+
+type WasmSupportedType = typeof WASM_SUPPORTED_EFFECTS extends Set<infer T> ? T : never;
+
+/**
+ * Check if ALL enabled effects in a chain have WASM equivalents.
+ * Also rejects sidechain compression (no WASM sidechain support).
+ */
+export function canUseWasmForChain(effects: TrackEffect[]): boolean {
+  for (const effect of effects) {
+    if (!effect.enabled) continue;
+    if (!WASM_SUPPORTED_EFFECTS.has(effect.type as WasmSupportedType)) return false;
+    // Reject sidechain
+    if (effect.type === 'compressor') {
+      const p = effect.params as { sidechainSourceTrackId?: string };
+      if (p.sidechainSourceTrackId) return false;
+    }
+  }
+  return true;
+}
+
+/** Distortion type string → WASM int mapping */
+const DIST_TYPE_MAP: Record<string, number> = { soft: 0, overdrive: 1, fuzz: 2 };
+
+/** Filter type string → WASM FilterType enum */
+const FILTER_TYPE_MAP: Record<string, number> = {
+  lowpass: FilterType.Lowpass,
+  highpass: FilterType.Highpass,
+  bandpass: FilterType.Bandpass,
+};
+
+/**
+ * Map a single effect's params to a WASM message object.
+ * Returns null if the effect type is not WASM-supported.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function mapEffectToWasm(type: string, params: Record<string, any>): Record<string, any> | null {
+  switch (type) {
+    case 'compressor':
+      return {
+        type: 'set-compressor',
+        threshold: params.threshold,
+        ratio: params.ratio,
+        attackMs: params.attack * 1000,
+        releaseMs: params.release * 1000,
+        kneeDb: params.knee,
+        makeupDb: 0,
+      };
+
+    case 'delay':
+      return {
+        type: 'set-delay',
+        delayMs: params.time * 1000,
+        feedback: params.feedback,
+        wet: params.wet,
+      };
+
+    case 'distortion':
+      return {
+        type: 'set-distortion',
+        distType: DIST_TYPE_MAP[params.distortionType] ?? 0,
+        drive: params.amount,
+        mix: params.wet,
+        outputGain: 0,
+        bitDepth: 8,
+      };
+
+    case 'filter':
+      return {
+        type: 'set-filter',
+        filterType: FILTER_TYPE_MAP[params.filterType] ?? FilterType.Lowpass,
+        frequency: params.frequency,
+        q: params.resonance,
+        gainDb: 0,
+      };
+
+    case 'reverb':
+      return {
+        type: 'set-reverb',
+        roomSize: Math.min(1, params.decay / 10),
+        damping: 0.5,
+        wet: params.wet,
+        dry: 1 - params.wet,
+      };
+
+    case 'chorus':
+      return {
+        type: 'set-chorus',
+        rateHz: params.frequency,
+        depthMs: params.depth * params.delayTime,
+        delayMs: params.delayTime,
+        feedback: params.feedback,
+        wet: params.wet,
+        dry: 1 - params.wet,
+      };
+
+    case 'phaser':
+      return {
+        type: 'set-phaser',
+        rateHz: params.frequency,
+        depth: params.octaves / 6, // normalize octaves (1-6) to 0-1
+        feedback: Math.min(0.95, params.Q / 20), // Q (0-20) → feedback (0-0.95)
+        stages: params.stages ?? 4,
+        mix: params.wet ?? 0.5,
+      };
+
+    case 'gate':
+      return {
+        type: 'set-gate',
+        threshold: params.threshold,
+        attackMs: params.attack * 1000,
+        holdMs: params.hold * 1000,
+        releaseMs: params.release * 1000,
+        rangeDb: params.range,
+      };
+
+    case 'limiter':
+      return {
+        type: 'set-limiter',
+        ceilingDb: params.ceiling,
+        releaseMs: params.release * 1000,
+        lookaheadMs: (params.lookahead ?? 0.005) * 1000,
+      };
+
+    case 'stereoImager':
+      return {
+        type: 'set-stereo-width',
+        width: params.width,
+      };
+
+    case 'parametricEq':
+      // ParametricEQ is special — multiple bands
+      return {
+        type: 'set-parametric-eq',
+        bands: params.bands,
+      };
+
+    default:
+      return null;
+  }
+}
+
+/** All WASM disable messages keyed by effect type. */
+const DISABLE_MESSAGES: Record<string, string> = {
+  compressor: 'disable-compressor',
+  delay: 'disable-delay',
+  distortion: 'disable-distortion',
+  filter: 'disable-filter',
+  reverb: 'disable-reverb',
+  chorus: 'disable-chorus',
+  phaser: 'disable-phaser',
+  gate: 'disable-gate',
+  limiter: 'disable-limiter',
+  stereoImager: 'disable-stereo-imager',
+  parametricEq: 'disable-eq',
+};
+
+/**
+ * Apply a full effects chain to a WasmDspNode.
+ * Disables all effects first, then enables + configures each active one.
+ */
+export function applyEffectsToWasmNode(node: WasmDspNode, effects: TrackEffect[]): void {
+  // 1. Disable all WASM effects to start clean
+  for (const disableType of Object.values(DISABLE_MESSAGES)) {
+    node.audioNode.port.postMessage({ type: disableType });
+  }
+
+  // 2. Enable + configure each active effect
+  for (const effect of effects) {
+    if (!effect.enabled) continue;
+    const msg = mapEffectToWasm(effect.type, effect.params as unknown as Record<string, unknown>);
+    if (msg) {
+      node.audioNode.port.postMessage(msg);
+    }
+  }
+}

--- a/src/hooks/useEffectsSync.ts
+++ b/src/hooks/useEffectsSync.ts
@@ -3,15 +3,35 @@
  *
  * Runs at the app level so effects are always applied regardless of UI visibility.
  * Also wires sidechain compression when a compressor has sidechainSourceTrackId.
+ * Initializes WASM DSP engine on mount when dspBackend !== 'tonejs'.
  */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useProjectStore } from '../store/projectStore';
-import { effectsEngine } from '../engine/EffectsEngine';
+import { useUIStore } from '../store/uiStore';
+import { effectsEngine, initWasmDsp } from '../engine/EffectsEngine';
 import { getAudioEngine } from './useAudioEngine';
 import type { CompressorParams } from '../types/project';
 
 export function useEffectsSync() {
   const tracks = useProjectStore((s) => s.project?.tracks);
+  const dspBackend = useUIStore((s) => s.dspBackend);
+  const wasmInitRef = useRef(false);
+
+  // Initialize WASM DSP engine once when dspBackend allows it
+  useEffect(() => {
+    if (dspBackend === 'tonejs' || wasmInitRef.current) return;
+    wasmInitRef.current = true;
+    initWasmDsp().then((ok) => {
+      if (ok) console.info('[useEffectsSync] WASM DSP ready');
+    });
+  }, [dspBackend]);
+
+  // Disable WASM when user explicitly chooses Tone.js
+  useEffect(() => {
+    if (dspBackend === 'tonejs') {
+      effectsEngine.setUseWasm(false);
+    }
+  }, [dspBackend]);
 
   useEffect(() => {
     if (!tracks) return;

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -208,6 +208,10 @@ export interface UIState {
   /** Slice marker positions in seconds relative to clip start, keyed by clip ID. */
   sliceMarkersByClip: Record<string, number[]>;
 
+  // DSP backend preference
+  dspBackend: 'auto' | 'wasm' | 'tonejs';
+  setDspBackend: (mode: 'auto' | 'wasm' | 'tonejs') => void;
+
   // Theme
   theme: ThemeId;
 
@@ -694,6 +698,8 @@ export const useUIStore = create<UIState>()(
   sliceModeClipId: null,
   sliceMarkersByClip: {},
 
+  dspBackend: 'auto',
+
   theme: 'ableton',
 
   regionRegenerateTarget: null,
@@ -837,6 +843,7 @@ export const useUIStore = create<UIState>()(
   setShowInstrumentPicker: (v) => set(v ? { ...ALL_MODALS_CLOSED, showInstrumentPicker: true } : { showInstrumentPicker: false }),
   setShowExportDialog: (v) => set(v ? { ...ALL_MODALS_CLOSED, showExportDialog: true } : { showExportDialog: false }),
   setShowSettingsDialog: (v) => set(v ? { ...ALL_MODALS_CLOSED, showSettingsDialog: true } : { showSettingsDialog: false }),
+  setDspBackend: (mode) => set({ dspBackend: mode }),
   setTheme: (theme) => set({ theme }),
   setShowProjectListDialog: (v) => set(v ? { ...ALL_MODALS_CLOSED, showProjectListDialog: true } : { showProjectListDialog: false }),
   openBounceInPlaceDialog: (trackId) => set({ bounceInPlaceTrackId: trackId }),
@@ -1391,6 +1398,8 @@ export const useUIStore = create<UIState>()(
         suggestionFrequency: state.suggestionFrequency,
         // Command palette
         recentCommandIds: state.recentCommandIds,
+        // DSP backend
+        dspBackend: state.dspBackend,
         // Theme
         theme: state.theme,
         // Synth presets


### PR DESCRIPTION
## Summary

Routes audio effects through Rust WASM DSP engine by default when all effects in a track's chain have WASM equivalents. Automatic Tone.js fallback for unsupported effects.

### Architecture: Hybrid Per-Track Routing
- **WASM path**: Single `WasmDspNode` (AudioWorkletNode) per track — processes all effects in one `process_stereo_interleaved()` call
- **Tone.js path**: Individual nodes chained together (unchanged, existing behavior)

### WASM-Supported Effects (11/19)
compressor, parametricEq, reverb, delay, distortion, filter, chorus, phaser, gate, limiter, stereoImager

### Tone.js Only (8/19)
eq3, flanger, convolver, deesser, transientShaper, saturation, algorithmicReverb, noiseReduction

### Key Files
- `src/engine/wasmParamMapper.ts` — NEW: param translation + compatibility check (18 unit tests)
- `src/engine/EffectsEngine.ts` — WASM routing in rebuildChain/updateParams/dispose
- `src/hooks/useEffectsSync.ts` — WASM init on mount
- `src/store/uiStore.ts` — `dspBackend` preference (auto/wasm/tonejs)

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3804 passed (18 new)
- [x] `npm run build` — success

Closes #1333

🤖 Generated with [Claude Code](https://claude.com/claude-code)