### PR TITLE
fix: AudioWorklet migration follow-up — 8 bug fixes from Copilot review

### DIFF
--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -67,6 +67,8 @@ type EffectNode = {
   spectralRuntime?: {
     processor: SpectralProcessor;
     workletNode: AudioWorkletNode | ScriptProcessorNode;
+    /** MessagePort for forwarding params to AudioWorkletProcessor (null when using ScriptProcessor fallback). */
+    port: MessagePort | null;
     inputGain: IDSPGain;
     outputGain: IDSPGain;
     dryGain: IDSPGain;
@@ -1040,10 +1042,8 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
         'spectral-worklet-processor',
         1,
         { fftSize, mode },
-        bufferSize,
-        scriptNode.onaudioprocess!,
       );
-      if (result?.isWorklet) {
+      if (result) {
         // Swap: disconnect ScriptProcessor, connect AudioWorklet
         inputGain.outputNode.disconnect(scriptNode);
         scriptNode.disconnect();
@@ -1428,6 +1428,7 @@ class EffectsEngine {
         else rt.processor.unfreeze();
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
+        rt.port?.postMessage({ type: 'params', decay: p.decay, brightness: p.brightness, frozen: p.frozen });
         break;
       }
       case 'spectralBlur': {
@@ -1439,6 +1440,7 @@ class EffectsEngine {
         rt.processor.blurBrightness = p.brightness;
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
+        rt.port?.postMessage({ type: 'params', blurAmount: p.blurAmount, frequencySpread: p.frequencySpread, brightness: p.brightness });
         break;
       }
       case 'spectralFilter': {
@@ -1450,6 +1452,7 @@ class EffectsEngine {
         rt.processor.setFilterCurve(curve);
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
+        rt.port?.postMessage({ type: 'filterCurve', curve: Array.from(curve) });
         break;
       }
       case 'spectralMorph': {
@@ -1461,6 +1464,7 @@ class EffectsEngine {
         else rt.processor.unfreeze();
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
+        rt.port?.postMessage({ type: 'params', morphAmount: p.morphAmount, frozen: p.frozen });
         break;
       }
     }

--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -1019,8 +1019,18 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
   dryGain.connect(outputGain);
   wetGain.connect(outputGain);
 
+  // Mutable references updated after async worklet swap
+  const spectralRuntime = {
+    processor,
+    workletNode: scriptNode as AudioWorkletNode | ScriptProcessorNode,
+    port: null as MessagePort | null,
+    inputGain,
+    outputGain,
+    dryGain,
+    wetGain,
+  };
+
   // Attempt async upgrade to AudioWorklet
-  let activeWorkletNode: AudioWorkletNode | ScriptProcessorNode = scriptNode;
   void (async () => {
     try {
       const { createDspNode } = await import('./dsp/workletLoader');
@@ -1029,17 +1039,19 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
         '/spectral-worklet-processor.js',
         'spectral-worklet-processor',
         1,
-        { fftSize, mode: effect.type === 'spectralFreeze' ? 'freeze' : effect.type === 'spectralMorph' ? 'morph' : 'filter' },
+        { fftSize, mode },
         bufferSize,
         scriptNode.onaudioprocess!,
       );
-      if (result.isWorklet) {
+      if (result?.isWorklet) {
         // Swap: disconnect ScriptProcessor, connect AudioWorklet
         inputGain.outputNode.disconnect(scriptNode);
         scriptNode.disconnect();
         inputGain.outputNode.connect(result.node);
         result.node.connect(wetGain.inputNode);
-        activeWorkletNode = result.node;
+        // Update mutable refs so callers see the live worklet
+        spectralRuntime.workletNode = result.node;
+        spectralRuntime.port = result.port;
       }
     } catch {
       // Keep ScriptProcessorNode fallback — already connected
@@ -1052,14 +1064,7 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
     node: inputGain,
     inputNode: inputGain.inputNode,
     outputNode: outputGain.outputNode,
-    spectralRuntime: {
-      processor,
-      workletNode: activeWorkletNode,
-      inputGain,
-      outputGain,
-      dryGain,
-      wetGain,
-    },
+    spectralRuntime,
     dispose: () => {
       scriptNode.onaudioprocess = null;
       scriptNode.disconnect();

--- a/src/engine/dsp/NativeAdapter.ts
+++ b/src/engine/dsp/NativeAdapter.ts
@@ -280,7 +280,7 @@ class NativeDelay extends NativeNodeWrapper implements IDSPDelay {
 // AudioWorklet-based effects with ScriptProcessorNode fallback
 // ---------------------------------------------------------------------------
 
-import { createDspNode, type DspNodeResult } from './workletLoader';
+import { createDspNode, type DspWorkletResult } from './workletLoader';
 
 const BUFFER_SIZE = 2048;
 
@@ -288,7 +288,7 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
   private readonly _verb: FreeVerb;
   private readonly _mix: DryWetMix;
   private readonly _preDelayNode: DelayNode;
-  private _dspNode: DspNodeResult | null = null;
+  private _dspNode: DspWorkletResult | null = null;
   private _decay = 1.5;
   private _preDelay = 0.01;
 
@@ -350,11 +350,9 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
         'reverb-worklet-processor',
         2,
         { roomSize, damping: 0.5, wet: 1, dry: 0 },
-        BUFFER_SIZE,
-        scriptNode.onaudioprocess!,
       );
 
-      if (result?.isWorklet) {
+      if (result) {
         // Swap: disconnect ScriptProcessor, connect AudioWorklet
         preDelayNode.disconnect(scriptNode);
         scriptNode.disconnect();

--- a/src/engine/dsp/NativeAdapter.ts
+++ b/src/engine/dsp/NativeAdapter.ts
@@ -354,13 +354,16 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
         scriptNode.onaudioprocess!,
       );
 
-      if (result.isWorklet) {
+      if (result?.isWorklet) {
         // Swap: disconnect ScriptProcessor, connect AudioWorklet
         preDelayNode.disconnect(scriptNode);
         scriptNode.disconnect();
         preDelayNode.connect(result.node);
         result.node.connect(mix.wetInput);
         this._dspNode = result;
+        // Send current params in case decay changed while worklet was loading
+        const currentRoomSize = Math.min(1, this._decay / 10);
+        result.port?.postMessage({ type: 'roomSize', value: currentRoomSize });
       }
     } catch {
       // Keep ScriptProcessorNode fallback — already connected

--- a/src/engine/dsp/__tests__/NativeSynths.test.ts
+++ b/src/engine/dsp/__tests__/NativeSynths.test.ts
@@ -327,10 +327,15 @@ describe('parseDuration', () => {
 
   it('requires explicit BPM — no silent 120 BPM default', () => {
     // parseDuration(dur, bpm) now requires BPM to prevent silent defaults.
-    // TypeScript enforces this at compile time. At runtime, omitting BPM
-    // produces NaN for notation strings (60 / undefined).
-    const result = parseDuration('4n', undefined as unknown as number);
-    expect(result).toBeNaN();
+    // TypeScript enforces this at compile time. Verify that different BPMs
+    // produce different results (i.e., the parameter is actually used).
+    const at60 = parseDuration('4n', 60);
+    const at120 = parseDuration('4n', 120);
+    const at180 = parseDuration('4n', 180);
+    expect(at60).not.toBe(at120);
+    expect(at120).not.toBe(at180);
+    expect(at60).toBeGreaterThan(at120);
+    expect(at120).toBeGreaterThan(at180);
   });
 
   it('returns fallback for unparseable strings', () => {

--- a/src/engine/dsp/workletLoader.ts
+++ b/src/engine/dsp/workletLoader.ts
@@ -10,18 +10,19 @@ import { createDebugLogger } from '../../utils/debugLogger';
 
 const log = createDebugLogger('dsp:worklet-loader');
 
-const registeredWorklets = new Set<string>();
+const registeredWorklets = new WeakMap<BaseAudioContext, Set<string>>();
 
 /**
  * Ensure a worklet module is registered on the given AudioContext.
  * No-ops if already registered for this context + URL combination.
  */
 async function ensureWorkletRegistered(ctx: AudioContext, url: string): Promise<boolean> {
-  const key = `${ctx.sampleRate}:${url}`;
-  if (registeredWorklets.has(key)) return true;
+  let ctxSet = registeredWorklets.get(ctx);
+  if (ctxSet?.has(url)) return true;
   try {
     await ctx.audioWorklet.addModule(url);
-    registeredWorklets.add(key);
+    if (!ctxSet) { ctxSet = new Set(); registeredWorklets.set(ctx, ctxSet); }
+    ctxSet.add(url);
     return true;
   } catch (err) {
     log.warn(`Failed to register worklet ${url}:`, err);
@@ -57,7 +58,7 @@ export async function createDspNode(
   processorOptions: Record<string, unknown>,
   fallbackBufferSize: number,
   fallbackProcess: (e: AudioProcessingEvent) => void,
-): Promise<DspNodeResult> {
+): Promise<DspNodeResult | null> {
   // Try AudioWorklet first
   if (typeof AudioWorkletNode !== 'undefined' && ctx.audioWorklet) {
     const registered = await ensureWorkletRegistered(ctx, workletUrl);
@@ -67,6 +68,8 @@ export async function createDspNode(
           numberOfInputs: 1,
           numberOfOutputs: 1,
           channelCount: channels,
+          outputChannelCount: [channels],
+          channelCountMode: 'explicit',
           processorOptions: { sampleRate: ctx.sampleRate, ...processorOptions },
         });
         log.info(`Created AudioWorkletNode: ${processorName}`);
@@ -77,9 +80,9 @@ export async function createDspNode(
     }
   }
 
-  // Fallback to ScriptProcessorNode
-  log.info(`Using ScriptProcessorNode fallback for ${processorName}`);
-  const scriptNode = ctx.createScriptProcessor(fallbackBufferSize, channels, channels);
-  scriptNode.onaudioprocess = fallbackProcess;
-  return { node: scriptNode, port: null, isWorklet: false };
+  // Fallback: callers already have a ScriptProcessorNode wired —
+  // return null to signal worklet creation failed and keep existing fallback.
+  log.info(`AudioWorklet unavailable for ${processorName} — caller should keep existing ScriptProcessor`);
+  return null;
 }
+

--- a/src/engine/dsp/workletLoader.ts
+++ b/src/engine/dsp/workletLoader.ts
@@ -1,9 +1,10 @@
 /**
- * AudioWorklet loader with ScriptProcessorNode fallback.
+ * AudioWorklet loader — attempts to create an AudioWorkletNode.
  *
- * Tries to register and create an AudioWorkletNode. If AudioWorklet is
- * unavailable (older Safari, insecure context) or fails to load, falls
- * back to the deprecated ScriptProcessorNode.
+ * Returns the node + port on success, or null if AudioWorklet is
+ * unavailable (older Safari, insecure context) or fails to load.
+ * Callers are responsible for maintaining their own ScriptProcessorNode
+ * fallback — this module does not create fallback nodes.
  */
 
 import { createDebugLogger } from '../../utils/debugLogger';
@@ -30,25 +31,25 @@ async function ensureWorkletRegistered(ctx: AudioContext, url: string): Promise<
   }
 }
 
-export interface DspNodeResult {
-  /** The audio node (AudioWorkletNode or ScriptProcessorNode). */
-  node: AudioWorkletNode | ScriptProcessorNode;
-  /** MessagePort for sending parameter updates (null for ScriptProcessor fallback). */
-  port: MessagePort | null;
-  /** Whether this is using the modern AudioWorklet path. */
-  isWorklet: boolean;
+export interface DspWorkletResult {
+  /** The AudioWorkletNode. */
+  node: AudioWorkletNode;
+  /** MessagePort for sending parameter updates to the worklet processor. */
+  port: MessagePort;
 }
 
 /**
- * Create a DSP processing node, preferring AudioWorklet with ScriptProcessor fallback.
+ * Try to create an AudioWorkletNode. Returns the node + port on success,
+ * or null if AudioWorklet is unavailable or creation fails.
+ *
+ * Callers should keep their existing ScriptProcessorNode wired as fallback
+ * and only swap to the worklet node when this returns non-null.
  *
  * @param ctx - AudioContext
  * @param workletUrl - URL of the worklet processor file (e.g., '/reverb-worklet-processor.js')
  * @param processorName - Name registered via registerProcessor() in the worklet file
  * @param channels - Number of input/output channels
  * @param processorOptions - Options passed to the AudioWorkletProcessor constructor
- * @param fallbackBufferSize - Buffer size for ScriptProcessorNode fallback
- * @param fallbackProcess - Processing callback for ScriptProcessorNode fallback
  */
 export async function createDspNode(
   ctx: AudioContext,
@@ -56,10 +57,7 @@ export async function createDspNode(
   processorName: string,
   channels: number,
   processorOptions: Record<string, unknown>,
-  fallbackBufferSize: number,
-  fallbackProcess: (e: AudioProcessingEvent) => void,
-): Promise<DspNodeResult | null> {
-  // Try AudioWorklet first
+): Promise<DspWorkletResult | null> {
   if (typeof AudioWorkletNode !== 'undefined' && ctx.audioWorklet) {
     const registered = await ensureWorkletRegistered(ctx, workletUrl);
     if (registered) {
@@ -73,16 +71,13 @@ export async function createDspNode(
           processorOptions: { sampleRate: ctx.sampleRate, ...processorOptions },
         });
         log.info(`Created AudioWorkletNode: ${processorName}`);
-        return { node, port: node.port, isWorklet: true };
+        return { node, port: node.port };
       } catch (err) {
         log.warn(`AudioWorkletNode creation failed for ${processorName}, falling back:`, err);
       }
     }
   }
 
-  // Fallback: callers already have a ScriptProcessorNode wired —
-  // return null to signal worklet creation failed and keep existing fallback.
   log.info(`AudioWorklet unavailable for ${processorName} — caller should keep existing ScriptProcessor`);
   return null;
 }
-


### PR DESCRIPTION
## Summary

Addresses all 8 Copilot review findings from the AudioWorklet migration (PR #1640):

1. **workletLoader**: Per-context registration cache using `WeakMap<BaseAudioContext>` instead of sampleRate-keyed `Set` (prevents cross-context false cache hits)
2. **workletLoader**: Add `outputChannelCount` + `channelCountMode: 'explicit'` to prevent stereo-to-mono collapse
3. **workletLoader**: Return `null` instead of allocating unused ScriptProcessorNode — callers already have one wired
4. **EffectsEngine**: Use pre-computed `mode` variable for spectral worklet instead of ternary that omitted `'blur'`
5. **EffectsEngine**: Store worklet port in `spectralRuntime` for parameter forwarding
6. **EffectsEngine**: Update `spectralRuntime.workletNode` after hot-swap so callers see the live node
7. **NativeAdapter**: Send current `roomSize` after worklet creation to handle decay changes during async load
8. **NativeSynths test**: Replace NaN implementation-detail assertion with behavioral BPM-sensitivity test

Closes #1645

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 7156 passed, 0 failures, 0 regressions
- [ ] Verify reverb effect still works in dev server (worklet + fallback paths)
- [ ] Verify spectral effects (freeze, blur, filter, morph) work correctly

https://claude.ai/code/session_01EGxo1vBtnKbEPLfNZinC7j"