### PR TITLE
fix: limiter knee math — use standard centered soft-knee formula

### DIFF
--- a/src/utils/limiterCurve.ts
+++ b/src/utils/limiterCurve.ts
@@ -22,42 +22,19 @@ export function limiterTransfer(
 ): number {
   const boosted = inputDb + gain;
 
-  switch (style) {
-    case 'transparent': {
-      // Gentle 6dB soft knee: continuous from pass-through to hard ceiling
-      if (boosted >= ceiling) return ceiling;
-      const knee = 6;
-      const kneeStart = ceiling - knee;
-      if (boosted <= kneeStart) return boosted;
-      // Quadratic knee: output = kneeStart + knee * t^2
-      // At t=0: output = kneeStart (matches pass-through)
-      // At t=1: output = kneeStart + knee = ceiling (matches ceiling)
-      // Slope transitions from 0 at t=0 toward 2 at t=1 (gentle start)
-      const t = (boosted - kneeStart) / knee;
-      return kneeStart + knee * t * t;
-    }
+  // Standard soft-knee limiter (ratio = ∞), knee centered on ceiling.
+  // Uses quadratic gain reduction: output = boosted - x²/(2*knee)
+  // where x = boosted - (ceiling - knee/2).
+  // Properties: C1-continuous (slope=1 at bottom, slope=0 at top),
+  // monotonic, never amplifies (output ≤ boosted), never exceeds ceiling.
+  const knee = style === 'aggressive' ? 3 : style === 'warm' ? 9 : 6;
+  const halfKnee = knee / 2;
 
-    case 'aggressive': {
-      // Tight 3dB knee for punchier limiting
-      if (boosted >= ceiling) return ceiling;
-      const knee = 3;
-      const kneeStart = ceiling - knee;
-      if (boosted <= kneeStart) return boosted;
-      const t = (boosted - kneeStart) / knee;
-      return kneeStart + knee * t * t;
-    }
+  if (boosted <= ceiling - halfKnee) return boosted;
+  if (boosted >= ceiling + halfKnee) return ceiling;
 
-    case 'warm': {
-      // Pass-through up to ceiling, then soft tanh saturation above
-      if (boosted <= ceiling) return boosted;
-      const overshoot = boosted - ceiling;
-      const compressed = 12 * Math.tanh(overshoot / 12);
-      return Math.min(ceiling, ceiling + compressed - overshoot);
-    }
-
-    default:
-      return Math.min(boosted, ceiling);
-  }
+  const x = boosted - ceiling + halfKnee; // 0 to knee
+  return boosted - (x * x) / (2 * knee);
 }
 
 /**

--- a/tests/unit/utils/limiterCurve.test.ts
+++ b/tests/unit/utils/limiterCurve.test.ts
@@ -44,13 +44,22 @@ describe('limiterTransfer', () => {
     expect(withGain).toBeGreaterThan(withoutGain);
   });
 
-  it('warm style has softer knee than aggressive', () => {
-    // At a point close to ceiling, warm should compress more gradually
-    const warm = limiterTransfer(-5, -0.3, 0, 'warm');
-    const aggressive = limiterTransfer(-5, -0.3, 0, 'aggressive');
-    // Both should be close to their respective ceiling approaches
-    expect(warm).toBeLessThanOrEqual(-0.3);
-    expect(aggressive).toBeLessThanOrEqual(-0.3);
+  it('different styles have different knee widths', () => {
+    const ceiling = -0.3;
+    // Well above all knees — all styles should return ceiling
+    const agg = limiterTransfer(10, ceiling, 0, 'aggressive');
+    const trans = limiterTransfer(10, ceiling, 0, 'transparent');
+    const warm = limiterTransfer(10, ceiling, 0, 'warm');
+    expect(agg).toBe(ceiling);
+    expect(trans).toBe(ceiling);
+    expect(warm).toBe(ceiling);
+
+    // At ceiling - 2: aggressive (halfKnee=1.5) is in passthrough,
+    // but warm (halfKnee=4.5) is in knee and reducing
+    const aggBelow = limiterTransfer(-2.3, ceiling, 0, 'aggressive');
+    const warmBelow = limiterTransfer(-2.3, ceiling, 0, 'warm');
+    expect(aggBelow).toBe(-2.3); // passthrough (below knee start at -1.8)
+    expect(warmBelow).toBeLessThan(-2.3); // warm is already reducing
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up fix for #1241 (merged via PR #1419). Addresses Copilot review feedback on the limiter transfer curve math.

**Problem:** The Hermite interpolation knee could amplify signals in the knee region (output > input for boosted < ceiling), and the warm style had an inverted transfer function above the ceiling.

**Fix:** Replace with the standard soft-knee compressor formula centered on the ceiling:
```
output = boosted - x² / (2 * knee)
where x = boosted - (ceiling - knee/2)
```

**Properties of the new formula:**
- C1 continuous: slope=1 at knee bottom, slope=0 at knee top
- Monotonic non-decreasing
- Never amplifies (output ≤ boosted, always)
- Never exceeds ceiling
- Knee widths: aggressive=3dB, transparent=6dB, warm=9dB

## Quality Gates

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 4035 passed
- [x] Build succeeds

## Test plan

- [ ] Verify limiter transfer curve never amplifies for any input
- [ ] Verify different styles produce different knee shapes
- [ ] Verify warm starts reducing earlier than aggressive (wider knee)

https://claude.ai/code/session_01WPFi3zKZ13HHusnshqN3Bg