### PR TITLE
test: add unit tests for PluginEngine and RecordingEngine

### DIFF
--- a/src/engine/__tests__/PluginEngine.test.ts
+++ b/src/engine/__tests__/PluginEngine.test.ts
@@ -61,12 +61,11 @@ describe('PluginEngine', () => {
     const plugin2 = makePlugin();
     const ctx = makeCtx();
 
-    engine.addPlugin('track-1', 'inst-1', plugin1 as never, ctx);
-    engine.addPlugin('track-1', 'inst-2', plugin2 as never, ctx);
+    const firstNode = engine.addPlugin('track-1', 'inst-1', plugin1 as never, ctx);
+    const secondNode = engine.addPlugin('track-1', 'inst-2', plugin2 as never, ctx);
 
     // The first plugin's output should be connected to second's input
-    const firstNode = plugin1.createAudioNode();
-    expect(firstNode.outputNode.connect).toHaveBeenCalled();
+    expect(firstNode.outputNode.connect).toHaveBeenCalledWith(secondNode.inputNode);
   });
 
   // ── removePlugin ──

--- a/src/engine/__tests__/RecordingEngine.test.ts
+++ b/src/engine/__tests__/RecordingEngine.test.ts
@@ -1,6 +1,7 @@
 /**
  * RecordingEngine unit tests — focused on state management and public API.
- * Browser API tests (getUserMedia, MediaRecorder, AudioContext) are mocked.
+ * Uses vi.resetModules() + dynamic import per test so the singleton
+ * recordingEngine is re-created and state cannot leak between tests.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -14,12 +15,13 @@ vi.mock('tone', () => ({
   })),
 }));
 
-// Must use dynamic import since RecordingEngine uses browser APIs at module level
-import { recordingEngine } from '../RecordingEngine';
+let recordingEngine: (typeof import('../RecordingEngine'))['recordingEngine'];
 
 describe('RecordingEngine', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    vi.resetModules();
+    ({ recordingEngine } = await import('../RecordingEngine'));
   });
 
   // ── Initial state ──
@@ -49,15 +51,11 @@ describe('RecordingEngine', () => {
   it('sets count-in to 2bars', () => {
     recordingEngine.setCountInLength('2bars');
     expect(recordingEngine.getCountInLength()).toBe('2bars');
-    // Reset
-    recordingEngine.setCountInLength('1bar');
   });
 
   it('sets count-in to off', () => {
     recordingEngine.setCountInLength('off');
     expect(recordingEngine.getCountInLength()).toBe('off');
-    // Reset
-    recordingEngine.setCountInLength('1bar');
   });
 
   // ── Monitoring ──
@@ -71,8 +69,6 @@ describe('RecordingEngine', () => {
     recordingEngine.setMonitoring('track-1', true);
     expect(recordingEngine.getMonitoring('track-1')).toBe(true);
     expect(recordingEngine.getMonitoring('track-2')).toBe(false);
-    // Cleanup
-    recordingEngine.setMonitoring('track-1', false);
   });
 
   it('disables monitoring for a track', () => {
@@ -115,27 +111,19 @@ describe('RecordingEngine', () => {
   // ── Recording without permission ──
 
   it('fails to start recording without permission', async () => {
-    // Mock getUserMedia to fail
     const originalNavigator = globalThis.navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: {
-        mediaDevices: {
-          getUserMedia: vi.fn().mockRejectedValue(new Error('NotAllowed')),
-          enumerateDevices: vi.fn().mockResolvedValue([]),
-        },
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockRejectedValue(new Error('NotAllowed')),
+        enumerateDevices: vi.fn().mockResolvedValue([]),
       },
-      writable: true,
-      configurable: true,
     });
 
-    const result = await recordingEngine.startRecording('track-1', 'region-1', 0);
-    expect(result).toBe(false);
-
-    // Restore
-    Object.defineProperty(globalThis, 'navigator', {
-      value: originalNavigator,
-      writable: true,
-      configurable: true,
-    });
+    try {
+      const result = await recordingEngine.startRecording('track-1', 'region-1', 0);
+      expect(result).toBe(false);
+    } finally {
+      vi.stubGlobal('navigator', originalNavigator);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds **36 new unit tests** for PluginEngine and RecordingEngine, which were previously untested

## Changes

### PluginEngine (19 tests)
- Add/remove plugins with chain management and reconnection
- Plugin parameter updates
- Input/output node retrieval for first/last in chain
- noteOn/noteOff dispatching to all plugins in chain
- Chain latency calculation (sums across plugins)
- Dispose chain and dispose all
- Edge cases: nonexistent tracks, nonexistent instances

### RecordingEngine (17 tests)
- Initial state verification (no permission, not recording, not counting in)
- Count-in configuration (1bar, 2bars, off)
- Per-track monitoring toggle (set, get, disable)
- Device selection defaults
- Input level readings (-Infinity when not connected, linear 0 conversion)
- Session state and waveform data for non-recording tracks
- Recording failure without microphone permission

## Test plan
- [x] `npm test` — all tests pass
- [x] `npx tsc --noEmit` — 0 type errors

Closes #1091

https://claude.ai/code/session_012ttM1E8DVfPuUfujy1bx6y