### PR TITLE
feat: micro-interaction system — hover, focus, drag, scroll fades

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -123,7 +123,11 @@ select:focus-visible,
 [tabindex]:focus-visible {
   outline: 2px solid var(--color-daw-focus-ring);
   outline-offset: 1px;
-  box-shadow: 0 0 0 4px var(--color-daw-focus-ring);
+  box-shadow:
+    var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow, 0 0 #0000),
+    0 0 0 4px var(--color-daw-focus-ring);
 }
 
 /* #556 — Webkit/Chromium scrollbar styling */
@@ -184,7 +188,7 @@ select:focus-visible,
 
 /* Interactive button: smooth hover + press feedback */
 .daw-btn-interactive {
-  transition: background-color 200ms ease-out, box-shadow 200ms ease-out, transform 100ms ease-out;
+  transition: box-shadow var(--duration-normal) var(--ease-out), transform var(--duration-fast) var(--ease-out);
 }
 .daw-btn-interactive:hover {
   box-shadow: var(--daw-shadow-sm);
@@ -196,7 +200,7 @@ select:focus-visible,
 
 /* Clip block hover: border brightening */
 .daw-clip-interactive {
-  transition: border-color 100ms ease-out, box-shadow 200ms ease-out;
+  transition: border-color var(--duration-fast) var(--ease-out);
 }
 .daw-clip-interactive:hover {
   border-color: rgba(255, 255, 255, 0.2);
@@ -204,7 +208,7 @@ select:focus-visible,
 
 /* Drag lift: element elevates when being dragged */
 .daw-drag-lift {
-  transition: transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 200ms ease-out, opacity 200ms ease-out;
+  transition: transform var(--duration-normal) var(--ease-spring), box-shadow var(--duration-normal) var(--ease-out), opacity var(--duration-normal) var(--ease-out);
 }
 .daw-drag-lift[data-dragging="true"] {
   transform: scale(1.02);

--- a/tests/unit/designTokens.test.ts
+++ b/tests/unit/designTokens.test.ts
@@ -150,16 +150,21 @@ describe('Design System Tokens (index.css)', () => {
       expect(indexCss).toContain('mask-image: linear-gradient');
     });
 
-    it('enhanced focus ring has glow spread', () => {
-      expect(indexCss).toContain('box-shadow: 0 0 0 4px var(--color-daw-focus-ring)');
+    it('enhanced focus ring has glow spread composed with Tailwind', () => {
+      expect(indexCss).toContain('0 0 0 4px var(--color-daw-focus-ring)');
+      expect(indexCss).toContain('var(--tw-ring-shadow');
     });
 
     it('disables micro-interaction transitions in reduced motion', () => {
       const reducedMotionBlocks = indexCss.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]*?\n\}/g) ?? [];
-      const hasMicroInteractionDisable = reducedMotionBlocks.some((block) =>
-        block.includes('.daw-btn-interactive')
-      );
-      expect(hasMicroInteractionDisable).toBe(true);
+      const reducedMotionCss = reducedMotionBlocks.join('\n');
+
+      expect(reducedMotionBlocks.length).toBeGreaterThan(0);
+      expect(reducedMotionCss).toMatch(/\.daw-btn-interactive[\s\S]*?transition\s*:\s*none/);
+      expect(reducedMotionCss).toMatch(/\.daw-clip-interactive[\s\S]*?transition\s*:\s*none/);
+      expect(reducedMotionCss).toMatch(/\.daw-drag-lift[\s\S]*?transition\s*:\s*none/);
+      expect(reducedMotionCss).toMatch(/\.daw-btn-interactive:active[\s\S]*?transform\s*:\s*none/);
+      expect(reducedMotionCss).toMatch(/\[data-dragging="true"\][\s\S]*?transform\s*:\s*none/);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `.daw-btn-interactive`: hover shadow + active scale(0.97) + inset shadow transition
- Add `.daw-clip-interactive`: hover border brightening for clip blocks
- Add `.daw-drag-lift`: data-dragging attribute triggers scale(1.02) + shadow + opacity  
- Add `.daw-scroll-fade-x/y`: gradient mask for scroll edge containment
- Enhance focus-visible ring: add 4px glow spread behind existing outline
- All transitions respect `prefers-reduced-motion` (disabled in reduced mode)

Closes #1124

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] CSS utility class tests verify all new classes exist
- [x] Reduced motion test verifies transitions are disabled
- [ ] Visual verification: focus ring glow visible on keyboard navigation
- [ ] Visual verification: scroll fades on timeline edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)