### PR TITLE
feat: Phase 2B-1a — AudioGraph data structures + mixer DSP math (#1693)

### DIFF
--- a/src-tauri/src/engine/graph.rs
+++ b/src-tauri/src/engine/graph.rs
@@ -1,0 +1,218 @@
+//! Audio processing graph — pure data structures.
+//!
+//! # Why a fixed-capacity slab?
+//!
+//! The audio callback runs on a real-time thread that cannot allocate.
+//! Pre-allocating the track storage at engine construction means the
+//! audio thread only ever reads or mutates existing entries — it never
+//! asks the allocator for memory while a buffer is being processed.
+//!
+//! 256 tracks is generous: Ableton Live 11 default templates cap at 128
+//! and Logic Pro at 255. At `sizeof::<Track>` ≈ 20 bytes, the total cost
+//! is ~5 KiB — cache-friendly, easy to iterate.
+//!
+//! # What's NOT in this module
+//!
+//! - The command queue (`EngineCommand`) that mutates tracks → 2B-1b
+//! - `AudioGraph::apply(cmd)` → 2B-1b
+//! - Integration with the CPAL audio callback → 2B-1c
+//!
+//! This file is intentionally leaf data: `Track`, `AudioGraph`, and
+//! simple queries. Nothing here is real-time sensitive yet.
+
+/// Maximum number of simultaneously active tracks. Increase only after
+/// a memory / cache-line audit — contiguous iteration over the full
+/// slab runs on every callback, so the number directly affects CPU.
+pub const MAX_TRACKS: usize = 256;
+
+/// A single track in the processing graph. Flat POD — no heap allocation,
+/// no references, cheap to copy, easy to reason about across threads.
+///
+/// `occupied` is the authoritative liveness flag: the main thread sets
+/// it to `true` when a track is added and `false` when it is removed.
+/// The audio callback iterates the full array and skips unoccupied
+/// slots. Keeping occupancy inside the Track itself (rather than in a
+/// side-channel bitmap) simplifies the audio-thread read path to a
+/// single cache line per slot.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Track {
+    pub occupied: bool,
+    /// Linear gain (1.0 = unity, 0.0 = silent). UI-side dB values are
+    /// converted to linear before being sent as a command.
+    pub volume: f32,
+    /// Pan ∈ [-1.0, 1.0]. -1 = hard left, 0 = center, +1 = hard right.
+    /// Out-of-range input is clamped by `mixer::equal_power_pan`.
+    pub pan: f32,
+    pub mute: bool,
+    pub solo: bool,
+}
+
+impl Default for Track {
+    fn default() -> Self {
+        Self {
+            occupied: false,
+            volume: 1.0,
+            pan: 0.0,
+            mute: false,
+            solo: false,
+        }
+    }
+}
+
+/// The processing graph's audio-thread-visible state.
+///
+/// Owned by whoever runs the audio callback (in 2B-1c that will be the
+/// CPAL owner thread). The main thread never touches this struct
+/// directly — it sends `EngineCommand`s that the audio thread applies
+/// in-place.
+pub struct AudioGraph {
+    tracks: Box<[Track; MAX_TRACKS]>,
+    /// Master output gain (linear). Applied after all track summing.
+    pub master_volume: f32,
+}
+
+impl AudioGraph {
+    /// Construct an empty graph with every slot pre-allocated and
+    /// `occupied = false`. Exactly one heap allocation happens here,
+    /// on the main thread at engine init — zero allocation after.
+    pub fn new() -> Self {
+        Self {
+            tracks: Box::new([Track::default(); MAX_TRACKS]),
+            master_volume: 1.0,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        MAX_TRACKS
+    }
+
+    pub fn track(&self, slot: usize) -> Option<&Track> {
+        self.tracks.get(slot)
+    }
+
+    pub fn track_mut(&mut self, slot: usize) -> Option<&mut Track> {
+        self.tracks.get_mut(slot)
+    }
+
+    /// Unconditional slice accessor for the audio callback. Iterating
+    /// the full slab (with an `if occupied` skip per slot) is the
+    /// hot-path pattern in 2B-1c.
+    pub fn all_tracks(&self) -> &[Track] {
+        self.tracks.as_ref()
+    }
+
+    pub fn all_tracks_mut(&mut self) -> &mut [Track] {
+        self.tracks.as_mut()
+    }
+
+    /// Iterator over currently-occupied tracks. Convenience for
+    /// main-thread queries (tests, debug, metering summaries).
+    pub fn active_tracks(&self) -> impl Iterator<Item = (usize, &Track)> {
+        self.tracks
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| t.occupied)
+    }
+
+    /// True iff at least one occupied track has `solo = true`.
+    pub fn any_solo(&self) -> bool {
+        self.tracks.iter().any(|t| t.occupied && t.solo)
+    }
+
+    /// Count of currently-occupied tracks.
+    pub fn active_count(&self) -> usize {
+        self.tracks.iter().filter(|t| t.occupied).count()
+    }
+}
+
+impl Default for AudioGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_track_is_unoccupied_unity_centered() {
+        let t = Track::default();
+        assert!(!t.occupied);
+        assert_eq!(t.volume, 1.0);
+        assert_eq!(t.pan, 0.0);
+        assert!(!t.mute);
+        assert!(!t.solo);
+    }
+
+    #[test]
+    fn new_graph_has_max_tracks_all_unoccupied() {
+        let g = AudioGraph::new();
+        assert_eq!(g.capacity(), MAX_TRACKS);
+        assert_eq!(g.active_count(), 0);
+        assert_eq!(g.master_volume, 1.0);
+        assert!(g.all_tracks().iter().all(|t| !t.occupied));
+        assert_eq!(g.all_tracks().len(), MAX_TRACKS);
+    }
+
+    #[test]
+    fn active_tracks_returns_only_occupied_slots() {
+        let mut g = AudioGraph::new();
+        g.track_mut(5).unwrap().occupied = true;
+        g.track_mut(42).unwrap().occupied = true;
+        g.track_mut(200).unwrap().occupied = true;
+
+        let active: Vec<usize> = g.active_tracks().map(|(i, _)| i).collect();
+        assert_eq!(active, vec![5, 42, 200]);
+        assert_eq!(g.active_count(), 3);
+    }
+
+    #[test]
+    fn any_solo_is_false_on_empty_graph() {
+        let g = AudioGraph::new();
+        assert!(!g.any_solo());
+    }
+
+    #[test]
+    fn any_solo_ignores_solo_flag_on_unoccupied_slots() {
+        // Edge case: an unoccupied slot may still have dirty solo data
+        // left over from a removed track. any_solo() must not observe it,
+        // otherwise removing a soloed track would leave the mixer stuck
+        // in "any solo" mode with all remaining tracks silent.
+        let mut g = AudioGraph::new();
+        g.track_mut(1).unwrap().solo = true; // occupied stays false
+        assert!(!g.any_solo());
+    }
+
+    #[test]
+    fn any_solo_detects_occupied_soloed_track() {
+        let mut g = AudioGraph::new();
+        let t = g.track_mut(7).unwrap();
+        t.occupied = true;
+        t.solo = true;
+        assert!(g.any_solo());
+    }
+
+    #[test]
+    fn track_accessors_return_none_for_out_of_range() {
+        let mut g = AudioGraph::new();
+        assert!(g.track(MAX_TRACKS).is_none());
+        assert!(g.track_mut(MAX_TRACKS + 1).is_none());
+    }
+
+    #[test]
+    fn graph_storage_pointer_is_stable_after_mutation() {
+        // The audio callback will hold &[Track] across mutations — the
+        // underlying storage must be stable. Box<[Track; N]> is a fixed
+        // allocation so this is trivially true, but assert it here so a
+        // future refactor to Vec<Track> cannot silently break the
+        // invariant.
+        let mut g = AudioGraph::new();
+        let ptr_before = g.all_tracks().as_ptr();
+        g.track_mut(0).unwrap().occupied = true;
+        g.track_mut(255).unwrap().occupied = true;
+        g.master_volume = 0.5;
+        let ptr_after = g.all_tracks().as_ptr();
+        assert_eq!(ptr_before, ptr_after, "graph storage moved");
+    }
+}

