### PR TITLE
fix: AudioWorklet migration follow-up — 12 review findings

### DIFF
--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -1019,8 +1019,34 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
   dryGain.connect(outputGain);
   wetGain.connect(outputGain);
 
+  // Derive worklet mode from effect type
+  const modeMap: Record<string, string> = {
+    spectralFreeze: 'freeze',
+    spectralBlur: 'blur',
+    spectralFilter: 'filter',
+    spectralMorph: 'morph',
+  };
+  const workletMode = modeMap[effect.type] ?? 'filter';
+
   // Attempt async upgrade to AudioWorklet
-  let activeWorkletNode: AudioWorkletNode | ScriptProcessorNode = scriptNode;
+  const spectralRuntime: {
+    processor: typeof processor;
+    workletNode: AudioWorkletNode | ScriptProcessorNode;
+    port: MessagePort | null;
+    inputGain: typeof inputGain;
+    outputGain: typeof outputGain;
+    dryGain: typeof dryGain;
+    wetGain: typeof wetGain;
+  } = {
+    processor,
+    workletNode: scriptNode,
+    port: null,
+    inputGain,
+    outputGain,
+    dryGain,
+    wetGain,
+  };
+
   void (async () => {
     try {
       const { createDspNode } = await import('./dsp/workletLoader');
@@ -1029,17 +1055,16 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
         '/spectral-worklet-processor.js',
         'spectral-worklet-processor',
         1,
-        { fftSize, mode: effect.type === 'spectralFreeze' ? 'freeze' : effect.type === 'spectralMorph' ? 'morph' : 'filter' },
-        bufferSize,
-        scriptNode.onaudioprocess!,
+        { fftSize, mode: workletMode },
       );
-      if (result.isWorklet) {
+      if (result) {
         // Swap: disconnect ScriptProcessor, connect AudioWorklet
         inputGain.outputNode.disconnect(scriptNode);
         scriptNode.disconnect();
         inputGain.outputNode.connect(result.node);
         result.node.connect(wetGain.inputNode);
-        activeWorkletNode = result.node;
+        spectralRuntime.workletNode = result.node;
+        spectralRuntime.port = result.port;
       }
     } catch {
       // Keep ScriptProcessorNode fallback — already connected
@@ -1052,14 +1077,7 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
     node: inputGain,
     inputNode: inputGain.inputNode,
     outputNode: outputGain.outputNode,
-    spectralRuntime: {
-      processor,
-      workletNode: activeWorkletNode,
-      inputGain,
-      outputGain,
-      dryGain,
-      wetGain,
-    },
+    spectralRuntime,
     dispose: () => {
       scriptNode.onaudioprocess = null;
       scriptNode.disconnect();

--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -1066,6 +1066,14 @@ function createSpectralNode(effect: TrackEffect): EffectNode {
         result.node.connect(wetGain.inputNode);
         spectralRuntime.workletNode = result.node;
         spectralRuntime.port = result.port;
+
+        // Sync current processor state to worklet so upgraded node matches pre-swap sound
+        result.port.postMessage({ type: 'param', name: 'freezeDecay', value: processor.freezeDecay });
+        result.port.postMessage({ type: 'param', name: 'freezeBrightness', value: processor.freezeBrightness });
+        result.port.postMessage({ type: 'param', name: 'blurAmount', value: processor.blurAmount });
+        result.port.postMessage({ type: 'param', name: 'blurFrequencySpread', value: processor.blurFrequencySpread });
+        result.port.postMessage({ type: 'param', name: 'blurBrightness', value: processor.blurBrightness });
+        result.port.postMessage({ type: 'param', name: 'morphAmount', value: processor.morphAmount });
       }
     } catch {
       // Keep ScriptProcessorNode fallback — already connected
@@ -1440,7 +1448,9 @@ class EffectsEngine {
         rt.processor.freezeBrightness = p.brightness;
         if (p.frozen) rt.processor.freeze();
         else rt.processor.unfreeze();
-        rt.port?.postMessage({ type: p.frozen ? 'freeze' : 'unfreeze', decay: p.decay, brightness: p.brightness });
+        rt.port?.postMessage({ type: 'param', name: 'freezeDecay', value: p.decay });
+        rt.port?.postMessage({ type: 'param', name: 'freezeBrightness', value: p.brightness });
+        rt.port?.postMessage({ type: p.frozen ? 'freeze' : 'unfreeze' });
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
         break;
@@ -1452,7 +1462,9 @@ class EffectsEngine {
         rt.processor.blurAmount = p.blurAmount;
         rt.processor.blurFrequencySpread = p.frequencySpread;
         rt.processor.blurBrightness = p.brightness;
-        rt.port?.postMessage({ type: 'param', blurAmount: p.blurAmount, frequencySpread: p.frequencySpread, brightness: p.brightness });
+        rt.port?.postMessage({ type: 'param', name: 'blurAmount', value: p.blurAmount });
+        rt.port?.postMessage({ type: 'param', name: 'blurFrequencySpread', value: p.frequencySpread });
+        rt.port?.postMessage({ type: 'param', name: 'blurBrightness', value: p.brightness });
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
         break;
@@ -1464,7 +1476,7 @@ class EffectsEngine {
         const ctx = getDSPFactory().getContext();
         const curve = buildFilterCurve(p.points, rt.processor.fftSize >> 1, ctx.sampleRate, p.resolution);
         rt.processor.setFilterCurve(curve);
-        rt.port?.postMessage({ type: 'filterCurve', curve: Array.from(curve) });
+        rt.port?.postMessage({ type: 'filterCurve', value: curve });
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
         break;
@@ -1476,7 +1488,8 @@ class EffectsEngine {
         rt.processor.morphAmount = p.morphAmount;
         if (p.frozen) rt.processor.freeze();
         else rt.processor.unfreeze();
-        rt.port?.postMessage({ type: p.frozen ? 'freeze' : 'unfreeze', morphAmount: p.morphAmount });
+        rt.port?.postMessage({ type: 'param', name: 'morphAmount', value: p.morphAmount });
+        rt.port?.postMessage({ type: p.frozen ? 'freeze' : 'unfreeze' });
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
         break;
@@ -1712,17 +1725,17 @@ class EffectsEngine {
         const rt = effectNode.spectralRuntime;
         if (!rt) break;
         if (target.param === 'mix') { rt.dryGain.gain.value = 1 - value; rt.wetGain.gain.value = value; }
-        if (target.param === 'decay') { rt.processor.freezeDecay = value; rt.port?.postMessage({ type: 'param', decay: value }); }
-        if (target.param === 'brightness') { rt.processor.freezeBrightness = value; rt.port?.postMessage({ type: 'param', brightness: value }); }
+        if (target.param === 'decay') { rt.processor.freezeDecay = value; rt.port?.postMessage({ type: 'param', name: 'freezeDecay', value }); }
+        if (target.param === 'brightness') { rt.processor.freezeBrightness = value; rt.port?.postMessage({ type: 'param', name: 'freezeBrightness', value }); }
         break;
       }
       case 'spectralBlur': {
         const rt = effectNode.spectralRuntime;
         if (!rt) break;
         if (target.param === 'mix') { rt.dryGain.gain.value = 1 - value; rt.wetGain.gain.value = value; }
-        if (target.param === 'blurAmount') { rt.processor.blurAmount = value; rt.port?.postMessage({ type: 'param', blurAmount: value }); }
-        if (target.param === 'frequencySpread') { rt.processor.blurFrequencySpread = value; rt.port?.postMessage({ type: 'param', frequencySpread: value }); }
-        if (target.param === 'brightness') { rt.processor.blurBrightness = value; rt.port?.postMessage({ type: 'param', brightness: value }); }
+        if (target.param === 'blurAmount') { rt.processor.blurAmount = value; rt.port?.postMessage({ type: 'param', name: 'blurAmount', value }); }
+        if (target.param === 'frequencySpread') { rt.processor.blurFrequencySpread = value; rt.port?.postMessage({ type: 'param', name: 'blurFrequencySpread', value }); }
+        if (target.param === 'brightness') { rt.processor.blurBrightness = value; rt.port?.postMessage({ type: 'param', name: 'blurBrightness', value }); }
         break;
       }
       case 'spectralFilter': {

--- a/src/engine/EffectsEngine.ts
+++ b/src/engine/EffectsEngine.ts
@@ -67,6 +67,7 @@ type EffectNode = {
   spectralRuntime?: {
     processor: SpectralProcessor;
     workletNode: AudioWorkletNode | ScriptProcessorNode;
+    port: MessagePort | null;
     inputGain: IDSPGain;
     outputGain: IDSPGain;
     dryGain: IDSPGain;
@@ -1439,6 +1440,7 @@ class EffectsEngine {
         rt.processor.freezeBrightness = p.brightness;
         if (p.frozen) rt.processor.freeze();
         else rt.processor.unfreeze();
+        rt.port?.postMessage({ type: p.frozen ? 'freeze' : 'unfreeze', decay: p.decay, brightness: p.brightness });
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
         break;
@@ -1450,6 +1452,7 @@ class EffectsEngine {
         rt.processor.blurAmount = p.blurAmount;
         rt.processor.blurFrequencySpread = p.frequencySpread;
         rt.processor.blurBrightness = p.brightness;
+        rt.port?.postMessage({ type: 'param', blurAmount: p.blurAmount, frequencySpread: p.frequencySpread, brightness: p.brightness });
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
         break;
@@ -1461,6 +1464,7 @@ class EffectsEngine {
         const ctx = getDSPFactory().getContext();
         const curve = buildFilterCurve(p.points, rt.processor.fftSize >> 1, ctx.sampleRate, p.resolution);
         rt.processor.setFilterCurve(curve);
+        rt.port?.postMessage({ type: 'filterCurve', curve: Array.from(curve) });
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
         break;
@@ -1472,6 +1476,7 @@ class EffectsEngine {
         rt.processor.morphAmount = p.morphAmount;
         if (p.frozen) rt.processor.freeze();
         else rt.processor.unfreeze();
+        rt.port?.postMessage({ type: p.frozen ? 'freeze' : 'unfreeze', morphAmount: p.morphAmount });
         rt.dryGain.gain.value = 1 - p.mix;
         rt.wetGain.gain.value = p.mix;
         break;
@@ -1707,17 +1712,17 @@ class EffectsEngine {
         const rt = effectNode.spectralRuntime;
         if (!rt) break;
         if (target.param === 'mix') { rt.dryGain.gain.value = 1 - value; rt.wetGain.gain.value = value; }
-        if (target.param === 'decay') rt.processor.freezeDecay = value;
-        if (target.param === 'brightness') rt.processor.freezeBrightness = value;
+        if (target.param === 'decay') { rt.processor.freezeDecay = value; rt.port?.postMessage({ type: 'param', decay: value }); }
+        if (target.param === 'brightness') { rt.processor.freezeBrightness = value; rt.port?.postMessage({ type: 'param', brightness: value }); }
         break;
       }
       case 'spectralBlur': {
         const rt = effectNode.spectralRuntime;
         if (!rt) break;
         if (target.param === 'mix') { rt.dryGain.gain.value = 1 - value; rt.wetGain.gain.value = value; }
-        if (target.param === 'blurAmount') rt.processor.blurAmount = value;
-        if (target.param === 'frequencySpread') rt.processor.blurFrequencySpread = value;
-        if (target.param === 'brightness') rt.processor.blurBrightness = value;
+        if (target.param === 'blurAmount') { rt.processor.blurAmount = value; rt.port?.postMessage({ type: 'param', blurAmount: value }); }
+        if (target.param === 'frequencySpread') { rt.processor.blurFrequencySpread = value; rt.port?.postMessage({ type: 'param', frequencySpread: value }); }
+        if (target.param === 'brightness') { rt.processor.blurBrightness = value; rt.port?.postMessage({ type: 'param', brightness: value }); }
         break;
       }
       case 'spectralFilter': {

--- a/src/engine/dsp/NativeAdapter.ts
+++ b/src/engine/dsp/NativeAdapter.ts
@@ -332,7 +332,7 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
     this._preDelay = preDelayTime;
 
     // Attempt async upgrade to AudioWorklet
-    void this._upgradeToWorklet(ctx, scriptFallback, mix, preDelayNode, roomSize, options);
+    void this._upgradeToWorklet(ctx, scriptFallback, mix, preDelayNode);
   }
 
   private async _upgradeToWorklet(
@@ -340,27 +340,27 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
     scriptNode: ScriptProcessorNode,
     mix: DryWetMix,
     preDelayNode: DelayNode,
-    roomSize: number,
-    options?: IDSPReverbOptions,
   ): Promise<void> {
     try {
+      // Derive roomSize from current _decay (may have changed since constructor)
+      const currentRoomSize = Math.min(1, this._decay / 10);
       const result = await createDspNode(
         ctx,
         '/reverb-worklet-processor.js',
         'reverb-worklet-processor',
         2,
-        { roomSize, damping: 0.5, wet: 1, dry: 0 },
-        BUFFER_SIZE,
-        scriptNode.onaudioprocess!,
+        { roomSize: currentRoomSize, damping: 0.5, wet: 1, dry: 0 },
       );
 
-      if (result.isWorklet) {
+      if (result) {
         // Swap: disconnect ScriptProcessor, connect AudioWorklet
         preDelayNode.disconnect(scriptNode);
         scriptNode.disconnect();
         preDelayNode.connect(result.node);
         result.node.connect(mix.wetInput);
         this._dspNode = result;
+        // Send current params to worklet in case decay changed during load
+        result.port?.postMessage({ type: 'roomSize', value: currentRoomSize });
       }
     } catch {
       // Keep ScriptProcessorNode fallback — already connected

--- a/src/engine/dsp/NativeAdapter.ts
+++ b/src/engine/dsp/NativeAdapter.ts
@@ -359,8 +359,9 @@ class NativeReverb extends NativeNodeWrapper implements IDSPReverb {
         preDelayNode.connect(result.node);
         result.node.connect(mix.wetInput);
         this._dspNode = result;
-        // Send current params to worklet in case decay changed during load
-        result.port?.postMessage({ type: 'roomSize', value: currentRoomSize });
+        // Recompute from latest _decay (may have changed during async load)
+        const latestRoomSize = Math.min(1, this._decay / 10);
+        result.port?.postMessage({ type: 'roomSize', value: latestRoomSize });
       }
     } catch {
       // Keep ScriptProcessorNode fallback — already connected

--- a/src/engine/dsp/__tests__/NativeSynths.test.ts
+++ b/src/engine/dsp/__tests__/NativeSynths.test.ts
@@ -325,14 +325,6 @@ describe('parseDuration', () => {
     expect(parseDuration('4n', 180)).toBeCloseTo(1 / 3);
   });
 
-  it('requires explicit BPM — no silent 120 BPM default', () => {
-    // parseDuration(dur, bpm) now requires BPM to prevent silent defaults.
-    // TypeScript enforces this at compile time. At runtime, omitting BPM
-    // produces NaN for notation strings (60 / undefined).
-    const result = parseDuration('4n', undefined as unknown as number);
-    expect(result).toBeNaN();
-  });
-
   it('returns fallback for unparseable strings', () => {
     expect(parseDuration('invalid', 120)).toBe(0.25);
   });

--- a/src/engine/dsp/workletLoader.ts
+++ b/src/engine/dsp/workletLoader.ts
@@ -10,18 +10,22 @@ import { createDebugLogger } from '../../utils/debugLogger';
 
 const log = createDebugLogger('dsp:worklet-loader');
 
-const registeredWorklets = new Set<string>();
+const registeredWorklets = new WeakMap<AudioContext, Set<string>>();
 
 /**
  * Ensure a worklet module is registered on the given AudioContext.
  * No-ops if already registered for this context + URL combination.
  */
 async function ensureWorkletRegistered(ctx: AudioContext, url: string): Promise<boolean> {
-  const key = `${ctx.sampleRate}:${url}`;
-  if (registeredWorklets.has(key)) return true;
+  let contextSet = registeredWorklets.get(ctx);
+  if (contextSet?.has(url)) return true;
   try {
     await ctx.audioWorklet.addModule(url);
-    registeredWorklets.add(key);
+    if (!contextSet) {
+      contextSet = new Set();
+      registeredWorklets.set(ctx, contextSet);
+    }
+    contextSet.add(url);
     return true;
   } catch (err) {
     log.warn(`Failed to register worklet ${url}:`, err);
@@ -39,15 +43,14 @@ export interface DspNodeResult {
 }
 
 /**
- * Create a DSP processing node, preferring AudioWorklet with ScriptProcessor fallback.
+ * Try to create an AudioWorkletNode. Returns null if AudioWorklet is
+ * unavailable so callers can keep their existing ScriptProcessorNode.
  *
  * @param ctx - AudioContext
  * @param workletUrl - URL of the worklet processor file (e.g., '/reverb-worklet-processor.js')
  * @param processorName - Name registered via registerProcessor() in the worklet file
  * @param channels - Number of input/output channels
  * @param processorOptions - Options passed to the AudioWorkletProcessor constructor
- * @param fallbackBufferSize - Buffer size for ScriptProcessorNode fallback
- * @param fallbackProcess - Processing callback for ScriptProcessorNode fallback
  */
 export async function createDspNode(
   ctx: AudioContext,
@@ -55,9 +58,7 @@ export async function createDspNode(
   processorName: string,
   channels: number,
   processorOptions: Record<string, unknown>,
-  fallbackBufferSize: number,
-  fallbackProcess: (e: AudioProcessingEvent) => void,
-): Promise<DspNodeResult> {
+): Promise<DspNodeResult | null> {
   // Try AudioWorklet first
   if (typeof AudioWorkletNode !== 'undefined' && ctx.audioWorklet) {
     const registered = await ensureWorkletRegistered(ctx, workletUrl);
@@ -67,6 +68,8 @@ export async function createDspNode(
           numberOfInputs: 1,
           numberOfOutputs: 1,
           channelCount: channels,
+          outputChannelCount: [channels],
+          channelCountMode: 'explicit',
           processorOptions: { sampleRate: ctx.sampleRate, ...processorOptions },
         });
         log.info(`Created AudioWorkletNode: ${processorName}`);
@@ -77,9 +80,7 @@ export async function createDspNode(
     }
   }
 
-  // Fallback to ScriptProcessorNode
-  log.info(`Using ScriptProcessorNode fallback for ${processorName}`);
-  const scriptNode = ctx.createScriptProcessor(fallbackBufferSize, channels, channels);
-  scriptNode.onaudioprocess = fallbackProcess;
-  return { node: scriptNode, port: null, isWorklet: false };
+  // AudioWorklet unavailable — return null so callers can keep their existing fallback
+  log.info(`AudioWorklet unavailable for ${processorName}, caller should use existing fallback`);
+  return null;
 }

--- a/src/engine/dsp/workletLoader.ts
+++ b/src/engine/dsp/workletLoader.ts
@@ -34,12 +34,10 @@ async function ensureWorkletRegistered(ctx: AudioContext, url: string): Promise<
 }
 
 export interface DspNodeResult {
-  /** The audio node (AudioWorkletNode or ScriptProcessorNode). */
-  node: AudioWorkletNode | ScriptProcessorNode;
-  /** MessagePort for sending parameter updates (null for ScriptProcessor fallback). */
-  port: MessagePort | null;
-  /** Whether this is using the modern AudioWorklet path. */
-  isWorklet: boolean;
+  /** The AudioWorkletNode (createDspNode returns null if worklet unavailable). */
+  node: AudioWorkletNode;
+  /** MessagePort for sending parameter updates to the worklet processor. */
+  port: MessagePort;
 }
 
 /**
@@ -73,9 +71,9 @@ export async function createDspNode(
           processorOptions: { sampleRate: ctx.sampleRate, ...processorOptions },
         });
         log.info(`Created AudioWorkletNode: ${processorName}`);
-        return { node, port: node.port, isWorklet: true };
+        return { node, port: node.port };
       } catch (err) {
-        log.warn(`AudioWorkletNode creation failed for ${processorName}, falling back:`, err);
+        log.warn(`AudioWorkletNode creation failed for ${processorName}, caller will use existing fallback:`, err);
       }
     }
   }

--- a/src/engine/dsp/workletLoader.ts
+++ b/src/engine/dsp/workletLoader.ts
@@ -1,9 +1,11 @@
 /**
- * AudioWorklet loader with ScriptProcessorNode fallback.
+ * AudioWorklet loader — worklet-only creation.
  *
- * Tries to register and create an AudioWorkletNode. If AudioWorklet is
- * unavailable (older Safari, insecure context) or fails to load, falls
- * back to the deprecated ScriptProcessorNode.
+ * Tries to register and create an AudioWorkletNode. Returns null if
+ * AudioWorklet is unavailable (older Safari, insecure context), module
+ * registration fails, or AudioWorkletNode construction throws.
+ * Callers are responsible for keeping their own ScriptProcessorNode
+ * fallback already wired into the audio graph.
  */
 
 import { createDebugLogger } from '../../utils/debugLogger';


### PR DESCRIPTION
## Summary

Addresses 8 Copilot review findings from the AudioWorklet migration in PR #1640, plus 4 additional review improvements from the first round.

Closes #1645

### Fixes

1. **Per-context worklet registration cache** — `WeakMap<AudioContext, Set<string>>` instead of global `Set` keyed by sampleRate
2. **outputChannelCount** — Prevents stereo-to-mono collapse in multi-channel AudioWorkletNodes
3. **createDspNode API** — Returns `null` instead of allocating unused ScriptProcessorNode; callers keep existing fallback
4. **Spectral blur mode bug** — Was mapping `spectralBlur` to `'filter'` instead of `'blur'`. Now uses lookup table.
5. **Worklet port stored + forwarding** — `spectralRuntime.port` stored and used to forward param updates (freeze/blur/filter/morph) through worklet port
6. **workletNode reference updated** — `spectralRuntime.workletNode` correctly updated after hot-swap
7. **Stale roomSize** — NativeAdapter recomputes roomSize from latest `_decay` after async worklet load
8. **Remove NaN assertion** — Test coupled to `undefined` division behavior
9. **DspNodeResult interface** — Simplified to worklet-only contract (non-null port, no isWorklet)
10. **Automation port forwarding** — Spectral automation values also forwarded through port
11. **Log message accuracy** — Updated misleading "falling back" message
12. **EffectNode type** — Added `port` to `spectralRuntime` type definition

## Test plan

- [x] `npx tsc --noEmit` — 0 type errors
- [x] 753 engine tests pass (0 regressions)
- [x] `npx vite build` — succeeds
- [x] Rebased cleanly on latest main

https://claude.ai/code/session_01W16oPoY56dVqWadTDeL4iR