### PR TITLE
feat: show generation progress state on clip blocks in timeline

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -35,17 +35,20 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
   const setEditingClip = useUIStore((s) => s.setEditingClip);
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
   const contextWindow = useUIStore((s) => s.contextWindow);
-  const generatingProgress = useGenerationStore((s) => {
+  const generationJob = useGenerationStore((s) => {
     for (let i = s.jobs.length - 1; i >= 0; i--) {
       const j = s.jobs[i];
       if (j.clipId === clip.id && (j.status === 'generating' || j.status === 'queued' || j.status === 'processing')) {
-        return j.progressPercent != null
-          ? `${j.stage ?? j.progress} ${Math.round(j.progressPercent)}%`
-          : j.stage ?? j.progress;
+        return j;
       }
     }
     return null;
   });
+  const generatingProgress = generationJob
+    ? generationJob.progressPercent != null
+      ? `${generationJob.stage ?? generationJob.progress} ${Math.round(generationJob.progressPercent)}%`
+      : generationJob.stage ?? generationJob.progress
+    : null;
   const bpm = useProjectStore((s) => s.project?.bpm ?? 120);
   const totalDuration = useProjectStore((s) => s.project?.totalDuration ?? 600);
   const isMidiClip = Boolean(clip.midiData);
@@ -373,7 +376,7 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
           canRegenerate={clip.source === 'generated' && !!(clip.generationParams || track.trackType === 'mix')}
         />
 
-        <ClipStatusOverlay clip={clip} generatingProgress={generatingProgress} isMidiClip={isMidiClip} />
+        <ClipStatusOverlay clip={clip} generatingProgress={generatingProgress} generationJob={generationJob} isMidiClip={isMidiClip} />
 
         {/* Muted overlay */}
         {clip.muted && (

--- a/src/components/timeline/ClipStatusOverlay.tsx
+++ b/src/components/timeline/ClipStatusOverlay.tsx
@@ -1,30 +1,77 @@
 import type { Clip } from '../../types/project';
+import type { GenerationJob } from '../../store/generationStore';
 
 interface ClipStatusOverlayProps {
   clip: Clip;
   generatingProgress: string | number | null;
+  generationJob: GenerationJob | null;
   isMidiClip: boolean;
 }
 
-export function ClipStatusOverlay({ clip, generatingProgress, isMidiClip }: ClipStatusOverlayProps) {
+export function ClipStatusOverlay({ clip, generatingProgress, generationJob, isMidiClip }: ClipStatusOverlayProps) {
+  const isGenerating = generationJob?.status === 'generating' || generationJob?.status === 'processing';
+  const isQueued = generationJob?.status === 'queued';
+  const progressPct = generationJob?.progressPercent ?? null;
+
   return (
     <>
-      {generatingProgress && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none bg-black/30 rounded-md">
-          <div className="w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin mb-0.5" />
-          <span className="text-[8px] text-white/90 font-medium text-center px-1 leading-tight max-w-full truncate">
-            {generatingProgress}
-          </span>
+      {/* Generating: animated border + progress bar */}
+      {isGenerating && (
+        <div className="absolute inset-0 pointer-events-none rounded-md" data-testid="clip-generating-overlay">
+          {/* Animated border glow */}
+          <div className="absolute inset-0 rounded-md animate-pulse" style={{
+            boxShadow: '0 0 0 1.5px rgba(99, 102, 241, 0.6), 0 0 8px rgba(99, 102, 241, 0.3)',
+          }} />
+
+          {/* Semi-transparent overlay */}
+          <div className="absolute inset-0 bg-black/25 rounded-md flex flex-col items-center justify-center gap-0.5">
+            <div className="w-3.5 h-3.5 border-2 border-indigo-300 border-t-transparent rounded-full animate-spin" />
+            <span className="text-[8px] text-white/90 font-medium text-center px-1 leading-tight max-w-full truncate">
+              {generatingProgress}
+            </span>
+          </div>
+
+          {/* Bottom progress bar */}
+          {progressPct != null && (
+            <div className="absolute bottom-0 left-0 right-0 h-[3px] bg-black/30 rounded-b-md overflow-hidden">
+              <div
+                className="h-full bg-indigo-400 transition-[width] duration-300 ease-out"
+                style={{ width: `${Math.min(100, progressPct)}%` }}
+              />
+            </div>
+          )}
         </div>
       )}
-      {clip.generationStatus === 'error' && (
-        <div
-          className="absolute bottom-0 left-1.5 right-1.5 text-[8px] text-red-300 truncate pointer-events-none"
-          title={clip.errorMessage}
-        >
-          {clip.errorMessage ? clip.errorMessage : 'Error'}
+
+      {/* Queued: pulsing border + label */}
+      {isQueued && (
+        <div className="absolute inset-0 pointer-events-none rounded-md" data-testid="clip-queued-overlay">
+          <div className="absolute inset-0 rounded-md animate-pulse" style={{
+            boxShadow: '0 0 0 1px rgba(251, 191, 36, 0.4)',
+          }} />
+          <div className="absolute inset-0 bg-black/20 rounded-md flex items-center justify-center">
+            <span className="text-[9px] text-amber-300/90 font-medium tracking-wide">
+              Queued
+            </span>
+          </div>
         </div>
       )}
+
+      {/* Error: red border + message */}
+      {clip.generationStatus === 'error' && !generationJob && (
+        <div className="absolute inset-0 pointer-events-none rounded-md" data-testid="clip-error-overlay" style={{
+          boxShadow: '0 0 0 1.5px rgba(239, 68, 68, 0.5)',
+        }}>
+          <div
+            className="absolute bottom-0 left-1.5 right-1.5 text-[8px] text-red-300 truncate"
+            title={clip.errorMessage}
+          >
+            {clip.errorMessage ?? 'Error'}
+          </div>
+        </div>
+      )}
+
+      {/* Ready: inferred metadata */}
       {clip.generationStatus === 'ready' && clip.inferredMetas && (
         <div className="absolute bottom-0 left-1.5 right-1.5 text-[8px] text-zinc-400 truncate pointer-events-none">
           {[
@@ -33,7 +80,9 @@ export function ClipStatusOverlay({ clip, generatingProgress, isMidiClip }: Clip
           ].filter(Boolean).join(' | ')}
         </div>
       )}
-      {isMidiClip && (
+
+      {/* MIDI clip hint */}
+      {isMidiClip && !generationJob && (
         <div className="absolute bottom-0 left-1.5 right-1.5 text-[8px] text-zinc-300/80 truncate pointer-events-none">
           MIDI clip • double-click to edit
         </div>


### PR DESCRIPTION
## Summary
Enhances ClipStatusOverlay with per-status visual feedback on clip blocks:
- **Generating**: indigo animated border glow + spinner + progress bar at bottom
- **Queued**: amber pulsing border + 'Queued' label  
- **Error**: red border glow + error message
- Progress bar shows `progressPercent` with smooth CSS transition

Each clip independently shows its own generation status.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3857 passed
- [x] Existing ClipBlock tests pass

Closes #1364

🤖 Generated with [Claude Code](https://claude.com/claude-code)