### PR TITLE
feat: OpenSpec → GitHub Issues spec-driven pipeline

### DIFF
--- a/.claude/agents/do-todo.md
+++ b/.claude/agents/do-todo.md
@@ -32,15 +32,17 @@ You are a TDD-driven developer agent. Your job is to pick up ONE task and comple
    - If branch doesn't exist, create it from main
 3. **Check for spec context** (spec-aware TDD):
    - Check if the issue has a `spec:` label: `gh issue view NUMBER --json labels`
-   - If `spec:` label present, read the issue body for Given/When/Then scenarios
-   - Use those scenarios directly as your test cases in the Red phase
-   - Each `Given/When/Then` becomes one test assertion
-   - MUST/SHALL keywords in specs are mandatory — every MUST becomes a test
+   - If a `spec:<change-name>` label is present, read the actual spec files:
+     - First check `openspec/changes/<change-name>/specs/` (active change)
+     - Fallback: `openspec/specs/` (archived specs)
+     - Use the issue body as supplementary context only (it may drift from source)
+   - Each Given/When/Then scenario becomes at least one test case
+   - MUST/SHALL keywords are mandatory — every MUST must be asserted in the test suite
 4. **Understand** the task — read relevant source files
 5. **Write a failing test first** (Red phase):
    - For store/utility tasks: create a Vitest test in `src/**/__tests__/`
    - For UI/workflow tasks: create a Playwright test in `tests/e2e/`
-   - If spec scenarios exist: each Given/When/Then becomes a test case
+   - If spec scenarios exist: each Given/When/Then scenario becomes a test case
 6. **Run the test** to confirm it fails: `npm test` or `npx playwright test`
 7. **Implement** the minimum code to make the test pass (Green phase)
 8. **Run all tests** to ensure nothing else broke: `npm test`

--- a/.claude/agents/do-todo.md
+++ b/.claude/agents/do-todo.md
@@ -30,22 +30,29 @@ You are a TDD-driven developer agent. Your job is to pick up ONE task and comple
 2. **Ensure you're on the correct branch**:
    - If working on a GitHub Issue: branch should be `feat/issue-NUMBER` or `fix/issue-NUMBER`
    - If branch doesn't exist, create it from main
-3. **Understand** the task — read relevant source files
-4. **Write a failing test first** (Red phase):
+3. **Check for spec context** (spec-aware TDD):
+   - Check if the issue has a `spec:` label: `gh issue view NUMBER --json labels`
+   - If `spec:` label present, read the issue body for Given/When/Then scenarios
+   - Use those scenarios directly as your test cases in the Red phase
+   - Each `Given/When/Then` becomes one test assertion
+   - MUST/SHALL keywords in specs are mandatory — every MUST becomes a test
+4. **Understand** the task — read relevant source files
+5. **Write a failing test first** (Red phase):
    - For store/utility tasks: create a Vitest test in `src/**/__tests__/`
    - For UI/workflow tasks: create a Playwright test in `tests/e2e/`
-5. **Run the test** to confirm it fails: `npm test` or `npx playwright test`
-6. **Implement** the minimum code to make the test pass (Green phase)
-7. **Run all tests** to ensure nothing else broke: `npm test`
-8. **Refactor** if needed while keeping tests green
-9. **Run quality gates**:
-   - `npx tsc --noEmit` — must be 0 errors
-   - `npm test` — all pass
-   - `npm run build` — succeeds
-10. **Mark progress**:
+   - If spec scenarios exist: each Given/When/Then becomes a test case
+6. **Run the test** to confirm it fails: `npm test` or `npx playwright test`
+7. **Implement** the minimum code to make the test pass (Green phase)
+8. **Run all tests** to ensure nothing else broke: `npm test`
+9. **Refactor** if needed while keeping tests green
+10. **Run quality gates**:
+    - `npx tsc --noEmit` — must be 0 errors
+    - `npm test` — all pass
+    - `npm run build` — succeeds
+11. **Mark progress**:
     - If from `.llm/todo.md`: change `- [ ]` to `- [x]`
     - If from GitHub Issue: note the issue number in your commit
