### PR TITLE
refactor: add React.memo to performance-critical components

### DIFF
--- a/src/components/mixer/MixerPanel.tsx
+++ b/src/components/mixer/MixerPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useState } from 'react';
+import React, { useRef, useCallback, useState } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useUIStore } from '../../store/uiStore';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
@@ -51,7 +51,7 @@ interface ChannelStripProps {
   returnTracks: ReturnTrack[];
 }
 
-function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
+const ChannelStrip = React.memo(function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
   const updateTrack = useProjectStore((s) => s.updateTrack);
   const renameTrack = useProjectStore((s) => s.renameTrack);
   const updateTrackMixer = useProjectStore((s) => s.updateTrackMixer);
@@ -382,7 +382,7 @@ function ChannelStrip({ track, faderHeight, returnTracks }: ChannelStripProps) {
       </div>
     </div>
   );
-}
+});
 
 interface MasterStripProps {
   faderHeight: number;

--- a/src/components/session/SessionClipSlotView.tsx
+++ b/src/components/session/SessionClipSlotView.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import type { SessionClipSlot } from '../../types/session';
 import { useSessionStore } from '../../store/sessionStore';
 
@@ -7,7 +7,7 @@ interface SessionClipSlotViewProps {
   trackColor: string;
 }
 
-export function SessionClipSlotView({ slot, trackColor }: SessionClipSlotViewProps) {
+export const SessionClipSlotView = React.memo(function SessionClipSlotView({ slot, trackColor }: SessionClipSlotViewProps) {
   const launchSlot = useSessionStore((s) => s.launchSlot);
   const stopSlot = useSessionStore((s) => s.stopSlot);
 
@@ -61,4 +61,4 @@ export function SessionClipSlotView({ slot, trackColor }: SessionClipSlotViewPro
       {isEmpty && <span className="text-zinc-600">+</span>}
     </button>
   );
-}
+});

--- a/src/components/session/SessionSceneStrip.tsx
+++ b/src/components/session/SessionSceneStrip.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useSessionStore } from '../../store/sessionStore';
 import type { SessionScene } from '../../types/session';
 
@@ -6,7 +6,7 @@ interface SessionSceneStripProps {
   scene: SessionScene;
 }
 
-export function SessionSceneStrip({ scene }: SessionSceneStripProps) {
+export const SessionSceneStrip = React.memo(function SessionSceneStrip({ scene }: SessionSceneStripProps) {
   const launchScene = useSessionStore((s) => s.launchScene);
   const stopScene = useSessionStore((s) => s.stopScene);
   const renameScene = useSessionStore((s) => s.renameScene);
@@ -86,4 +86,4 @@ export function SessionSceneStrip({ scene }: SessionSceneStripProps) {
       )}
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary
Wraps frequently-rendered components with React.memo:
- **ChannelStrip** (MixerPanel) — prevents re-render when unrelated tracks change
- **SessionClipSlotView** — grid slots only re-render on own slot data change
- **SessionSceneStrip** — scene rows only re-render on own scene change

ClipBlock and TrackLane were already memoized (verified in codebase).

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 3865 passed
- [x] No behavioral regression

Closes #1365

🤖 Generated with [Claude Code](https://claude.com/claude-code)