### PR TITLE
fix: Session View infinite re-render + focus ring cleanup

### DIFF
--- a/src/components/session/SessionView.tsx
+++ b/src/components/session/SessionView.tsx
@@ -108,6 +108,8 @@ const CLIP_FOLLOW_ACTION_OPTIONS: { value: FollowActionType; label: string }[] =
 ];
 
 
+const EMPTY_STRING_ARRAY: string[] = [];
+
 export function SessionView() {
   const project = useProjectStore((s) => s.project);
   const setSessionLaunchQuantization = useProjectStore((s) => s.setSessionLaunchQuantization);
@@ -157,7 +159,7 @@ export function SessionView() {
   const [midiEnabled, setMidiEnabled] = useState(false);
   const midiState = useSessionMidiController(midiEnabled);
   const { startSlotRecording, stopSlotRecording, countInEnabled, setCountInEnabled, countInRemaining } = useSessionRecording();
-  const recordingSlotIds = useProjectStore((s) => s.project?.session?.recordingSlotIds ?? []);
+  const recordingSlotIds = useProjectStore((s) => s.project?.session?.recordingSlotIds ?? EMPTY_STRING_ARRAY);
   const fixedLengthBars = useProjectStore((s) => s.project?.session?.fixedLengthBars ?? null);
   const setSessionFixedLengthBars = useProjectStore((s) => s.setSessionFixedLengthBars);
   const toggleArmTrack = useTransportStore((s) => s.toggleArmTrack);

--- a/src/components/tracks/TrackHeader.tsx
+++ b/src/components/tracks/TrackHeader.tsx
@@ -519,7 +519,7 @@ export const TrackHeader = React.memo(function TrackHeader({
             >
               <button
                 onClick={() => track.isGroup ? setGroupMuted(track.id, !track.muted) : updateTrack(track.id, { muted: !track.muted })}
-                className={`w-[18px] h-[18px] rounded-full text-[9px] font-bold leading-none flex items-center justify-center transition-colors duration-150 focus:outline-none ${
+                className={`w-[18px] h-[18px] rounded-full text-[9px] font-bold leading-none flex items-center justify-center transition-colors duration-150 focus:outline-none focus-visible:outline-none focus-visible:ring-0 ${
                   track.muted ? 'text-red-400' : 'text-zinc-500 hover:text-zinc-200'
                 }`}
                 title="Mute (M)"
@@ -527,7 +527,7 @@ export const TrackHeader = React.memo(function TrackHeader({
               >M</button>
               <button
                 onClick={() => track.isGroup ? setGroupSoloed(track.id, !track.soloed) : updateTrack(track.id, { soloed: !track.soloed })}
-                className={`w-[18px] h-[18px] rounded-full text-[9px] font-bold leading-none flex items-center justify-center transition-colors duration-150 focus:outline-none ${
+                className={`w-[18px] h-[18px] rounded-full text-[9px] font-bold leading-none flex items-center justify-center transition-colors duration-150 focus:outline-none focus-visible:outline-none focus-visible:ring-0 ${
                   track.soloed ? 'text-amber-400' : 'text-zinc-500 hover:text-zinc-200'
                 }`}
                 title="Solo (S)"
@@ -536,7 +536,7 @@ export const TrackHeader = React.memo(function TrackHeader({
               {!track.isGroup && (
                 <button
                   onClick={() => setOpenEffectChainTrackId(isFxPanelOpen ? null : track.id)}
-                  className={`w-[18px] h-[18px] rounded-full text-[9px] font-bold leading-none flex items-center justify-center transition-colors duration-150 focus:outline-none ${
+                  className={`w-[18px] h-[18px] rounded-full text-[9px] font-bold leading-none flex items-center justify-center transition-colors duration-150 focus:outline-none focus-visible:outline-none focus-visible:ring-0 ${
                     track.frozen
                       ? 'text-zinc-600 cursor-not-allowed'
                       : isFxPanelOpen
@@ -615,7 +615,7 @@ export const TrackHeader = React.memo(function TrackHeader({
           <div className="flex items-center gap-1 flex-shrink-0">
             <button
               onClick={() => track.isGroup ? setGroupMuted(track.id, !track.muted) : updateTrack(track.id, { muted: !track.muted })}
-              className={`text-[8px] font-bold leading-none transition-colors duration-150 focus:outline-none ${
+              className={`text-[8px] font-bold leading-none transition-colors duration-150 focus:outline-none focus-visible:outline-none focus-visible:ring-0 ${
                 track.muted ? 'text-red-400' : 'text-zinc-500 hover:text-zinc-200'
               }`}
               title="Mute (M)"
@@ -623,7 +623,7 @@ export const TrackHeader = React.memo(function TrackHeader({
             >M</button>
             <button
               onClick={() => track.isGroup ? setGroupSoloed(track.id, !track.soloed) : updateTrack(track.id, { soloed: !track.soloed })}
-              className={`text-[8px] font-bold leading-none transition-colors duration-150 focus:outline-none ${
+              className={`text-[8px] font-bold leading-none transition-colors duration-150 focus:outline-none focus-visible:outline-none focus-visible:ring-0 ${
                 track.soloed ? 'text-amber-400' : 'text-zinc-500 hover:text-zinc-200'
               }`}
               title="Solo (S)"


### PR DESCRIPTION
## Summary

- **Session View crash**: `recordingSlotIds` Zustand selector used `?? []` which created a new array reference every call → infinite re-render loop. Fixed with stable `EMPTY_STRING_ARRAY` constant.
- **Focus ring**: Added `focus-visible:outline-none focus-visible:ring-0` to M/S/FX buttons to fully suppress browser focus indicators.

Closes #1673

## Test plan

- [ ] Switch to Session View — no crash
- [ ] Click M/S/FX buttons — no blue focus ring
- [ ] Session View functional: launch clips, scenes work

🤖 Generated with [Claude Code](https://claude.com/claude-code)