-11. **Commit** with a conventional commit message:
+12. **Commit** with a conventional commit message:
     ```
     git add -A
     # Use an appropriate conventional commit type: feat, fix, refactor, test, docs, etc.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -22,22 +22,25 @@ You are a QA agent. Your job is to run the full test suite, analyze results, and
    npm test 2>&1
    npm run build 2>&1
    ```
-2. **Spec validation** (if spec-labeled issues exist):
-   - Find issues with `spec:` labels: `gh issue list --repo ace-step/ACE-Step-DAW --label "spec:" --state closed --json number,body`
-   - For each closed spec issue, extract MUST/SHALL requirements from the issue body
-   - Verify each MUST has a corresponding test (search test files for the requirement)
+2. **Spec validation** (if given a change name or spec-labeled issues exist):
+   - If a change name is provided: read specs from `openspec/changes/<name>/specs/` or `openspec/specs/`
+   - Otherwise: find active spec labels via `gh issue list --repo ace-step/ACE-Step-DAW --json labels --jq '[.[].labels[].name | select(startswith("spec:"))] | unique'`
+   - For each spec change, read the actual spec files (source of truth, not issue bodies)
+   - Extract MUST/SHALL requirements from spec files
+   - Search test files for corresponding test cases covering those requirements
    - Report any uncovered MUST/SHALL as a spec gap
+   - Scope: only validate specs relevant to the current task/PR, not entire repo history
 3. **Analyze results**:
    - Collect all errors, warnings, and test failures
    - For each failure, identify the root cause (read the failing test + source)
    - Categorize: type error | test failure | build error | runtime error | spec gap
-3. **Create fix tasks** — file as GitHub Issues with label `bug` and `priority: P1` if tools are available.
+4. **Create fix tasks** — file as GitHub Issues with label `bug` and `priority: P1` if tools are available.
    Fallback: append to `.llm/todo.md` under appropriate priority:
    - Type errors -> Priority 1 (blocks everything)
    - Test failures -> Priority 1
    - Build errors -> Priority 1
    - Code quality issues -> Priority 3
-4. **Generate report** to `.llm/reports/test-report-<date>.md`:
+5. **Generate report** to `.llm/reports/test-report-<date>.md`:
    ```markdown
    ## Test Report — <date>
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -22,10 +22,15 @@ You are a QA agent. Your job is to run the full test suite, analyze results, and
    npm test 2>&1
    npm run build 2>&1
    ```
-2. **Analyze results**:
+2. **Spec validation** (if spec-labeled issues exist):
+   - Find issues with `spec:` labels: `gh issue list --repo ace-step/ACE-Step-DAW --label "spec:" --state closed --json number,body`
+   - For each closed spec issue, extract MUST/SHALL requirements from the issue body
+   - Verify each MUST has a corresponding test (search test files for the requirement)
+   - Report any uncovered MUST/SHALL as a spec gap
+3. **Analyze results**:
    - Collect all errors, warnings, and test failures
    - For each failure, identify the root cause (read the failing test + source)
-   - Categorize: type error | test failure | build error | runtime error
+   - Categorize: type error | test failure | build error | runtime error | spec gap
 3. **Create fix tasks** — file as GitHub Issues with label `bug` and `priority: P1` if tools are available.
    Fallback: append to `.llm/todo.md` under appropriate priority:
    - Type errors -> Priority 1 (blocks everything)
@@ -43,6 +48,10 @@ You are a QA agent. Your job is to run the full test suite, analyze results, and
    ### Failures
    | Test | Error | Root Cause | Fix Task |
    |------|-------|------------|----------|
+
+   ### Spec Coverage (if applicable)
+   | Spec Change | MUST/SHALL | Covered | Gap |
+   |-------------|-----------|---------|-----|
 
    ### Coverage Summary
    - Statements: X%

--- a/.claude/commands/spec-cycle.md
+++ b/.claude/commands/spec-cycle.md
@@ -35,7 +35,7 @@ Full spec-driven development cycle: from idea to merged code via formal specs.
 
    Show: how many issues were created, their numbers.
 
-3. **Phase 2 — Dispatch (automatic)**
+3. **Phase 2 — Dispatch + Review (automatic with gates)**
 
    Issues are automatically picked up by `pm-auto.sh` → `sprint-runner.sh`.
    Monitor progress at: http://127.0.0.1:5175 (Agent Dashboard).
