### PR TITLE
fix: set Vitest pool to 'forks' to prevent test suite hanging

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    pool: 'forks',
     setupFiles: ['./tests/setup.ts'],
     server: {
       deps: {


### PR DESCRIPTION
## Summary

- Set `pool: 'forks'` in `vitest.config.ts` to fix test suite hanging

Closes #1608

## Problem

`npm test` hangs indefinitely with the default Vitest thread pool. The hang is caused by shared state or unresolved async between tests that thread isolation cannot handle. With `pool: 'forks'`, each test file runs in a separate process, preventing cross-contamination.

## Test plan

- [x] `npm test` completes reliably: 7020 tests pass in ~259s across 604 files
- [x] No `--pool=forks` flag needed on command line
- [x] TypeScript: 0 errors
- [x] Build: successful

## Files changed

- `vitest.config.ts` — Add `pool: 'forks'` (1 line)

https://claude.ai/code/session_01438CNU4cTeGjEensUVg6xu