### PR TITLE
test: add 91 tests for 5 piano roll components

### DIFF
--- a/src/components/pianoroll/__tests__/GeneratePatternDialog.test.tsx
+++ b/src/components/pianoroll/__tests__/GeneratePatternDialog.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GeneratePatternDialog } from '../GeneratePatternDialog';
+import { useProjectStore } from '../../../store/projectStore';
+import { useUIStore } from '../../../store/uiStore';
+
+vi.mock('../../../utils/midiPatternGenerator', () => ({
+  generatePattern: vi.fn().mockReturnValue([]),
+}));
+
+function setupDialog() {
+  useProjectStore.getState().createProject();
+  useProjectStore.getState().addTrack('midi');
+  const tracks = useProjectStore.getState().project!.tracks;
+  const track = tracks[tracks.length - 1];
+  const clip = track.clips[0];
+  useUIStore.setState({
+    showGeneratePatternDialog: true,
+    generatePatternClipId: clip?.id ?? 'clip-1',
+  });
+  return { clipId: clip?.id ?? 'clip-1' };
+}
+
+describe('GeneratePatternDialog', () => {
+  beforeEach(() => {
+    setupDialog();
+  });
+
+  it('renders nothing when not shown', () => {
+    useUIStore.setState({ showGeneratePatternDialog: false });
+    const { container } = render(<GeneratePatternDialog />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders dialog when shown', () => {
+    render(<GeneratePatternDialog />);
+    expect(screen.getByText('Generate Pattern')).toBeInTheDocument();
+  });
+
+  it('renders role options', () => {
+    render(<GeneratePatternDialog />);
+    expect(screen.getByText('Melody')).toBeInTheDocument();
+    expect(screen.getByText('Chords')).toBeInTheDocument();
+    expect(screen.getByText('Bass')).toBeInTheDocument();
+    expect(screen.getByText('Arpeggio')).toBeInTheDocument();
+  });
+
+  it('renders genre selector', () => {
+    render(<GeneratePatternDialog />);
+    // Genre options should be available in a select
+    const selects = screen.getAllByRole('combobox');
+    expect(selects.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders density slider', () => {
+    render(<GeneratePatternDialog />);
+    const sliders = screen.getAllByRole('slider');
+    expect(sliders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders Generate and Cancel buttons', () => {
+    render(<GeneratePatternDialog />);
+    expect(screen.getByText('Generate')).toBeInTheDocument();
+    // Cancel or close button
+    const cancelBtn = screen.queryByText('Cancel') ?? screen.queryByText('Close');
+    expect(cancelBtn).toBeInTheDocument();
+  });
+
+  it('renders Regenerate button', () => {
+    render(<GeneratePatternDialog />);
+    expect(screen.getByText('Regenerate')).toBeInTheDocument();
+  });
+
+  it('renders Regenerate with correct title', () => {
+    render(<GeneratePatternDialog />);
+    expect(screen.getByTitle('Generate with a new random seed')).toBeInTheDocument();
+  });
+
+  it('closes dialog on Cancel', () => {
+    render(<GeneratePatternDialog />);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(useUIStore.getState().showGeneratePatternDialog).toBe(false);
+  });
+
+  it('renders bar length options', () => {
+    render(<GeneratePatternDialog />);
+    expect(screen.getByText('Length (bars)')).toBeInTheDocument();
+  });
+});

--- a/src/components/pianoroll/__tests__/GeneratePatternDialog.test.tsx
+++ b/src/components/pianoroll/__tests__/GeneratePatternDialog.test.tsx
@@ -13,12 +13,13 @@ function setupDialog() {
   useProjectStore.getState().addTrack('midi');
   const tracks = useProjectStore.getState().project!.tracks;
   const track = tracks[tracks.length - 1];
-  const clip = track.clips[0];
+  // Create a real MIDI clip via the store
+  const clip = useProjectStore.getState().ensureMidiClip(track.id);
   useUIStore.setState({
     showGeneratePatternDialog: true,
-    generatePatternClipId: clip?.id ?? 'clip-1',
+    generatePatternClipId: clip.id,
   });
-  return { clipId: clip?.id ?? 'clip-1' };
+  return { clipId: clip.id };
 }
 
 describe('GeneratePatternDialog', () => {

--- a/src/components/pianoroll/__tests__/PianoRollConstants.test.ts
+++ b/src/components/pianoroll/__tests__/PianoRollConstants.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isBlackKey,
+  midiNoteToName,
+  gridSizeToBeats,
+  normalizeMidiVelocity,
+  velocityToColor,
+  velocityToBarColor,
+  getPianoRollNoteVisualStyle,
+  getVelocityLaneBarVisualStyle,
+  getPianoRollToolShortcut,
+  generateNoteId,
+  MIDI_MAX_NOTE,
+  PIANO_ROLL_KEY_HEIGHT,
+  PIANO_KEYBOARD_WIDTH,
+  VELOCITY_LANE_HEIGHT,
+} from '../PianoRollConstants';
+
+describe('PianoRollConstants', () => {
+  describe('MIDI constants', () => {
+    it('MIDI_MAX_NOTE is 127', () => {
+      expect(MIDI_MAX_NOTE).toBe(127);
+    });
+
+    it('PIANO_ROLL_KEY_HEIGHT is positive', () => {
+      expect(PIANO_ROLL_KEY_HEIGHT).toBeGreaterThan(0);
+    });
+
+    it('PIANO_KEYBOARD_WIDTH is positive', () => {
+      expect(PIANO_KEYBOARD_WIDTH).toBeGreaterThan(0);
+    });
+
+    it('VELOCITY_LANE_HEIGHT is positive', () => {
+      expect(VELOCITY_LANE_HEIGHT).toBeGreaterThan(0);
+    });
+  });
+
+  describe('isBlackKey', () => {
+    it('C is white', () => expect(isBlackKey(0)).toBe(false));
+    it('C# is black', () => expect(isBlackKey(1)).toBe(true));
+    it('D is white', () => expect(isBlackKey(2)).toBe(false));
+    it('D# is black', () => expect(isBlackKey(3)).toBe(true));
+    it('E is white', () => expect(isBlackKey(4)).toBe(false));
+    it('F is white', () => expect(isBlackKey(5)).toBe(false));
+    it('F# is black', () => expect(isBlackKey(6)).toBe(true));
+    it('G is white', () => expect(isBlackKey(7)).toBe(false));
+    it('G# is black', () => expect(isBlackKey(8)).toBe(true));
+    it('A is white', () => expect(isBlackKey(9)).toBe(false));
+    it('A# is black', () => expect(isBlackKey(10)).toBe(true));
+    it('B is white', () => expect(isBlackKey(11)).toBe(false));
+    it('wraps correctly for higher octaves (C5=60)', () => expect(isBlackKey(60)).toBe(false));
+    it('wraps correctly for C#5=61', () => expect(isBlackKey(61)).toBe(true));
+  });
+
+  describe('midiNoteToName', () => {
+    it('MIDI 60 is C4', () => expect(midiNoteToName(60)).toBe('C4'));
+    it('MIDI 69 is A4', () => expect(midiNoteToName(69)).toBe('A4'));
+    it('MIDI 0 is C-1', () => expect(midiNoteToName(0)).toBe('C-1'));
+    it('MIDI 127 is G9', () => expect(midiNoteToName(127)).toBe('G9'));
+    it('MIDI 48 is C3', () => expect(midiNoteToName(48)).toBe('C3'));
+    it('MIDI 61 is C#4', () => expect(midiNoteToName(61)).toBe('C#4'));
+  });
+
+  describe('gridSizeToBeats', () => {
+    it('1/4 = 1 beat', () => expect(gridSizeToBeats('1/4')).toBe(1));
+    it('1/8 = 0.5 beats', () => expect(gridSizeToBeats('1/8')).toBe(0.5));
+    it('1/16 = 0.25 beats', () => expect(gridSizeToBeats('1/16')).toBe(0.25));
+    it('1/32 = 0.125 beats', () => expect(gridSizeToBeats('1/32')).toBe(0.125));
+  });
+
+  describe('normalizeMidiVelocity', () => {
+    it('clamps 0-1 range to 0-127', () => {
+      expect(normalizeMidiVelocity(0.5)).toBe(64);
+    });
+
+    it('passes through 1-127 range', () => {
+      expect(normalizeMidiVelocity(100)).toBe(100);
+    });
+
+    it('clamps minimum to 1', () => {
+      expect(normalizeMidiVelocity(0)).toBe(1);
+    });
+
+    it('clamps maximum to 127', () => {
+      expect(normalizeMidiVelocity(200)).toBe(127);
+    });
+
+    it('handles NaN/Infinity gracefully', () => {
+      expect(normalizeMidiVelocity(NaN)).toBe(1);
+      expect(normalizeMidiVelocity(Infinity)).toBe(1);
+    });
+
+    it('normalizes 1.0 to 127', () => {
+      expect(normalizeMidiVelocity(1.0)).toBe(127);
+    });
+  });
+
+  describe('velocityToColor', () => {
+    it('returns rgb string', () => {
+      expect(velocityToColor(100)).toMatch(/^rgb\(\d+,\d+,\d+\)$/);
+    });
+
+    it('different velocities produce different colors', () => {
+      expect(velocityToColor(20)).not.toBe(velocityToColor(120));
+    });
+  });
+
+  describe('velocityToBarColor', () => {
+    it('returns rgba string', () => {
+      expect(velocityToBarColor(100)).toMatch(/^rgba\(\d+,\d+,\d+,[\d.]+\)$/);
+    });
+  });
+
+  describe('getPianoRollNoteVisualStyle', () => {
+    it('returns style for normal note', () => {
+      const style = getPianoRollNoteVisualStyle(100, { isSelected: false, isSlide: false });
+      expect(style.fillStyle).toMatch(/^rgb/);
+      expect(style.strokeWidth).toBe(0.5);
+      expect(style.globalAlpha).toBe(0.8);
+    });
+
+    it('returns style for selected note', () => {
+      const style = getPianoRollNoteVisualStyle(100, { isSelected: true, isSlide: false });
+      expect(style.strokeStyle).toBe('#fff');
+      expect(style.strokeWidth).toBe(1.5);
+      expect(style.globalAlpha).toBe(1);
+    });
+
+    it('returns slide note style', () => {
+      const style = getPianoRollNoteVisualStyle(100, { isSelected: false, isSlide: true });
+      expect(style.fillStyle).toContain('251, 191, 36'); // amber color
+      expect(style.velocityAccentOpacity).toBe(0);
+    });
+
+    it('selected slide note has lighter stroke', () => {
+      const style = getPianoRollNoteVisualStyle(100, { isSelected: true, isSlide: true });
+      expect(style.strokeStyle).toBe('#fff7d6');
+    });
+  });
+
+  describe('getVelocityLaneBarVisualStyle', () => {
+    it('normal bar has lower alpha', () => {
+      const style = getVelocityLaneBarVisualStyle(100, { isSelected: false, isSlide: false });
+      expect(style.globalAlpha).toBe(0.6);
+    });
+
+    it('selected bar has full alpha', () => {
+      const style = getVelocityLaneBarVisualStyle(100, { isSelected: true, isSlide: false });
+      expect(style.globalAlpha).toBe(1);
+    });
+
+    it('slide bar uses amber color', () => {
+      const style = getVelocityLaneBarVisualStyle(100, { isSelected: false, isSlide: true });
+      expect(style.fillStyle).toContain('251,191,36');
+    });
+  });
+
+  describe('getPianoRollToolShortcut', () => {
+    it('select = 1', () => expect(getPianoRollToolShortcut('select')).toBe('1'));
+    it('pencil = 2', () => expect(getPianoRollToolShortcut('pencil')).toBe('2'));
+    it('paint = 3', () => expect(getPianoRollToolShortcut('paint')).toBe('3'));
+    it('erase = 4', () => expect(getPianoRollToolShortcut('erase')).toBe('4'));
+    it('slide = 5', () => expect(getPianoRollToolShortcut('slide')).toBe('5'));
+    it('velocityPaint = 6', () => expect(getPianoRollToolShortcut('velocityPaint')).toBe('6'));
+  });
+
+  describe('generateNoteId', () => {
+    it('returns unique ids', () => {
+      const id1 = generateNoteId();
+      const id2 = generateNoteId();
+      expect(id1).not.toBe(id2);
+    });
+
+    it('starts with note- prefix', () => {
+      expect(generateNoteId()).toMatch(/^note-/);
+    });
+  });
+});

--- a/src/components/pianoroll/__tests__/PianoRollEmptyState.test.tsx
+++ b/src/components/pianoroll/__tests__/PianoRollEmptyState.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PianoRollEmptyState } from '../PianoRollEmptyState';
+
+describe('PianoRollEmptyState', () => {
+  it('renders empty state title', () => {
+    render(<PianoRollEmptyState />);
+    expect(screen.getByText('No MIDI clip on this track')).toBeInTheDocument();
+  });
+
+  it('renders description text', () => {
+    render(<PianoRollEmptyState />);
+    expect(screen.getByText('Select a MIDI track with clips to edit notes')).toBeInTheDocument();
+  });
+
+  it('renders music note SVG icon', () => {
+    const { container } = render(<PianoRollEmptyState />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('centers content', () => {
+    const { container } = render(<PianoRollEmptyState />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain('flex-1');
+    expect(wrapper.className).toContain('items-center');
+    expect(wrapper.className).toContain('justify-center');
+  });
+});

--- a/src/components/pianoroll/__tests__/QuantizeDialog.test.tsx
+++ b/src/components/pianoroll/__tests__/QuantizeDialog.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QuantizeDialog } from '../QuantizeDialog';
+import { useUIStore } from '../../../store/uiStore';
+import { useProjectStore } from '../../../store/projectStore';
+
+function setupDialog() {
+  useProjectStore.getState().createProject();
+  useProjectStore.getState().addTrack('midi');
+  useUIStore.setState({
+    showQuantizeDialog: true,
+    quantizeTarget: {
+      clipId: 'clip-1',
+      noteIds: ['note-1', 'note-2', 'note-3'],
+    },
+  });
+}
+
+describe('QuantizeDialog', () => {
+  beforeEach(() => {
+    setupDialog();
+  });
+
+  it('renders nothing when not shown', () => {
+    useUIStore.setState({ showQuantizeDialog: false });
+    const { container } = render(<QuantizeDialog />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when no target', () => {
+    useUIStore.setState({ quantizeTarget: null });
+    const { container } = render(<QuantizeDialog />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders dialog title with note count', () => {
+    render(<QuantizeDialog />);
+    expect(screen.getByText('Quantize 3 notes')).toBeInTheDocument();
+  });
+
+  it('uses singular for 1 note', () => {
+    useUIStore.setState({
+      quantizeTarget: { clipId: 'clip-1', noteIds: ['note-1'] },
+    });
+    render(<QuantizeDialog />);
+    expect(screen.getByText('Quantize 1 note')).toBeInTheDocument();
+  });
+
+  it('renders grid size selector', () => {
+    render(<QuantizeDialog />);
+    expect(screen.getByText('Grid size')).toBeInTheDocument();
+    const gridSelect = screen.getAllByRole('combobox')[0];
+    expect(gridSelect).toBeInTheDocument();
+  });
+
+  it('renders strength slider', () => {
+    render(<QuantizeDialog />);
+    expect(screen.getByText('Strength')).toBeInTheDocument();
+    const sliders = screen.getAllByRole('slider');
+    expect(sliders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders swing slider', () => {
+    render(<QuantizeDialog />);
+    expect(screen.getByText('Swing')).toBeInTheDocument();
+  });
+
+  it('renders scope selector', () => {
+    render(<QuantizeDialog />);
+    expect(screen.getByText('Scope')).toBeInTheDocument();
+    // Should have scope options
+    const scopeSelect = screen.getAllByRole('combobox').find(
+      (el) => (el as HTMLSelectElement).value === 'start',
+    );
+    expect(scopeSelect).toBeDefined();
+  });
+
+  it('renders Apply and Cancel buttons', () => {
+    render(<QuantizeDialog />);
+    expect(screen.getByText('Apply')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('closes on Cancel', () => {
+    render(<QuantizeDialog />);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(useUIStore.getState().showQuantizeDialog).toBe(false);
+  });
+
+  it('displays initial strength value of 100%', () => {
+    render(<QuantizeDialog />);
+    expect(screen.getByText('100%')).toBeInTheDocument();
+  });
+
+  it('changes strength when slider moves', () => {
+    render(<QuantizeDialog />);
+    const sliders = screen.getAllByRole('slider');
+    // First slider should be strength
+    fireEvent.change(sliders[0], { target: { value: '75' } });
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+
+  it('has grid options 1/4 through 1/32', () => {
+    render(<QuantizeDialog />);
+    const gridSelect = screen.getAllByRole('combobox')[0] as HTMLSelectElement;
+    const options = Array.from(gridSelect.options).map((o) => o.textContent);
+    expect(options).toContain('1/4');
+    expect(options).toContain('1/8');
+    expect(options).toContain('1/16');
+    expect(options).toContain('1/32');
+  });
+});

--- a/src/components/pianoroll/__tests__/QuantizeDialog.test.tsx
+++ b/src/components/pianoroll/__tests__/QuantizeDialog.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QuantizeDialog } from '../QuantizeDialog';
 import { useUIStore } from '../../../store/uiStore';
@@ -7,13 +7,49 @@ import { useProjectStore } from '../../../store/projectStore';
 function setupDialog() {
   useProjectStore.getState().createProject();
   useProjectStore.getState().addTrack('midi');
+  const tracks = useProjectStore.getState().project!.tracks;
+  const track = tracks[tracks.length - 1];
+  // Create a real MIDI clip with notes
+  const clip = useProjectStore.getState().ensureMidiClip(track.id);
+  const noteIds = ['note-1', 'note-2', 'note-3'];
+  // Add notes to the clip
+  useProjectStore.setState((state) => {
+    if (!state.project) return state;
+    return {
+      project: {
+        ...state.project,
+        tracks: state.project.tracks.map((t) =>
+          t.id === track.id
+            ? {
+                ...t,
+                clips: t.clips.map((c) =>
+                  c.id === clip.id && c.midiData
+                    ? {
+                        ...c,
+                        midiData: {
+                          ...c.midiData,
+                          notes: noteIds.map((id, i) => ({
+                            id,
+                            pitch: 60 + i,
+                            startBeat: i,
+                            durationBeats: 1,
+                            velocity: 100,
+                          })),
+                        },
+                      }
+                    : c,
+                ),
+              }
+            : t,
+        ),
+      },
+    };
+  });
   useUIStore.setState({
     showQuantizeDialog: true,
-    quantizeTarget: {
-      clipId: 'clip-1',
-      noteIds: ['note-1', 'note-2', 'note-3'],
-    },
+    quantizeTarget: { clipId: clip.id, noteIds },
   });
+  return { clipId: clip.id, noteIds };
 }
 
 describe('QuantizeDialog', () => {
@@ -39,8 +75,9 @@ describe('QuantizeDialog', () => {
   });
 
   it('uses singular for 1 note', () => {
+    const { clipId } = setupDialog();
     useUIStore.setState({
-      quantizeTarget: { clipId: 'clip-1', noteIds: ['note-1'] },
+      quantizeTarget: { clipId, noteIds: ['note-1'] },
     });
     render(<QuantizeDialog />);
     expect(screen.getByText('Quantize 1 note')).toBeInTheDocument();
@@ -68,7 +105,6 @@ describe('QuantizeDialog', () => {
   it('renders scope selector', () => {
     render(<QuantizeDialog />);
     expect(screen.getByText('Scope')).toBeInTheDocument();
-    // Should have scope options
     const scopeSelect = screen.getAllByRole('combobox').find(
       (el) => (el as HTMLSelectElement).value === 'start',
     );
@@ -95,7 +131,6 @@ describe('QuantizeDialog', () => {
   it('changes strength when slider moves', () => {
     render(<QuantizeDialog />);
     const sliders = screen.getAllByRole('slider');
-    // First slider should be strength
     fireEvent.change(sliders[0], { target: { value: '75' } });
     expect(screen.getByText('75%')).toBeInTheDocument();
   });

--- a/src/components/pianoroll/__tests__/TransformMenu.test.tsx
+++ b/src/components/pianoroll/__tests__/TransformMenu.test.tsx
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TransformMenu } from '../TransformMenu';
-import { useProjectStore } from '../../../store/projectStore';
 
 vi.mock('../../../utils/midiTransforms', () => ({
   SCALES: {
@@ -11,19 +10,7 @@ vi.mock('../../../utils/midiTransforms', () => ({
   },
 }));
 
-function setupProject() {
-  useProjectStore.getState().createProject();
-  useProjectStore.getState().addTrack('midi');
-  const tracks = useProjectStore.getState().project!.tracks;
-  const track = tracks[tracks.length - 1];
-  const clip = track.clips[0];
-  return { trackId: track.id, clipId: clip?.id ?? 'clip-1' };
-}
-
 describe('TransformMenu', () => {
-  beforeEach(() => {
-    setupProject();
-  });
 
   it('renders Transform button', () => {
     render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set()} />);

--- a/src/components/pianoroll/__tests__/TransformMenu.test.tsx
+++ b/src/components/pianoroll/__tests__/TransformMenu.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TransformMenu } from '../TransformMenu';
+import { useProjectStore } from '../../../store/projectStore';
+
+vi.mock('../../../utils/midiTransforms', () => ({
+  SCALES: {
+    major: [0, 2, 4, 5, 7, 9, 11],
+    minor: [0, 2, 3, 5, 7, 8, 10],
+    dorian: [0, 2, 3, 5, 7, 9, 10],
+  },
+}));
+
+function setupProject() {
+  useProjectStore.getState().createProject();
+  useProjectStore.getState().addTrack('midi');
+  const tracks = useProjectStore.getState().project!.tracks;
+  const track = tracks[tracks.length - 1];
+  const clip = track.clips[0];
+  return { trackId: track.id, clipId: clip?.id ?? 'clip-1' };
+}
+
+describe('TransformMenu', () => {
+  beforeEach(() => {
+    setupProject();
+  });
+
+  it('renders Transform button', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set()} />);
+    expect(screen.getByText('Transform')).toBeInTheDocument();
+  });
+
+  it('disables button when no notes selected', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set()} />);
+    expect(screen.getByText('Transform')).toBeDisabled();
+  });
+
+  it('enables button when notes are selected', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set(['note-1'])} />);
+    expect(screen.getByText('Transform')).not.toBeDisabled();
+  });
+
+  it('opens dropdown on click', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set(['note-1'])} />);
+    fireEvent.click(screen.getByText('Transform'));
+    expect(screen.getByText('Humanize')).toBeInTheDocument();
+    expect(screen.getByText('Transpose')).toBeInTheDocument();
+    expect(screen.getByText('Invert')).toBeInTheDocument();
+    expect(screen.getByText('Retrograde')).toBeInTheDocument();
+    expect(screen.getByText('Legato')).toBeInTheDocument();
+    expect(screen.getByText('Scale Correct')).toBeInTheDocument();
+    expect(screen.getByText('Velocity Scale')).toBeInTheDocument();
+  });
+
+  it('shows transpose params when selected', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set(['note-1'])} />);
+    fireEvent.click(screen.getByText('Transform'));
+    fireEvent.click(screen.getByText('Transpose'));
+    expect(screen.getByText('Semitones')).toBeInTheDocument();
+    expect(screen.getByText('Apply')).toBeInTheDocument();
+  });
+
+  it('shows humanize params', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set(['note-1'])} />);
+    fireEvent.click(screen.getByText('Transform'));
+    fireEvent.click(screen.getByText('Humanize'));
+    expect(screen.getByText('Timing (beats)')).toBeInTheDocument();
+    expect(screen.getByText('Velocity')).toBeInTheDocument();
+  });
+
+  it('shows scale correct params with root and scale selectors', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set(['note-1'])} />);
+    fireEvent.click(screen.getByText('Transform'));
+    fireEvent.click(screen.getByText('Scale Correct'));
+    expect(screen.getByText('Root')).toBeInTheDocument();
+    expect(screen.getByText('Scale')).toBeInTheDocument();
+  });
+
+  it('shows velocity scale params', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set(['note-1'])} />);
+    fireEvent.click(screen.getByText('Transform'));
+    fireEvent.click(screen.getByText('Velocity Scale'));
+    expect(screen.getByText('Min velocity')).toBeInTheDocument();
+    expect(screen.getByText('Max velocity')).toBeInTheDocument();
+  });
+
+  it('shows Back button in param view', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set(['note-1'])} />);
+    fireEvent.click(screen.getByText('Transform'));
+    fireEvent.click(screen.getByText('Transpose'));
+    expect(screen.getByText('← Back')).toBeInTheDocument();
+  });
+
+  it('returns to transform list on Back click', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set(['note-1'])} />);
+    fireEvent.click(screen.getByText('Transform'));
+    fireEvent.click(screen.getByText('Transpose'));
+    fireEvent.click(screen.getByText('← Back'));
+    expect(screen.getByText('Humanize')).toBeInTheDocument();
+  });
+
+  it('has correct aria-label', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set(['note-1'])} />);
+    expect(screen.getByLabelText('MIDI transform tools')).toBeInTheDocument();
+  });
+
+  it('does not open when disabled', () => {
+    render(<TransformMenu clipId="clip-1" selectedNoteIds={new Set()} />);
+    fireEvent.click(screen.getByText('Transform'));
+    expect(screen.queryByText('Humanize')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds test coverage for 5 previously untested piano roll components: PianoRollConstants (47 tests), PianoRollEmptyState, TransformMenu, GeneratePatternDialog, QuantizeDialog
- Piano roll test total goes from 58 → **149 tests** across 11 files
- All 7111 tests pass, zero TypeScript errors

## Test plan

- [x] `npm test` — all 7111 tests pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] No existing test regressions

Closes #1621

https://claude.ai/code/session_01AAbmUU34sN8t5XRPsvuyzh