@@ -45,15 +45,24 @@ Full spec-driven development cycle: from idea to merged code via formal specs.
    npm run dashboard  # Start if not already running
    ```
 
-4. **Phase 3 — Verify**
+   **Review gate** (per AGENTS.md Step 5): Each PR must pass before merge:
+   - CI passes (type check + tests + build)
+   - GitHub Copilot automatic review: check via `gh pr view <num> --json reviews`
+   - Codex independent review: run `/codex review`, post findings as PR comment
+   - Both reviewers' feedback must be addressed before merge
 
-   After all issues are closed and PRs merged, verify the spec:
-   ```bash
-   openspec status --change "<name>"
-   ```
+4. **Phase 3 — Verify (spec coverage)**
 
-   Check that all MUST/SHALL requirements from specs are covered.
-   If any are missing, create additional issues.
+   After all issues are closed and PRs merged, verify spec coverage:
+
+   Run `@tester` with the change name to check MUST/SHALL coverage:
+   - Read the actual spec files from `openspec/changes/<name>/specs/`
+   - Extract all MUST/SHALL requirements
+   - Search test files for corresponding test cases
+   - Report any uncovered requirements as spec gaps
+
+   If any MUST/SHALL requirements are uncovered, create additional issues.
+   Only proceed to Phase 4 when all requirements have passing tests.
 
 5. **Phase 4 — Archive**
 

--- a/.claude/commands/spec-cycle.md
+++ b/.claude/commands/spec-cycle.md
@@ -1,0 +1,83 @@
+---
+name: "Spec Cycle"
+description: Full spec-driven development cycle — propose → decompose → dispatch → verify → archive
+category: Workflow
+tags: [workflow, openspec, pipeline]
+---
+
+Full spec-driven development cycle: from idea to merged code via formal specs.
+
+**Input**: A feature name or description (e.g., `/spec-cycle add-mixer-eq-band`).
+
+**Steps**
+
+1. **Phase 0 — Propose (spec)**
+
+   Run `/opsx:propose "<name>"` to create the formal specification:
+   - `proposal.md` — what and why
+   - `specs/` — Given/When/Then behavior contracts
+   - `design.md` — technical approach
+   - `tasks.md` — implementation steps
+
+   Wait for all artifacts to be complete before proceeding.
+
+2. **Phase 1 — Decompose (spec → issues)**
+
+   Run the decomposition script:
+   ```bash
+   bash scripts/agents/spec-to-issues.sh "<name>"
+   ```
+
+   This creates one GitHub Issue per task from `tasks.md`, with:
+   - Given/When/Then scenarios from specs in the issue body
+   - Label `spec:<name>` for tracking
+   - Standard acceptance criteria
+
+   Show: how many issues were created, their numbers.
+
+3. **Phase 2 — Dispatch (automatic)**
+
+   Issues are automatically picked up by `pm-auto.sh` → `sprint-runner.sh`.
+   Monitor progress at: http://127.0.0.1:5175 (Agent Dashboard).
+
+   Show the user the dashboard URL and suggest:
+   ```
+   npm run dashboard  # Start if not already running
+   ```
+
+4. **Phase 3 — Verify**
+
+   After all issues are closed and PRs merged, verify the spec:
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+   Check that all MUST/SHALL requirements from specs are covered.
+   If any are missing, create additional issues.
+
+5. **Phase 4 — Archive**
+
+   Run `/opsx:archive "<name>"` to:
+   - Sync specs to `openspec/specs/` (tracked in git)
+   - Archive the change
+
+**Output**
+
+Show a progress summary at each phase transition:
+```
+## Spec Cycle: <name>
+
+Phase 0 (Propose):  ✓ 4 artifacts created
+Phase 1 (Decompose): ✓ 6 issues created (#A, #B, #C, #D, #E, #F)
+Phase 2 (Dispatch):  In progress — 3/6 complete
+Phase 3 (Verify):    Pending
+Phase 4 (Archive):   Pending
+```
+
+**Guardrails**
+- Phase 0 is interactive — wait for user to review and approve specs
+- Phase 1 is automatic — creates issues immediately
+- Phase 2 is hands-off — agents work autonomously
+- Phase 3 requires human judgment — verify spec coverage
+- Phase 4 is the final step — only after all work is verified
+- If any phase fails, stop and report — don't continue blindly

--- a/scripts/agents/spec-to-issues.sh
+++ b/scripts/agents/spec-to-issues.sh
@@ -2,7 +2,7 @@
 # spec-to-issues.sh — Parse OpenSpec tasks.md → GitHub Issues
 # Usage: bash scripts/agents/spec-to-issues.sh <change-name>
 # Creates one GitHub Issue per task, with Given/When/Then from specs/ in the body
-set -e
+set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 REPO="ace-step/ACE-Step-DAW"
@@ -22,16 +22,20 @@ TASKS_FILE="$CHANGE_DIR/tasks.md"
 
 info "Decomposing spec '$CHANGE_NAME' into GitHub Issues"
 
+# ── Create spec label if it doesn't exist (before issue loop) ──
+gh label create "spec:$CHANGE_NAME" --repo "$REPO" \
+  --description "OpenSpec change: $CHANGE_NAME" \
+  --color "D4C5F9" 2>/dev/null || true
+
 # ── Read specs (if available) ──
 SPEC_CONTEXT=""
 if [ -d "$CHANGE_DIR/specs" ]; then
-  for spec_file in "$CHANGE_DIR/specs"/*.md "$CHANGE_DIR/specs"/**/*.md; do
-    [ -f "$spec_file" ] || continue
+  while IFS= read -r spec_file; do
     SPEC_CONTEXT="$SPEC_CONTEXT
 ---
 $(cat "$spec_file")
 "
-  done
+  done < <(find "$CHANGE_DIR/specs" -name '*.md' -type f)
 fi
 
 # ── Read proposal summary ──
@@ -47,14 +51,14 @@ CREATED_COUNT=0
 
 while IFS= read -r line; do
   # Match markdown task items: - [ ] Task description
-  if echo "$line" | grep -qE '^\s*-\s*\[\s*\]\s+'; then
-    TASK_DESC=$(echo "$line" | sed 's/^\s*-\s*\[\s*\]\s*//')
+  if echo "$line" | grep -qE '^[[:space:]]*-[[:space:]]*\[[[:space:]]*\][[:space:]]+'; then
+    TASK_DESC=$(echo "$line" | sed -E 's/^[[:space:]]*-[[:space:]]*\[[[:space:]]*\][[:space:]]*//')
     [ -z "$TASK_DESC" ] && continue
     TASK_COUNT=$((TASK_COUNT + 1))
 
     # Check for duplicate (issue with same title already exists)
     EXISTING=$(gh issue list --repo "$REPO" --state open --search "$TASK_DESC" --json number,title \
-      --jq ".[] | select(.title == \"$TASK_DESC\") | .number" 2>/dev/null | head -1)
+      --jq --arg title "$TASK_DESC" '.[] | select(.title == $title) | .number' 2>/dev/null | head -1)
     if [ -n "$EXISTING" ]; then
       warn "Skip duplicate: #$EXISTING — $TASK_DESC"
       continue
@@ -96,30 +100,24 @@ $SPEC_CONTEXT
 - [ ] \`npm run build\` succeeds
 "
 
-    # Create issue
-    ISSUE_NUM=$(gh issue create --repo "$REPO" \
+    # Create issue (wrapped in if-block for graceful failure)
+    if ISSUE_URL=$(gh issue create --repo "$REPO" \
       --title "$TASK_DESC" \
       --body "$ISSUE_BODY" \
       --label "enhancement" \
-      --label "spec:$CHANGE_NAME" \
-      2>/dev/null | grep -oE '[0-9]+$')
-
-    if [ -n "$ISSUE_NUM" ]; then
+      --label "spec:$CHANGE_NAME" 2>&1); then
+      ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
       ok "Created #$ISSUE_NUM — $TASK_DESC"
       CREATED_COUNT=$((CREATED_COUNT + 1))
     else
       warn "Failed to create issue for: $TASK_DESC"
+      warn "  Error: $ISSUE_URL"
     fi
 
     # Rate limit: avoid GitHub API throttling
     sleep 1
   fi
 done < "$TASKS_FILE"
-
-# ── Create spec label if it doesn't exist ──
-gh label create "spec:$CHANGE_NAME" --repo "$REPO" \
-  --description "OpenSpec change: $CHANGE_NAME" \
-  --color "D4C5F9" 2>/dev/null || true
 
 # ── Summary ──
 echo ""
@@ -134,6 +132,6 @@ echo ""
 echo "  Next steps:"
 echo "    - pm-auto.sh will dispatch agents automatically"
 echo "    - Monitor at: http://127.0.0.1:5175 (Agent Dashboard)"
-echo "    - Verify: /opsx:verify"
+echo "    - Verify: @tester"
 echo "    - Archive: /opsx:archive $CHANGE_NAME"
 echo "════════════════════════════════════════"

--- a/scripts/agents/spec-to-issues.sh
+++ b/scripts/agents/spec-to-issues.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# spec-to-issues.sh — Parse OpenSpec tasks.md → GitHub Issues
+# Usage: bash scripts/agents/spec-to-issues.sh <change-name>
+# Creates one GitHub Issue per task, with Given/When/Then from specs/ in the body
+set -e
+cd "$(dirname "$0")/../.."
+
+REPO="ace-step/ACE-Step-DAW"
+
+info()  { printf "\033[1;36m==> %s\033[0m\n" "$*"; }
+ok()    { printf "\033[1;32m✓ %s\033[0m\n" "$*"; }
+warn()  { printf "\033[1;33m⚠ %s\033[0m\n" "$*"; }
+fail()  { printf "\033[1;31m✗ %s\033[0m\n" "$*" >&2; exit 1; }
+
+# ── Args ──
+CHANGE_NAME="${1:?Usage: spec-to-issues.sh <change-name>}"
+CHANGE_DIR="openspec/changes/$CHANGE_NAME"
+TASKS_FILE="$CHANGE_DIR/tasks.md"
+
+[ -d "$CHANGE_DIR" ] || fail "Change not found: $CHANGE_DIR"
+[ -f "$TASKS_FILE" ] || fail "Tasks file not found: $TASKS_FILE"
+
+info "Decomposing spec '$CHANGE_NAME' into GitHub Issues"
+
+# ── Read specs (if available) ──
+SPEC_CONTEXT=""
+if [ -d "$CHANGE_DIR/specs" ]; then
+  for spec_file in "$CHANGE_DIR/specs"/*.md "$CHANGE_DIR/specs"/**/*.md; do
+    [ -f "$spec_file" ] || continue
+    SPEC_CONTEXT="$SPEC_CONTEXT
+---
+$(cat "$spec_file")
+"
+  done
+fi
+
+# ── Read proposal summary ──
+PROPOSAL_SUMMARY=""
+if [ -f "$CHANGE_DIR/proposal.md" ]; then
+  # Extract first 10 non-empty lines as summary
+  PROPOSAL_SUMMARY=$(grep -v '^$\|^#\|^---' "$CHANGE_DIR/proposal.md" | head -10)
+fi
+
+# ── Parse tasks ──
+TASK_COUNT=0
+CREATED_COUNT=0
+
+while IFS= read -r line; do
+  # Match markdown task items: - [ ] Task description
+  if echo "$line" | grep -qE '^\s*-\s*\[\s*\]\s+'; then
+    TASK_DESC=$(echo "$line" | sed 's/^\s*-\s*\[\s*\]\s*//')
+    [ -z "$TASK_DESC" ] && continue
+    TASK_COUNT=$((TASK_COUNT + 1))
+
+    # Check for duplicate (issue with same title already exists)
+    EXISTING=$(gh issue list --repo "$REPO" --state open --search "$TASK_DESC" --json number,title \
+      --jq ".[] | select(.title == \"$TASK_DESC\") | .number" 2>/dev/null | head -1)
+    if [ -n "$EXISTING" ]; then
+      warn "Skip duplicate: #$EXISTING — $TASK_DESC"
+      continue
+    fi
+
+    # Build issue body
+    ISSUE_BODY="## Context
+
+Part of OpenSpec change: \`$CHANGE_NAME\`
+Task $TASK_COUNT from \`$TASKS_FILE\`
+"
+
+    if [ -n "$PROPOSAL_SUMMARY" ]; then
+      ISSUE_BODY="$ISSUE_BODY
+### Proposal Summary
+$PROPOSAL_SUMMARY
+"
+    fi
+
+    if [ -n "$SPEC_CONTEXT" ]; then
+      ISSUE_BODY="$ISSUE_BODY
+### Spec (Given/When/Then)
+
+Implement according to these behavior contracts:
+
+\`\`\`
+$SPEC_CONTEXT
+\`\`\`
+"
+    fi
+
+    ISSUE_BODY="$ISSUE_BODY
+## Acceptance Criteria
+
+- [ ] Implementation matches spec scenarios above
+- [ ] Unit tests covering all Given/When/Then cases
+- [ ] \`npx tsc --noEmit\` passes
+- [ ] \`npm test\` passes
+- [ ] \`npm run build\` succeeds
+"
+
+    # Create issue
+    ISSUE_NUM=$(gh issue create --repo "$REPO" \
+      --title "$TASK_DESC" \
+      --body "$ISSUE_BODY" \
+      --label "enhancement" \
+      --label "spec:$CHANGE_NAME" \
+      2>/dev/null | grep -oE '[0-9]+$')
+
+    if [ -n "$ISSUE_NUM" ]; then
+      ok "Created #$ISSUE_NUM — $TASK_DESC"
+      CREATED_COUNT=$((CREATED_COUNT + 1))
+    else
+      warn "Failed to create issue for: $TASK_DESC"
+    fi
+
+    # Rate limit: avoid GitHub API throttling
+    sleep 1
+  fi
+done < "$TASKS_FILE"
+
+# ── Create spec label if it doesn't exist ──
+gh label create "spec:$CHANGE_NAME" --repo "$REPO" \
+  --description "OpenSpec change: $CHANGE_NAME" \
+  --color "D4C5F9" 2>/dev/null || true
+
+# ── Summary ──
+echo ""
+echo "════════════════════════════════════════"
+echo "  Spec Decomposition Complete"
+echo "════════════════════════════════════════"
+echo "  Change:   $CHANGE_NAME"
+echo "  Tasks:    $TASK_COUNT found"
+echo "  Created:  $CREATED_COUNT issues"
+echo "  Label:    spec:$CHANGE_NAME"
+echo ""
+echo "  Next steps:"
+echo "    - pm-auto.sh will dispatch agents automatically"
+echo "    - Monitor at: http://127.0.0.1:5175 (Agent Dashboard)"
+echo "    - Verify: /opsx:verify"
+echo "    - Archive: /opsx:archive $CHANGE_NAME"
+echo "════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Connect OpenSpec specs to the agent dispatch pipeline: specs decompose into GitHub Issues with Given/When/Then in the body, agents use those scenarios for TDD, tester validates MUST/SHALL coverage.

- `spec-to-issues.sh` — parse `tasks.md` → GitHub Issues with spec content
- `/spec-cycle` — full pipeline command (propose → decompose → dispatch → verify → archive)
- `do-todo` agent — spec-aware TDD (reads Given/When/Then from issue body)
- `tester` agent — validates MUST/SHALL coverage from spec-labeled issues

Closes #1677

## Pipeline Flow

```
/opsx:propose → specs + tasks
       ↓
spec-to-issues.sh → GitHub Issues (labeled spec:<name>)
       ↓
pm-auto.sh → sprint-runner.sh → agents
       ↓
agents read spec from issue body → TDD from Given/When/Then
       ↓
/opsx:verify → check MUST coverage
/opsx:archive → merge to openspec/specs/
```

## Verification

- [x] `bash -n spec-to-issues.sh` — syntax OK
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — success

## Test plan

- [ ] Create test change with tasks → run `spec-to-issues.sh` → verify issues created with spec body + labels
- [ ] Verify `do-todo` agent reads spec from issue body before writing tests
- [ ] Verify `tester` agent reports spec gaps for MUST/SHALL

🤖 Generated with [Claude Code](https://claude.com/claude-code)