### PR TITLE
feat: add Voice Library for voice cloning (#1087, #1092, #1095)

### DIFF
--- a/src/components/generation/FullSongForm.tsx
+++ b/src/components/generation/FullSongForm.tsx
@@ -12,6 +12,7 @@ import { toastError, toastInfo } from '../../hooks/useToast';
 import { PromptAutocompleteTextarea } from './PromptAutocompleteTextarea';
 import { TimbrePresetPicker } from './TimbrePresetPicker';
 import { NegativePromptSection } from './NegativePromptSection';
+import { VoiceLibrary } from './VoiceLibrary';
 
 /** Magic pen icon for AI enhance buttons */
 function MagicPenIcon({ size = 16 }: { size?: number }) {
@@ -340,6 +341,9 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
         onChange={setNegativePrompt}
         disabled={isDisabled}
       />
+
+      {/* Voice Reference (collapsed by default) */}
+      <VoiceLibrary disabled={isDisabled} />
 
       {/* Lyrics — with Language + Instrumental inline */}
       <section className="space-y-1.5">

--- a/src/components/generation/FullSongForm.tsx
+++ b/src/components/generation/FullSongForm.tsx
@@ -13,6 +13,7 @@ import { PromptAutocompleteTextarea } from './PromptAutocompleteTextarea';
 import { TimbrePresetPicker } from './TimbrePresetPicker';
 import { NegativePromptSection } from './NegativePromptSection';
 import { VoiceLibrary } from './VoiceLibrary';
+import { VoiceInfluenceControls } from './VoiceInfluenceControls';
 
 /** Magic pen icon for AI enhance buttons */
 function MagicPenIcon({ size = 16 }: { size?: number }) {
@@ -344,6 +345,9 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
 
       {/* Voice Reference (collapsed by default) */}
       <VoiceLibrary disabled={isDisabled} />
+
+      {/* Voice Influence sliders — only visible when a voice is selected */}
+      <VoiceInfluenceControls disabled={isDisabled} />
 
       {/* Lyrics — with Language + Instrumental inline */}
       <section className="space-y-1.5">

--- a/src/components/generation/VoiceInfluenceControls.tsx
+++ b/src/components/generation/VoiceInfluenceControls.tsx
@@ -1,0 +1,117 @@
+/**
+ * Voice Influence Controls — audio/style influence sliders (#1095)
+ *
+ * Only visible when a voice profile is selected. Controls how much the
+ * reference voice (audio influence) and AI style (style influence) affect
+ * the generated output.
+ */
+
+import { useCallback } from 'react';
+import { useVoiceStore } from '../../store/voiceStore';
+import { VOICE_INFLUENCE_PRESETS } from '../../types/voice';
+
+export function VoiceInfluenceControls({ disabled }: { disabled?: boolean }) {
+  const selectedProfileId = useVoiceStore((s) => s.selectedProfileId);
+  const audioInfluence = useVoiceStore((s) => s.audioInfluence);
+  const styleInfluence = useVoiceStore((s) => s.styleInfluence);
+  const setAudioInfluence = useVoiceStore((s) => s.setAudioInfluence);
+  const setStyleInfluence = useVoiceStore((s) => s.setStyleInfluence);
+  const applyInfluencePreset = useVoiceStore((s) => s.applyInfluencePreset);
+
+  const handleReset = useCallback(() => {
+    setAudioInfluence(0.4);
+    setStyleInfluence(0.6);
+  }, [setAudioInfluence, setStyleInfluence]);
+
+  if (!selectedProfileId) return null;
+
+  return (
+    <section className="space-y-2" data-testid="voice-influence-controls">
+      <div className="flex items-center justify-between">
+        <label className="text-[11px] font-medium uppercase text-zinc-400">
+          Voice Influence
+        </label>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="text-[9px] text-zinc-500 hover:text-zinc-300 transition-colors"
+          disabled={disabled}
+          data-testid="voice-influence-reset"
+        >
+          Reset
+        </button>
+      </div>
+
+      {/* Presets */}
+      <div className="flex gap-1" data-testid="voice-influence-presets">
+        {VOICE_INFLUENCE_PRESETS.map((preset) => {
+          const isActive =
+            Math.abs(audioInfluence - preset.audioInfluence) < 0.01 &&
+            Math.abs(styleInfluence - preset.styleInfluence) < 0.01;
+          return (
+            <button
+              key={preset.name}
+              type="button"
+              onClick={() => applyInfluencePreset(preset.audioInfluence, preset.styleInfluence)}
+              disabled={disabled}
+              className={`flex-1 rounded px-1.5 py-1 text-[9px] font-medium transition-colors ${
+                isActive
+                  ? 'bg-indigo-600/25 text-indigo-300 border border-indigo-500/40'
+                  : 'bg-white/[0.04] text-zinc-400 border border-transparent hover:bg-white/[0.08]'
+              }`}
+              data-testid={`voice-preset-${preset.name.toLowerCase().replace(/\s/g, '-')}`}
+            >
+              {preset.name}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Audio Influence slider */}
+      <div className="space-y-0.5">
+        <div className="flex items-center justify-between">
+          <span className="text-[9px] text-zinc-500">Audio (Voice Fidelity)</span>
+          <span className="text-[9px] text-zinc-400 font-mono w-8 text-right" data-testid="voice-audio-influence-value">
+            {Math.round(audioInfluence * 100)}%
+          </span>
+        </div>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={audioInfluence}
+          onChange={(e) => setAudioInfluence(parseFloat(e.target.value))}
+          onDoubleClick={() => setAudioInfluence(0.4)}
+          disabled={disabled}
+          className="w-full h-1 accent-indigo-400"
+          title={`Audio influence: ${Math.round(audioInfluence * 100)}%`}
+          data-testid="voice-audio-influence-slider"
+        />
+      </div>
+
+      {/* Style Influence slider */}
+      <div className="space-y-0.5">
+        <div className="flex items-center justify-between">
+          <span className="text-[9px] text-zinc-500">Style (AI Styling)</span>
+          <span className="text-[9px] text-zinc-400 font-mono w-8 text-right" data-testid="voice-style-influence-value">
+            {Math.round(styleInfluence * 100)}%
+          </span>
+        </div>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={styleInfluence}
+          onChange={(e) => setStyleInfluence(parseFloat(e.target.value))}
+          onDoubleClick={() => setStyleInfluence(0.6)}
+          disabled={disabled}
+          className="w-full h-1 accent-violet-400"
+          title={`Style influence: ${Math.round(styleInfluence * 100)}%`}
+          data-testid="voice-style-influence-slider"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/generation/VoiceInfluenceControls.tsx
+++ b/src/components/generation/VoiceInfluenceControls.tsx
@@ -12,16 +12,21 @@ import { VOICE_INFLUENCE_PRESETS } from '../../types/voice';
 
 export function VoiceInfluenceControls({ disabled }: { disabled?: boolean }) {
   const selectedProfileId = useVoiceStore((s) => s.selectedProfileId);
+  const profiles = useVoiceStore((s) => s.profiles);
   const audioInfluence = useVoiceStore((s) => s.audioInfluence);
   const styleInfluence = useVoiceStore((s) => s.styleInfluence);
   const setAudioInfluence = useVoiceStore((s) => s.setAudioInfluence);
   const setStyleInfluence = useVoiceStore((s) => s.setStyleInfluence);
   const applyInfluencePreset = useVoiceStore((s) => s.applyInfluencePreset);
 
+  const selectedProfile = profiles.find((p) => p.id === selectedProfileId) ?? null;
+  const defaultAudio = selectedProfile?.defaultAudioInfluence ?? 0.4;
+  const defaultStyle = selectedProfile?.defaultStyleInfluence ?? 0.6;
+
   const handleReset = useCallback(() => {
-    setAudioInfluence(0.4);
-    setStyleInfluence(0.6);
-  }, [setAudioInfluence, setStyleInfluence]);
+    setAudioInfluence(defaultAudio);
+    setStyleInfluence(defaultStyle);
+  }, [setAudioInfluence, setStyleInfluence, defaultAudio, defaultStyle]);
 
   if (!selectedProfileId) return null;
 
@@ -82,7 +87,7 @@ export function VoiceInfluenceControls({ disabled }: { disabled?: boolean }) {
           step="0.01"
           value={audioInfluence}
           onChange={(e) => setAudioInfluence(parseFloat(e.target.value))}
-          onDoubleClick={() => setAudioInfluence(0.4)}
+          onDoubleClick={() => setAudioInfluence(defaultAudio)}
           disabled={disabled}
           className="w-full h-1 accent-indigo-400"
           title={`Audio influence: ${Math.round(audioInfluence * 100)}%`}
@@ -105,7 +110,7 @@ export function VoiceInfluenceControls({ disabled }: { disabled?: boolean }) {
           step="0.01"
           value={styleInfluence}
           onChange={(e) => setStyleInfluence(parseFloat(e.target.value))}
-          onDoubleClick={() => setStyleInfluence(0.6)}
+          onDoubleClick={() => setStyleInfluence(defaultStyle)}
           disabled={disabled}
           className="w-full h-1 accent-violet-400"
           title={`Style influence: ${Math.round(styleInfluence * 100)}%`}

--- a/src/components/generation/VoiceLibrary.tsx
+++ b/src/components/generation/VoiceLibrary.tsx
@@ -1,0 +1,435 @@
+/**
+ * Voice Library — browse, record, upload, and select voice profiles (#1087)
+ *
+ * Renders inside the generation side panel as a collapsible section.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useVoiceStore } from '../../store/voiceStore';
+import { ACCEPTED_VOICE_EXTENSIONS, MAX_VOICE_FILE_SIZE, MIN_VOICE_DURATION } from '../../types/voice';
+import type { VoiceProfile } from '../../types/voice';
+
+// ── Inline waveform mini-viz ──
+
+function WaveformMini({ peaks }: { peaks: number[] }) {
+  const count = peaks.length || 1;
+  return (
+    <div
+      className="flex items-end gap-px h-5"
+      aria-hidden="true"
+      data-testid="voice-waveform-mini"
+    >
+      {peaks.map((p, i) => (
+        <div
+          key={i}
+          className="w-[2px] rounded-sm bg-indigo-400/60"
+          style={{ height: `${Math.max(2, p * 100)}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── Profile card ──
+
+function VoiceProfileCard({
+  profile,
+  selected,
+  onSelect,
+  onDelete,
+  onRename,
+}: {
+  profile: VoiceProfile;
+  selected: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+  onRename: (name: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editName, setEditName] = useState(profile.name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const commitRename = () => {
+    const trimmed = editName.trim();
+    if (trimmed && trimmed !== profile.name) {
+      onRename(trimmed);
+    } else {
+      setEditName(profile.name);
+    }
+    setEditing(false);
+  };
+
+  const durationLabel = profile.duration >= 60
+    ? `${Math.floor(profile.duration / 60)}m ${Math.round(profile.duration % 60)}s`
+    : `${Math.round(profile.duration)}s`;
+
+  return (
+    <div
+      role="option"
+      aria-selected={selected}
+      className={`group flex items-center gap-2 rounded-md px-2 py-1.5 cursor-pointer transition-colors ${
+        selected
+          ? 'bg-indigo-600/20 border border-indigo-500/40'
+          : 'hover:bg-white/[0.04] border border-transparent'
+      }`}
+      onClick={onSelect}
+      data-testid={`voice-profile-card-${profile.id}`}
+    >
+      {/* Waveform */}
+      <div className="shrink-0 w-12 overflow-hidden">
+        <WaveformMini peaks={profile.waveformPeaks.slice(0, 16)} />
+      </div>
+
+      {/* Info */}
+      <div className="flex-1 min-w-0">
+        {editing ? (
+          <input
+            ref={inputRef}
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitRename();
+              if (e.key === 'Escape') { setEditName(profile.name); setEditing(false); }
+            }}
+            className="w-full bg-transparent border-b border-indigo-500 text-[11px] text-zinc-100 outline-none"
+            maxLength={100}
+            data-testid="voice-rename-input"
+          />
+        ) : (
+          <p
+            className="text-[11px] text-zinc-200 truncate"
+            onDoubleClick={(e) => { e.stopPropagation(); setEditing(true); }}
+            title="Double-click to rename"
+          >
+            {profile.name}
+          </p>
+        )}
+        <p className="text-[9px] text-zinc-500">
+          {profile.source === 'recording' ? 'Recorded' : 'Uploaded'} &middot; {durationLabel}
+        </p>
+      </div>
+
+      {/* Delete button */}
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onDelete(); }}
+        className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-zinc-500 hover:text-red-400 p-0.5"
+        aria-label={`Delete ${profile.name}`}
+        data-testid={`voice-delete-${profile.id}`}
+      >
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+          <path d="M4 4l8 8M12 4l-8 8" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+// ── Recording overlay ──
+
+function RecordingIndicator({ elapsed }: { elapsed: number }) {
+  const label = `${Math.floor(elapsed / 60)}:${String(Math.floor(elapsed % 60)).padStart(2, '0')}`;
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 rounded bg-red-950/30 border border-red-700/40" data-testid="voice-recording-indicator">
+      <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
+      <span className="text-[11px] text-red-300 font-mono">{label}</span>
+      <span className="text-[9px] text-zinc-500">Recording...</span>
+    </div>
+  );
+}
+
+// ── Main component ──
+
+export function VoiceLibrary({ disabled }: { disabled?: boolean }) {
+  const profiles = useVoiceStore((s) => s.profiles);
+  const selectedProfileId = useVoiceStore((s) => s.selectedProfileId);
+  const recording = useVoiceStore((s) => s.recording);
+  const loading = useVoiceStore((s) => s.loading);
+  const error = useVoiceStore((s) => s.error);
+  const {
+    loadProfiles,
+    addProfile,
+    removeProfile,
+    renameProfile,
+    selectProfile,
+    setRecording,
+    clearError,
+  } = useVoiceStore.getState();
+
+  const [expanded, setExpanded] = useState(false);
+  const [recordingElapsed, setRecordingElapsed] = useState(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const recordedChunksRef = useRef<Blob[]>([]);
+  const recordingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const recordingStartRef = useRef<number>(0);
+
+  // Load profiles on first expand
+  useEffect(() => {
+    if (expanded && profiles.length === 0 && !loading) {
+      loadProfiles();
+    }
+  }, [expanded, profiles.length, loading, loadProfiles]);
+
+  // ── Recording ──
+
+  const startRecording = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const recorder = new MediaRecorder(stream, {
+        mimeType: MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+          ? 'audio/webm;codecs=opus'
+          : 'audio/webm',
+      });
+
+      recordedChunksRef.current = [];
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) recordedChunksRef.current.push(e.data);
+      };
+
+      recorder.onstop = async () => {
+        stream.getTracks().forEach((t) => t.stop());
+        if (recordingTimerRef.current) clearInterval(recordingTimerRef.current);
+        setRecording(false);
+
+        const blob = new Blob(recordedChunksRef.current, { type: 'audio/webm' });
+        const elapsed = (Date.now() - recordingStartRef.current) / 1000;
+
+        if (elapsed < MIN_VOICE_DURATION) {
+          // Too short — discard
+          return;
+        }
+
+        try {
+          await addProfile(
+            `Recording ${new Date().toLocaleTimeString()}`,
+            'recording',
+            blob,
+            elapsed,
+          );
+        } catch {
+          // Error handled by store
+        }
+      };
+
+      mediaRecorderRef.current = recorder;
+      recordingStartRef.current = Date.now();
+      setRecordingElapsed(0);
+      setRecording(true);
+      recorder.start(250);
+
+      recordingTimerRef.current = setInterval(() => {
+        setRecordingElapsed((Date.now() - recordingStartRef.current) / 1000);
+      }, 200);
+    } catch {
+      // Microphone permission denied or unavailable
+    }
+  }, [addProfile, setRecording]);
+
+  const stopRecording = useCallback(() => {
+    mediaRecorderRef.current?.stop();
+  }, []);
+
+  // ── File upload ──
+
+  const handleFileUpload = useCallback(
+    async (file: File) => {
+      if (file.size > MAX_VOICE_FILE_SIZE) return;
+      if (!file.type.startsWith('audio/')) return;
+
+      // Compute duration
+      let durationSec = 30; // fallback
+      try {
+        const ctx = new OfflineAudioContext(1, 1, 44100);
+        const buf = await file.arrayBuffer();
+        const audioBuf = await ctx.decodeAudioData(buf);
+        durationSec = audioBuf.duration;
+      } catch {
+        // Use fallback
+      }
+
+      const name = file.name.replace(/\.[^.]+$/, '');
+      try {
+        await addProfile(name, 'upload', file, durationSec);
+      } catch {
+        // Error handled by store
+      }
+    },
+    [addProfile],
+  );
+
+  // ── Drop handling ──
+
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const files = Array.from(e.dataTransfer.files);
+      const audio = files.find(
+        (f) => f.type.startsWith('audio/') || /\.(wav|mp3|ogg|flac|webm)$/i.test(f.name),
+      );
+      if (audio) handleFileUpload(audio);
+    },
+    [handleFileUpload],
+  );
+
+  const selectedProfile = profiles.find((p) => p.id === selectedProfileId) ?? null;
+
+  return (
+    <section className="space-y-1.5" data-testid="voice-library">
+      {/* Header */}
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center justify-between w-full text-left"
+        aria-expanded={expanded}
+        data-testid="voice-library-toggle"
+      >
+        <span className="text-[11px] font-medium uppercase text-zinc-400 flex items-center gap-1.5">
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className={`transition-transform ${expanded ? 'rotate-90' : ''}`}
+          >
+            <path d="M6 3l5 5-5 5V3z" />
+          </svg>
+          Voice Reference
+          {selectedProfile && (
+            <span className="text-[9px] text-indigo-400 font-normal normal-case">
+              &middot; {selectedProfile.name}
+            </span>
+          )}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="space-y-2">
+          {/* Error banner */}
+          {error && (
+            <div className="flex items-center justify-between rounded bg-red-950/30 px-2 py-1 text-[10px] text-red-300" data-testid="voice-error">
+              <span>{error}</span>
+              <button type="button" onClick={clearError} className="text-red-500 hover:text-red-300 ml-2">&times;</button>
+            </div>
+          )}
+
+          {/* Actions: Record + Upload */}
+          <div className="flex gap-1.5">
+            <button
+              type="button"
+              onClick={recording ? stopRecording : startRecording}
+              disabled={disabled}
+              className={`flex-1 flex items-center justify-center gap-1.5 rounded px-2 py-1.5 text-[10px] font-medium transition-colors ${
+                recording
+                  ? 'bg-red-600/20 text-red-300 border border-red-600/40 hover:bg-red-600/30'
+                  : 'bg-white/[0.04] text-zinc-300 border border-transparent hover:bg-white/[0.08]'
+              }`}
+              data-testid="voice-record-btn"
+            >
+              {recording ? (
+                <>
+                  <div className="w-2 h-2 rounded-sm bg-red-400" />
+                  Stop
+                </>
+              ) : (
+                <>
+                  <div className="w-2 h-2 rounded-full bg-red-500" />
+                  Record
+                </>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={disabled || recording}
+              className="flex-1 flex items-center justify-center gap-1.5 rounded px-2 py-1.5 text-[10px] font-medium bg-white/[0.04] text-zinc-300 border border-transparent hover:bg-white/[0.08] transition-colors"
+              data-testid="voice-upload-btn"
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                <path d="M8 10V3M5 5l3-3 3 3M3 13h10" />
+              </svg>
+              Upload
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPTED_VOICE_EXTENSIONS}
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) handleFileUpload(file);
+                e.target.value = '';
+              }}
+              disabled={disabled}
+              data-testid="voice-file-input"
+            />
+          </div>
+
+          {/* Recording indicator */}
+          {recording && <RecordingIndicator elapsed={recordingElapsed} />}
+
+          {/* Profile list or drop zone */}
+          {profiles.length === 0 && !loading ? (
+            <div
+              onDrop={handleDrop}
+              onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+              onDragLeave={() => setIsDragOver(false)}
+              className={`rounded border border-dashed px-3 py-4 text-center transition-colors ${
+                isDragOver
+                  ? 'border-indigo-500 bg-indigo-950/20 text-indigo-300'
+                  : 'border-zinc-700 text-zinc-600'
+              }`}
+              data-testid="voice-drop-zone"
+            >
+              <p className="text-[10px]">No voice profiles yet</p>
+              <p className="text-[9px] text-zinc-700 mt-0.5">
+                Record or upload a vocal sample (min {MIN_VOICE_DURATION}s)
+              </p>
+            </div>
+          ) : (
+            <div
+              role="listbox"
+              aria-label="Voice profiles"
+              className="space-y-0.5 max-h-40 overflow-y-auto"
+              onDrop={handleDrop}
+              onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+              onDragLeave={() => setIsDragOver(false)}
+              data-testid="voice-profile-list"
+            >
+              {loading && (
+                <p className="text-[10px] text-zinc-500 px-2 py-1">Loading...</p>
+              )}
+              {profiles.map((p) => (
+                <VoiceProfileCard
+                  key={p.id}
+                  profile={p}
+                  selected={p.id === selectedProfileId}
+                  onSelect={() => selectProfile(p.id === selectedProfileId ? null : p.id)}
+                  onDelete={() => removeProfile(p.id)}
+                  onRename={(name) => renameProfile(p.id, name)}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Selected voice info */}
+          {selectedProfile && (
+            <div className="rounded bg-indigo-950/15 border border-indigo-500/20 px-2 py-1.5" data-testid="voice-selected-info">
+              <p className="text-[9px] text-indigo-300">
+                Voice reference: <span className="text-zinc-200">{selectedProfile.name}</span> will be used for generation
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/generation/VoiceLibrary.tsx
+++ b/src/components/generation/VoiceLibrary.tsx
@@ -6,6 +6,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useVoiceStore } from '../../store/voiceStore';
+import { loadVoiceAudio } from '../../services/voiceProfileService';
 import { ACCEPTED_VOICE_EXTENSIONS, MAX_VOICE_FILE_SIZE, MIN_VOICE_DURATION } from '../../types/voice';
 import type { VoiceProfile } from '../../types/voice';
 
@@ -35,18 +36,23 @@ function WaveformMini({ peaks }: { peaks: number[] }) {
 function VoiceProfileCard({
   profile,
   selected,
+  playing,
   onSelect,
   onDelete,
   onRename,
+  onTogglePreview,
 }: {
   profile: VoiceProfile;
   selected: boolean;
+  playing: boolean;
   onSelect: () => void;
   onDelete: () => void;
   onRename: (name: string) => void;
+  onTogglePreview: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [editName, setEditName] = useState(profile.name);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -79,8 +85,32 @@ function VoiceProfileCard({
       onClick={onSelect}
       data-testid={`voice-profile-card-${profile.id}`}
     >
+      {/* Play/Preview button */}
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onTogglePreview(); }}
+        className={`shrink-0 flex items-center justify-center w-6 h-6 rounded-full transition-colors ${
+          playing
+            ? 'bg-indigo-500/30 text-indigo-300'
+            : 'bg-white/[0.06] text-zinc-400 hover:bg-white/[0.12] hover:text-zinc-200'
+        }`}
+        aria-label={playing ? `Stop preview ${profile.name}` : `Preview ${profile.name}`}
+        data-testid={`voice-preview-${profile.id}`}
+      >
+        {playing ? (
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+            <rect x="3" y="3" width="4" height="10" rx="1" />
+            <rect x="9" y="3" width="4" height="10" rx="1" />
+          </svg>
+        ) : (
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M4 2l10 6-10 6V2z" />
+          </svg>
+        )}
+      </button>
+
       {/* Waveform */}
-      <div className="shrink-0 w-12 overflow-hidden">
+      <div className="shrink-0 w-10 overflow-hidden">
         <WaveformMini peaks={profile.waveformPeaks.slice(0, 16)} />
       </div>
 
@@ -114,18 +144,38 @@ function VoiceProfileCard({
         </p>
       </div>
 
-      {/* Delete button */}
-      <button
-        type="button"
-        onClick={(e) => { e.stopPropagation(); onDelete(); }}
-        className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-zinc-500 hover:text-red-400 p-0.5"
-        aria-label={`Delete ${profile.name}`}
-        data-testid={`voice-delete-${profile.id}`}
-      >
-        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-          <path d="M4 4l8 8M12 4l-8 8" />
-        </svg>
-      </button>
+      {/* Delete button with confirmation */}
+      {confirmDelete ? (
+        <div className="flex items-center gap-1 shrink-0" onClick={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            onClick={() => onDelete()}
+            className="text-[9px] text-red-400 hover:text-red-300 px-1"
+            data-testid={`voice-confirm-delete-${profile.id}`}
+          >
+            Delete
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(false)}
+            className="text-[9px] text-zinc-500 hover:text-zinc-300 px-1"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setConfirmDelete(true); }}
+          className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-zinc-500 hover:text-red-400 p-0.5"
+          aria-label={`Delete ${profile.name}`}
+          data-testid={`voice-delete-${profile.id}`}
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+            <path d="M4 4l8 8M12 4l-8 8" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }
@@ -163,11 +213,14 @@ export function VoiceLibrary({ disabled }: { disabled?: boolean }) {
 
   const [expanded, setExpanded] = useState(false);
   const [recordingElapsed, setRecordingElapsed] = useState(0);
+  const [previewingId, setPreviewingId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const recordedChunksRef = useRef<Blob[]>([]);
   const recordingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const recordingStartRef = useRef<number>(0);
+  const previewAudioRef = useRef<HTMLAudioElement | null>(null);
 
   // Load profiles on first expand
   useEffect(() => {
@@ -280,6 +333,52 @@ export function VoiceLibrary({ disabled }: { disabled?: boolean }) {
     [handleFileUpload],
   );
 
+  // ── Audio preview ──
+
+  const togglePreview = useCallback(async (profileId: string) => {
+    // Stop current preview
+    if (previewAudioRef.current) {
+      previewAudioRef.current.pause();
+      previewAudioRef.current = null;
+    }
+    if (previewingId === profileId) {
+      setPreviewingId(null);
+      return;
+    }
+
+    try {
+      const blob = await loadVoiceAudio(profileId);
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audio.onended = () => {
+        setPreviewingId(null);
+        URL.revokeObjectURL(url);
+      };
+      previewAudioRef.current = audio;
+      setPreviewingId(profileId);
+      await audio.play();
+    } catch {
+      setPreviewingId(null);
+    }
+  }, [previewingId]);
+
+  // Cleanup preview on unmount
+  useEffect(() => {
+    return () => {
+      if (previewAudioRef.current) {
+        previewAudioRef.current.pause();
+        previewAudioRef.current = null;
+      }
+    };
+  }, []);
+
+  // ── Search filter ──
+
+  const filteredProfiles = searchQuery.trim()
+    ? profiles.filter((p) => p.name.toLowerCase().includes(searchQuery.toLowerCase()))
+    : profiles;
+
   const selectedProfile = profiles.find((p) => p.id === selectedProfileId) ?? null;
 
   return (
@@ -376,6 +475,18 @@ export function VoiceLibrary({ disabled }: { disabled?: boolean }) {
           {/* Recording indicator */}
           {recording && <RecordingIndicator elapsed={recordingElapsed} />}
 
+          {/* Search (only show when there are profiles) */}
+          {profiles.length > 2 && (
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search voices..."
+              className="w-full rounded border border-[#3a3a3a] bg-[#1a1a1e] px-2 py-1 text-[10px] text-zinc-300 placeholder-zinc-600 outline-none focus:border-indigo-500/50"
+              data-testid="voice-search-input"
+            />
+          )}
+
           {/* Profile list or drop zone */}
           {profiles.length === 0 && !loading ? (
             <div
@@ -407,14 +518,16 @@ export function VoiceLibrary({ disabled }: { disabled?: boolean }) {
               {loading && (
                 <p className="text-[10px] text-zinc-500 px-2 py-1">Loading...</p>
               )}
-              {profiles.map((p) => (
+              {filteredProfiles.map((p) => (
                 <VoiceProfileCard
                   key={p.id}
                   profile={p}
                   selected={p.id === selectedProfileId}
+                  playing={p.id === previewingId}
                   onSelect={() => selectProfile(p.id === selectedProfileId ? null : p.id)}
                   onDelete={() => removeProfile(p.id)}
                   onRename={(name) => renameProfile(p.id, name)}
+                  onTogglePreview={() => togglePreview(p.id)}
                 />
               ))}
             </div>

--- a/src/components/generation/VoiceLibrary.tsx
+++ b/src/components/generation/VoiceLibrary.tsx
@@ -46,8 +46,8 @@ function VoiceProfileCard({
   selected: boolean;
   playing: boolean;
   onSelect: () => void;
-  onDelete: () => void;
-  onRename: (name: string) => void;
+  onDelete: () => void | Promise<void>;
+  onRename: (name: string) => void | Promise<void>;
   onTogglePreview: () => void;
 }) {
   const [editing, setEditing] = useState(false);
@@ -62,7 +62,7 @@ function VoiceProfileCard({
   const commitRename = () => {
     const trimmed = editName.trim();
     if (trimmed && trimmed !== profile.name) {
-      onRename(trimmed);
+      void Promise.resolve(onRename(trimmed)).catch(() => {/* error shown via store banner */});
     } else {
       setEditName(profile.name);
     }
@@ -149,7 +149,7 @@ function VoiceProfileCard({
         <div className="flex items-center gap-1 shrink-0" onClick={(e) => e.stopPropagation()}>
           <button
             type="button"
-            onClick={() => onDelete()}
+            onClick={() => void Promise.resolve(onDelete()).catch(() => {/* error shown via store banner */})}
             className="text-[9px] text-red-400 hover:text-red-300 px-1"
             data-testid={`voice-confirm-delete-${profile.id}`}
           >
@@ -221,6 +221,7 @@ export function VoiceLibrary({ disabled }: { disabled?: boolean }) {
   const recordingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const recordingStartRef = useRef<number>(0);
   const previewAudioRef = useRef<HTMLAudioElement | null>(null);
+  const previewUrlRef = useRef<string | null>(null);
 
   // Load profiles on first expand
   useEffect(() => {
@@ -293,7 +294,10 @@ export function VoiceLibrary({ disabled }: { disabled?: boolean }) {
   const handleFileUpload = useCallback(
     async (file: File) => {
       if (file.size > MAX_VOICE_FILE_SIZE) return;
-      if (!file.type.startsWith('audio/')) return;
+      // Accept by MIME type or by extension (some browsers report empty MIME)
+      const hasAudioMime = file.type.startsWith('audio/');
+      const hasAudioExt = /\.(wav|mp3|flac|ogg|webm|mpeg)$/i.test(file.name);
+      if (!hasAudioMime && !hasAudioExt) return;
 
       // Compute duration
       let durationSec = 30; // fallback
@@ -335,12 +339,19 @@ export function VoiceLibrary({ disabled }: { disabled?: boolean }) {
 
   // ── Audio preview ──
 
-  const togglePreview = useCallback(async (profileId: string) => {
-    // Stop current preview
+  const stopPreview = useCallback(() => {
     if (previewAudioRef.current) {
       previewAudioRef.current.pause();
       previewAudioRef.current = null;
     }
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+  }, []);
+
+  const togglePreview = useCallback(async (profileId: string) => {
+    stopPreview();
     if (previewingId === profileId) {
       setPreviewingId(null);
       return;
@@ -350,28 +361,25 @@ export function VoiceLibrary({ disabled }: { disabled?: boolean }) {
       const blob = await loadVoiceAudio(profileId);
       if (!blob) return;
       const url = URL.createObjectURL(blob);
+      previewUrlRef.current = url;
       const audio = new Audio(url);
       audio.onended = () => {
         setPreviewingId(null);
-        URL.revokeObjectURL(url);
+        stopPreview();
       };
       previewAudioRef.current = audio;
       setPreviewingId(profileId);
       await audio.play();
     } catch {
       setPreviewingId(null);
+      stopPreview();
     }
-  }, [previewingId]);
+  }, [previewingId, stopPreview]);
 
   // Cleanup preview on unmount
   useEffect(() => {
-    return () => {
-      if (previewAudioRef.current) {
-        previewAudioRef.current.pause();
-        previewAudioRef.current = null;
-      }
-    };
-  }, []);
+    return () => stopPreview();
+  }, [stopPreview]);
 
   // ── Search filter ──
 

--- a/src/components/generation/__tests__/VoiceInfluenceControls.test.tsx
+++ b/src/components/generation/__tests__/VoiceInfluenceControls.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('../../../services/voiceProfileService', () => ({
+  listVoiceProfiles: vi.fn().mockResolvedValue([]),
+  saveVoiceProfile: vi.fn().mockResolvedValue(undefined),
+  deleteVoiceProfile: vi.fn().mockResolvedValue(undefined),
+  updateVoiceProfileName: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('uuid', () => ({ v4: () => 'test-uuid' }));
+vi.mock('../../../utils/waveformPeaks', () => ({
+  computeWaveformPeaks: vi.fn(() => [0.5]),
+}));
+
+import { useVoiceStore } from '../../../store/voiceStore';
+import { VoiceInfluenceControls } from '../VoiceInfluenceControls';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useVoiceStore.setState({
+    profiles: [],
+    selectedProfileId: null,
+    audioInfluence: 0.4,
+    styleInfluence: 0.6,
+    loading: false,
+    recording: false,
+    error: null,
+  });
+});
+
+describe('VoiceInfluenceControls', () => {
+  it('renders nothing when no voice is selected', () => {
+    const { container } = render(<VoiceInfluenceControls />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders sliders when a voice is selected', () => {
+    useVoiceStore.setState({ selectedProfileId: 'v1' });
+    render(<VoiceInfluenceControls />);
+
+    expect(screen.getByTestId('voice-influence-controls')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-audio-influence-slider')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-style-influence-slider')).toBeInTheDocument();
+  });
+
+  it('displays current influence values as percentages', () => {
+    useVoiceStore.setState({ selectedProfileId: 'v1', audioInfluence: 0.4, styleInfluence: 0.6 });
+    render(<VoiceInfluenceControls />);
+
+    expect(screen.getByTestId('voice-audio-influence-value')).toHaveTextContent('40%');
+    expect(screen.getByTestId('voice-style-influence-value')).toHaveTextContent('60%');
+  });
+
+  it('updates audio influence when slider changes', () => {
+    useVoiceStore.setState({ selectedProfileId: 'v1' });
+    render(<VoiceInfluenceControls />);
+
+    fireEvent.change(screen.getByTestId('voice-audio-influence-slider'), {
+      target: { value: '0.75' },
+    });
+
+    expect(useVoiceStore.getState().audioInfluence).toBeCloseTo(0.75);
+  });
+
+  it('updates style influence when slider changes', () => {
+    useVoiceStore.setState({ selectedProfileId: 'v1' });
+    render(<VoiceInfluenceControls />);
+
+    fireEvent.change(screen.getByTestId('voice-style-influence-slider'), {
+      target: { value: '0.9' },
+    });
+
+    expect(useVoiceStore.getState().styleInfluence).toBeCloseTo(0.9);
+  });
+
+  it('renders three preset buttons', () => {
+    useVoiceStore.setState({ selectedProfileId: 'v1' });
+    render(<VoiceInfluenceControls />);
+
+    expect(screen.getByTestId('voice-preset-natural')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-preset-ai-enhanced')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-preset-voice-forward')).toBeInTheDocument();
+  });
+
+  it('applies "Voice Forward" preset when clicked', () => {
+    useVoiceStore.setState({ selectedProfileId: 'v1' });
+    render(<VoiceInfluenceControls />);
+
+    fireEvent.click(screen.getByTestId('voice-preset-voice-forward'));
+
+    expect(useVoiceStore.getState().audioInfluence).toBeCloseTo(0.7);
+    expect(useVoiceStore.getState().styleInfluence).toBeCloseTo(0.3);
+  });
+
+  it('resets values when reset button is clicked', () => {
+    useVoiceStore.setState({
+      selectedProfileId: 'v1',
+      audioInfluence: 0.9,
+      styleInfluence: 0.1,
+    });
+    render(<VoiceInfluenceControls />);
+
+    fireEvent.click(screen.getByTestId('voice-influence-reset'));
+
+    expect(useVoiceStore.getState().audioInfluence).toBeCloseTo(0.4);
+    expect(useVoiceStore.getState().styleInfluence).toBeCloseTo(0.6);
+  });
+
+  it('disables controls when disabled prop is true', () => {
+    useVoiceStore.setState({ selectedProfileId: 'v1' });
+    render(<VoiceInfluenceControls disabled />);
+
+    expect(screen.getByTestId('voice-audio-influence-slider')).toBeDisabled();
+    expect(screen.getByTestId('voice-style-influence-slider')).toBeDisabled();
+    expect(screen.getByTestId('voice-influence-reset')).toBeDisabled();
+  });
+});

--- a/src/components/generation/__tests__/VoiceLibrary.test.tsx
+++ b/src/components/generation/__tests__/VoiceLibrary.test.tsx
@@ -27,6 +27,8 @@ function makeProfile(overrides: Partial<VoiceProfile> = {}): VoiceProfile {
     duration: 30,
     fileSize: 1024,
     waveformPeaks: [0.2, 0.5, 0.8, 0.3],
+    defaultAudioInfluence: 0.4,
+    defaultStyleInfluence: 0.6,
     createdAt: 1000,
     updatedAt: 2000,
     ...overrides,

--- a/src/components/generation/__tests__/VoiceLibrary.test.tsx
+++ b/src/components/generation/__tests__/VoiceLibrary.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { VoiceProfile } from '../../../types/voice';
+
+// Mock voiceProfileService before store import
+vi.mock('../../../services/voiceProfileService', () => ({
+  listVoiceProfiles: vi.fn().mockResolvedValue([]),
+  saveVoiceProfile: vi.fn().mockResolvedValue(undefined),
+  deleteVoiceProfile: vi.fn().mockResolvedValue(undefined),
+  updateVoiceProfileName: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('uuid', () => ({ v4: () => 'test-uuid' }));
+vi.mock('../../../utils/waveformPeaks', () => ({
+  computeWaveformPeaks: vi.fn(() => [0.5]),
+}));
+
+import { useVoiceStore } from '../../../store/voiceStore';
+import { VoiceLibrary } from '../VoiceLibrary';
+
+function makeProfile(overrides: Partial<VoiceProfile> = {}): VoiceProfile {
+  return {
+    id: 'v1',
+    name: 'Test Voice',
+    source: 'upload',
+    mimeType: 'audio/wav',
+    duration: 30,
+    fileSize: 1024,
+    waveformPeaks: [0.2, 0.5, 0.8, 0.3],
+    createdAt: 1000,
+    updatedAt: 2000,
+    ...overrides,
+  };
+}
+
+// Sentinel profile to prevent auto-loadProfiles from firing.
+// The useEffect only calls loadProfiles when profiles.length === 0 && !loading.
+// By setting loading: true we prevent the auto-load side effect.
+const PREVENT_AUTOLOAD = { loading: true };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useVoiceStore.setState({
+    profiles: [],
+    selectedProfileId: null,
+    loading: false,
+    recording: false,
+    error: null,
+  });
+});
+
+describe('VoiceLibrary', () => {
+  it('renders collapsed by default with toggle button', () => {
+    render(<VoiceLibrary />);
+    const toggle = screen.getByTestId('voice-library-toggle');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('voice-drop-zone')).not.toBeInTheDocument();
+  });
+
+  it('expands when toggle is clicked', () => {
+    useVoiceStore.setState(PREVENT_AUTOLOAD);
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+    expect(screen.getByTestId('voice-library-toggle')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('shows empty state with drop zone when no profiles and not loading', () => {
+    // Pre-expand: set loading false but profiles empty
+    // We need to prevent the useEffect from calling loadProfiles.
+    // Trick: set a dummy profile then remove it — or just test with loading=false
+    // Actually, better: spy on loadProfiles and make it a no-op
+    const spy = vi.spyOn(useVoiceStore.getState(), 'loadProfiles').mockImplementation(async () => {});
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+    expect(screen.getByTestId('voice-drop-zone')).toBeInTheDocument();
+    expect(screen.getByText(/No voice profiles yet/)).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  it('shows record and upload buttons when expanded', () => {
+    useVoiceStore.setState(PREVENT_AUTOLOAD);
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+    expect(screen.getByTestId('voice-record-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-upload-btn')).toBeInTheDocument();
+  });
+
+  it('renders profile cards when profiles exist', () => {
+    const p1 = makeProfile({ id: 'v1', name: 'Voice A' });
+    const p2 = makeProfile({ id: 'v2', name: 'Voice B' });
+    useVoiceStore.setState({ profiles: [p1, p2] });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByTestId('voice-profile-card-v1')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-profile-card-v2')).toBeInTheDocument();
+    expect(screen.getByText('Voice A')).toBeInTheDocument();
+    expect(screen.getByText('Voice B')).toBeInTheDocument();
+  });
+
+  it('selects a profile when clicked', () => {
+    const p1 = makeProfile({ id: 'v1', name: 'Voice A' });
+    useVoiceStore.setState({ profiles: [p1] });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+    fireEvent.click(screen.getByTestId('voice-profile-card-v1'));
+
+    expect(useVoiceStore.getState().selectedProfileId).toBe('v1');
+  });
+
+  it('deselects a profile when clicked again', () => {
+    const p1 = makeProfile({ id: 'v1' });
+    useVoiceStore.setState({ profiles: [p1], selectedProfileId: 'v1' });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+    fireEvent.click(screen.getByTestId('voice-profile-card-v1'));
+
+    expect(useVoiceStore.getState().selectedProfileId).toBeNull();
+  });
+
+  it('shows selected voice info when a profile is selected', () => {
+    const p1 = makeProfile({ id: 'v1', name: 'My Voice' });
+    useVoiceStore.setState({ profiles: [p1], selectedProfileId: 'v1' });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByTestId('voice-selected-info')).toBeInTheDocument();
+    expect(screen.getByText(/will be used for generation/)).toBeInTheDocument();
+  });
+
+  it('shows error banner when error exists', () => {
+    useVoiceStore.setState({
+      profiles: [makeProfile()],
+      error: 'Test error message',
+    });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByTestId('voice-error')).toBeInTheDocument();
+    expect(screen.getByText('Test error message')).toBeInTheDocument();
+  });
+
+  it('shows duration formatted as minutes:seconds for long recordings', () => {
+    const p1 = makeProfile({ id: 'v1', duration: 90 });
+    useVoiceStore.setState({ profiles: [p1] });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByText(/1m 30s/)).toBeInTheDocument();
+  });
+
+  it('shows duration in seconds for short recordings', () => {
+    const p1 = makeProfile({ id: 'v1', duration: 30 });
+    useVoiceStore.setState({ profiles: [p1] });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByText(/30s/)).toBeInTheDocument();
+  });
+
+  it('shows selected profile name in collapsed header', () => {
+    const p1 = makeProfile({ id: 'v1', name: 'My Vocal' });
+    useVoiceStore.setState({ profiles: [p1], selectedProfileId: 'v1' });
+
+    render(<VoiceLibrary />);
+
+    expect(screen.getByText(/My Vocal/)).toBeInTheDocument();
+  });
+
+  it('disables buttons when disabled prop is true', () => {
+    useVoiceStore.setState(PREVENT_AUTOLOAD);
+    render(<VoiceLibrary disabled />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByTestId('voice-record-btn')).toBeDisabled();
+    expect(screen.getByTestId('voice-upload-btn')).toBeDisabled();
+  });
+
+  it('shows recording indicator when recording', () => {
+    useVoiceStore.setState({ recording: true, ...PREVENT_AUTOLOAD });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByTestId('voice-recording-indicator')).toBeInTheDocument();
+    expect(screen.getByText(/Recording.../)).toBeInTheDocument();
+  });
+
+  it('shows waveform mini visualization for profiles', () => {
+    const p1 = makeProfile({ id: 'v1', waveformPeaks: [0.1, 0.5, 0.8, 0.3] });
+    useVoiceStore.setState({ profiles: [p1] });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByTestId('voice-waveform-mini')).toBeInTheDocument();
+  });
+
+  it('shows profile list with listbox role', () => {
+    useVoiceStore.setState({ profiles: [makeProfile()] });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByTestId('voice-profile-list')).toHaveAttribute('role', 'listbox');
+  });
+});

--- a/src/components/generation/__tests__/VoiceLibrary.test.tsx
+++ b/src/components/generation/__tests__/VoiceLibrary.test.tsx
@@ -212,4 +212,70 @@ describe('VoiceLibrary', () => {
 
     expect(screen.getByTestId('voice-profile-list')).toHaveAttribute('role', 'listbox');
   });
+
+  it('shows preview button for each profile', () => {
+    useVoiceStore.setState({ profiles: [makeProfile({ id: 'v1' })] });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByTestId('voice-preview-v1')).toBeInTheDocument();
+  });
+
+  it('shows delete confirmation when delete is clicked', () => {
+    useVoiceStore.setState({ profiles: [makeProfile({ id: 'v1' })] });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+    fireEvent.click(screen.getByTestId('voice-delete-v1'));
+
+    expect(screen.getByTestId('voice-confirm-delete-v1')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('shows search input when more than 2 profiles exist', () => {
+    useVoiceStore.setState({
+      profiles: [
+        makeProfile({ id: 'v1', name: 'Alpha' }),
+        makeProfile({ id: 'v2', name: 'Beta' }),
+        makeProfile({ id: 'v3', name: 'Gamma' }),
+      ],
+    });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.getByTestId('voice-search-input')).toBeInTheDocument();
+  });
+
+  it('does not show search input when 2 or fewer profiles exist', () => {
+    useVoiceStore.setState({
+      profiles: [makeProfile({ id: 'v1' }), makeProfile({ id: 'v2' })],
+    });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+
+    expect(screen.queryByTestId('voice-search-input')).not.toBeInTheDocument();
+  });
+
+  it('filters profiles by search query', () => {
+    useVoiceStore.setState({
+      profiles: [
+        makeProfile({ id: 'v1', name: 'Alpha Voice' }),
+        makeProfile({ id: 'v2', name: 'Beta Vocal' }),
+        makeProfile({ id: 'v3', name: 'Gamma Voice' }),
+      ],
+    });
+
+    render(<VoiceLibrary />);
+    fireEvent.click(screen.getByTestId('voice-library-toggle'));
+    fireEvent.change(screen.getByTestId('voice-search-input'), {
+      target: { value: 'Voice' },
+    });
+
+    expect(screen.getByTestId('voice-profile-card-v1')).toBeInTheDocument();
+    expect(screen.queryByTestId('voice-profile-card-v2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('voice-profile-card-v3')).toBeInTheDocument();
+  });
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,7 @@ import { getMidiCaptureService } from './services/midiCaptureService';
 import { executeCoreDawShortcut } from './services/coreDawShortcuts';
 import { useAnalysisStore } from './store/analysisStore';
 import { analyzeClipLocally } from './services/localAnalysisService';
+import { useVoiceStore } from './store/voiceStore';
 
 const agentProjectStore = {
   getState: () => ({
@@ -109,6 +110,7 @@ const agentProjectStore = {
 (window as unknown as Record<string, unknown>).__modelStore = useModelStore;
 (window as unknown as Record<string, unknown>).__getAudioEngine = () => getAudioEngine();
 (window as unknown as Record<string, unknown>).__shortcutsStore = useShortcutsStore;
+(window as unknown as Record<string, unknown>).__voiceStore = useVoiceStore;
 (window as unknown as Record<string, unknown>).__coreDawShortcuts = {
   execute: (actionId: Parameters<typeof executeCoreDawShortcut>[0]) => executeCoreDawShortcut(actionId),
 };

--- a/src/services/__tests__/voiceProfileService.test.ts
+++ b/src/services/__tests__/voiceProfileService.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VoiceProfile } from '../../types/voice';
+
+// Mock idb-keyval before importing
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+const mockDel = vi.fn();
+const mockKeys = vi.fn();
+vi.mock('idb-keyval', () => ({
+  get: (...args: unknown[]) => mockGet(...args),
+  set: (...args: unknown[]) => mockSet(...args),
+  del: (...args: unknown[]) => mockDel(...args),
+  keys: (...args: unknown[]) => mockKeys(...args),
+}));
+
+import {
+  saveVoiceProfile,
+  loadVoiceProfile,
+  loadVoiceAudio,
+  deleteVoiceProfile,
+  updateVoiceProfileName,
+  listVoiceProfiles,
+  validateName,
+  validateDuration,
+  validateFileSize,
+  validateMimeType,
+  VoiceProfileError,
+} from '../voiceProfileService';
+
+function makeProfile(overrides: Partial<VoiceProfile> = {}): VoiceProfile {
+  return {
+    id: 'voice-1',
+    name: 'My Voice',
+    source: 'upload',
+    mimeType: 'audio/wav',
+    duration: 30,
+    fileSize: 1024 * 100,
+    waveformPeaks: [0.1, 0.5, 0.8],
+    createdAt: 1000,
+    updatedAt: 2000,
+    ...overrides,
+  };
+}
+
+function makeBlob(size = 1024 * 100, type = 'audio/wav'): Blob {
+  return new Blob([new ArrayBuffer(size)], { type });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSet.mockResolvedValue(undefined);
+  mockDel.mockResolvedValue(undefined);
+});
+
+// ── Validation ──
+
+describe('validateName', () => {
+  it('accepts a normal name', () => {
+    expect(() => validateName('My Voice')).not.toThrow();
+  });
+
+  it('rejects empty string', () => {
+    expect(() => validateName('')).toThrow(VoiceProfileError);
+    expect(() => validateName('  ')).toThrow(VoiceProfileError);
+  });
+
+  it('rejects name over 100 characters', () => {
+    expect(() => validateName('a'.repeat(101))).toThrow(VoiceProfileError);
+  });
+
+  it('throws with INVALID_NAME code', () => {
+    try {
+      validateName('');
+    } catch (e) {
+      expect((e as VoiceProfileError).code).toBe('INVALID_NAME');
+    }
+  });
+});
+
+describe('validateDuration', () => {
+  it('accepts duration within range', () => {
+    expect(() => validateDuration(30)).not.toThrow();
+    expect(() => validateDuration(10)).not.toThrow();
+    expect(() => validateDuration(300)).not.toThrow();
+  });
+
+  it('rejects too short', () => {
+    expect(() => validateDuration(5)).toThrow(VoiceProfileError);
+  });
+
+  it('rejects too long', () => {
+    expect(() => validateDuration(301)).toThrow(VoiceProfileError);
+  });
+
+  it('rejects NaN and Infinity', () => {
+    expect(() => validateDuration(NaN)).toThrow(VoiceProfileError);
+    expect(() => validateDuration(Infinity)).toThrow(VoiceProfileError);
+  });
+});
+
+describe('validateFileSize', () => {
+  it('accepts valid sizes', () => {
+    expect(() => validateFileSize(1024)).not.toThrow();
+  });
+
+  it('rejects zero', () => {
+    expect(() => validateFileSize(0)).toThrow(VoiceProfileError);
+  });
+
+  it('rejects over 50 MB', () => {
+    expect(() => validateFileSize(51 * 1024 * 1024)).toThrow(VoiceProfileError);
+  });
+});
+
+describe('validateMimeType', () => {
+  it('accepts wav', () => {
+    expect(() => validateMimeType('audio/wav')).not.toThrow();
+  });
+
+  it('accepts mp3 and flac', () => {
+    expect(() => validateMimeType('audio/mpeg')).not.toThrow();
+    expect(() => validateMimeType('audio/flac')).not.toThrow();
+  });
+
+  it('rejects video/mp4', () => {
+    expect(() => validateMimeType('video/mp4')).toThrow(VoiceProfileError);
+  });
+
+  it('rejects empty string', () => {
+    expect(() => validateMimeType('')).toThrow(VoiceProfileError);
+  });
+});
+
+// ── CRUD ──
+
+describe('saveVoiceProfile', () => {
+  it('stores profile metadata and audio blob with correct keys', async () => {
+    const profile = makeProfile();
+    const blob = makeBlob();
+
+    await saveVoiceProfile(profile, blob);
+
+    expect(mockSet).toHaveBeenCalledTimes(2);
+    expect(mockSet).toHaveBeenCalledWith('voice:voice-1', profile);
+    expect(mockSet).toHaveBeenCalledWith('voice-audio:voice-1', blob);
+  });
+
+  it('rejects invalid name', async () => {
+    const profile = makeProfile({ name: '' });
+    const blob = makeBlob();
+
+    await expect(saveVoiceProfile(profile, blob)).rejects.toThrow(
+      VoiceProfileError,
+    );
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid duration', async () => {
+    const profile = makeProfile({ duration: 3 });
+    const blob = makeBlob();
+
+    await expect(saveVoiceProfile(profile, blob)).rejects.toThrow(
+      VoiceProfileError,
+    );
+  });
+
+  it('rejects oversized blob', async () => {
+    const profile = makeProfile();
+    const blob = makeBlob(51 * 1024 * 1024);
+
+    await expect(saveVoiceProfile(profile, blob)).rejects.toThrow(
+      VoiceProfileError,
+    );
+  });
+
+  it('rejects unsupported mime type', async () => {
+    const profile = makeProfile({ mimeType: 'video/mp4' });
+    const blob = makeBlob();
+
+    await expect(saveVoiceProfile(profile, blob)).rejects.toThrow(
+      VoiceProfileError,
+    );
+  });
+});
+
+describe('loadVoiceProfile', () => {
+  it('returns profile when found', async () => {
+    const profile = makeProfile();
+    mockGet.mockResolvedValueOnce(profile);
+
+    const result = await loadVoiceProfile('voice-1');
+    expect(result).toEqual(profile);
+    expect(mockGet).toHaveBeenCalledWith('voice:voice-1');
+  });
+
+  it('returns null when not found', async () => {
+    mockGet.mockResolvedValueOnce(undefined);
+
+    const result = await loadVoiceProfile('nonexistent');
+    expect(result).toBeNull();
+  });
+});
+
+describe('loadVoiceAudio', () => {
+  it('returns audio blob when found', async () => {
+    const blob = makeBlob();
+    mockGet.mockResolvedValueOnce(blob);
+
+    const result = await loadVoiceAudio('voice-1');
+    expect(result).toBe(blob);
+    expect(mockGet).toHaveBeenCalledWith('voice-audio:voice-1');
+  });
+
+  it('returns null when not found', async () => {
+    mockGet.mockResolvedValueOnce(undefined);
+
+    const result = await loadVoiceAudio('nonexistent');
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteVoiceProfile', () => {
+  it('deletes both metadata and audio', async () => {
+    await deleteVoiceProfile('voice-1');
+
+    expect(mockDel).toHaveBeenCalledTimes(2);
+    expect(mockDel).toHaveBeenCalledWith('voice:voice-1');
+    expect(mockDel).toHaveBeenCalledWith('voice-audio:voice-1');
+  });
+});
+
+describe('updateVoiceProfileName', () => {
+  it('updates name and updatedAt timestamp', async () => {
+    const profile = makeProfile();
+    mockGet.mockResolvedValueOnce(profile);
+
+    const updated = await updateVoiceProfileName('voice-1', 'New Name');
+
+    expect(updated.name).toBe('New Name');
+    expect(updated.updatedAt).toBeGreaterThan(profile.updatedAt);
+    expect(mockSet).toHaveBeenCalledWith(
+      'voice:voice-1',
+      expect.objectContaining({ name: 'New Name' }),
+    );
+  });
+
+  it('trims whitespace from name', async () => {
+    const profile = makeProfile();
+    mockGet.mockResolvedValueOnce(profile);
+
+    const updated = await updateVoiceProfileName('voice-1', '  Trimmed  ');
+    expect(updated.name).toBe('Trimmed');
+  });
+
+  it('throws NOT_FOUND for missing profile', async () => {
+    mockGet.mockResolvedValueOnce(undefined);
+
+    await expect(
+      updateVoiceProfileName('missing', 'Name'),
+    ).rejects.toThrow(VoiceProfileError);
+  });
+
+  it('rejects empty name', async () => {
+    await expect(
+      updateVoiceProfileName('voice-1', ''),
+    ).rejects.toThrow(VoiceProfileError);
+    // Should not even attempt to load — validation runs first
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('listVoiceProfiles', () => {
+  it('returns profiles sorted by updatedAt descending', async () => {
+    const p1 = makeProfile({ id: 'v1', updatedAt: 1000 });
+    const p2 = makeProfile({ id: 'v2', updatedAt: 3000 });
+    const p3 = makeProfile({ id: 'v3', updatedAt: 2000 });
+
+    mockKeys.mockResolvedValueOnce([
+      'voice:v1',
+      'voice:v2',
+      'voice:v3',
+      'voice-audio:v1', // should be filtered out
+      'project:x',      // should be filtered out
+    ]);
+    mockGet
+      .mockResolvedValueOnce(p1)
+      .mockResolvedValueOnce(p2)
+      .mockResolvedValueOnce(p3);
+
+    const result = await listVoiceProfiles();
+
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe('v2');
+    expect(result[1].id).toBe('v3');
+    expect(result[2].id).toBe('v1');
+  });
+
+  it('returns empty array when no profiles exist', async () => {
+    mockKeys.mockResolvedValueOnce([]);
+
+    const result = await listVoiceProfiles();
+    expect(result).toEqual([]);
+  });
+});

--- a/src/services/__tests__/voiceProfileService.test.ts
+++ b/src/services/__tests__/voiceProfileService.test.ts
@@ -36,6 +36,8 @@ function makeProfile(overrides: Partial<VoiceProfile> = {}): VoiceProfile {
     duration: 30,
     fileSize: 1024 * 100,
     waveformPeaks: [0.1, 0.5, 0.8],
+    defaultAudioInfluence: 0.4,
+    defaultStyleInfluence: 0.6,
     createdAt: 1000,
     updatedAt: 2000,
     ...overrides,

--- a/src/services/voiceProfileService.ts
+++ b/src/services/voiceProfileService.ts
@@ -1,0 +1,138 @@
+/**
+ * Voice Profile Service — IndexedDB persistence for voice profiles (#1087)
+ *
+ * Stores voice profile metadata under `voice:` prefix and audio blobs
+ * under `voice-audio:` prefix using idb-keyval (same pattern as projectStorage).
+ */
+
+import { get, set, del, keys } from 'idb-keyval';
+import type { VoiceProfile } from '../types/voice';
+import {
+  MAX_VOICE_FILE_SIZE,
+  MAX_VOICE_DURATION,
+  MIN_VOICE_DURATION,
+  ACCEPTED_VOICE_MIME_TYPES,
+} from '../types/voice';
+
+const PROFILE_PREFIX = 'voice:';
+const AUDIO_PREFIX = 'voice-audio:';
+
+// ── Validation ──
+
+export class VoiceProfileError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | 'INVALID_NAME'
+      | 'INVALID_DURATION'
+      | 'INVALID_FILE_SIZE'
+      | 'INVALID_MIME_TYPE'
+      | 'NOT_FOUND'
+      | 'STORAGE_ERROR',
+  ) {
+    super(message);
+    this.name = 'VoiceProfileError';
+  }
+}
+
+export function validateName(name: string): void {
+  const trimmed = name.trim();
+  if (!trimmed || trimmed.length > 100) {
+    throw new VoiceProfileError(
+      'Voice name must be 1-100 characters',
+      'INVALID_NAME',
+    );
+  }
+}
+
+export function validateDuration(durationSec: number): void {
+  if (
+    !Number.isFinite(durationSec) ||
+    durationSec < MIN_VOICE_DURATION ||
+    durationSec > MAX_VOICE_DURATION
+  ) {
+    throw new VoiceProfileError(
+      `Duration must be ${MIN_VOICE_DURATION}–${MAX_VOICE_DURATION} seconds`,
+      'INVALID_DURATION',
+    );
+  }
+}
+
+export function validateFileSize(bytes: number): void {
+  if (!Number.isFinite(bytes) || bytes <= 0 || bytes > MAX_VOICE_FILE_SIZE) {
+    throw new VoiceProfileError(
+      `File size must be 1 byte – ${MAX_VOICE_FILE_SIZE / 1024 / 1024} MB`,
+      'INVALID_FILE_SIZE',
+    );
+  }
+}
+
+export function validateMimeType(mime: string): void {
+  if (!(ACCEPTED_VOICE_MIME_TYPES as readonly string[]).includes(mime)) {
+    throw new VoiceProfileError(
+      `Unsupported audio format: ${mime}`,
+      'INVALID_MIME_TYPE',
+    );
+  }
+}
+
+// ── CRUD ──
+
+export async function saveVoiceProfile(
+  profile: VoiceProfile,
+  audioBlob: Blob,
+): Promise<void> {
+  validateName(profile.name);
+  validateDuration(profile.duration);
+  validateFileSize(audioBlob.size);
+  validateMimeType(profile.mimeType);
+
+  await set(`${PROFILE_PREFIX}${profile.id}`, profile);
+  await set(`${AUDIO_PREFIX}${profile.id}`, audioBlob);
+}
+
+export async function loadVoiceProfile(
+  id: string,
+): Promise<VoiceProfile | null> {
+  const data = await get<VoiceProfile>(`${PROFILE_PREFIX}${id}`);
+  return data ?? null;
+}
+
+export async function loadVoiceAudio(id: string): Promise<Blob | null> {
+  const blob = await get<Blob>(`${AUDIO_PREFIX}${id}`);
+  return blob ?? null;
+}
+
+export async function deleteVoiceProfile(id: string): Promise<void> {
+  await del(`${PROFILE_PREFIX}${id}`);
+  await del(`${AUDIO_PREFIX}${id}`);
+}
+
+export async function updateVoiceProfileName(
+  id: string,
+  newName: string,
+): Promise<VoiceProfile> {
+  validateName(newName);
+  const profile = await loadVoiceProfile(id);
+  if (!profile) {
+    throw new VoiceProfileError('Voice profile not found', 'NOT_FOUND');
+  }
+  const updated = { ...profile, name: newName.trim(), updatedAt: Date.now() };
+  await set(`${PROFILE_PREFIX}${id}`, updated);
+  return updated;
+}
+
+export async function listVoiceProfiles(): Promise<VoiceProfile[]> {
+  const allKeys = await keys();
+  const profileKeys = allKeys.filter(
+    (k) => typeof k === 'string' && k.startsWith(PROFILE_PREFIX),
+  );
+
+  const profiles: VoiceProfile[] = [];
+  for (const key of profileKeys) {
+    const data = await get<VoiceProfile>(key as string);
+    if (data) profiles.push(data);
+  }
+
+  return profiles.sort((a, b) => b.updatedAt - a.updatedAt);
+}

--- a/src/store/__tests__/voiceStore.test.ts
+++ b/src/store/__tests__/voiceStore.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VoiceProfile } from '../../types/voice';
+
+// Mock voiceProfileService
+const mockListVoiceProfiles = vi.fn();
+const mockSaveVoiceProfile = vi.fn();
+const mockDeleteVoiceProfile = vi.fn();
+const mockUpdateVoiceProfileName = vi.fn();
+vi.mock('../../services/voiceProfileService', () => ({
+  listVoiceProfiles: (...args: unknown[]) => mockListVoiceProfiles(...args),
+  saveVoiceProfile: (...args: unknown[]) => mockSaveVoiceProfile(...args),
+  deleteVoiceProfile: (...args: unknown[]) => mockDeleteVoiceProfile(...args),
+  updateVoiceProfileName: (...args: unknown[]) => mockUpdateVoiceProfileName(...args),
+}));
+
+// Mock uuid
+vi.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
+
+// Mock waveform
+vi.mock('../../utils/waveformPeaks', () => ({
+  computeWaveformPeaks: vi.fn(() => [0.5]),
+}));
+
+import { useVoiceStore } from '../voiceStore';
+
+function makeProfile(overrides: Partial<VoiceProfile> = {}): VoiceProfile {
+  return {
+    id: 'voice-1',
+    name: 'My Voice',
+    source: 'upload',
+    mimeType: 'audio/wav',
+    duration: 30,
+    fileSize: 1024,
+    waveformPeaks: [0.5],
+    createdAt: 1000,
+    updatedAt: 2000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSaveVoiceProfile.mockResolvedValue(undefined);
+  mockDeleteVoiceProfile.mockResolvedValue(undefined);
+  // Reset store state
+  useVoiceStore.setState({
+    profiles: [],
+    selectedProfileId: null,
+    loading: false,
+    recording: false,
+    error: null,
+  });
+});
+
+describe('voiceStore', () => {
+  describe('loadProfiles', () => {
+    it('loads profiles from service and sets them in state', async () => {
+      const profiles = [makeProfile({ id: 'v1' }), makeProfile({ id: 'v2' })];
+      mockListVoiceProfiles.mockResolvedValueOnce(profiles);
+
+      await useVoiceStore.getState().loadProfiles();
+
+      const state = useVoiceStore.getState();
+      expect(state.profiles).toEqual(profiles);
+      expect(state.loading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it('sets error on failure', async () => {
+      mockListVoiceProfiles.mockRejectedValueOnce(new Error('DB error'));
+
+      await useVoiceStore.getState().loadProfiles();
+
+      const state = useVoiceStore.getState();
+      expect(state.profiles).toEqual([]);
+      expect(state.error).toBe('DB error');
+      expect(state.loading).toBe(false);
+    });
+  });
+
+  describe('addProfile', () => {
+    it('saves profile to service and prepends to state', async () => {
+      const existing = makeProfile({ id: 'existing' });
+      useVoiceStore.setState({ profiles: [existing] });
+
+      const blob = new Blob([new ArrayBuffer(1024)], { type: 'audio/wav' });
+      const result = await useVoiceStore.getState().addProfile(
+        'New Voice',
+        'upload',
+        blob,
+        30,
+      );
+
+      expect(result.id).toBe('mock-uuid');
+      expect(result.name).toBe('New Voice');
+      expect(result.source).toBe('upload');
+      expect(mockSaveVoiceProfile).toHaveBeenCalledTimes(1);
+
+      const state = useVoiceStore.getState();
+      expect(state.profiles).toHaveLength(2);
+      expect(state.profiles[0].id).toBe('mock-uuid');
+    });
+  });
+
+  describe('removeProfile', () => {
+    it('deletes profile from service and removes from state', async () => {
+      const p1 = makeProfile({ id: 'v1' });
+      const p2 = makeProfile({ id: 'v2' });
+      useVoiceStore.setState({ profiles: [p1, p2], selectedProfileId: 'v1' });
+
+      await useVoiceStore.getState().removeProfile('v1');
+
+      const state = useVoiceStore.getState();
+      expect(state.profiles).toHaveLength(1);
+      expect(state.profiles[0].id).toBe('v2');
+      expect(state.selectedProfileId).toBeNull(); // deselected
+      expect(mockDeleteVoiceProfile).toHaveBeenCalledWith('v1');
+    });
+
+    it('keeps selectedProfileId if a different profile is deleted', async () => {
+      useVoiceStore.setState({
+        profiles: [makeProfile({ id: 'v1' }), makeProfile({ id: 'v2' })],
+        selectedProfileId: 'v2',
+      });
+
+      await useVoiceStore.getState().removeProfile('v1');
+
+      expect(useVoiceStore.getState().selectedProfileId).toBe('v2');
+    });
+  });
+
+  describe('renameProfile', () => {
+    it('renames profile in service and updates state', async () => {
+      const profile = makeProfile({ id: 'v1', name: 'Old' });
+      const updated = { ...profile, name: 'New', updatedAt: 9999 };
+      mockUpdateVoiceProfileName.mockResolvedValueOnce(updated);
+      useVoiceStore.setState({ profiles: [profile] });
+
+      await useVoiceStore.getState().renameProfile('v1', 'New');
+
+      const state = useVoiceStore.getState();
+      expect(state.profiles[0].name).toBe('New');
+      expect(mockUpdateVoiceProfileName).toHaveBeenCalledWith('v1', 'New');
+    });
+  });
+
+  describe('selectProfile', () => {
+    it('sets selectedProfileId', () => {
+      useVoiceStore.getState().selectProfile('v1');
+      expect(useVoiceStore.getState().selectedProfileId).toBe('v1');
+    });
+
+    it('clears selection with null', () => {
+      useVoiceStore.setState({ selectedProfileId: 'v1' });
+      useVoiceStore.getState().selectProfile(null);
+      expect(useVoiceStore.getState().selectedProfileId).toBeNull();
+    });
+  });
+
+  describe('setRecording', () => {
+    it('toggles recording state', () => {
+      useVoiceStore.getState().setRecording(true);
+      expect(useVoiceStore.getState().recording).toBe(true);
+      useVoiceStore.getState().setRecording(false);
+      expect(useVoiceStore.getState().recording).toBe(false);
+    });
+  });
+});

--- a/src/store/__tests__/voiceStore.test.ts
+++ b/src/store/__tests__/voiceStore.test.ts
@@ -32,6 +32,8 @@ function makeProfile(overrides: Partial<VoiceProfile> = {}): VoiceProfile {
     duration: 30,
     fileSize: 1024,
     waveformPeaks: [0.5],
+    defaultAudioInfluence: 0.4,
+    defaultStyleInfluence: 0.6,
     createdAt: 1000,
     updatedAt: 2000,
     ...overrides,
@@ -46,6 +48,8 @@ beforeEach(() => {
   useVoiceStore.setState({
     profiles: [],
     selectedProfileId: null,
+    audioInfluence: 0.4,
+    styleInfluence: 0.6,
     loading: false,
     recording: false,
     error: null,

--- a/src/store/__tests__/voiceStore.test.ts
+++ b/src/store/__tests__/voiceStore.test.ts
@@ -149,15 +149,30 @@ describe('voiceStore', () => {
   });
 
   describe('selectProfile', () => {
-    it('sets selectedProfileId', () => {
+    it('sets selectedProfileId when profile exists', () => {
+      useVoiceStore.setState({ profiles: [makeProfile({ id: 'v1' })] });
       useVoiceStore.getState().selectProfile('v1');
       expect(useVoiceStore.getState().selectedProfileId).toBe('v1');
+    });
+
+    it('sets null when profile id not found in profiles', () => {
+      useVoiceStore.getState().selectProfile('nonexistent');
+      expect(useVoiceStore.getState().selectedProfileId).toBeNull();
     });
 
     it('clears selection with null', () => {
       useVoiceStore.setState({ selectedProfileId: 'v1' });
       useVoiceStore.getState().selectProfile(null);
       expect(useVoiceStore.getState().selectedProfileId).toBeNull();
+    });
+
+    it('loads per-profile influence defaults on selection', () => {
+      useVoiceStore.setState({
+        profiles: [makeProfile({ id: 'v1', defaultAudioInfluence: 0.7, defaultStyleInfluence: 0.3 })],
+      });
+      useVoiceStore.getState().selectProfile('v1');
+      expect(useVoiceStore.getState().audioInfluence).toBeCloseTo(0.7);
+      expect(useVoiceStore.getState().styleInfluence).toBeCloseTo(0.3);
     });
   });
 

--- a/src/store/voiceStore.ts
+++ b/src/store/voiceStore.ts
@@ -1,0 +1,124 @@
+/**
+ * Voice Store — Zustand state for voice cloning feature (#1087)
+ *
+ * Manages voice profiles in memory with IndexedDB persistence via voiceProfileService.
+ */
+
+import { create } from 'zustand';
+import { v4 as uuidv4 } from 'uuid';
+import type { VoiceProfile } from '../types/voice';
+import * as svc from '../services/voiceProfileService';
+import { computeWaveformPeaks } from '../utils/waveformPeaks';
+
+const VOICE_WAVEFORM_PEAKS = 64;
+
+export interface VoiceStoreState {
+  profiles: VoiceProfile[];
+  selectedProfileId: string | null;
+  loading: boolean;
+  recording: boolean;
+  error: string | null;
+}
+
+export interface VoiceStoreActions {
+  /** Load all profiles from IndexedDB */
+  loadProfiles: () => Promise<void>;
+
+  /** Add a voice profile from an uploaded or recorded audio blob */
+  addProfile: (
+    name: string,
+    source: 'recording' | 'upload',
+    audioBlob: Blob,
+    durationSec: number,
+  ) => Promise<VoiceProfile>;
+
+  /** Delete a voice profile */
+  removeProfile: (id: string) => Promise<void>;
+
+  /** Rename a voice profile */
+  renameProfile: (id: string, newName: string) => Promise<void>;
+
+  /** Select a voice profile for generation */
+  selectProfile: (id: string | null) => void;
+
+  /** Set recording state */
+  setRecording: (recording: boolean) => void;
+
+  /** Clear error */
+  clearError: () => void;
+}
+
+export type VoiceStore = VoiceStoreState & VoiceStoreActions;
+
+export const useVoiceStore = create<VoiceStore>()((set, get) => ({
+  profiles: [],
+  selectedProfileId: null,
+  loading: false,
+  recording: false,
+  error: null,
+
+  loadProfiles: async () => {
+    set({ loading: true, error: null });
+    try {
+      const profiles = await svc.listVoiceProfiles();
+      set({ profiles, loading: false });
+    } catch (e) {
+      set({
+        loading: false,
+        error: e instanceof Error ? e.message : 'Failed to load voice profiles',
+      });
+    }
+  },
+
+  addProfile: async (name, source, audioBlob, durationSec) => {
+    const id = uuidv4();
+    let peaks: number[] = [];
+    try {
+      const ctx = new OfflineAudioContext(1, 1, 44100);
+      const arrayBuf = await audioBlob.arrayBuffer();
+      const audioBuf = await ctx.decodeAudioData(arrayBuf);
+      peaks = computeWaveformPeaks(audioBuf, VOICE_WAVEFORM_PEAKS);
+    } catch {
+      // Waveform computation is best-effort
+      peaks = Array.from({ length: VOICE_WAVEFORM_PEAKS }, () => 0);
+    }
+
+    const now = Date.now();
+    const profile: VoiceProfile = {
+      id,
+      name: name.trim(),
+      source,
+      mimeType: audioBlob.type || 'audio/wav',
+      duration: durationSec,
+      fileSize: audioBlob.size,
+      waveformPeaks: peaks,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await svc.saveVoiceProfile(profile, audioBlob);
+    set((s) => ({ profiles: [profile, ...s.profiles], error: null }));
+    return profile;
+  },
+
+  removeProfile: async (id) => {
+    await svc.deleteVoiceProfile(id);
+    set((s) => ({
+      profiles: s.profiles.filter((p) => p.id !== id),
+      selectedProfileId: s.selectedProfileId === id ? null : s.selectedProfileId,
+    }));
+  },
+
+  renameProfile: async (id, newName) => {
+    const updated = await svc.updateVoiceProfileName(id, newName);
+    set((s) => ({
+      profiles: s.profiles.map((p) => (p.id === id ? updated : p)),
+    }));
+  },
+
+  selectProfile: (id) => set({ selectedProfileId: id }),
+
+  setRecording: (recording) => set({ recording }),
+
+  clearError: () => set({ error: null }),
+}));

--- a/src/store/voiceStore.ts
+++ b/src/store/voiceStore.ts
@@ -15,6 +15,10 @@ const VOICE_WAVEFORM_PEAKS = 64;
 export interface VoiceStoreState {
   profiles: VoiceProfile[];
   selectedProfileId: string | null;
+  /** Audio influence: how much to preserve reference voice (0-1) */
+  audioInfluence: number;
+  /** Style influence: how much AI style to apply (0-1) */
+  styleInfluence: number;
   loading: boolean;
   recording: boolean;
   error: string | null;
@@ -44,6 +48,15 @@ export interface VoiceStoreActions {
   /** Set recording state */
   setRecording: (recording: boolean) => void;
 
+  /** Set audio influence */
+  setAudioInfluence: (value: number) => void;
+
+  /** Set style influence */
+  setStyleInfluence: (value: number) => void;
+
+  /** Apply an influence preset */
+  applyInfluencePreset: (audioInfluence: number, styleInfluence: number) => void;
+
   /** Clear error */
   clearError: () => void;
 }
@@ -53,6 +66,8 @@ export type VoiceStore = VoiceStoreState & VoiceStoreActions;
 export const useVoiceStore = create<VoiceStore>()((set, get) => ({
   profiles: [],
   selectedProfileId: null,
+  audioInfluence: 0.4,
+  styleInfluence: 0.6,
   loading: false,
   recording: false,
   error: null,
@@ -92,6 +107,8 @@ export const useVoiceStore = create<VoiceStore>()((set, get) => ({
       duration: durationSec,
       fileSize: audioBlob.size,
       waveformPeaks: peaks,
+      defaultAudioInfluence: 0.4,
+      defaultStyleInfluence: 0.6,
       createdAt: now,
       updatedAt: now,
     };
@@ -116,7 +133,24 @@ export const useVoiceStore = create<VoiceStore>()((set, get) => ({
     }));
   },
 
-  selectProfile: (id) => set({ selectedProfileId: id }),
+  selectProfile: (id) => {
+    if (id) {
+      const profile = get().profiles.find((p) => p.id === id);
+      if (profile) {
+        set({
+          selectedProfileId: id,
+          audioInfluence: profile.defaultAudioInfluence,
+          styleInfluence: profile.defaultStyleInfluence,
+        });
+        return;
+      }
+    }
+    set({ selectedProfileId: id });
+  },
+
+  setAudioInfluence: (value) => set({ audioInfluence: Math.max(0, Math.min(1, value)) }),
+  setStyleInfluence: (value) => set({ styleInfluence: Math.max(0, Math.min(1, value)) }),
+  applyInfluencePreset: (audioInfluence, styleInfluence) => set({ audioInfluence, styleInfluence }),
 
   setRecording: (recording) => set({ recording }),
 

--- a/src/store/voiceStore.ts
+++ b/src/store/voiceStore.ts
@@ -87,12 +87,19 @@ export const useVoiceStore = create<VoiceStore>()((set, get) => ({
 
   addProfile: async (name, source, audioBlob, durationSec) => {
     const id = uuidv4();
+    // Compute a simple 0–1 positive envelope from interleaved stereo peaks
     let peaks: number[] = [];
     try {
       const ctx = new OfflineAudioContext(1, 1, 44100);
       const arrayBuf = await audioBlob.arrayBuffer();
       const audioBuf = await ctx.decodeAudioData(arrayBuf);
-      peaks = computeWaveformPeaks(audioBuf, VOICE_WAVEFORM_PEAKS);
+      const raw = computeWaveformPeaks(audioBuf, VOICE_WAVEFORM_PEAKS);
+      // raw = [Lmax0, Lmin0, Rmax0, Rmin0, ...] — extract max(Lmax, Rmax) per peak
+      peaks = Array.from({ length: VOICE_WAVEFORM_PEAKS }, (_, i) => {
+        const lMax = Math.abs(raw[i * 4] ?? 0);
+        const rMax = Math.abs(raw[i * 4 + 2] ?? 0);
+        return Math.max(lMax, rMax);
+      });
     } catch {
       // Waveform computation is best-effort
       peaks = Array.from({ length: VOICE_WAVEFORM_PEAKS }, () => 0);
@@ -113,24 +120,41 @@ export const useVoiceStore = create<VoiceStore>()((set, get) => ({
       updatedAt: now,
     };
 
-    await svc.saveVoiceProfile(profile, audioBlob);
-    set((s) => ({ profiles: [profile, ...s.profiles], error: null }));
-    return profile;
+    try {
+      await svc.saveVoiceProfile(profile, audioBlob);
+      set((s) => ({ profiles: [profile, ...s.profiles], error: null }));
+      return profile;
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : 'Failed to save voice profile.' });
+      throw e;
+    }
   },
 
   removeProfile: async (id) => {
-    await svc.deleteVoiceProfile(id);
-    set((s) => ({
-      profiles: s.profiles.filter((p) => p.id !== id),
-      selectedProfileId: s.selectedProfileId === id ? null : s.selectedProfileId,
-    }));
+    try {
+      await svc.deleteVoiceProfile(id);
+      set((s) => ({
+        profiles: s.profiles.filter((p) => p.id !== id),
+        selectedProfileId: s.selectedProfileId === id ? null : s.selectedProfileId,
+        error: null,
+      }));
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : 'Failed to remove voice profile.' });
+      throw e;
+    }
   },
 
   renameProfile: async (id, newName) => {
-    const updated = await svc.updateVoiceProfileName(id, newName);
-    set((s) => ({
-      profiles: s.profiles.map((p) => (p.id === id ? updated : p)),
-    }));
+    try {
+      const updated = await svc.updateVoiceProfileName(id, newName);
+      set((s) => ({
+        profiles: s.profiles.map((p) => (p.id === id ? updated : p)),
+        error: null,
+      }));
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : 'Failed to rename voice profile.' });
+      throw e;
+    }
   },
 
   selectProfile: (id) => {
@@ -145,12 +169,15 @@ export const useVoiceStore = create<VoiceStore>()((set, get) => ({
         return;
       }
     }
-    set({ selectedProfileId: id });
+    set({ selectedProfileId: null });
   },
 
   setAudioInfluence: (value) => set({ audioInfluence: Math.max(0, Math.min(1, value)) }),
   setStyleInfluence: (value) => set({ styleInfluence: Math.max(0, Math.min(1, value)) }),
-  applyInfluencePreset: (audioInfluence, styleInfluence) => set({ audioInfluence, styleInfluence }),
+  applyInfluencePreset: (audioInfluence, styleInfluence) => set({
+    audioInfluence: Math.max(0, Math.min(1, audioInfluence)),
+    styleInfluence: Math.max(0, Math.min(1, styleInfluence)),
+  }),
 
   setRecording: (recording) => set({ recording }),
 

--- a/src/types/voice.ts
+++ b/src/types/voice.ts
@@ -13,9 +13,26 @@ export interface VoiceProfile {
   fileSize: number;
   /** Waveform peaks for visual preview (0-1 normalized) */
   waveformPeaks: number[];
+  /** Default audio influence (0-1): how much to preserve reference voice */
+  defaultAudioInfluence: number;
+  /** Default style influence (0-1): how much AI style to apply */
+  defaultStyleInfluence: number;
   createdAt: number;
   updatedAt: number;
 }
+
+/** Influence preset: named combination of audio + style influence */
+export interface VoiceInfluencePreset {
+  name: string;
+  audioInfluence: number;
+  styleInfluence: number;
+}
+
+export const VOICE_INFLUENCE_PRESETS: VoiceInfluencePreset[] = [
+  { name: 'Natural', audioInfluence: 0.4, styleInfluence: 0.6 },
+  { name: 'AI Enhanced', audioInfluence: 0.2, styleInfluence: 0.8 },
+  { name: 'Voice Forward', audioInfluence: 0.7, styleInfluence: 0.3 },
+];
 
 /** Minimum recording duration in seconds */
 export const MIN_VOICE_DURATION = 10;

--- a/src/types/voice.ts
+++ b/src/types/voice.ts
@@ -1,0 +1,41 @@
+/** Voice profile types for voice cloning feature (#1087) */
+
+export interface VoiceProfile {
+  id: string;
+  name: string;
+  /** How the voice sample was obtained */
+  source: 'recording' | 'upload';
+  /** MIME type of the audio */
+  mimeType: string;
+  /** Duration in seconds */
+  duration: number;
+  /** File size in bytes */
+  fileSize: number;
+  /** Waveform peaks for visual preview (0-1 normalized) */
+  waveformPeaks: number[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Minimum recording duration in seconds */
+export const MIN_VOICE_DURATION = 10;
+
+/** Maximum recording/upload duration in seconds */
+export const MAX_VOICE_DURATION = 300;
+
+/** Maximum file size for voice uploads (50 MB) */
+export const MAX_VOICE_FILE_SIZE = 50 * 1024 * 1024;
+
+/** Accepted audio MIME types for voice upload */
+export const ACCEPTED_VOICE_MIME_TYPES = [
+  'audio/wav',
+  'audio/x-wav',
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/flac',
+  'audio/ogg',
+  'audio/webm',
+] as const;
+
+/** File extensions matching the accepted MIME types */
+export const ACCEPTED_VOICE_EXTENSIONS = '.wav,.mp3,.flac,.ogg,.webm';

--- a/src/types/voice.ts
+++ b/src/types/voice.ts
@@ -11,7 +11,7 @@ export interface VoiceProfile {
   duration: number;
   /** File size in bytes */
   fileSize: number;
-  /** Waveform peaks for visual preview (0-1 normalized) */
+  /** Waveform peaks for visual preview — simple 0-1 positive envelope per peak */
   waveformPeaks: number[];
   /** Default audio influence (0-1): how much to preserve reference voice */
   defaultAudioInfluence: number;


### PR DESCRIPTION
## Summary

- Add voice profile management with recording, upload, and IndexedDB persistence
- Integrated as a collapsible "Voice Reference" section in the generation panel (Custom mode)
- Audio/style influence sliders with presets for voice-conditioned generation
- Full TDD with 70 tests across service, store, and component layers

## What's Included

### New Files (9)
- `src/types/voice.ts` — VoiceProfile interface, validation constants, influence presets
- `src/services/voiceProfileService.ts` — CRUD with idb-keyval IndexedDB persistence
- `src/store/voiceStore.ts` — Zustand store for voice profiles + influence state
- `src/components/generation/VoiceLibrary.tsx` — Voice Library UI component
- `src/components/generation/VoiceInfluenceControls.tsx` — Audio/style influence sliders
- 4 test files with 70 tests total

### Modified Files (2)
- `src/components/generation/FullSongForm.tsx` — Added VoiceLibrary + VoiceInfluenceControls
- `src/main.tsx` — Exposed `window.__voiceStore` for agent access

### Features
- Record voice via MediaRecorder (min 10s)
- Upload audio files (WAV, MP3, FLAC, OGG, WebM — max 50MB)
- Drag-and-drop audio file upload
- Inline audio preview (play/pause per profile)
- Waveform mini-visualization for each profile
- Inline rename (double-click), search/filter by name
- Delete with confirmation step
- Profile selection for generation
- Audio Influence slider (0–100%): voice fidelity
- Style Influence slider (0–100%): AI styling strength
- Three presets: Natural (40/60), AI Enhanced (20/80), Voice Forward (70/30)
- Per-voice default influence values
- IndexedDB persistence (survives page reload)

## Test Plan
- [x] VoiceProfileService: 31 tests (validation, CRUD, listing)
- [x] voiceStore: 9 tests (load, add, remove, rename, select, influence)
- [x] VoiceLibrary UI: 21 tests (render states, interactions, preview, search, delete confirm)
- [x] VoiceInfluenceControls: 9 tests (sliders, presets, reset, conditional visibility)
- [x] TypeScript: 0 errors (`npx tsc --noEmit`)
- [x] Build: passes (`npx vite build`)
- [x] No regressions: 1312 existing tests still pass (110 test files)

Closes #1087
Closes #1092
Closes #1095

https://claude.ai/code/session_01Aizr9QHaRppx5rZ9vD3ggT