### PR TITLE
feat: MIDI retroactive capture — session auto-assign + tests

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -8744,9 +8744,12 @@ export const useProjectStore = create<ProjectState>()(
       t.id === trackId ? { ...t, clips: [...t.clips, clip] } : t,
     );
 
-    // Auto-assign captured clip to session slot so it appears in the session grid
+    // Auto-assign captured clip to session slot so it appears in the session grid.
+    // Reuse the existing normalized session when available to avoid the extra
+    // project-wide recomputation performed by ensureProjectSession(...).
+    const normalizedSession = state.project.session ?? ensureProjectSession(state.project).session!;
     const session = autoAssignClipToSession(
-      ensureProjectSession(state.project).session!,
+      normalizedSession,
       trackId,
       clip.id,
     );

--- a/tests/unit/midiRetroactiveCapture.test.ts
+++ b/tests/unit/midiRetroactiveCapture.test.ts
@@ -55,7 +55,7 @@ describe('MidiCaptureService', () => {
     const secPerBeat = 60 / bpm; // 0.5s
     const barDuration = timeSig * secPerBeat; // 2s
 
-    // Play a note at bar 2, beat 1 (time = 4.0s)
+    // Play a note at bar 3, beat 1 (time = 4.0s)
     service.noteOn('track-1', 60, 0.9, 4.0);
     service.noteOff('track-1', 60, 4.5);
 


### PR DESCRIPTION
## Summary\n\n- Fix `captureMidi()` to auto-assign captured clips to session slots via `autoAssignClipToSession()`, so retroactively captured MIDI appears in the session grid immediately\n- Add 15 unit tests covering MidiCaptureService (noteOn/Off, prune, drain, bar-boundary alignment, held note closure) and captureMidi integration (clip creation, session slot assignment, configurable bar count)\n\n## Test plan\n\n- [x] `npx tsc --noEmit` — 0 type errors\n- [x] `npx vitest run` — all tests pass\n- [x] New test file: `tests/unit/midiRetroactiveCapture.test.ts` — 15 tests\n\nCloses #1034\n\nhttps://claude.ai/code/session_01NJBftrVqojFb7yEYVHuty8