### PR TITLE
fix: waveform repeats beyond audio duration when clip is extended (#1665)

### DIFF
--- a/src/components/timeline/CanvasClipWaveform.tsx
+++ b/src/components/timeline/CanvasClipWaveform.tsx
@@ -195,17 +195,19 @@ function WaveformCanvas({
     ctx.scale(dpr, dpr);
 
     // Try synchronous mipmap query first (Rust WASM)
-    // Use pixel-proportional column count — matches visible resolution,
-    // capped at 4096 for deep zoom to avoid excessive queries.
+    // Use audioDuration (not clipDuration) for sample range so waveform
+    // doesn't repeat/extend beyond the actual audio content.
     if (mipmapReady && audioKey) {
       const sampleRate = audioBufferCache.get(audioKey)?.sampleRate ?? 44100;
+      const actualDur = Math.min(audioDuration, clipDuration);
       const startSample = Math.round(audioOffset * sampleRate);
-      const endSample = Math.round((audioOffset + clipDuration) * sampleRate);
-      const columns = Math.min(4096, Math.max(1, Math.round(width)));
+      const endSample = Math.round((audioOffset + actualDur) * sampleRate);
+      const audioWidthPx = clipDuration > 0 ? width * (actualDur / clipDuration) : width;
+      const columns = Math.min(4096, Math.max(1, Math.round(audioWidthPx)));
       const peakData = queryPeaksSync(audioKey, startSample, endSample, columns);
       if (peakData && peakData.length > 0) {
         drawMipmapWaveform(ctx, {
-          peakData, leftPx: 0, width, height: h, color, opacity: 1, trackVolume,
+          peakData, leftPx: 0, width: audioWidthPx, height: h, color, opacity: 1, trackVolume,
         });
         return;
       }
@@ -257,14 +259,17 @@ function ChunkedWaveform({
   const totalChunks = Math.ceil(totalWidth / CHUNK_CSS_WIDTH);
 
   // Query mipmap with pixel-proportional column count, capped at 4096.
-  const mipmapColumns = Math.min(4096, Math.max(1, Math.round(totalWidth)));
+  // Use audioDuration (not clipDuration) so waveform doesn't repeat beyond audio.
+  const actualDur = Math.min(audioDuration, clipDuration);
+  const audioWidthPx = clipDuration > 0 ? totalWidth * (actualDur / clipDuration) : totalWidth;
+  const mipmapColumns = Math.min(4096, Math.max(1, Math.round(audioWidthPx)));
   const fullMipmapData = useMemo(() => {
     if (!mipmapReady || !audioKey) return null;
     const sampleRate = audioBufferCache.get(audioKey)?.sampleRate ?? 44100;
     const startSample = Math.round(audioOffset * sampleRate);
-    const endSample = Math.round((audioOffset + clipDuration) * sampleRate);
+    const endSample = Math.round((audioOffset + actualDur) * sampleRate);
     return queryPeaksSync(audioKey, startSample, endSample, mipmapColumns);
-  }, [mipmapReady, audioKey, audioOffset, clipDuration, mipmapColumns]);
+  }, [mipmapReady, audioKey, audioOffset, actualDur, mipmapColumns]);
 
   const chunks = useMemo(() => {
     const result: Array<{ idx: number; left: number; w: number }> = [];


### PR DESCRIPTION
## Summary

When extending a clip beyond its audio duration, the waveform visual repeated/looped instead of showing empty space. Playback correctly produced silence but the visual was misleading.

**Root cause**: Mipmap query used `clipDuration` (visual) instead of `audioDuration` (actual audio) for `endSample`, causing the WASM to read beyond audio boundaries.

**Fix**: Use `Math.min(audioDuration, clipDuration)` for sample range, proportionally reduce drawing width so extended region is visually empty.

Closes #1665

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [ ] Extend a clip right edge past audio duration → extended area shows no waveform
- [ ] Waveform renders correctly within actual audio bounds
- [ ] Shrink clip back → waveform updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)