### PR TITLE
feat: add voice cloning Phase 1 — upload, store, and library UI

### DIFF
--- a/src/components/generation/FullSongForm.tsx
+++ b/src/components/generation/FullSongForm.tsx
@@ -10,6 +10,7 @@ import { generateText2Music, regenerateClip } from '../../services/generationPip
 import { formatInput, createRandomSample } from '../../services/aceStepApi';
 import { toastError, toastInfo } from '../../hooks/useToast';
 import { PromptAutocompleteTextarea } from './PromptAutocompleteTextarea';
+import { VoiceLibrarySection } from './VoiceLibrarySection';
 import { TimbrePresetPicker } from './TimbrePresetPicker';
 import { NegativePromptSection } from './NegativePromptSection';
 
@@ -417,6 +418,9 @@ export function FullSongForm({ initialData, onFooterChange }: FullSongFormProps)
           placeholder="[Verse 1]\nYour lyrics here..."
         />
       </section>
+
+      {/* Voice Library */}
+      <VoiceLibrarySection />
 
       {/* Random Example */}
       <button

--- a/src/components/generation/VoiceLibrarySection.tsx
+++ b/src/components/generation/VoiceLibrarySection.tsx
@@ -5,7 +5,7 @@ import { uploadVoiceFile } from '../../services/voiceUploadService';
 /** Format seconds as M:SS. */
 function formatDuration(seconds: number): string {
   const m = Math.floor(seconds / 60);
-  const s = Math.round(seconds % 60);
+  const s = Math.floor(seconds % 60);
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 

--- a/src/components/generation/VoiceLibrarySection.tsx
+++ b/src/components/generation/VoiceLibrarySection.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useRef } from 'react';
+import { useVoiceStore, ACCEPTED_VOICE_EXTENSIONS } from '../../store/voiceStore';
+import { uploadVoiceFile } from '../../services/voiceUploadService';
+
+/** Format seconds as M:SS. */
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Voice Library section for the generation side panel.
+ * Allows uploading, listing, and managing voice profiles used
+ * for voice-conditioned AI generation.
+ */
+export function VoiceLibrarySection() {
+  const profiles = useVoiceStore((s) => s.profiles);
+  const isProcessing = useVoiceStore((s) => s.isProcessing);
+  const error = useVoiceStore((s) => s.error);
+  const removeProfile = useVoiceStore((s) => s.removeProfile);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleUploadClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      await uploadVoiceFile(file);
+      // Reset input so same file can be re-uploaded
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    },
+    [],
+  );
+
+  const handleDelete = useCallback(
+    async (profileId: string) => {
+      await removeProfile(profileId);
+    },
+    [removeProfile],
+  );
+
+  return (
+    <section className="space-y-2">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-medium uppercase text-zinc-400">
+          Voice Library
+        </span>
+        <button
+          type="button"
+          onClick={handleUploadClick}
+          disabled={isProcessing}
+          className="rounded bg-[var(--daw-surface-3)] px-2 py-0.5 text-[10px] text-zinc-300 transition-colors hover:text-white disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {isProcessing ? 'Processing...' : 'Upload'}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_VOICE_EXTENSIONS.join(',')}
+          onChange={handleFileChange}
+          className="hidden"
+          aria-hidden="true"
+        />
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="rounded border border-red-500/30 bg-red-950/20 px-2 py-1 text-[10px] text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* Profile list */}
+      {profiles.length === 0 ? (
+        <div className="rounded bg-[var(--daw-surface-2)] px-3 py-4 text-center text-[10px] text-zinc-500">
+          No voice profiles yet. Upload a vocal sample (WAV, MP3, FLAC) to get started.
+        </div>
+      ) : (
+        <div className="space-y-1">
+          {profiles.map((profile) => (
+            <div
+              key={profile.id}
+              className="flex items-center justify-between rounded bg-[var(--daw-surface-2)] px-2 py-1.5 group"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                {/* Mic icon */}
+                <svg
+                  width={12}
+                  height={12}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  className="shrink-0 text-zinc-500"
+                >
+                  <rect x={9} y={1} width={6} height={13} rx={3} />
+                  <path d="M5 10a7 7 0 0 0 14 0" />
+                  <line x1={12} y1={19} x2={12} y2={23} />
+                  <line x1={8} y1={23} x2={16} y2={23} />
+                </svg>
+                <span className="text-[11px] text-zinc-200 truncate">
+                  {profile.name}
+                </span>
+                <span className="text-[9px] text-zinc-500 shrink-0">
+                  {formatDuration(profile.duration)}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleDelete(profile.id)}
+                aria-label={`Delete ${profile.name}`}
+                className="opacity-0 group-hover:opacity-100 transition-opacity text-zinc-500 hover:text-red-400 p-0.5"
+              >
+                <svg width={12} height={12} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                  <path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/generation/__tests__/VoiceLibrarySection.test.tsx
+++ b/src/components/generation/__tests__/VoiceLibrarySection.test.tsx
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VoiceLibrarySection } from '../VoiceLibrarySection';
+import { useVoiceStore } from '../../../store/voiceStore';
+import type { VoiceProfile } from '../../../types/voice';
+import { DEFAULT_AUDIO_INFLUENCE, DEFAULT_STYLE_INFLUENCE } from '../../../types/voice';
+
+// Mock idb-keyval
+vi.mock('idb-keyval', () => ({
+  get: vi.fn(),
+  set: vi.fn().mockResolvedValue(undefined),
+  del: vi.fn().mockResolvedValue(undefined),
+  keys: vi.fn().mockResolvedValue([]),
+}));
+
+function makeProfile(overrides: Partial<VoiceProfile> = {}): VoiceProfile {
+  return {
+    id: `voice-${Math.random().toString(36).slice(2)}`,
+    name: 'Test Voice',
+    audioKey: 'voice-audio:test',
+    duration: 45,
+    defaultAudioInfluence: DEFAULT_AUDIO_INFLUENCE,
+    defaultStyleInfluence: DEFAULT_STYLE_INFLUENCE,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('VoiceLibrarySection', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useVoiceStore.setState(useVoiceStore.getInitialState(), true);
+  });
+
+  it('renders the section header', () => {
+    render(<VoiceLibrarySection />);
+    expect(screen.getByText('Voice Library')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no profiles exist', () => {
+    render(<VoiceLibrarySection />);
+    expect(screen.getByText(/no voice profiles/i)).toBeInTheDocument();
+  });
+
+  it('lists existing voice profiles', () => {
+    useVoiceStore.getState().addProfile(makeProfile({ id: 'v1', name: 'Singer A' }));
+    useVoiceStore.getState().addProfile(makeProfile({ id: 'v2', name: 'Singer B' }));
+
+    render(<VoiceLibrarySection />);
+
+    expect(screen.getByText('Singer A')).toBeInTheDocument();
+    expect(screen.getByText('Singer B')).toBeInTheDocument();
+  });
+
+  it('shows duration for each profile', () => {
+    useVoiceStore.getState().addProfile(makeProfile({ id: 'v1', name: 'Voice', duration: 65 }));
+
+    render(<VoiceLibrarySection />);
+
+    expect(screen.getByText('1:05')).toBeInTheDocument();
+  });
+
+  it('renders upload button', () => {
+    render(<VoiceLibrarySection />);
+    expect(screen.getByRole('button', { name: /upload/i })).toBeInTheDocument();
+  });
+
+  it('renders delete button for each profile', () => {
+    useVoiceStore.getState().addProfile(makeProfile({ id: 'v1', name: 'Voice' }));
+
+    render(<VoiceLibrarySection />);
+
+    const deleteBtn = screen.getByLabelText(/delete.*voice/i);
+    expect(deleteBtn).toBeInTheDocument();
+  });
+
+  it('shows processing state', () => {
+    useVoiceStore.setState({ isProcessing: true });
+
+    render(<VoiceLibrarySection />);
+
+    expect(screen.getByText(/processing/i)).toBeInTheDocument();
+  });
+
+  it('shows error message', () => {
+    useVoiceStore.setState({ error: 'Something went wrong' });
+
+    render(<VoiceLibrarySection />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+});

--- a/src/services/__tests__/voiceUploadService.test.ts
+++ b/src/services/__tests__/voiceUploadService.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock idb-keyval
+vi.mock('idb-keyval', () => ({
+  get: vi.fn(),
+  set: vi.fn().mockResolvedValue(undefined),
+  del: vi.fn().mockResolvedValue(undefined),
+  keys: vi.fn().mockResolvedValue([]),
+}));
+
+import { useVoiceStore, MIN_VOICE_SAMPLE_DURATION } from '../../store/voiceStore';
+import { uploadVoiceFile, audioBufferToWavBlob } from '../voiceUploadService';
+
+// Mock AudioContext — must be a class-like constructor
+const mockDecodeAudioData = vi.fn();
+const mockClose = vi.fn().mockResolvedValue(undefined);
+
+class MockAudioContext {
+  decodeAudioData = mockDecodeAudioData;
+  close = mockClose;
+}
+
+vi.stubGlobal('AudioContext', MockAudioContext);
+
+function makeAudioBuffer(duration: number, sampleRate = 44100): AudioBuffer {
+  const numFrames = Math.round(duration * sampleRate);
+  const channelData = new Float32Array(numFrames);
+  // Fill with a simple sine wave
+  for (let i = 0; i < numFrames; i++) {
+    channelData[i] = Math.sin((2 * Math.PI * 440 * i) / sampleRate) * 0.5;
+  }
+  return {
+    duration,
+    sampleRate,
+    numberOfChannels: 1,
+    length: numFrames,
+    getChannelData: () => channelData,
+    copyFromChannel: vi.fn(),
+    copyToChannel: vi.fn(),
+  } as unknown as AudioBuffer;
+}
+
+function makeFile(name: string, type: string, size = 1024): File {
+  const content = new Uint8Array(size);
+  return new File([content], name, { type });
+}
+
+describe('voiceUploadService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useVoiceStore.setState(useVoiceStore.getInitialState(), true);
+  });
+
+  describe('uploadVoiceFile', () => {
+    it('rejects unsupported file types', async () => {
+      const file = makeFile('test.pdf', 'application/pdf');
+      const result = await uploadVoiceFile(file);
+
+      expect(result).toBeNull();
+      expect(useVoiceStore.getState().error).toContain('Unsupported file type');
+    });
+
+    it('accepts WAV files', async () => {
+      mockDecodeAudioData.mockResolvedValueOnce(makeAudioBuffer(45));
+      const file = makeFile('my-voice.wav', 'audio/wav');
+      const result = await uploadVoiceFile(file);
+
+      expect(result).toBeTruthy();
+      expect(useVoiceStore.getState().profiles).toHaveLength(1);
+      expect(useVoiceStore.getState().profiles[0].name).toBe('my-voice');
+    });
+
+    it('accepts MP3 files', async () => {
+      mockDecodeAudioData.mockResolvedValueOnce(makeAudioBuffer(60));
+      const file = makeFile('singer.mp3', 'audio/mpeg');
+      const result = await uploadVoiceFile(file);
+
+      expect(result).toBeTruthy();
+      expect(useVoiceStore.getState().profiles[0].name).toBe('singer');
+    });
+
+    it('accepts FLAC files', async () => {
+      mockDecodeAudioData.mockResolvedValueOnce(makeAudioBuffer(45));
+      const file = makeFile('vocal.flac', 'audio/flac');
+      const result = await uploadVoiceFile(file);
+
+      expect(result).toBeTruthy();
+    });
+
+    it('accepts files by extension when MIME type is missing', async () => {
+      mockDecodeAudioData.mockResolvedValueOnce(makeAudioBuffer(45));
+      const file = makeFile('recording.wav', '');
+      const result = await uploadVoiceFile(file);
+
+      expect(result).toBeTruthy();
+    });
+
+    it('rejects samples shorter than minimum duration', async () => {
+      mockDecodeAudioData.mockResolvedValueOnce(makeAudioBuffer(15));
+      const file = makeFile('short.wav', 'audio/wav');
+      const result = await uploadVoiceFile(file);
+
+      expect(result).toBeNull();
+      expect(useVoiceStore.getState().error).toContain(`${MIN_VOICE_SAMPLE_DURATION}`);
+    });
+
+    it('sets error on decode failure', async () => {
+      mockDecodeAudioData.mockRejectedValueOnce(new Error('Invalid audio data'));
+      const file = makeFile('corrupt.wav', 'audio/wav');
+      const result = await uploadVoiceFile(file);
+
+      expect(result).toBeNull();
+      expect(useVoiceStore.getState().error).toContain('Invalid audio data');
+    });
+
+    it('strips file extension from profile name', async () => {
+      mockDecodeAudioData.mockResolvedValueOnce(makeAudioBuffer(45));
+      const file = makeFile('my.voice.sample.wav', 'audio/wav');
+      const result = await uploadVoiceFile(file);
+
+      expect(result).toBeTruthy();
+      expect(useVoiceStore.getState().profiles[0].name).toBe('my.voice.sample');
+    });
+  });
+
+  describe('audioBufferToWavBlob', () => {
+    it('produces a valid WAV blob', () => {
+      const buffer = makeAudioBuffer(1, 44100);
+      const blob = audioBufferToWavBlob(buffer);
+
+      expect(blob.type).toBe('audio/wav');
+      expect(blob.size).toBeGreaterThan(44); // At least header size
+    });
+
+    it('has correct size for mono 16-bit audio', () => {
+      const sampleRate = 44100;
+      const duration = 1;
+      const buffer = makeAudioBuffer(duration, sampleRate);
+      const blob = audioBufferToWavBlob(buffer);
+
+      const expectedFrames = Math.round(duration * sampleRate);
+      const expectedSize = 44 + expectedFrames * 2; // header + 16-bit mono
+      expect(blob.size).toBe(expectedSize);
+    });
+  });
+});

--- a/src/services/__tests__/voiceUploadService.test.ts
+++ b/src/services/__tests__/voiceUploadService.test.ts
@@ -9,7 +9,8 @@ vi.mock('idb-keyval', () => ({
 }));
 
 import { useVoiceStore, MIN_VOICE_SAMPLE_DURATION } from '../../store/voiceStore';
-import { uploadVoiceFile, audioBufferToWavBlob } from '../voiceUploadService';
+import { uploadVoiceFile } from '../voiceUploadService';
+import { audioBufferToWavBlob } from '../../utils/wav';
 
 // Mock AudioContext — must be a class-like constructor
 const mockDecodeAudioData = vi.fn();

--- a/src/services/voiceUploadService.ts
+++ b/src/services/voiceUploadService.ts
@@ -1,10 +1,11 @@
 import { useVoiceStore, ACCEPTED_VOICE_MIME_TYPES, MIN_VOICE_SAMPLE_DURATION } from '../store/voiceStore';
+import { audioBufferToWavBlob } from '../utils/wav';
 
 /**
  * Validates and processes an uploaded audio file for use as a voice profile.
  * Decodes audio to determine duration, then saves via voiceStore.
  *
- * @returns The created VoiceProfile, or null on validation/processing failure.
+ * @returns The created profile ID, or null on validation/processing failure.
  */
 export async function uploadVoiceFile(file: File): Promise<string | null> {
   const store = useVoiceStore.getState();
@@ -53,63 +54,5 @@ export async function uploadVoiceFile(file: File): Promise<string | null> {
     store.setError(err instanceof Error ? err.message : 'Failed to process audio file.');
     store.setIsProcessing(false);
     return null;
-  }
-}
-
-/**
- * Convert an AudioBuffer to a WAV Blob for consistent IndexedDB storage.
- * Supports mono and stereo buffers.
- */
-export function audioBufferToWavBlob(buffer: AudioBuffer): Blob {
-  const numChannels = buffer.numberOfChannels;
-  const sampleRate = buffer.sampleRate;
-  const numFrames = buffer.length;
-  const bitsPerSample = 16;
-  const bytesPerSample = bitsPerSample / 8;
-  const blockAlign = numChannels * bytesPerSample;
-  const dataSize = numFrames * blockAlign;
-  const headerSize = 44;
-  const totalSize = headerSize + dataSize;
-
-  const arrayBuffer = new ArrayBuffer(totalSize);
-  const view = new DataView(arrayBuffer);
-
-  // WAV header
-  writeString(view, 0, 'RIFF');
-  view.setUint32(4, totalSize - 8, true);
-  writeString(view, 8, 'WAVE');
-  writeString(view, 12, 'fmt ');
-  view.setUint32(16, 16, true); // chunk size
-  view.setUint16(20, 1, true); // PCM format
-  view.setUint16(22, numChannels, true);
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, sampleRate * blockAlign, true);
-  view.setUint16(32, blockAlign, true);
-  view.setUint16(34, bitsPerSample, true);
-  writeString(view, 36, 'data');
-  view.setUint32(40, dataSize, true);
-
-  // Interleave channels and write 16-bit PCM samples
-  const channels: Float32Array[] = [];
-  for (let ch = 0; ch < numChannels; ch++) {
-    channels.push(buffer.getChannelData(ch));
-  }
-
-  let offset = headerSize;
-  for (let i = 0; i < numFrames; i++) {
-    for (let ch = 0; ch < numChannels; ch++) {
-      const sample = Math.max(-1, Math.min(1, channels[ch][i]));
-      const int16 = sample < 0 ? sample * 0x8000 : sample * 0x7FFF;
-      view.setInt16(offset, int16, true);
-      offset += 2;
-    }
-  }
-
-  return new Blob([arrayBuffer], { type: 'audio/wav' });
-}
-
-function writeString(view: DataView, offset: number, str: string): void {
-  for (let i = 0; i < str.length; i++) {
-    view.setUint8(offset + i, str.charCodeAt(i));
   }
 }

--- a/src/services/voiceUploadService.ts
+++ b/src/services/voiceUploadService.ts
@@ -1,0 +1,115 @@
+import { useVoiceStore, ACCEPTED_VOICE_MIME_TYPES, MIN_VOICE_SAMPLE_DURATION } from '../store/voiceStore';
+
+/**
+ * Validates and processes an uploaded audio file for use as a voice profile.
+ * Decodes audio to determine duration, then saves via voiceStore.
+ *
+ * @returns The created VoiceProfile, or null on validation/processing failure.
+ */
+export async function uploadVoiceFile(file: File): Promise<string | null> {
+  const store = useVoiceStore.getState();
+
+  // Validate MIME type
+  const isAccepted = ACCEPTED_VOICE_MIME_TYPES.some((mime) => file.type === mime) ||
+    /\.(wav|mp3|flac)$/i.test(file.name);
+  if (!isAccepted) {
+    store.setError(`Unsupported file type: ${file.type || 'unknown'}. Use WAV, MP3, or FLAC.`);
+    return null;
+  }
+
+  store.setIsProcessing(true);
+  store.setError(null);
+
+  try {
+    // Read file as ArrayBuffer and decode
+    const arrayBuffer = await file.arrayBuffer();
+    const audioContext = new AudioContext();
+    let audioBuffer: AudioBuffer;
+    try {
+      audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    } finally {
+      await audioContext.close();
+    }
+
+    const duration = audioBuffer.duration;
+
+    if (duration < MIN_VOICE_SAMPLE_DURATION) {
+      store.setError(
+        `Voice sample is ${Math.round(duration)}s — minimum is ${MIN_VOICE_SAMPLE_DURATION}s.`,
+      );
+      store.setIsProcessing(false);
+      return null;
+    }
+
+    // Convert to WAV blob for consistent storage
+    const wavBlob = audioBufferToWavBlob(audioBuffer);
+
+    // Generate name from filename without extension
+    const name = file.name.replace(/\.[^.]+$/, '') || 'Uploaded Voice';
+
+    const profile = await store.saveVoiceFromBlob({ name, blob: wavBlob, duration });
+    return profile?.id ?? null;
+  } catch (err) {
+    store.setError(err instanceof Error ? err.message : 'Failed to process audio file.');
+    store.setIsProcessing(false);
+    return null;
+  }
+}
+
+/**
+ * Convert an AudioBuffer to a WAV Blob for consistent IndexedDB storage.
+ * Supports mono and stereo buffers.
+ */
+export function audioBufferToWavBlob(buffer: AudioBuffer): Blob {
+  const numChannels = buffer.numberOfChannels;
+  const sampleRate = buffer.sampleRate;
+  const numFrames = buffer.length;
+  const bitsPerSample = 16;
+  const bytesPerSample = bitsPerSample / 8;
+  const blockAlign = numChannels * bytesPerSample;
+  const dataSize = numFrames * blockAlign;
+  const headerSize = 44;
+  const totalSize = headerSize + dataSize;
+
+  const arrayBuffer = new ArrayBuffer(totalSize);
+  const view = new DataView(arrayBuffer);
+
+  // WAV header
+  writeString(view, 0, 'RIFF');
+  view.setUint32(4, totalSize - 8, true);
+  writeString(view, 8, 'WAVE');
+  writeString(view, 12, 'fmt ');
+  view.setUint32(16, 16, true); // chunk size
+  view.setUint16(20, 1, true); // PCM format
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * blockAlign, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitsPerSample, true);
+  writeString(view, 36, 'data');
+  view.setUint32(40, dataSize, true);
+
+  // Interleave channels and write 16-bit PCM samples
+  const channels: Float32Array[] = [];
+  for (let ch = 0; ch < numChannels; ch++) {
+    channels.push(buffer.getChannelData(ch));
+  }
+
+  let offset = headerSize;
+  for (let i = 0; i < numFrames; i++) {
+    for (let ch = 0; ch < numChannels; ch++) {
+      const sample = Math.max(-1, Math.min(1, channels[ch][i]));
+      const int16 = sample < 0 ? sample * 0x8000 : sample * 0x7FFF;
+      view.setInt16(offset, int16, true);
+      offset += 2;
+    }
+  }
+
+  return new Blob([arrayBuffer], { type: 'audio/wav' });
+}
+
+function writeString(view: DataView, offset: number, str: string): void {
+  for (let i = 0; i < str.length; i++) {
+    view.setUint8(offset + i, str.charCodeAt(i));
+  }
+}

--- a/src/store/__tests__/voiceStore.test.ts
+++ b/src/store/__tests__/voiceStore.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock idb-keyval before importing voiceStore
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+const mockDel = vi.fn();
+const mockKeys = vi.fn(() => Promise.resolve([]));
+
+vi.mock('idb-keyval', () => ({
+  get: (...args: unknown[]) => mockGet(...args),
+  set: (...args: unknown[]) => mockSet(...args),
+  del: (...args: unknown[]) => mockDel(...args),
+  keys: () => mockKeys(),
+}));
+
+import { useVoiceStore, MIN_VOICE_SAMPLE_DURATION, ACCEPTED_VOICE_MIME_TYPES, ACCEPTED_VOICE_EXTENSIONS } from '../voiceStore';
+import type { VoiceProfile } from '../../types/voice';
+import { DEFAULT_AUDIO_INFLUENCE, DEFAULT_STYLE_INFLUENCE } from '../../types/voice';
+
+function makeProfile(overrides: Partial<VoiceProfile> = {}): VoiceProfile {
+  return {
+    id: `voice-${Math.random().toString(36).slice(2)}`,
+    name: 'Test Voice',
+    audioKey: 'voice-audio:test-id',
+    duration: 45,
+    defaultAudioInfluence: DEFAULT_AUDIO_INFLUENCE,
+    defaultStyleInfluence: DEFAULT_STYLE_INFLUENCE,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('voiceStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockSet.mockResolvedValue(undefined);
+    mockDel.mockResolvedValue(undefined);
+    mockGet.mockResolvedValue(undefined);
+    mockKeys.mockResolvedValue([]);
+    useVoiceStore.setState(useVoiceStore.getInitialState(), true);
+  });
+
+  describe('initial state', () => {
+    it('starts with empty profiles', () => {
+      expect(useVoiceStore.getState().profiles).toEqual([]);
+    });
+
+    it('starts with no recording in progress', () => {
+      expect(useVoiceStore.getState().recordingProfileId).toBeNull();
+    });
+
+    it('starts with no processing', () => {
+      expect(useVoiceStore.getState().isProcessing).toBe(false);
+    });
+
+    it('starts with no error', () => {
+      expect(useVoiceStore.getState().error).toBeNull();
+    });
+  });
+
+  describe('CRUD operations', () => {
+    it('adds a voice profile', () => {
+      const profile = makeProfile({ id: 'v1', name: 'Singer A' });
+      useVoiceStore.getState().addProfile(profile);
+
+      const profiles = useVoiceStore.getState().profiles;
+      expect(profiles).toHaveLength(1);
+      expect(profiles[0].name).toBe('Singer A');
+    });
+
+    it('removes a voice profile and deletes audio', async () => {
+      const profile = makeProfile({ id: 'v1' });
+      useVoiceStore.getState().addProfile(profile);
+      await useVoiceStore.getState().removeProfile('v1');
+
+      expect(useVoiceStore.getState().profiles).toHaveLength(0);
+      expect(mockDel).toHaveBeenCalledWith('voice-audio:v1');
+    });
+
+    it('updates a voice profile', () => {
+      const profile = makeProfile({ id: 'v1', name: 'Old Name' });
+      useVoiceStore.getState().addProfile(profile);
+      useVoiceStore.getState().updateProfile('v1', { name: 'New Name' });
+
+      expect(useVoiceStore.getState().profiles[0].name).toBe('New Name');
+    });
+
+    it('sets updatedAt when updating', () => {
+      const profile = makeProfile({ id: 'v1', updatedAt: 1000 });
+      useVoiceStore.getState().addProfile(profile);
+      useVoiceStore.getState().updateProfile('v1', { name: 'Updated' });
+
+      expect(useVoiceStore.getState().profiles[0].updatedAt).toBeGreaterThan(1000);
+    });
+
+    it('retrieves a profile by ID', () => {
+      const profile = makeProfile({ id: 'v1', name: 'Found' });
+      useVoiceStore.getState().addProfile(profile);
+
+      expect(useVoiceStore.getState().getProfile('v1')?.name).toBe('Found');
+      expect(useVoiceStore.getState().getProfile('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('saveVoiceFromBlob', () => {
+    it('saves a valid voice sample', async () => {
+      const blob = new Blob(['audio data'], { type: 'audio/wav' });
+      const result = await useVoiceStore.getState().saveVoiceFromBlob({
+        name: 'My Voice',
+        blob,
+        duration: 45,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe('My Voice');
+      expect(result!.duration).toBe(45);
+      expect(result!.defaultAudioInfluence).toBe(DEFAULT_AUDIO_INFLUENCE);
+      expect(result!.defaultStyleInfluence).toBe(DEFAULT_STYLE_INFLUENCE);
+      expect(useVoiceStore.getState().profiles).toHaveLength(1);
+      expect(useVoiceStore.getState().isProcessing).toBe(false);
+      expect(mockSet).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects samples shorter than minimum duration', async () => {
+      const blob = new Blob(['short'], { type: 'audio/wav' });
+      const result = await useVoiceStore.getState().saveVoiceFromBlob({
+        name: 'Too Short',
+        blob,
+        duration: 10,
+      });
+
+      expect(result).toBeNull();
+      expect(useVoiceStore.getState().profiles).toHaveLength(0);
+      expect(useVoiceStore.getState().error).toContain(`${MIN_VOICE_SAMPLE_DURATION}`);
+    });
+
+    it('trims blank name to "Untitled Voice"', async () => {
+      const blob = new Blob(['audio'], { type: 'audio/wav' });
+      const result = await useVoiceStore.getState().saveVoiceFromBlob({
+        name: '   ',
+        blob,
+        duration: 60,
+      });
+
+      expect(result!.name).toBe('Untitled Voice');
+    });
+
+    it('sets error on IndexedDB failure', async () => {
+      mockSet.mockRejectedValueOnce(new Error('QuotaExceededError'));
+      const blob = new Blob(['audio'], { type: 'audio/wav' });
+      const result = await useVoiceStore.getState().saveVoiceFromBlob({
+        name: 'Fail',
+        blob,
+        duration: 45,
+      });
+
+      expect(result).toBeNull();
+      expect(useVoiceStore.getState().error).toContain('QuotaExceededError');
+      expect(useVoiceStore.getState().isProcessing).toBe(false);
+    });
+
+    it('sets isProcessing during save', async () => {
+      let capturedProcessing = false;
+      mockSet.mockImplementation(async () => {
+        capturedProcessing = useVoiceStore.getState().isProcessing;
+      });
+
+      const blob = new Blob(['audio'], { type: 'audio/wav' });
+      await useVoiceStore.getState().saveVoiceFromBlob({
+        name: 'Test',
+        blob,
+        duration: 45,
+      });
+
+      expect(capturedProcessing).toBe(true);
+      expect(useVoiceStore.getState().isProcessing).toBe(false);
+    });
+  });
+
+  describe('recording state', () => {
+    it('sets and clears recording profile ID', () => {
+      useVoiceStore.getState().setRecordingProfileId('v1');
+      expect(useVoiceStore.getState().recordingProfileId).toBe('v1');
+
+      useVoiceStore.getState().setRecordingProfileId(null);
+      expect(useVoiceStore.getState().recordingProfileId).toBeNull();
+    });
+  });
+
+  describe('constants', () => {
+    it('minimum duration is 30 seconds', () => {
+      expect(MIN_VOICE_SAMPLE_DURATION).toBe(30);
+    });
+
+    it('accepts WAV, MP3, and FLAC MIME types', () => {
+      expect(ACCEPTED_VOICE_MIME_TYPES).toContain('audio/wav');
+      expect(ACCEPTED_VOICE_MIME_TYPES).toContain('audio/mpeg');
+      expect(ACCEPTED_VOICE_MIME_TYPES).toContain('audio/flac');
+    });
+
+    it('accepts .wav, .mp3, .flac extensions', () => {
+      expect(ACCEPTED_VOICE_EXTENSIONS).toContain('.wav');
+      expect(ACCEPTED_VOICE_EXTENSIONS).toContain('.mp3');
+      expect(ACCEPTED_VOICE_EXTENSIONS).toContain('.flac');
+    });
+  });
+});

--- a/src/store/voiceStore.ts
+++ b/src/store/voiceStore.ts
@@ -119,7 +119,10 @@ export const useVoiceStore = create<VoiceStoreState>()(
 
       saveVoiceFromBlob: async ({ name, blob, duration }) => {
         if (duration < MIN_VOICE_SAMPLE_DURATION) {
-          set({ error: `Voice sample must be at least ${MIN_VOICE_SAMPLE_DURATION} seconds (got ${Math.round(duration)}s).` });
+          set({
+            isProcessing: false,
+            error: `Voice sample must be at least ${MIN_VOICE_SAMPLE_DURATION} seconds (got ${Math.round(duration)}s).`,
+          });
           return null;
         }
 
@@ -157,7 +160,7 @@ export const useVoiceStore = create<VoiceStoreState>()(
     {
       name: 'ace-step-voice-store',
       storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ profiles: state.profiles }) as unknown as VoiceStoreState,
+      partialize: (state): Pick<VoiceStoreState, 'profiles'> => ({ profiles: state.profiles }),
     },
   ),
 );

--- a/src/store/voiceStore.ts
+++ b/src/store/voiceStore.ts
@@ -1,0 +1,163 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { get, set, del, keys } from 'idb-keyval';
+import type { VoiceProfile } from '../types/voice';
+import { DEFAULT_AUDIO_INFLUENCE, DEFAULT_STYLE_INFLUENCE } from '../types/voice';
+
+/** Minimum voice sample duration in seconds (matches Suno v5.5 requirement). */
+export const MIN_VOICE_SAMPLE_DURATION = 30;
+
+/** Accepted audio MIME types for voice upload. */
+export const ACCEPTED_VOICE_MIME_TYPES = [
+  'audio/wav',
+  'audio/x-wav',
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/flac',
+  'audio/x-flac',
+] as const;
+
+/** Accepted file extensions for voice upload. */
+export const ACCEPTED_VOICE_EXTENSIONS = ['.wav', '.mp3', '.flac'] as const;
+
+// ─── IndexedDB helpers for voice audio blobs ────────────────────────────────
+
+function voiceAudioKey(profileId: string): string {
+  return `voice-audio:${profileId}`;
+}
+
+export async function saveVoiceAudioBlob(profileId: string, blob: Blob): Promise<string> {
+  const key = voiceAudioKey(profileId);
+  await set(key, blob);
+  return key;
+}
+
+export async function loadVoiceAudioBlob(profileId: string): Promise<Blob | undefined> {
+  return get<Blob>(voiceAudioKey(profileId));
+}
+
+export async function deleteVoiceAudioBlob(profileId: string): Promise<void> {
+  await del(voiceAudioKey(profileId));
+}
+
+export async function deleteAllVoiceAudioBlobs(): Promise<void> {
+  const allKeys = await keys();
+  const voiceKeys = allKeys.filter(
+    (k) => typeof k === 'string' && k.startsWith('voice-audio:'),
+  );
+  await Promise.all(voiceKeys.map((k) => del(k)));
+}
+
+// ─── Voice Store ─────────────────────────────────────────────────────────────
+
+export interface VoiceStoreState {
+  /** All voice profiles (metadata only; audio in IndexedDB). */
+  profiles: VoiceProfile[];
+  /** Currently recording voice profile (null when not recording). */
+  recordingProfileId: string | null;
+  /** Upload/processing in progress. */
+  isProcessing: boolean;
+  /** Error message from last operation. */
+  error: string | null;
+
+  // ── CRUD ──
+  addProfile: (profile: VoiceProfile) => void;
+  removeProfile: (profileId: string) => Promise<void>;
+  updateProfile: (profileId: string, updates: Partial<Omit<VoiceProfile, 'id'>>) => void;
+  getProfile: (profileId: string) => VoiceProfile | undefined;
+
+  // ── Recording ──
+  setRecordingProfileId: (id: string | null) => void;
+
+  // ── Upload / Processing ──
+  setIsProcessing: (v: boolean) => void;
+  setError: (msg: string | null) => void;
+
+  /**
+   * Save a voice audio blob to IndexedDB and create a VoiceProfile.
+   * Returns the created profile, or null on failure.
+   */
+  saveVoiceFromBlob: (params: {
+    name: string;
+    blob: Blob;
+    duration: number;
+  }) => Promise<VoiceProfile | null>;
+}
+
+export const useVoiceStore = create<VoiceStoreState>()(
+  persist(
+    (set, get) => ({
+      profiles: [],
+      recordingProfileId: null,
+      isProcessing: false,
+      error: null,
+
+      addProfile: (profile) =>
+        set((s) => ({ profiles: [...s.profiles, profile] })),
+
+      removeProfile: async (profileId) => {
+        await deleteVoiceAudioBlob(profileId);
+        set((s) => ({
+          profiles: s.profiles.filter((p) => p.id !== profileId),
+          error: null,
+        }));
+      },
+
+      updateProfile: (profileId, updates) =>
+        set((s) => ({
+          profiles: s.profiles.map((p) =>
+            p.id === profileId ? { ...p, ...updates, updatedAt: Date.now() } : p,
+          ),
+        })),
+
+      getProfile: (profileId) =>
+        get().profiles.find((p) => p.id === profileId),
+
+      setRecordingProfileId: (id) => set({ recordingProfileId: id }),
+      setIsProcessing: (v) => set({ isProcessing: v }),
+      setError: (msg) => set({ error: msg }),
+
+      saveVoiceFromBlob: async ({ name, blob, duration }) => {
+        if (duration < MIN_VOICE_SAMPLE_DURATION) {
+          set({ error: `Voice sample must be at least ${MIN_VOICE_SAMPLE_DURATION} seconds (got ${Math.round(duration)}s).` });
+          return null;
+        }
+
+        const profileId = crypto.randomUUID();
+        try {
+          set({ isProcessing: true, error: null });
+
+          const audioKey = await saveVoiceAudioBlob(profileId, blob);
+
+          const profile: VoiceProfile = {
+            id: profileId,
+            name: name.trim() || 'Untitled Voice',
+            audioKey,
+            duration,
+            defaultAudioInfluence: DEFAULT_AUDIO_INFLUENCE,
+            defaultStyleInfluence: DEFAULT_STYLE_INFLUENCE,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          };
+
+          set((s) => ({
+            profiles: [...s.profiles, profile],
+            isProcessing: false,
+          }));
+          return profile;
+        } catch (err) {
+          set({
+            isProcessing: false,
+            error: err instanceof Error ? err.message : 'Failed to save voice profile.',
+          });
+          return null;
+        }
+      },
+    }),
+    {
+      name: 'ace-step-voice-store',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ profiles: state.profiles }) as unknown as VoiceStoreState,
+    },
+  ),
+);

--- a/src/types/voice.ts
+++ b/src/types/voice.ts
@@ -1,0 +1,43 @@
+/** Voice profile for voice-conditioned AI generation. */
+export interface VoiceProfile {
+  id: string;
+  /** Display name chosen by user. */
+  name: string;
+  /** IndexedDB audio key for the stored voice sample. */
+  audioKey: string;
+  /** Duration of the voice sample in seconds. */
+  duration: number;
+  /** Default Audio Influence (0–100) for this voice. */
+  defaultAudioInfluence: number;
+  /** Default Style Influence (0–100) for this voice. */
+  defaultStyleInfluence: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Named preset for Audio/Style Influence slider combinations. */
+export interface VoiceInfluencePreset {
+  /** Machine-readable key. */
+  id: string;
+  /** Human-readable label. */
+  label: string;
+  /** Audio Influence value (0–100). */
+  audioInfluence: number;
+  /** Style Influence value (0–100). */
+  styleInfluence: number;
+}
+
+/** Built-in influence presets inspired by Suno v5.5 sweet-spots. */
+export const VOICE_INFLUENCE_PRESETS: readonly VoiceInfluencePreset[] = [
+  { id: 'natural', label: 'Natural', audioInfluence: 40, styleInfluence: 60 },
+  { id: 'ai-enhanced', label: 'AI Enhanced', audioInfluence: 20, styleInfluence: 80 },
+  { id: 'voice-forward', label: 'Voice Forward', audioInfluence: 70, styleInfluence: 30 },
+] as const;
+
+/** Default influence values when no voice-specific defaults are set. */
+export const DEFAULT_AUDIO_INFLUENCE = 40;
+export const DEFAULT_STYLE_INFLUENCE = 60;
+
+export function clampInfluence(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}


### PR DESCRIPTION
## Summary

- Add `VoiceProfile` type with influence presets and `clampInfluence` utility
- Implement `voiceStore` (Zustand + localStorage persistence) with CRUD and IndexedDB audio blob storage
- Build voice upload service with format validation (WAV/MP3/FLAC), 30s minimum duration, AudioBuffer→WAV conversion
- Create `VoiceLibrarySection` UI with upload button, profile list, delete, duration display, and error states
- Integrate `VoiceLibrarySection` into `FullSongForm` generation panel
- Reuse existing `audioBufferToWavBlob` from `src/utils/wav.ts` (no duplication)
- 36 new tests across 3 test files, 0 TypeScript errors

Closes #1087

## Acceptance Criteria (Phase 1)

- [x] Audio file upload support (WAV, MP3, FLAC)
- [x] 30-second minimum duration validation
- [x] Cross-session persistence (localStorage metadata + IndexedDB audio)
- [x] Generation panel integration (VoiceLibrarySection in FullSongForm)
- [x] Unit tests for CRUD operations (36 tests)
- [x] TypeScript: 0 errors
- [x] Build: successful

## Test plan

- [ ] Upload a WAV file longer than 30s — profile appears in Voice Library
- [ ] Upload a file shorter than 30s — error message shown
- [ ] Upload a non-audio file — rejected with error
- [ ] Delete a voice profile — removed from list and IndexedDB
- [ ] Reload page — profiles persist from localStorage
- [ ] Run `npm test` — 36 new tests pass with 0 regressions

https://claude.ai/code/session_01WKLnBJjQqPLrNpB8kprhzL