--- a/src-tauri/src/engine/graph.rs
+++ b/src-tauri/src/engine/graph.rs
@@ -123,6 +123,23 @@ impl AudioGraph {
     pub fn active_count(&self) -> usize {
         self.tracks.iter().filter(|t| t.occupied).count()
     }
+
+    /// Reset a slot back to [`Track::default`].
+    ///
+    /// This is the **only** supported way to remove a track: it
+    /// clears `occupied`, `volume`, `pan`, `mute`, **and** `solo` in a
+    /// single step. Callers that flip `occupied = false` directly and
+    /// leave the other fields stale risk leaking that state into the
+    /// next track that reuses the slot — e.g. the new track would
+    /// start out muted, soloed, or hard-panned because the previous
+    /// track was. Found by codex review on PR #1694.
+    ///
+    /// Out-of-range slots are ignored.
+    pub fn clear_slot(&mut self, slot: usize) {
+        if let Some(t) = self.tracks.get_mut(slot) {
+            *t = Track::default();
+        }
+    }
 }
 
 impl Default for AudioGraph {
@@ -198,6 +215,68 @@ mod tests {
         let mut g = AudioGraph::new();
         assert!(g.track(MAX_TRACKS).is_none());
         assert!(g.track_mut(MAX_TRACKS + 1).is_none());
+    }
+
+    #[test]
+    fn clear_slot_wipes_all_fields_including_solo_and_pan() {
+        // Regression guard for codex finding #2 on PR #1694.
+        //
+        // Directly toggling `occupied = false` leaves volume / pan /
+        // mute / solo dirty on the slab entry, so the next track
+        // added to that slot would inherit stale state. `clear_slot`
+        // is the supported "remove" primitive — it must zero every
+        // field so slot reuse is safe without callers having to
+        // manually remember which fields to reset.
+        let mut g = AudioGraph::new();
+        {
+            let t = g.track_mut(3).unwrap();
+            t.occupied = true;
+            t.volume = 0.2;
+            t.pan = 0.8;
+            t.mute = true;
+            t.solo = true;
+        }
+        assert_eq!(g.active_count(), 1);
+        assert!(g.any_solo());
+
+        g.clear_slot(3);
+
+        assert_eq!(g.active_count(), 0);
+        assert!(!g.any_solo());
+        let t = g.track(3).unwrap();
+        assert_eq!(*t, Track::default(), "every field must be reset");
+    }
+
+    #[test]
+    fn clear_slot_out_of_range_is_noop() {
+        let mut g = AudioGraph::new();
+        g.clear_slot(MAX_TRACKS);
+        g.clear_slot(usize::MAX);
+        assert_eq!(g.active_count(), 0);
+    }
+
+    #[test]
+    fn clear_slot_then_reuse_has_no_leakage() {
+        // End-to-end: create a soloed muted track, clear the slot,
+        // re-mark it occupied with default params, verify no bleed.
+        let mut g = AudioGraph::new();
+        {
+            let t = g.track_mut(0).unwrap();
+            t.occupied = true;
+            t.mute = true;
+            t.solo = true;
+            t.pan = -0.9;
+            t.volume = 0.1;
+        }
+        g.clear_slot(0);
+        // Simulate a fresh "add" by re-flipping occupied (what
+        // 2B-1b's EngineCommand::AddTrack will do via apply()).
+        g.track_mut(0).unwrap().occupied = true;
+        let t = g.track(0).unwrap();
+        assert_eq!(t.volume, 1.0);
+        assert_eq!(t.pan, 0.0);
+        assert!(!t.mute);
+        assert!(!t.solo);
     }
 
     #[test]

--- a/src-tauri/src/engine/mixer.rs
+++ b/src-tauri/src/engine/mixer.rs
@@ -1,0 +1,183 @@
+//! Pure DSP math for the mixer — pan law + audibility resolution.
+//!
+//! These are stateless, allocation-free functions safe to call from the
+//! audio thread. The audio callback in 2B-1c will invoke them per
+//! sample or per buffer; for now they are unit-testable in isolation.
+
+use super::graph::Track;
+
+/// Equal-power sin/cos pan law.
+///
+/// Given `pan ∈ [-1.0, 1.0]`, returns `(left_gain, right_gain)`. Out of
+/// range input is clamped.
+///
+/// # Convention
+///
+/// - `-1.0` → `(1.0, 0.0)` (hard left)
+/// - ` 0.0` → `(≈0.7071, ≈0.7071)` (center, -3 dB per channel)
+/// - `+1.0` → `(0.0, 1.0)` (hard right)
+///
+/// The -3 dB center dip is the de facto standard for digital mixing
+/// consoles (Logic, Cubase, Pro Tools default). It preserves perceived
+/// loudness as a mono source pans from the mono-sum point to either
+/// extreme — a linear pan law sounds "louder in the middle" because
+/// phantom center doubles the power, which is almost never what the
+/// user wants.
+#[inline]
+pub fn equal_power_pan(pan: f32) -> (f32, f32) {
+    let clamped = if pan < -1.0 {
+        -1.0
+    } else if pan > 1.0 {
+        1.0
+    } else {
+        pan
+    };
+    let theta = (clamped + 1.0) * std::f32::consts::FRAC_PI_4;
+    (theta.cos(), theta.sin())
+}
+
+/// Resolve whether a track is audible given the current global solo
+/// state.
+///
+/// # Convention (matches every major DAW)
+///
+/// - **Mute ≻ solo**: a track that is both muted *and* soloed is silent.
+///   Ableton, Logic, Pro Tools, Cubase, Bitwig all agree on this. A
+///   user who has muted a track has made an explicit "silence this"
+///   decision that solo must not override.
+/// - When `any_solo` is true, non-soloed tracks are silent.
+/// - Unoccupied slots are always silent — this guards against stale
+///   mute/solo flags on freed slots.
+#[inline]
+pub fn is_audible(track: &Track, any_solo: bool) -> bool {
+    track.occupied && !track.mute && (!any_solo || track.solo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::FRAC_1_SQRT_2;
+
+    fn close(a: f32, b: f32) -> bool {
+        (a - b).abs() < 1e-5
+    }
+
+    #[test]
+    fn pan_center_is_minus_three_db_on_both_channels() {
+        let (l, r) = equal_power_pan(0.0);
+        assert!(close(l, FRAC_1_SQRT_2), "left {l} ≠ 1/√2");
+        assert!(close(r, FRAC_1_SQRT_2), "right {r} ≠ 1/√2");
+        // Power sums to unity: L² + R² = 1
+        assert!(close(l * l + r * r, 1.0));
+    }
+
+    #[test]
+    fn pan_hard_left_sends_all_to_left_channel() {
+        let (l, r) = equal_power_pan(-1.0);
+        assert!(close(l, 1.0), "left {l} ≠ 1");
+        assert!(close(r, 0.0), "right {r} ≠ 0");
+    }
+
+    #[test]
+    fn pan_hard_right_sends_all_to_right_channel() {
+        let (l, r) = equal_power_pan(1.0);
+        assert!(close(l, 0.0), "left {l} ≠ 0");
+        assert!(close(r, 1.0), "right {r} ≠ 1");
+    }
+
+    #[test]
+    fn pan_is_monotonic_across_range() {
+        // Left gain strictly decreases from 1.0 → 0.0 as pan goes -1 → +1.
+        // Right gain strictly increases symmetrically.
+        let mut prev_l = f32::INFINITY;
+        let mut prev_r = f32::NEG_INFINITY;
+        for i in -10..=10 {
+            let pan = i as f32 / 10.0;
+            let (l, r) = equal_power_pan(pan);
+            assert!(l <= prev_l, "pan {pan}: left {l} not ≤ prev {prev_l}");
+            assert!(r >= prev_r, "pan {pan}: right {r} not ≥ prev {prev_r}");
+            prev_l = l;
+            prev_r = r;
+        }
+    }
+
+    #[test]
+    fn pan_conserves_power_at_every_position() {
+        // Equal-power property: L² + R² ≈ 1 for all pan values.
+        for i in -100..=100 {
+            let pan = i as f32 / 100.0;
+            let (l, r) = equal_power_pan(pan);
+            let power = l * l + r * r;
+            assert!(
+                (power - 1.0).abs() < 1e-5,
+                "pan {pan}: power {power} ≠ 1"
+            );
+        }
+    }
+
+    #[test]
+    fn pan_clamps_out_of_range_input() {
+        assert_eq!(equal_power_pan(-2.0), equal_power_pan(-1.0));
+        assert_eq!(equal_power_pan(1.5), equal_power_pan(1.0));
+        assert_eq!(equal_power_pan(f32::NEG_INFINITY), equal_power_pan(-1.0));
+        assert_eq!(equal_power_pan(f32::INFINITY), equal_power_pan(1.0));
+    }
+
+    // ── audibility ──────────────────────────────────────────────────
+
+    fn occupied_track() -> Track {
+        Track {
+            occupied: true,
+            ..Track::default()
+        }
+    }
+
+    #[test]
+    fn unoccupied_is_never_audible() {
+        let t = Track::default();
+        assert!(!is_audible(&t, false));
+        assert!(!is_audible(&t, true));
+    }
+
+    #[test]
+    fn plain_occupied_track_is_audible_without_solo() {
+        assert!(is_audible(&occupied_track(), false));
+    }
+
+    #[test]
+    fn muted_track_is_silent_even_without_solo() {
+        let t = Track {
+            mute: true,
+            ..occupied_track()
+        };
+        assert!(!is_audible(&t, false));
+    }
+
+    #[test]
+    fn non_soloed_track_is_silent_when_any_solo_active() {
+        assert!(!is_audible(&occupied_track(), true));
+    }
+
+    #[test]
+    fn soloed_track_is_audible_when_any_solo_active() {
+        let t = Track {
+            solo: true,
+            ..occupied_track()
+        };
+        assert!(is_audible(&t, true));
+    }
+
+    #[test]
+    fn mute_beats_solo_convention() {
+        // Regression guard for the "mute ≻ solo" convention: a track
+        // that is both muted and soloed must be silent. Every major DAW
+        // does this; flipping the precedence breaks user expectations.
+        let t = Track {
+            mute: true,
+            solo: true,
+            ..occupied_track()
+        };
+        assert!(!is_audible(&t, true));
+        assert!(!is_audible(&t, false));
+    }
+}

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -20,11 +20,17 @@
 
 pub mod audio_io;
 pub mod config;
+pub mod graph;
+pub mod mixer;
+pub mod slot;
 
 pub use config::{
     AudioDeviceInfo, ConfigError, EngineConfig, EngineStatus, VALID_BUFFER_SIZES,
     VALID_SAMPLE_RATES,
 };
+pub use graph::{AudioGraph, Track, MAX_TRACKS};
+pub use mixer::{equal_power_pan, is_audible};
+pub use slot::SlotAllocator;
 
 use crossbeam_channel::{bounded, Receiver, Sender};
 use serde::Serialize;

--- a/src-tauri/src/engine/slot.rs
+++ b/src-tauri/src/engine/slot.rs
@@ -3,38 +3,97 @@
 //! Runs entirely on the main thread. The audio callback never calls
 //! into this — it only reads `Track::occupied` on each slot. Slot
 //! allocation happens in response to UI actions (add/remove track),
-//! which are rare relative to audio callback frequency, so a linear
-//! O(N) insertion cost on `release` is fine for the 256-slot capacity.
+//! which are rare relative to audio callback frequency.
+//!
+//! # Why `SlotHandle` instead of a bare `usize`?
+//!
+//! Codex review on PR #1694 pointed out a race the original bare-usize
+//! API could not defend against:
+//!
+//! 1. `acquire()` → slot 0 handed to owner A
+//! 2. `release(0)` from owner A
+//! 3. `acquire()` → slot 0 re-handed to owner B
+//! 4. A stale, duplicated `release(0)` from owner A arrives
+//!
+//! With a bare `usize`, step 4 is indistinguishable from a legitimate
+//! release by owner B — the allocator would add slot 0 back to the
+//! free list while owner B is still using it, and the next `acquire()`
+//! would alias a third caller onto the same slab entry.
+//!
+//! The [`SlotHandle`] returned from [`SlotAllocator::acquire`] carries
+//! a generation counter that is bumped on every acquire. A stale
+//! release whose generation does not match the current value is
+//! dropped silently, so the re-acquired slot stays safely allocated.
 
 use super::graph::MAX_TRACKS;
 
+/// An opaque handle to a live slot. Contains the slot index and the
+/// generation number the slot had at the moment of acquisition.
+///
+/// Handles are `Copy` so they can be stored alongside track metadata
+/// without shared-ownership concerns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlotHandle {
+    slot: usize,
+    generation: u32,
+}
+
+impl SlotHandle {
+    /// The raw slot index — use this to address `AudioGraph::track(idx)`
+    /// and related accessors.
+    pub fn index(&self) -> usize {
+        self.slot
+    }
+
+    /// The generation at which this handle was issued. Exposed mostly
+    /// for debug output; `release` compares it internally.
+    pub fn generation(&self) -> u32 {
+        self.generation
+    }
+}
+
 /// Hands out and recycles track slot indices.
 ///
-/// Internally stores a free-list in **reverse** order (largest index
-/// first, smallest last) so that `Vec::pop()` can return the smallest
-/// free index in O(1). Insertion on `release` maintains the reverse
-/// order with a linear scan — cheap for N = 256 and only happens when
-/// the user removes a track.
+/// # Internals
 ///
-/// # Invariants
+/// - **`free`** is a reverse-sorted stack so that `Vec::pop()` returns
+///   the smallest free slot in O(1), which keeps the user-visible
+///   "new tracks appear at slot 0, 1, 2 …" property.
+/// - **`generation[i]`** is incremented on every acquisition of slot
+///   `i`. A release whose handle's generation does not match is a
+///   no-op, closing the stale-release race.
+/// - **`allocated[i]`** mirrors "is slot `i` currently handed out" —
+///   it enables idempotent double-release within a single generation
+///   (a caller that releases twice without re-acquiring sees the
+///   second release as a no-op).
 ///
-/// - Every index in `free` is `< capacity`.
-/// - No duplicates: releasing an already-free slot is a no-op.
-/// - Out-of-range release is a no-op (tolerates stale callers).
+/// Insertion into `free` on release is an O(N) linear scan, which is
+/// intentional: release happens on UI actions (track removed), not on
+/// the audio callback. For N = 256 the cost is trivial.
 #[derive(Debug)]
 pub struct SlotAllocator {
     capacity: usize,
     /// Reverse-sorted: `free[0]` is the largest free index, `free.last()`
     /// is the smallest. `pop()` therefore returns the smallest.
     free: Vec<usize>,
+    /// Per-slot generation counter. Incremented on `acquire`. `u32`
+    /// with wrapping arithmetic — 4 billion acquisitions of a single
+    /// slot before a generation aliases, far beyond any realistic
+    /// session.
+    generation: Vec<u32>,
+    /// `allocated[i] == true` iff slot `i` is currently handed out.
+    /// Authoritative state; `free` and `generation` are both
+    /// maintained in lockstep with it.
+    allocated: Vec<bool>,
 }
 
 impl SlotAllocator {
     pub fn new(capacity: usize) -> Self {
-        // Reverse-preload so pop() returns 0, then 1, then 2 ...
         Self {
             capacity,
             free: (0..capacity).rev().collect(),
+            generation: vec![0; capacity],
+            allocated: vec![false; capacity],
         }
     }
 
@@ -55,35 +114,63 @@ impl SlotAllocator {
         self.capacity - self.free.len()
     }
 
-    /// Acquire the smallest free slot. Returns `None` when the allocator
-    /// is at full capacity.
-    pub fn acquire(&mut self) -> Option<usize> {
-        self.free.pop()
+    /// True iff the given raw slot index is currently allocated to
+    /// some live caller. Useful for tests and for defensive assertions.
+    pub fn is_allocated(&self, slot: usize) -> bool {
+        self.allocated.get(slot).copied().unwrap_or(false)
+    }
+
+    /// Acquire the smallest free slot. Returns `None` when the
+    /// allocator is at full capacity.
+    pub fn acquire(&mut self) -> Option<SlotHandle> {
+        let slot = self.free.pop()?;
+        debug_assert!(
+            !self.allocated[slot],
+            "slot {slot} was on the free list but already marked allocated"
+        );
+        self.generation[slot] = self.generation[slot].wrapping_add(1);
+        self.allocated[slot] = true;
+        Some(SlotHandle {
+            slot,
+            generation: self.generation[slot],
+        })
     }
 
     /// Return a slot to the free pool.
     ///
-    /// - Out-of-range slot: no-op.
-    /// - Already-free slot: no-op (idempotent release is safe under any
-    ///   caller race between remove and stop).
-    /// - Otherwise inserted into the free list so the next `acquire`
-    ///   sees it at the correct sort position.
-    pub fn release(&mut self, slot: usize) {
-        if slot >= self.capacity {
+    /// - Out-of-range handle: no-op.
+    /// - Stale handle (generation mismatch): no-op. Protects against
+    ///   the release → reacquire → stale-release race documented on
+    ///   the module.
+    /// - Already-released handle (within the same generation, i.e.
+    ///   double release): no-op via the `allocated` check.
+    /// - Otherwise the slot is marked free and inserted into the
+    ///   free list so the next `acquire` sees it at the correct
+    ///   sort position.
+    pub fn release(&mut self, handle: SlotHandle) {
+        if handle.slot >= self.capacity {
             return;
         }
-        if self.free.iter().any(|&f| f == slot) {
+        if self.generation[handle.slot] != handle.generation {
+            // Stale release: the slot has been re-acquired since this
+            // handle was issued. Dropping the release is the only
+            // safe move — the current owner is still using the slot.
             return;
         }
+        if !self.allocated[handle.slot] {
+            // Double release within the same generation. Should not
+            // happen in well-formed callers but we tolerate it.
+            return;
+        }
+        self.allocated[handle.slot] = false;
         // Reverse-sorted list: find the first index whose value is
-        // strictly less than `slot`, insert before it. Linear scan is
-        // intentional — capacity is 256 and release is not a hot path.
+        // strictly less than `slot`, insert before it.
         let idx = self
             .free
             .iter()
-            .position(|&f| f < slot)
+            .position(|&f| f < handle.slot)
             .unwrap_or(self.free.len());
-        self.free.insert(idx, slot);
+        self.free.insert(idx, handle.slot);
     }
 }
 
@@ -102,72 +189,123 @@ mod tests {
         let mut a = SlotAllocator::new(0);
         assert_eq!(a.capacity(), 0);
         assert_eq!(a.free_count(), 0);
-        assert_eq!(a.acquire(), None);
+        assert!(a.acquire().is_none());
     }
 
     #[test]
     fn acquire_hands_out_smallest_index_first() {
         let mut a = SlotAllocator::new(4);
-        assert_eq!(a.acquire(), Some(0));
-        assert_eq!(a.acquire(), Some(1));
-        assert_eq!(a.acquire(), Some(2));
-        assert_eq!(a.acquire(), Some(3));
-        assert_eq!(a.acquire(), None);
+        assert_eq!(a.acquire().unwrap().index(), 0);
+        assert_eq!(a.acquire().unwrap().index(), 1);
+        assert_eq!(a.acquire().unwrap().index(), 2);
+        assert_eq!(a.acquire().unwrap().index(), 3);
+        assert!(a.acquire().is_none());
     }
 
     #[test]
     fn full_then_release_then_acquire_returns_released_slot() {
         let mut a = SlotAllocator::new(3);
-        let s0 = a.acquire().unwrap();
-        let s1 = a.acquire().unwrap();
-        let _s2 = a.acquire().unwrap();
-        assert_eq!(a.acquire(), None);
+        let h0 = a.acquire().unwrap();
+        let h1 = a.acquire().unwrap();
+        let _h2 = a.acquire().unwrap();
+        assert!(a.acquire().is_none());
 
-        a.release(s0);
-        assert_eq!(a.acquire(), Some(s0));
+        a.release(h0);
+        assert_eq!(a.acquire().unwrap().index(), h0.index());
 
-        a.release(s1);
-        assert_eq!(a.acquire(), Some(s1));
+        a.release(h1);
+        assert_eq!(a.acquire().unwrap().index(), h1.index());
     }
 
     #[test]
     fn release_restores_smallest_first_ordering() {
-        // Fill completely, then release in scrambled order. The next
-        // acquires must come back in ascending index order, not in the
-        // order of release.
+        // Fill completely, then release in scrambled order. Next
+        // acquires must come back in ascending index order.
         let mut a = SlotAllocator::new(4);
-        for _ in 0..4 {
-            a.acquire().unwrap();
-        }
+        let handles: Vec<SlotHandle> = (0..4).map(|_| a.acquire().unwrap()).collect();
 
-        a.release(3);
-        a.release(0);
-        a.release(2);
-        a.release(1);
+        a.release(handles[3]);
+        a.release(handles[0]);
+        a.release(handles[2]);
+        a.release(handles[1]);
 
-        assert_eq!(a.acquire(), Some(0));
-        assert_eq!(a.acquire(), Some(1));
-        assert_eq!(a.acquire(), Some(2));
-        assert_eq!(a.acquire(), Some(3));
-        assert_eq!(a.acquire(), None);
+        assert_eq!(a.acquire().unwrap().index(), 0);
+        assert_eq!(a.acquire().unwrap().index(), 1);
+        assert_eq!(a.acquire().unwrap().index(), 2);
+        assert_eq!(a.acquire().unwrap().index(), 3);
+        assert!(a.acquire().is_none());
     }
 
     #[test]
     fn double_release_is_idempotent() {
         let mut a = SlotAllocator::new(4);
-        let s = a.acquire().unwrap();
-        a.release(s);
-        a.release(s); // must not duplicate in free list
+        let h = a.acquire().unwrap();
+        a.release(h);
+        a.release(h); // same handle, same generation — no-op
         assert_eq!(a.free_count(), 4);
-        assert_eq!(a.acquire(), Some(s));
+        assert_eq!(a.acquire().unwrap().index(), h.index());
+    }
+
+    #[test]
+    fn stale_release_after_reacquire_does_not_double_free() {
+        // Regression guard for codex finding #1 on PR #1694.
+        //
+        // Scenario:
+        //   1. acquire() → handle_a (slot 0, gen 1)
+        //   2. release(handle_a) → slot 0 returns to free list
+        //   3. acquire() → handle_b (slot 0, gen 2) — NEW owner
+        //   4. stale release(handle_a) from owner A arrives
+        //
+        // With a bare-usize API, step 4 would be indistinguishable
+        // from a legitimate release by owner B. The generation
+        // counter inside SlotHandle makes the stale handle detectable:
+        // gen 1 != gen 2, so release(handle_a) is a no-op and
+        // owner B's slot stays allocated.
+        let mut a = SlotAllocator::new(4);
+        let handle_a = a.acquire().unwrap();
+        assert_eq!(handle_a.index(), 0);
+        assert_eq!(handle_a.generation(), 1);
+
+        a.release(handle_a);
+
+        let handle_b = a.acquire().unwrap();
+        assert_eq!(handle_b.index(), 0, "slot 0 should be reused");
+        assert_eq!(handle_b.generation(), 2, "generation should advance");
+        assert!(a.is_allocated(0));
+
+        // Stale release from owner A:
+        a.release(handle_a);
+
+        // Owner B must still hold slot 0.
+        assert!(
+            a.is_allocated(0),
+            "stale release must not free a slot that has been re-acquired"
+        );
+        assert_eq!(
+            a.free_count(),
+            3,
+            "free list must not grow from a stale release"
+        );
+
+        // Acquiring the next free slots must NOT return 0 again.
+        let next: Vec<usize> = (0..3).map(|_| a.acquire().unwrap().index()).collect();
+        assert_eq!(next, vec![1, 2, 3]);
+        assert!(a.acquire().is_none());
     }
 
     #[test]
     fn out_of_range_release_is_ignored() {
         let mut a = SlotAllocator::new(4);
         let before = a.free_count();
-        a.release(99);
-        a.release(usize::MAX);
+        // Construct an out-of-range handle manually. This is only
+        // possible because `SlotHandle` fields are exposed to
+        // `SlotAllocator` internally; external callers cannot forge
+        // them — we do it here to exercise the guard.
+        let fake = SlotHandle {
+            slot: 99,
+            generation: 0,
+        };
+        a.release(fake);
         assert_eq!(a.free_count(), before);
     }
 
@@ -175,15 +313,26 @@ mod tests {
     fn in_use_accounting_matches_acquires_and_releases() {
         let mut a = SlotAllocator::new(8);
         assert_eq!(a.in_use(), 0);
-        let s0 = a.acquire().unwrap();
-        let s1 = a.acquire().unwrap();
-        let s2 = a.acquire().unwrap();
+        let h0 = a.acquire().unwrap();
+        let h1 = a.acquire().unwrap();
+        let h2 = a.acquire().unwrap();
         assert_eq!(a.in_use(), 3);
-        a.release(s1);
+        a.release(h1);
         assert_eq!(a.in_use(), 2);
-        a.release(s0);
-        a.release(s2);
+        a.release(h0);
+        a.release(h2);
         assert_eq!(a.in_use(), 0);
+    }
+
+    #[test]
+    fn is_allocated_tracks_lifecycle() {
+        let mut a = SlotAllocator::new(3);
+        assert!(!a.is_allocated(0));
+        let h = a.acquire().unwrap();
+        assert!(a.is_allocated(h.index()));
+        a.release(h);
+        assert!(!a.is_allocated(h.index()));
+        assert!(!a.is_allocated(99), "out of range returns false");
     }
 
     #[test]
@@ -194,21 +343,39 @@ mod tests {
     }
 
     #[test]
+    fn handle_generation_advances_monotonically() {
+        let mut a = SlotAllocator::new(2);
+        let h1 = a.acquire().unwrap();
+        a.release(h1);
+        let h2 = a.acquire().unwrap();
+        a.release(h2);
+        let h3 = a.acquire().unwrap();
+        assert_eq!(h1.generation(), 1);
+        assert_eq!(h2.generation(), 2);
+        assert_eq!(h3.generation(), 3);
+    }
+
+    #[test]
     fn stress_full_cycle_across_capacity() {
         // Allocate every slot, release them in reverse, re-acquire all —
         // the second pass must return the same indices in the same
-        // order, proving the free-list bookkeeping is consistent across
-        // a full capacity cycle.
+        // order, proving the free-list bookkeeping is consistent
+        // across a full capacity cycle.
         let mut a = SlotAllocator::new(MAX_TRACKS);
-        let first: Vec<usize> = (0..MAX_TRACKS).map(|_| a.acquire().unwrap()).collect();
-        assert_eq!(a.acquire(), None);
+        let first: Vec<SlotHandle> = (0..MAX_TRACKS).map(|_| a.acquire().unwrap()).collect();
+        assert!(a.acquire().is_none());
 
-        for &slot in first.iter().rev() {
-            a.release(slot);
+        for handle in first.iter().rev() {
+            a.release(*handle);
         }
         assert_eq!(a.free_count(), MAX_TRACKS);
 
-        let second: Vec<usize> = (0..MAX_TRACKS).map(|_| a.acquire().unwrap()).collect();
-        assert_eq!(first, second);
+        let second: Vec<usize> = (0..MAX_TRACKS)
+            .map(|_| a.acquire().unwrap().index())
+            .collect();
+        assert_eq!(
+            first.iter().map(|h| h.index()).collect::<Vec<_>>(),
+            second
+        );
     }
 }

--- a/src-tauri/src/engine/slot.rs
+++ b/src-tauri/src/engine/slot.rs
@@ -1,0 +1,214 @@
+//! Slot allocator for the audio graph's track array.
+//!
+//! Runs entirely on the main thread. The audio callback never calls
+//! into this — it only reads `Track::occupied` on each slot. Slot
+//! allocation happens in response to UI actions (add/remove track),
+//! which are rare relative to audio callback frequency, so a linear
+//! O(N) insertion cost on `release` is fine for the 256-slot capacity.
+
+use super::graph::MAX_TRACKS;
+
+/// Hands out and recycles track slot indices.
+///
+/// Internally stores a free-list in **reverse** order (largest index
+/// first, smallest last) so that `Vec::pop()` can return the smallest
+/// free index in O(1). Insertion on `release` maintains the reverse
+/// order with a linear scan — cheap for N = 256 and only happens when
+/// the user removes a track.
+///
+/// # Invariants
+///
+/// - Every index in `free` is `< capacity`.
+/// - No duplicates: releasing an already-free slot is a no-op.
+/// - Out-of-range release is a no-op (tolerates stale callers).
+#[derive(Debug)]
+pub struct SlotAllocator {
+    capacity: usize,
+    /// Reverse-sorted: `free[0]` is the largest free index, `free.last()`
+    /// is the smallest. `pop()` therefore returns the smallest.
+    free: Vec<usize>,
+}
+
+impl SlotAllocator {
+    pub fn new(capacity: usize) -> Self {
+        // Reverse-preload so pop() returns 0, then 1, then 2 ...
+        Self {
+            capacity,
+            free: (0..capacity).rev().collect(),
+        }
+    }
+
+    /// Convenience constructor matching [`MAX_TRACKS`].
+    pub fn with_default_capacity() -> Self {
+        Self::new(MAX_TRACKS)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn free_count(&self) -> usize {
+        self.free.len()
+    }
+
+    pub fn in_use(&self) -> usize {
+        self.capacity - self.free.len()
+    }
+
+    /// Acquire the smallest free slot. Returns `None` when the allocator
+    /// is at full capacity.
+    pub fn acquire(&mut self) -> Option<usize> {
+        self.free.pop()
+    }
+
+    /// Return a slot to the free pool.
+    ///
+    /// - Out-of-range slot: no-op.
+    /// - Already-free slot: no-op (idempotent release is safe under any
+    ///   caller race between remove and stop).
+    /// - Otherwise inserted into the free list so the next `acquire`
+    ///   sees it at the correct sort position.
+    pub fn release(&mut self, slot: usize) {
+        if slot >= self.capacity {
+            return;
+        }
+        if self.free.iter().any(|&f| f == slot) {
+            return;
+        }
+        // Reverse-sorted list: find the first index whose value is
+        // strictly less than `slot`, insert before it. Linear scan is
+        // intentional — capacity is 256 and release is not a hot path.
+        let idx = self
+            .free
+            .iter()
+            .position(|&f| f < slot)
+            .unwrap_or(self.free.len());
+        self.free.insert(idx, slot);
+    }
+}
+
+impl Default for SlotAllocator {
+    fn default() -> Self {
+        Self::with_default_capacity()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_capacity_never_hands_out_a_slot() {
+        let mut a = SlotAllocator::new(0);
+        assert_eq!(a.capacity(), 0);
+        assert_eq!(a.free_count(), 0);
+        assert_eq!(a.acquire(), None);
+    }
+
+    #[test]
+    fn acquire_hands_out_smallest_index_first() {
+        let mut a = SlotAllocator::new(4);
+        assert_eq!(a.acquire(), Some(0));
+        assert_eq!(a.acquire(), Some(1));
+        assert_eq!(a.acquire(), Some(2));
+        assert_eq!(a.acquire(), Some(3));
+        assert_eq!(a.acquire(), None);
+    }
+
+    #[test]
+    fn full_then_release_then_acquire_returns_released_slot() {
+        let mut a = SlotAllocator::new(3);
+        let s0 = a.acquire().unwrap();
+        let s1 = a.acquire().unwrap();
+        let _s2 = a.acquire().unwrap();
+        assert_eq!(a.acquire(), None);
+
+        a.release(s0);
+        assert_eq!(a.acquire(), Some(s0));
+
+        a.release(s1);
+        assert_eq!(a.acquire(), Some(s1));
+    }
+
+    #[test]
+    fn release_restores_smallest_first_ordering() {
+        // Fill completely, then release in scrambled order. The next
+        // acquires must come back in ascending index order, not in the
+        // order of release.
+        let mut a = SlotAllocator::new(4);
+        for _ in 0..4 {
+            a.acquire().unwrap();
+        }
+
+        a.release(3);
+        a.release(0);
+        a.release(2);
+        a.release(1);
+
+        assert_eq!(a.acquire(), Some(0));
+        assert_eq!(a.acquire(), Some(1));
+        assert_eq!(a.acquire(), Some(2));
+        assert_eq!(a.acquire(), Some(3));
+        assert_eq!(a.acquire(), None);
+    }
+
+    #[test]
+    fn double_release_is_idempotent() {
+        let mut a = SlotAllocator::new(4);
+        let s = a.acquire().unwrap();
+        a.release(s);
+        a.release(s); // must not duplicate in free list
+        assert_eq!(a.free_count(), 4);
+        assert_eq!(a.acquire(), Some(s));
+    }
+
+    #[test]
+    fn out_of_range_release_is_ignored() {
+        let mut a = SlotAllocator::new(4);
+        let before = a.free_count();
+        a.release(99);
+        a.release(usize::MAX);
+        assert_eq!(a.free_count(), before);
+    }
+
+    #[test]
+    fn in_use_accounting_matches_acquires_and_releases() {
+        let mut a = SlotAllocator::new(8);
+        assert_eq!(a.in_use(), 0);
+        let s0 = a.acquire().unwrap();
+        let s1 = a.acquire().unwrap();
+        let s2 = a.acquire().unwrap();
+        assert_eq!(a.in_use(), 3);
+        a.release(s1);
+        assert_eq!(a.in_use(), 2);
+        a.release(s0);
+        a.release(s2);
+        assert_eq!(a.in_use(), 0);
+    }
+
+    #[test]
+    fn default_uses_max_tracks() {
+        let a = SlotAllocator::default();
+        assert_eq!(a.capacity(), MAX_TRACKS);
+        assert_eq!(a.free_count(), MAX_TRACKS);
+    }
+
+    #[test]
+    fn stress_full_cycle_across_capacity() {
+        // Allocate every slot, release them in reverse, re-acquire all —
+        // the second pass must return the same indices in the same
+        // order, proving the free-list bookkeeping is consistent across
+        // a full capacity cycle.
+        let mut a = SlotAllocator::new(MAX_TRACKS);
+        let first: Vec<usize> = (0..MAX_TRACKS).map(|_| a.acquire().unwrap()).collect();
+        assert_eq!(a.acquire(), None);
+
+        for &slot in first.iter().rev() {
+            a.release(slot);
+        }
+        assert_eq!(a.free_count(), MAX_TRACKS);
+
+        let second: Vec<usize> = (0..MAX_TRACKS).map(|_| a.acquire().unwrap()).collect();
+        assert_eq!(first, second);
+    }
+}


### PR DESCRIPTION
## Summary

First atomic slice of Phase 2B (real-time mixer). Adds three new pure-Rust modules under `src-tauri/src/engine/`:

- **`graph.rs`** — `Track` / `AudioGraph` / `MAX_TRACKS` (256). Fixed-capacity `Box<[Track; MAX_TRACKS]>` slab — one heap allocation at construction, zero thereafter, cache-friendly iteration for the audio callback in 2B-1c.
- **`slot.rs`** — `SlotAllocator`, main-thread-only helper. Reverse-sorted free list so `pop()` always returns the smallest free slot in O(1); `release` keeps the list sorted via a linear scan (cheap for N ≤ 256, cold path anyway).
- **`mixer.rs`** — stateless DSP math: `equal_power_pan` (sin/cos, -3 dB center dip) and `is_audible` (mute ≻ solo precedence matching every major DAW).

**No audio callback changes, no command queue, no TypeScript touched.** Phase 2B-1a is intentionally the smallest reviewable unit — everything it introduces is dead code until `EngineCommand::apply` lands in 2B-1b and the CPAL callback picks it up in 2B-1c.

Closes #1693. Part of #1522 and epic #1519.

## Why the shape it has

**Fixed capacity 256.** Contiguous memory, cache-friendly, matches or exceeds every mainstream DAW (Ableton 128, Logic 255). At `sizeof::<Track>` ≈ 20 B the total cost is ~5 KiB. One heap allocation on main thread at engine init means the audio thread never asks the allocator for memory — non-negotiable for real-time safety.

**Reverse-sorted free list.** The natural DAW UX expects "track 1, 2, 3…" to correspond to slots 0, 1, 2… The simplest way to preserve that on remove+add is a free list that always returns the smallest available index. `Vec::pop` is O(1), `insert` is O(N) but release is a user-action cold path so N = 256 is trivial.

**Equal-power sin/cos pan.** Linear pan sounds "louder in the middle" because phantom center doubles the power. Equal-power gives -3 dB per channel at center which preserves perceived loudness — de facto standard for Logic / Cubase / Pro Tools defaults.

**Mute ≻ solo.** A user who has muted a track has made an explicit "silence this" decision that solo must not override. Ableton, Logic, Pro Tools, Cubase, Bitwig all agree. Enshrined in a regression test.

## Tests — 29 new, all pure Rust

### Graph (`graph.rs`)
- `default_track_is_unoccupied_unity_centered`
- `new_graph_has_max_tracks_all_unoccupied`
- `active_tracks_returns_only_occupied_slots`
- `any_solo_is_false_on_empty_graph`
- `any_solo_ignores_solo_flag_on_unoccupied_slots` — **edge case**: when a soloed track is removed, its stale `solo` flag must not keep the mixer in "any solo" mode
- `any_solo_detects_occupied_soloed_track`
- `track_accessors_return_none_for_out_of_range`
- `graph_storage_pointer_is_stable_after_mutation` — regression guard for the "audio callback holds `&[Track]` across mutations" invariant

### Slot allocator (`slot.rs`)
- `zero_capacity_never_hands_out_a_slot`
- `acquire_hands_out_smallest_index_first`
- `full_then_release_then_acquire_returns_released_slot`
- `release_restores_smallest_first_ordering` — scrambled release must preserve ascending next-acquire order
- `double_release_is_idempotent`
- `out_of_range_release_is_ignored`
- `in_use_accounting_matches_acquires_and_releases`
- `default_uses_max_tracks`
- `stress_full_cycle_across_capacity` — full 256-slot allocation + release + re-allocation round-trip

### Mixer (`mixer.rs`)
- `pan_center_is_minus_three_db_on_both_channels`
- `pan_hard_left_sends_all_to_left_channel`
- `pan_hard_right_sends_all_to_right_channel`
- `pan_is_monotonic_across_range` — 21 samples across [-1, 1]
- `pan_conserves_power_at_every_position` — 201 samples, asserts `L² + R² ≈ 1`
- `pan_clamps_out_of_range_input` — including `±∞`
- `unoccupied_is_never_audible`
- `plain_occupied_track_is_audible_without_solo`
- `muted_track_is_silent_even_without_solo`
- `non_soloed_track_is_silent_when_any_solo_active`
- `soloed_track_is_audible_when_any_solo_active`
- `mute_beats_solo_convention` — regression guard for the `mute ≻ solo` convention

## Quality gates

- `cargo test --lib` — **59 passed, 0 failed** (30 pre-existing + 29 new), finishes in 0.41 s
- No production behavior changes — everything shipped here is dead code until 2B-1b wires it up. Zero regression risk for the running app or the Phase 2A CPAL lifecycle.

## Non-goals (for reviewer)

- `EngineCommand` enum + channel queue → **2B-1b**
- `AudioGraph::apply(cmd)` mutator → **2B-1b**
- Audio callback integration (command draining, graph processing) → **2B-1c**
- Tauri command handlers for track params → **2B-1d**
- `TauriBackend.ts` wiring → **2B-1d**
- Metering / effects / sends → **2B-2 / 2B-3 / 2B-4**

## Roadmap

| PR | Scope | Risk |
|---|---|---|
| **2B-1a (this)** | Data structures + DSP math | ⭐ (pure math, no runtime path) |
| 2B-1b | Command queue + `apply` | ⭐⭐ (still pure Rust) |
| 2B-1c | Audio callback integration | ⭐⭐⭐⭐ (real-time safety) |
| 2B-1d | TS wiring | ⭐⭐ |
| 2B-2 | Metering | ⭐⭐⭐ |
| 2B-3 | Effect chain | ⭐⭐⭐ |
| 2B-4 | Send/return routing | ⭐⭐⭐ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)