### PR TITLE
refactor: add React.memo to TrackHeader and narrow store selectors

### DIFF
--- a/src/components/timeline/ClipBlock.tsx
+++ b/src/components/timeline/ClipBlock.tsx
@@ -46,7 +46,6 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
     }
     return null;
   });
-  const tracks = useProjectStore((s) => s.project?.tracks);
   const bpm = useProjectStore((s) => s.project?.bpm ?? 120);
   const totalDuration = useProjectStore((s) => s.project?.totalDuration ?? 600);
   const isMidiClip = Boolean(clip.midiData);
@@ -202,8 +201,9 @@ function ClipBlockInner({ clip, track }: ClipBlockProps) {
   const audioOffset = clip.audioOffset ?? 0;
   const contentOffset = getClipContentOffset(clip);
   const selectedActionClipIds = isClipSelected ? [...useUIStore.getState().selectedClipIds] : [clip.id];
+  const allTracks = useProjectStore.getState().project?.tracks ?? [];
   const selectedActionClips = selectedActionClipIds
-    .map((clipId) => (tracks ?? []).flatMap((candidate) => candidate.clips).find((candidate) => candidate.id === clipId))
+    .map((clipId) => allTracks.flatMap((candidate) => candidate.clips).find((candidate) => candidate.id === clipId))
     .filter((candidate): candidate is Clip => Boolean(candidate));
   const canConsolidate = selectedActionClips.length === selectedActionClipIds.length
     && selectedActionClips.every((candidate) => candidate.trackId === track.id)

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import type { Track, InputMonitoringMode } from '../../types/project';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
@@ -57,7 +57,7 @@ interface TrackHeaderProps {
   dragOverPosition: 'before' | 'after' | null;
 }
 
-export function TrackHeader({
+export const TrackHeader = React.memo(function TrackHeader({
   track,
   isCollapsed = false,
   isChild,
@@ -83,11 +83,11 @@ export function TrackHeader({
   const setGroupSoloed = useProjectStore((s) => s.setGroupSoloed);
   const removeGroupTrack = useProjectStore((s) => s.removeGroupTrack);
   const moveTrackToGroup = useProjectStore((s) => s.moveTrackToGroup);
-  const project = useProjectStore((s) => s.project);
 
-  // Check if any track is soloed — if so, non-soloed tracks are "implied muted"
-  const anySoloed = project?.tracks.some((t) => t.soloed) ?? false;
+  // Narrow selectors: avoid subscribing to entire project object
+  const anySoloed = useProjectStore((s) => s.project?.tracks.some((t) => t.soloed) ?? false);
   const isImpliedMute = anySoloed && !track.soloed;
+  const hasAutomationLane = useProjectStore((s) => (s.project?.automationLanes ?? []).some((lane) => lane.trackId === track.id));
   const setOpenPianoRoll = useUIStore((s) => s.setOpenPianoRoll);
   const setOpenEffectChainTrackId = useUIStore((s) => s.setOpenEffectChainTrackId);
   const openBounceInPlaceDialog = useUIStore((s) => s.openBounceInPlaceDialog);
@@ -157,7 +157,6 @@ export function TrackHeader({
   const isCompact = laneHeight < 52;
   const isArmed = armedTrackIds.includes(track.id) || !!track.armed;
   const monitorMode: InputMonitoringMode = track.inputMonitoring ?? 'off';
-  const hasAutomationLane = (project?.automationLanes ?? []).some((lane) => lane.trackId === track.id);
   const effectsBypassed = track.effectsBypassed ?? false;
   const headerBackgroundColor = track.isGroup ? ARRANGEMENT_GROUP_ROW_BG : ARRANGEMENT_HEADER_ROW_BG;
   const isTwoRow = laneHeight >= 60;
@@ -263,10 +262,11 @@ export function TrackHeader({
       onMouseDown={(e) => {
         setExpandedTrackId(track.id);
         setKeyboardContext('timeline', track.id);
-        if (e.shiftKey && project) {
+        const currentProject = useProjectStore.getState().project;
+        if (e.shiftKey && currentProject) {
           // Shift+click: range select
           const selectedIds = useUIStore.getState().selectedTrackIds;
-          const tracks = project.tracks;
+          const tracks = currentProject.tracks;
           const clickedIdx = tracks.findIndex((t) => t.id === track.id);
           // Find anchor: first selected track or expanded track
           let anchorIdx = clickedIdx;
@@ -655,7 +655,7 @@ export function TrackHeader({
         <ContextMenuItem label="Duplicate Track" onClick={() => { setCtxMenu(null); duplicateTrack(track.id); }} />
         {/* Move to Group submenu — only for non-group tracks */}
         {!track.isGroup && (() => {
-          const groups = project?.tracks.filter((t) => t.isGroup) ?? [];
+          const groups = useProjectStore.getState().project?.tracks.filter((t) => t.isGroup) ?? [];
           return groups.length > 0 ? (
             <div
               className="relative"
@@ -731,4 +731,4 @@ export function TrackHeader({
     )}
     </>
   );
-}
+});


### PR DESCRIPTION
## Summary
- Wrap `TrackHeader` in `React.memo` (was the only unwrapped performance-critical timeline component, 734 lines, 33 store subscriptions)
- Replace broad `useProjectStore(s => s.project)` with narrow boolean selectors (`anySoloed`, `hasAutomationLane`)
- Move event-handler-only data access to `getState()` (shift-click range select, group list)
- Remove `useProjectStore(s => s.project?.tracks)` subscription from `ClipBlock`, use `getState()` for context menu resolution

## Impact
- **TrackHeader**: Previously re-rendered on ANY project state change. Now only re-renders when `track` prop, `anySoloed`, `hasAutomationLane`, or selection state changes.
- **ClipBlock**: Removed one broad store subscription that triggered on any track mutation.

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 3865 tests pass
- [x] No behavioral changes — only memoization and selector narrowing

Closes #1365

🤖 Generated with [Claude Code](https://claude.com/claude-code)