### PR TITLE
test: add 50 tests for 6 previously untested hooks

### DIFF
--- a/src/hooks/__tests__/useAnimatedPresence.test.ts
+++ b/src/hooks/__tests__/useAnimatedPresence.test.ts
@@ -3,6 +3,8 @@ import { renderHook, act } from '@testing-library/react';
 import { useAnimatedPresence } from '../useAnimatedPresence';
 
 describe('useAnimatedPresence', () => {
+  const originalMatchMedia = window.matchMedia;
+
   beforeEach(() => {
     vi.useFakeTimers();
     // Ensure prefers-reduced-motion is not set
@@ -19,6 +21,11 @@ describe('useAnimatedPresence', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    // Restore original matchMedia to avoid leaking into other test files
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
+    });
   });
 
   it('starts rendering when show is true', () => {

--- a/src/hooks/__tests__/useAnimatedPresence.test.ts
+++ b/src/hooks/__tests__/useAnimatedPresence.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAnimatedPresence } from '../useAnimatedPresence';
+
+describe('useAnimatedPresence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Ensure prefers-reduced-motion is not set
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts rendering when show is true', () => {
+    const { result } = renderHook(() => useAnimatedPresence(true));
+    expect(result.current.shouldRender).toBe(true);
+  });
+
+  it('does not render when show is false initially', () => {
+    const { result } = renderHook(() => useAnimatedPresence(false));
+    expect(result.current.shouldRender).toBe(false);
+  });
+
+  it('starts visible animation after mount', async () => {
+    const { result } = renderHook(() => useAnimatedPresence(true));
+    // isVisible becomes true after rAF
+    await act(async () => {
+      vi.advanceTimersByTime(16); // simulate rAF
+    });
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it('delays unmount by exitDurationMs', () => {
+    const { result, rerender } = renderHook(
+      ({ show }) => useAnimatedPresence(show, 300),
+      { initialProps: { show: true } },
+    );
+    // Make visible
+    act(() => { vi.advanceTimersByTime(16); });
+    expect(result.current.shouldRender).toBe(true);
+
+    // Start exit
+    rerender({ show: false });
+    expect(result.current.isVisible).toBe(false);
+    // Still rendering during exit animation
+    expect(result.current.shouldRender).toBe(true);
+
+    // After exit duration
+    act(() => { vi.advanceTimersByTime(300); });
+    expect(result.current.shouldRender).toBe(false);
+  });
+
+  it('keeps rendering during exit animation', () => {
+    const { result, rerender } = renderHook(
+      ({ show }) => useAnimatedPresence(show, 500),
+      { initialProps: { show: true } },
+    );
+    act(() => { vi.advanceTimersByTime(16); });
+
+    rerender({ show: false });
+    act(() => { vi.advanceTimersByTime(200); });
+    // Still rendering halfway through exit
+    expect(result.current.shouldRender).toBe(true);
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it('cancels exit if show becomes true again', () => {
+    const { result, rerender } = renderHook(
+      ({ show }) => useAnimatedPresence(show, 300),
+      { initialProps: { show: true } },
+    );
+    act(() => { vi.advanceTimersByTime(16); });
+
+    // Start exit
+    rerender({ show: false });
+    act(() => { vi.advanceTimersByTime(100); });
+
+    // Re-show before exit completes
+    rerender({ show: true });
+    act(() => { vi.advanceTimersByTime(16); });
+    expect(result.current.shouldRender).toBe(true);
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it('skips animation with reduced motion preference', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+
+    const { result } = renderHook(() => useAnimatedPresence(true));
+    // With reduced motion, both should immediately reflect the show state
+    expect(result.current.shouldRender).toBe(true);
+    expect(result.current.isVisible).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useMetaKeyDown.test.ts
+++ b/src/hooks/__tests__/useMetaKeyDown.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+import { useMetaKeyDown } from '../useMetaKeyDown';
+
+describe('useMetaKeyDown', () => {
+  it('returns false initially', () => {
+    const { result } = renderHook(() => useMetaKeyDown());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when Meta key is pressed', () => {
+    const { result } = renderHook(() => useMetaKeyDown());
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Meta' });
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when Meta key is released', () => {
+    const { result } = renderHook(() => useMetaKeyDown());
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Meta' });
+    });
+    expect(result.current).toBe(true);
+    act(() => {
+      fireEvent.keyUp(window, { key: 'Meta' });
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('resets on window blur', () => {
+    const { result } = renderHook(() => useMetaKeyDown());
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Meta' });
+    });
+    expect(result.current).toBe(true);
+    act(() => {
+      fireEvent.blur(window);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('ignores non-Meta keys', () => {
+    const { result } = renderHook(() => useMetaKeyDown());
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Shift' });
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/usePromptAutocomplete.test.ts
+++ b/src/hooks/__tests__/usePromptAutocomplete.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePromptAutocomplete, _extractCurrentToken } from '../usePromptAutocomplete';
+
+describe('extractCurrentToken', () => {
+  it('extracts token at cursor position', () => {
+    // Cursor after 'rock' → token is 'rock'
+    const result = _extractCurrentToken('pop rock jazz', 8);
+    expect(result.token).toBe('rock');
+  });
+
+  it('extracts partial token mid-word', () => {
+    // Cursor after 'ro' in 'rock' → token is 'ro'
+    const result = _extractCurrentToken('pop rock jazz', 6);
+    expect(result.token).toBe('ro');
+  });
+
+  it('extracts first token', () => {
+    const result = _extractCurrentToken('pop rock jazz', 3);
+    expect(result.token).toBe('pop');
+  });
+
+  it('handles cursor at start', () => {
+    const result = _extractCurrentToken('pop rock', 0);
+    expect(result.token).toBe('');
+  });
+
+  it('handles empty string', () => {
+    const result = _extractCurrentToken('', 0);
+    expect(result.token).toBe('');
+  });
+
+  it('handles comma-separated tokens', () => {
+    // 'pop, rock, jazz' - at position 12 (after 'j'), token is 'j'
+    const result = _extractCurrentToken('pop, rock, jazz', 12);
+    expect(result.token).toBe('j');
+  });
+});
+
+describe('usePromptAutocomplete', () => {
+  it('starts with empty state', () => {
+    const { result } = renderHook(() => usePromptAutocomplete());
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.suggestions).toEqual([]);
+    expect(result.current.selectedIndex).toBe(0);
+    expect(result.current.currentToken).toBe('');
+  });
+
+  it('opens with suggestions when input has matching token', () => {
+    const { result } = renderHook(() => usePromptAutocomplete());
+    act(() => {
+      result.current.handleInputChange('pop', 3);
+    });
+    // Should find "pop" related suggestions
+    if (result.current.suggestions.length > 0) {
+      expect(result.current.isOpen).toBe(true);
+    }
+  });
+
+  it('closes with empty input', () => {
+    const { result } = renderHook(() => usePromptAutocomplete());
+    act(() => {
+      result.current.handleInputChange('pop', 3);
+    });
+    act(() => {
+      result.current.handleInputChange('', 0);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('dismiss closes the autocomplete', () => {
+    const { result } = renderHook(() => usePromptAutocomplete());
+    act(() => {
+      result.current.handleInputChange('pop', 3);
+    });
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it('respects maxResults option', () => {
+    const { result } = renderHook(() => usePromptAutocomplete({ maxResults: 3 }));
+    act(() => {
+      result.current.handleInputChange('a', 1);
+    });
+    expect(result.current.suggestions.length).toBeLessThanOrEqual(3);
+  });
+
+  it('resets selectedIndex on new input', () => {
+    const { result } = renderHook(() => usePromptAutocomplete());
+    act(() => {
+      result.current.handleInputChange('pop', 3);
+    });
+    act(() => {
+      result.current.handleInputChange('rock', 4);
+    });
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it('accept returns null when not open', () => {
+    const { result } = renderHook(() => usePromptAutocomplete());
+    let accepted: string | null = null;
+    act(() => {
+      accepted = result.current.accept();
+    });
+    expect(accepted).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/usePromptAutocomplete.test.ts
+++ b/src/hooks/__tests__/usePromptAutocomplete.test.ts
@@ -51,10 +51,8 @@ describe('usePromptAutocomplete', () => {
     act(() => {
       result.current.handleInputChange('pop', 3);
     });
-    // Should find "pop" related suggestions
-    if (result.current.suggestions.length > 0) {
-      expect(result.current.isOpen).toBe(true);
-    }
+    expect(result.current.suggestions.length).toBeGreaterThan(0);
+    expect(result.current.isOpen).toBe(true);
   });
 
   it('closes with empty input', () => {

--- a/src/hooks/__tests__/useReducedMotion.test.ts
+++ b/src/hooks/__tests__/useReducedMotion.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useReducedMotionSync } from '../useReducedMotion';
 import { useUIStore } from '../../store/uiStore';
@@ -6,11 +6,13 @@ import { useUIStore } from '../../store/uiStore';
 describe('useReducedMotionSync', () => {
   let addListenerSpy: ReturnType<typeof vi.fn>;
   let removeListenerSpy: ReturnType<typeof vi.fn>;
+  const originalMatchMedia = window.matchMedia;
 
   beforeEach(() => {
     addListenerSpy = vi.fn();
     removeListenerSpy = vi.fn();
-    useUIStore.setState({ reducedMotionOverride: false });
+    // Explicitly reset both reducedMotion and reducedMotionOverride for determinism
+    useUIStore.setState({ reducedMotion: false, reducedMotionOverride: false });
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
       value: vi.fn().mockImplementation((query: string) => ({
@@ -19,6 +21,14 @@ describe('useReducedMotionSync', () => {
         addEventListener: addListenerSpy,
         removeEventListener: removeListenerSpy,
       })),
+    });
+  });
+
+  afterEach(() => {
+    // Restore original matchMedia to avoid leaking into other suites
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
     });
   });
 

--- a/src/hooks/__tests__/useReducedMotion.test.ts
+++ b/src/hooks/__tests__/useReducedMotion.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useReducedMotionSync } from '../useReducedMotion';
+import { useUIStore } from '../../store/uiStore';
+
+describe('useReducedMotionSync', () => {
+  let addListenerSpy: ReturnType<typeof vi.fn>;
+  let removeListenerSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    addListenerSpy = vi.fn();
+    removeListenerSpy = vi.fn();
+    useUIStore.setState({ reducedMotionOverride: false });
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: addListenerSpy,
+        removeEventListener: removeListenerSpy,
+      })),
+    });
+  });
+
+  it('registers a change listener on the media query', () => {
+    renderHook(() => useReducedMotionSync());
+    expect(addListenerSpy).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('removes listener on unmount', () => {
+    const { unmount } = renderHook(() => useReducedMotionSync());
+    unmount();
+    expect(removeListenerSpy).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('calls setReducedMotion when media query changes and no override', () => {
+    renderHook(() => useReducedMotionSync());
+    // Get the handler passed to addEventListener
+    const handler = addListenerSpy.mock.calls[0]?.[1];
+    expect(handler).toBeDefined();
+    // Simulate media query change
+    handler?.({ matches: true });
+    expect(useUIStore.getState().reducedMotion).toBe(true);
+  });
+
+  it('does not override when user has set manual override', () => {
+    useUIStore.setState({ reducedMotionOverride: true, reducedMotion: false });
+    renderHook(() => useReducedMotionSync());
+    const handler = addListenerSpy.mock.calls[0]?.[1];
+    handler?.({ matches: true });
+    // Should NOT change because override is active
+    expect(useUIStore.getState().reducedMotion).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useToast.test.ts
+++ b/src/hooks/__tests__/useToast.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useToastStore, showToast, toastSuccess, toastError, toastInfo } from '../useToast';
+
+describe('useToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useToastStore.getState().clearToasts();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('showToast', () => {
+    it('adds a toast to the store', () => {
+      showToast({ type: 'info', message: 'Hello' });
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+      expect(useToastStore.getState().toasts[0].message).toBe('Hello');
+      expect(useToastStore.getState().toasts[0].type).toBe('info');
+    });
+
+    it('returns a unique id', () => {
+      const id1 = showToast({ type: 'info', message: 'First' });
+      const id2 = showToast({ type: 'info', message: 'Second' });
+      expect(id1).not.toBe(id2);
+    });
+
+    it('uses default duration for info (3000ms)', () => {
+      showToast({ type: 'info', message: 'Test' });
+      expect(useToastStore.getState().toasts[0].durationMs).toBe(3000);
+    });
+
+    it('uses default duration for error (5000ms)', () => {
+      showToast({ type: 'error', message: 'Error!' });
+      expect(useToastStore.getState().toasts[0].durationMs).toBe(5000);
+    });
+
+    it('uses custom duration when provided', () => {
+      showToast({ type: 'info', message: 'Custom', durationMs: 10000 });
+      expect(useToastStore.getState().toasts[0].durationMs).toBe(10000);
+    });
+
+    it('auto-dismisses after duration', () => {
+      showToast({ type: 'info', message: 'Dismiss me', durationMs: 2000 });
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+      vi.advanceTimersByTime(2000);
+      expect(useToastStore.getState().toasts).toHaveLength(0);
+    });
+
+    it('supports multiple concurrent toasts', () => {
+      showToast({ type: 'info', message: 'First' });
+      showToast({ type: 'error', message: 'Second' });
+      showToast({ type: 'success', message: 'Third' });
+      expect(useToastStore.getState().toasts).toHaveLength(3);
+    });
+  });
+
+  describe('dismissToast', () => {
+    it('removes a specific toast', () => {
+      const id = showToast({ type: 'info', message: 'Remove me' });
+      showToast({ type: 'info', message: 'Keep me' });
+      useToastStore.getState().dismissToast(id);
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+      expect(useToastStore.getState().toasts[0].message).toBe('Keep me');
+    });
+
+    it('handles dismissing non-existent id gracefully', () => {
+      showToast({ type: 'info', message: 'Test' });
+      useToastStore.getState().dismissToast('non-existent');
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+    });
+  });
+
+  describe('pauseToast / resumeToast', () => {
+    it('pauses auto-dismiss timer', () => {
+      const id = showToast({ type: 'info', message: 'Pause me', durationMs: 2000 });
+      vi.advanceTimersByTime(1000);
+      useToastStore.getState().pauseToast(id);
+      vi.advanceTimersByTime(5000); // well past the original duration
+      // Toast should still be present
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+    });
+
+    it('resumes auto-dismiss with remaining time', () => {
+      const id = showToast({ type: 'info', message: 'Resume me', durationMs: 2000 });
+      vi.advanceTimersByTime(1000);
+      useToastStore.getState().pauseToast(id);
+      vi.advanceTimersByTime(5000);
+      expect(useToastStore.getState().toasts).toHaveLength(1);
+      useToastStore.getState().resumeToast(id);
+      // Remaining should be ~1000ms, but at least 500ms minimum
+      vi.advanceTimersByTime(1500);
+      expect(useToastStore.getState().toasts).toHaveLength(0);
+    });
+  });
+
+  describe('clearToasts', () => {
+    it('removes all toasts', () => {
+      showToast({ type: 'info', message: 'One' });
+      showToast({ type: 'error', message: 'Two' });
+      showToast({ type: 'success', message: 'Three' });
+      useToastStore.getState().clearToasts();
+      expect(useToastStore.getState().toasts).toHaveLength(0);
+    });
+
+    it('cancels all pending timers', () => {
+      showToast({ type: 'info', message: 'Timer 1', durationMs: 5000 });
+      showToast({ type: 'info', message: 'Timer 2', durationMs: 5000 });
+      useToastStore.getState().clearToasts();
+      // No errors should occur when timers fire
+      vi.advanceTimersByTime(10000);
+      expect(useToastStore.getState().toasts).toHaveLength(0);
+    });
+  });
+
+  describe('helper functions', () => {
+    it('toastSuccess creates success toast', () => {
+      toastSuccess('Done!');
+      expect(useToastStore.getState().toasts[0].type).toBe('success');
+      expect(useToastStore.getState().toasts[0].message).toBe('Done!');
+    });
+
+    it('toastError creates error toast', () => {
+      toastError('Failed!');
+      expect(useToastStore.getState().toasts[0].type).toBe('error');
+      expect(useToastStore.getState().toasts[0].message).toBe('Failed!');
+    });
+
+    it('toastInfo creates info toast', () => {
+      toastInfo('FYI');
+      expect(useToastStore.getState().toasts[0].type).toBe('info');
+      expect(useToastStore.getState().toasts[0].message).toBe('FYI');
+    });
+
+    it('toastSuccess supports custom duration', () => {
+      toastSuccess('Done!', 8000);
+      expect(useToastStore.getState().toasts[0].durationMs).toBe(8000);
+    });
+  });
+});

--- a/src/hooks/__tests__/useWaveform.test.ts
+++ b/src/hooks/__tests__/useWaveform.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useWaveform } from '../useWaveform';
 
 vi.mock('../useAudioEngine', () => ({
@@ -30,11 +30,9 @@ describe('useWaveform', () => {
 
   it('loads peaks for valid audioKey', async () => {
     const { result } = renderHook(() => useWaveform('audio-key-1', 100));
-    // Wait for async loading
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    await waitFor(() => {
+      expect(result.current).toHaveLength(100);
     });
-    expect(result.current).toHaveLength(100);
   });
 
   it('resets to null when audioKey changes to null', async () => {
@@ -42,10 +40,9 @@ describe('useWaveform', () => {
       ({ key }) => useWaveform(key),
       { initialProps: { key: 'audio-1' as string | null } },
     );
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    await waitFor(() => {
+      expect(result.current).toHaveLength(100);
     });
-    expect(result.current).toHaveLength(100);
 
     rerender({ key: null });
     expect(result.current).toBeNull();
@@ -53,15 +50,14 @@ describe('useWaveform', () => {
 
   it('uses default numPeaks of 100', async () => {
     const { computeWaveformPeaks } = await import('../../utils/waveformPeaks');
-    const { result } = renderHook(() => useWaveform('audio-1'));
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    renderHook(() => useWaveform('audio-1'));
+    await waitFor(() => {
+      expect(vi.mocked(computeWaveformPeaks)).toHaveBeenCalledWith(
+        expect.anything(),
+        100,
+        expect.any(Number),
+        expect.any(Number),
+      );
     });
-    expect(vi.mocked(computeWaveformPeaks)).toHaveBeenCalledWith(
-      expect.anything(),
-      100,
-      expect.any(Number),
-      expect.any(Number),
-    );
   });
 });

--- a/src/hooks/__tests__/useWaveform.test.ts
+++ b/src/hooks/__tests__/useWaveform.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWaveform } from '../useWaveform';
+
+vi.mock('../useAudioEngine', () => ({
+  getAudioEngine: () => ({
+    decodeAudioData: vi.fn().mockResolvedValue({
+      sampleRate: 44100,
+      length: 44100,
+      numberOfChannels: 1,
+      getChannelData: () => new Float32Array(44100),
+      duration: 1,
+    }),
+  }),
+}));
+
+vi.mock('../../services/audioFileManager', () => ({
+  loadAudioBlobByKey: vi.fn().mockResolvedValue(new Blob(['audio'], { type: 'audio/wav' })),
+}));
+
+vi.mock('../../utils/waveformPeaks', () => ({
+  computeWaveformPeaks: vi.fn().mockReturnValue(Array.from({ length: 100 }, () => 0.5)),
+}));
+
+describe('useWaveform', () => {
+  it('returns null when audioKey is null', () => {
+    const { result } = renderHook(() => useWaveform(null));
+    expect(result.current).toBeNull();
+  });
+
+  it('loads peaks for valid audioKey', async () => {
+    const { result } = renderHook(() => useWaveform('audio-key-1', 100));
+    // Wait for async loading
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    expect(result.current).toHaveLength(100);
+  });
+
+  it('resets to null when audioKey changes to null', async () => {
+    const { result, rerender } = renderHook(
+      ({ key }) => useWaveform(key),
+      { initialProps: { key: 'audio-1' as string | null } },
+    );
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    expect(result.current).toHaveLength(100);
+
+    rerender({ key: null });
+    expect(result.current).toBeNull();
+  });
+
+  it('uses default numPeaks of 100', async () => {
+    const { computeWaveformPeaks } = await import('../../utils/waveformPeaks');
+    const { result } = renderHook(() => useWaveform('audio-1'));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    expect(vi.mocked(computeWaveformPeaks)).toHaveBeenCalledWith(
+      expect.anything(),
+      100,
+      expect.any(Number),
+      expect.any(Number),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds test coverage for 6 hooks that had zero tests: useToast (16), useMetaKeyDown (5), useAnimatedPresence (7), usePromptAutocomplete (13), useWaveform (4), useReducedMotion (4)
- All **50 new tests** pass, zero TypeScript errors

## Test plan

- [x] `npm test` — all 7070 tests pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] No existing test regressions

Closes #1622

https://claude.ai/code/session_01AAbmUU34sN8t5XRPsvuyzh