### PR TITLE
fix: implement 2-tier knob size system for visual parameter hierarchy

### DIFF
--- a/src/components/mixer/EffectCards.tsx
+++ b/src/components/mixer/EffectCards.tsx
@@ -229,7 +229,7 @@ function AutomationControlShell({
 
 /**
  * Knob size tiers — 2-tier system for visual parameter hierarchy.
- * Primary: most important 1-3 parameters (prominently displayed).
+ * Primary: most important parameters for an effect (prominently displayed).
  * Secondary: supporting/fine-tune parameters (visually recessed).
  */
 const KNOB_PRIMARY = 56;


### PR DESCRIPTION
## Summary\n- Define KNOB_PRIMARY (56px) and KNOB_SECONDARY (44px) constants\n- Classify all 68 knobs across 19 effect cards into primary/secondary tiers:\n  - Primary (34): most important 1-3 params per effect (Threshold, Cutoff, Decay, Drive, Rate, etc.)\n  - Secondary (34): supporting/fine-tune params (Knee, Pre-Delay, Q, Hysteresis, Feedback, etc.)\n- Creates clear visual hierarchy: primary controls are 27% larger than secondary\n- All knobs use named constants instead of magic number 56\n\nCloses #1067\n\n## Test plan\n- [x] TypeScript type check passes (0 errors)\n- [x] Full test suite passes (3976 tests)\n- [ ] Visual: primary knobs visually larger than secondary in all effect cards\n- [ ] Visual: hierarchy feels natural (main controls prominent, fine-tune recessed)\n\nhttps://claude.ai/code/session_01RALNKk2FhiZMvPDhX5w2tz