### PR TITLE
fix: AudioWorklet migration follow-up — 8 Copilot review fixes

### DIFF
--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -67,6 +67,7 @@ type EffectNode = {
   spectralRuntime?: {
     processor: SpectralProcessor;
     workletNode: AudioWorkletNode | ScriptProcessorNode;
+    workletPort: MessagePort | null;
     inputGain: IDSPGain;
     outputGain: IDSPGain;
     dryGain: IDSPGain;
@@ -1438,6 +1439,12 @@ class EffectsEngine {
         else rt.processor.unfreeze();
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
+        // Forward to worklet if active
+        if (rt.workletPort) {
+          rt.workletPort.postMessage({ type: 'param', name: 'freezeDecay', value: p.decay });
+          rt.workletPort.postMessage({ type: 'param', name: 'freezeBrightness', value: p.brightness });
+          rt.workletPort.postMessage({ type: p.frozen ? 'freeze' : 'unfreeze' });
+        }
         break;
       }
       case 'spectralBlur': {
@@ -1449,6 +1456,11 @@ class EffectsEngine {
         rt.processor.blurBrightness = p.brightness;
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
+        if (rt.workletPort) {
+          rt.workletPort.postMessage({ type: 'param', name: 'blurAmount', value: p.blurAmount });
+          rt.workletPort.postMessage({ type: 'param', name: 'blurFrequencySpread', value: p.frequencySpread });
+          rt.workletPort.postMessage({ type: 'param', name: 'blurBrightness', value: p.brightness });
+        }
         break;
       }
       case 'spectralFilter': {
@@ -1460,6 +1472,9 @@ class EffectsEngine {
         rt.processor.setFilterCurve(curve);
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
+        if (rt.workletPort) {
+          rt.workletPort.postMessage({ type: 'filterCurve', value: curve });
+        }
         break;
       }
       case 'spectralMorph': {
@@ -1471,6 +1486,10 @@ class EffectsEngine {
         else rt.processor.unfreeze();
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
+        if (rt.workletPort) {
+          rt.workletPort.postMessage({ type: 'param', name: 'morphAmount', value: p.morphAmount });
+          rt.workletPort.postMessage({ type: p.frozen ? 'freeze' : 'unfreeze' });
+        }
         break;
       }
     }

--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -1019,27 +1019,46 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
   dryGain.connect(outputGain);
   wetGain.connect(outputGain);
 
+  // Build mutable runtime object so async worklet upgrade can update references
+  const spectralRuntime: {
+    processor: typeof processor;
+    workletNode: AudioWorkletNode | ScriptProcessorNode;
+    workletPort: MessagePort | null;
+    inputGain: typeof inputGain;
+    outputGain: typeof outputGain;
+    dryGain: typeof dryGain;
+    wetGain: typeof wetGain;
+  } = {
+    processor,
+    workletNode: scriptNode,
+    workletPort: null,
+    inputGain,
+    outputGain,
+    dryGain,
+    wetGain,
+  };
+
   // Attempt async upgrade to AudioWorklet
-  let activeWorkletNode: AudioWorkletNode | ScriptProcessorNode = scriptNode;
   void (async () => {
     try {
-      const { createDspNode } = await import('./dsp/workletLoader');
-      const result = await createDspNode(
+      const { tryCreateWorkletNode } = await import('./dsp/workletLoader');
+      const result = await tryCreateWorkletNode(
         ctx,
         '/spectral-worklet-processor.js',
         'spectral-worklet-processor',
         1,
-        { fftSize, mode: effect.type === 'spectralFreeze' ? 'freeze' : effect.type === 'spectralMorph' ? 'morph' : 'filter' },
-        bufferSize,
-        scriptNode.onaudioprocess!,
+        { fftSize, mode },
       );
-      if (result.isWorklet) {
+      if (result.isWorklet && result.node) {
         // Swap: disconnect ScriptProcessor, connect AudioWorklet
         inputGain.outputNode.disconnect(scriptNode);
         scriptNode.disconnect();
+        scriptNode.onaudioprocess = null;
         inputGain.outputNode.connect(result.node);
         result.node.connect(wetGain.inputNode);
-        activeWorkletNode = result.node;
+        // Update mutable runtime references
+        spectralRuntime.workletNode = result.node;
+        spectralRuntime.workletPort = result.port;
       }
     } catch {
       // Keep ScriptProcessorNode fallback — already connected
@@ -1052,17 +1071,13 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
     node: inputGain,
     inputNode: inputGain.inputNode,
     outputNode: outputGain.outputNode,
-    spectralRuntime: {
-      processor,
-      workletNode: activeWorkletNode,
-      inputGain,
-      outputGain,
-      dryGain,
-      wetGain,
-    },
+    spectralRuntime,
     dispose: () => {
       scriptNode.onaudioprocess = null;
       scriptNode.disconnect();
+      if (spectralRuntime.workletPort) {
+        spectralRuntime.workletPort.postMessage({ type: 'dispose' });
+      }
       inputGain.dispose();
       outputGain.dispose();
       dryGain.dispose();

--- a/src/engine/dsp/NativeAdapter.ts
+++ b/src/engine/dsp/NativeAdapter.ts
@@ -280,7 +280,7 @@ class NativeDelay extends NativeNodeWrapper implements IDSPDelay {
 // AudioWorklet-based effects with ScriptProcessorNode fallback
 // ---------------------------------------------------------------------------
 
-import { createDspNode, type DspNodeResult } from './workletLoader';
+import { tryCreateWorkletNode, type WorkletNodeResult } from './workletLoader';
 
 const BUFFER_SIZE = 2048;
 
@@ -288,7 +288,7 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
   private readonly _verb: FreeVerb;
   private readonly _mix: DryWetMix;
   private readonly _preDelayNode: DelayNode;
-  private _dspNode: DspNodeResult | null = null;
+  private _worklet: WorkletNodeResult | null = null;
   private _decay = 1.5;
   private _preDelay = 0.01;
 
@@ -300,8 +300,7 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
     const preDelayTime = options?.preDelay ?? 0.01;
     preDelayNode.delayTime.value = preDelayTime;
 
-    const roomSize = Math.min(1, (options?.decay ?? 1.5) / 10);
-    verb.roomSize = roomSize;
+    verb.roomSize = Math.min(1, (options?.decay ?? 1.5) / 10);
     verb.damping = 0.5;
     verb.wet = 1;
     verb.dry = 0;
@@ -332,7 +331,7 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
     this._preDelay = preDelayTime;
 
     // Attempt async upgrade to AudioWorklet
-    void this._upgradeToWorklet(ctx, scriptFallback, mix, preDelayNode, roomSize, options);
+    void this._upgradeToWorklet(ctx, scriptFallback, mix, preDelayNode);
   }
 
   private async _upgradeToWorklet(
@@ -340,27 +339,28 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
     scriptNode: ScriptProcessorNode,
     mix: DryWetMix,
     preDelayNode: DelayNode,
-    roomSize: number,
-    options?: IDSPReverbOptions,
   ): Promise<void> {
     try {
-      const result = await createDspNode(
+      // Derive current params at swap time (not stale constructor values)
+      const currentRoomSize = Math.min(1, this._decay / 10);
+      const result = await tryCreateWorkletNode(
         ctx,
         '/reverb-worklet-processor.js',
         'reverb-worklet-processor',
         2,
-        { roomSize, damping: 0.5, wet: 1, dry: 0 },
-        BUFFER_SIZE,
-        scriptNode.onaudioprocess!,
+        { roomSize: currentRoomSize, damping: 0.5, wet: 1, dry: 0 },
       );
 
-      if (result.isWorklet) {
+      if (result.isWorklet && result.node) {
+        // Send current params in case they changed during load
+        result.port!.postMessage({ type: 'roomSize', value: currentRoomSize });
+
         // Swap: disconnect ScriptProcessor, connect AudioWorklet
         preDelayNode.disconnect(scriptNode);
         scriptNode.disconnect();
         preDelayNode.connect(result.node);
         result.node.connect(mix.wetInput);
-        this._dspNode = result;
+        this._worklet = result;
       }
     } catch {
       // Keep ScriptProcessorNode fallback — already connected
@@ -371,7 +371,7 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
   set decay(v: number) {
     this._decay = v;
     this._verb.roomSize = Math.min(1, v / 10);
-    this._dspNode?.port?.postMessage({ type: 'roomSize', value: Math.min(1, v / 10) });
+    this._worklet?.port?.postMessage({ type: 'roomSize', value: Math.min(1, v / 10) });
   }
 
   get preDelay(): number { return this._preDelay; }

--- a/src/engine/dsp/NativeAdapter.ts
+++ b/src/engine/dsp/NativeAdapter.ts
@@ -352,8 +352,9 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
       );
 
       if (result.isWorklet && result.node) {
-        // Send current params in case they changed during load
-        result.port!.postMessage({ type: 'roomSize', value: currentRoomSize });
+        // Recompute from current state — decay may have changed during async load
+        const latestRoomSize = Math.min(1, this._decay / 10);
+        result.port!.postMessage({ type: 'roomSize', value: latestRoomSize });
 
         // Swap: disconnect ScriptProcessor, connect AudioWorklet
         preDelayNode.disconnect(scriptNode);

--- a/src/engine/dsp/__tests__/NativeSynths.test.ts
+++ b/src/engine/dsp/__tests__/NativeSynths.test.ts
@@ -325,14 +325,6 @@ describe('parseDuration', () => {
     expect(parseDuration('4n', 180)).toBeCloseTo(1 / 3);
   });
 
-  it('requires explicit BPM — no silent 120 BPM default', () => {
-    // parseDuration(dur, bpm) now requires BPM to prevent silent defaults.
-    // TypeScript enforces this at compile time. At runtime, omitting BPM
-    // produces NaN for notation strings (60 / undefined).
-    const result = parseDuration('4n', undefined as unknown as number);
-    expect(result).toBeNaN();
-  });
-
   it('returns fallback for unparseable strings', () => {
     expect(parseDuration('invalid', 120)).toBe(0.25);
   });

--- a/src/engine/dsp/workletLoader.ts
+++ b/src/engine/dsp/workletLoader.ts
@@ -76,7 +76,7 @@ export async function tryCreateWorkletNode(
         log.info(`Created AudioWorkletNode: ${processorName}`);
         return { node, port: node.port, isWorklet: true };
       } catch (err) {
-        log.warn(`AudioWorkletNode creation failed for ${processorName}, falling back:`, err);
+        log.warn(`AudioWorkletNode creation failed for ${processorName}; caller keeps ScriptProcessor fallback:`, err);
       }
     }
   }

--- a/src/engine/dsp/workletLoader.ts
+++ b/src/engine/dsp/workletLoader.ts
@@ -2,26 +2,32 @@
  * AudioWorklet loader with ScriptProcessorNode fallback.
  *
  * Tries to register and create an AudioWorkletNode. If AudioWorklet is
- * unavailable (older Safari, insecure context) or fails to load, falls
- * back to the deprecated ScriptProcessorNode.
+ * unavailable (older Safari, insecure context) or fails to load, returns
+ * a "not available" result so the caller keeps its existing fallback node.
  */
 
 import { createDebugLogger } from '../../utils/debugLogger';
 
 const log = createDebugLogger('dsp:worklet-loader');
 
-const registeredWorklets = new Set<string>();
+const registeredWorklets = new WeakMap<AudioContext, Set<string>>();
 
 /**
  * Ensure a worklet module is registered on the given AudioContext.
  * No-ops if already registered for this context + URL combination.
  */
 async function ensureWorkletRegistered(ctx: AudioContext, url: string): Promise<boolean> {
-  const key = `${ctx.sampleRate}:${url}`;
-  if (registeredWorklets.has(key)) return true;
+  let contextWorklets = registeredWorklets.get(ctx);
+  if (!contextWorklets) {
+    contextWorklets = new Set<string>();
+    registeredWorklets.set(ctx, contextWorklets);
+  }
+
+  if (contextWorklets.has(url)) return true;
+
   try {
     await ctx.audioWorklet.addModule(url);
-    registeredWorklets.add(key);
+    contextWorklets.add(url);
     return true;
   } catch (err) {
     log.warn(`Failed to register worklet ${url}:`, err);
@@ -29,36 +35,32 @@ async function ensureWorkletRegistered(ctx: AudioContext, url: string): Promise<
   }
 }
 
-export interface DspNodeResult {
-  /** The audio node (AudioWorkletNode or ScriptProcessorNode). */
-  node: AudioWorkletNode | ScriptProcessorNode;
-  /** MessagePort for sending parameter updates (null for ScriptProcessor fallback). */
+export interface WorkletNodeResult {
+  /** The AudioWorkletNode, or null if worklet is unavailable. */
+  node: AudioWorkletNode | null;
+  /** MessagePort for sending parameter updates (null if worklet unavailable). */
   port: MessagePort | null;
   /** Whether this is using the modern AudioWorklet path. */
   isWorklet: boolean;
 }
 
 /**
- * Create a DSP processing node, preferring AudioWorklet with ScriptProcessor fallback.
+ * Try to create an AudioWorkletNode. Returns null node if unavailable.
+ * Callers are responsible for keeping their own ScriptProcessorNode fallback.
  *
  * @param ctx - AudioContext
  * @param workletUrl - URL of the worklet processor file (e.g., '/reverb-worklet-processor.js')
  * @param processorName - Name registered via registerProcessor() in the worklet file
  * @param channels - Number of input/output channels
  * @param processorOptions - Options passed to the AudioWorkletProcessor constructor
- * @param fallbackBufferSize - Buffer size for ScriptProcessorNode fallback
- * @param fallbackProcess - Processing callback for ScriptProcessorNode fallback
  */
-export async function createDspNode(
+export async function tryCreateWorkletNode(
   ctx: AudioContext,
   workletUrl: string,
   processorName: string,
   channels: number,
   processorOptions: Record<string, unknown>,
-  fallbackBufferSize: number,
-  fallbackProcess: (e: AudioProcessingEvent) => void,
-): Promise<DspNodeResult> {
-  // Try AudioWorklet first
+): Promise<WorkletNodeResult> {
   if (typeof AudioWorkletNode !== 'undefined' && ctx.audioWorklet) {
     const registered = await ensureWorkletRegistered(ctx, workletUrl);
     if (registered) {
@@ -67,6 +69,8 @@ export async function createDspNode(
           numberOfInputs: 1,
           numberOfOutputs: 1,
           channelCount: channels,
+          channelCountMode: 'explicit',
+          outputChannelCount: [channels],
           processorOptions: { sampleRate: ctx.sampleRate, ...processorOptions },
         });
         log.info(`Created AudioWorkletNode: ${processorName}`);
@@ -77,9 +81,5 @@ export async function createDspNode(
     }
   }
 
-  // Fallback to ScriptProcessorNode
-  log.info(`Using ScriptProcessorNode fallback for ${processorName}`);
-  const scriptNode = ctx.createScriptProcessor(fallbackBufferSize, channels, channels);
-  scriptNode.onaudioprocess = fallbackProcess;
-  return { node: scriptNode, port: null, isWorklet: false };
+  return { node: null, port: null, isWorklet: false };
 }


### PR DESCRIPTION
## Summary

Addresses all 8 Copilot review findings from the AudioWorklet migration in #1640:

1. **workletLoader**: Per-context registration cache (`WeakMap<AudioContext, Set<string>>`)
2. **workletLoader**: `outputChannelCount` + `channelCountMode: 'explicit'` for multi-channel
3. **workletLoader**: Renamed to `tryCreateWorkletNode` — returns null instead of allocating unused ScriptProcessor
4. **EffectsEngine**: Fixed spectral blur mode (was using ternary that skipped `'blur'`)
5. **EffectsEngine**: Store `workletPort` in `spectralRuntime` for parameter forwarding
6. **EffectsEngine**: Mutable `spectralRuntime` object so async upgrade updates references
7. **NativeAdapter**: Derive `roomSize` from current `this._decay` at swap time + send current params
8. **Tests**: Removed implementation-detail NaN assertion

## Test plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] `npm test` — 7155 tests pass (0 regressions)

Closes #1645

https://claude.ai/code/session_016He7tRxdWeGetVaeQk3RCe