### PR TITLE
feat: Phase 2B-1b — EngineCommand queue + AudioGraph::apply (#1695)

### DIFF
--- a/src-tauri/src/engine/command.rs
+++ b/src-tauri/src/engine/command.rs
@@ -6,20 +6,25 @@
 //! [`super::graph::AudioGraph::apply`]; they are never reflected back
 //! to the main thread.
 //!
-//! # Invariants relied on by callers
+//! # Generation-checked slot targeting
 //!
-//! - **Do not reuse a slot** until any outstanding commands that
-//!   reference it have been processed by the audio thread. In practice
-//!   the command latency is one audio buffer (~5 ms at 256 frames /
-//!   48 kHz), so the main thread can safely assume a command is
-//!   applied after this much time. Reusing a slot immediately would
-//!   risk an in-flight `SetTrackParams` from the old occupant
-//!   mutating the new occupant's state.
+//! Targeted commands carry a [`super::slot::SlotHandle`] (slot index
+//! plus generation counter) rather than a bare `usize`. The audio
+//! thread validates the generation against the live value stored on
+//! the track before mutating, so a stale command from a previous
+//! owner — for example a `SetTrackParams` queued just before the
+//! main thread released and re-acquired the same slot for a new
+//! track — is silently dropped instead of overwriting the new
+//! owner's state. Found by codex review on PR #1696.
+//!
+//! # Caller invariants
 //!
 //! - Commands targeting an out-of-range slot index are silently
 //!   ignored by `apply` — tolerant of stale UI state.
 
 use serde::{Deserialize, Serialize};
+
+use super::slot::SlotHandle;
 
 /// Per-track parameters that the main thread can push at any time.
 /// This is the full mutable state of a `Track`; finer-grained commands
@@ -61,24 +66,36 @@ impl Default for TrackParams {
 /// cache-friendly constant.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum EngineCommand {
-    /// Mark a slot as occupied and seed its parameters. Out-of-range
-    /// slots are ignored. Idempotent: applying twice to the same slot
-    /// with the same params produces the same state.
-    AddTrack { slot: usize, params: TrackParams },
+    /// Seed a slot: mark it occupied, store the handle's generation,
+    /// and write the initial params. `AddTrack` is the *first* command
+    /// for a new owner so it does not validate the existing state —
+    /// it *establishes* the generation that subsequent commands will
+    /// be checked against.
+    AddTrack {
+        handle: SlotHandle,
+        params: TrackParams,
+    },
 
     /// Clear a slot back to `Track::default()` (occupied=false,
-    /// volume=1, pan=0, mute=false, solo=false). Crucially this also
-    /// clears the `solo` flag, so `any_solo()` cannot be left stuck on
-    /// a stale bit after the soloed track is removed.
-    RemoveTrack { slot: usize },
+    /// generation=0, volume=1, pan=0, mute=false, solo=false).
+    /// Applied only if the handle's generation matches the live
+    /// value on the track — a stale remove from a previous owner
+    /// is silently dropped.
+    RemoveTrack { handle: SlotHandle },
 
-    /// Replace the parameters of an **already occupied** slot. Applied
-    /// only if the slot is currently occupied — a command that arrives
-    /// after the track was removed is silently dropped, which is the
-    /// safer default when commands can race with remove-then-re-add.
-    SetTrackParams { slot: usize, params: TrackParams },
+    /// Replace the parameters of an already-occupied slot.
+    /// Generation-checked: a `SetTrackParams` whose handle's
+    /// generation no longer matches the live track is silently
+    /// dropped. This protects against a race where the main thread
+    /// releases a slot and the next track acquires it before an
+    /// in-flight `SetTrackParams` from the previous owner has been
+    /// drained.
+    SetTrackParams {
+        handle: SlotHandle,
+        params: TrackParams,
+    },
 
-    /// Master-bus linear gain.
+    /// Master-bus linear gain. Unconditional — no slot targeting.
     SetMasterVolume { volume: f32 },
 }
 
@@ -106,10 +123,10 @@ mod tests {
         assert_copy::<EngineCommand>();
 
         // Regression guard: keep the enum from growing unboundedly as
-        // new variants are added. `AddTrack` is currently the largest
-        // variant (usize + f32*2 + bool*2 + discriminant). 64 bytes is
-        // a generous ceiling that still fits comfortably in a single
-        // cache line.
+        // new variants are added. `AddTrack` carries a `SlotHandle`
+        // (usize + u32) + `TrackParams` (f32 × 2 + bool × 2) +
+        // discriminant. 64 bytes is a generous ceiling that still
+        // fits in one cache line on every reasonable target.
         assert!(
             std::mem::size_of::<EngineCommand>() <= 64,
             "EngineCommand grew to {} bytes",

--- a/src-tauri/src/engine/command.rs
+++ b/src-tauri/src/engine/command.rs
@@ -1,0 +1,136 @@
+//! Commands that mutate the audio processing graph.
+//!
+//! The command queue is a one-way pipe from the main thread (Tauri
+//! command handlers) to the audio thread (CPAL callback). Commands are
+//! applied to the [`super::graph::AudioGraph`] in-place via
+//! [`super::graph::AudioGraph::apply`]; they are never reflected back
+//! to the main thread.
+//!
+//! # Invariants relied on by callers
+//!
+//! - **Do not reuse a slot** until any outstanding commands that
+//!   reference it have been processed by the audio thread. In practice
+//!   the command latency is one audio buffer (~5 ms at 256 frames /
+//!   48 kHz), so the main thread can safely assume a command is
+//!   applied after this much time. Reusing a slot immediately would
+//!   risk an in-flight `SetTrackParams` from the old occupant
+//!   mutating the new occupant's state.
+//!
+//! - Commands targeting an out-of-range slot index are silently
+//!   ignored by `apply` — tolerant of stale UI state.
+
+use serde::{Deserialize, Serialize};
+
+/// Per-track parameters that the main thread can push at any time.
+/// This is the full mutable state of a `Track`; finer-grained commands
+/// (set volume only, set pan only) can be added later if automation
+/// wants to avoid the churn of re-sending unchanged fields.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackParams {
+    pub volume: f32,
+    pub pan: f32,
+    pub mute: bool,
+    pub solo: bool,
+}
+
+impl TrackParams {
+    /// Unity-gain, center-pan, unmuted, unsoloed — the default state of
+    /// a freshly added track.
+    pub fn unity() -> Self {
+        Self {
+            volume: 1.0,
+            pan: 0.0,
+            mute: false,
+            solo: false,
+        }
+    }
+}
+
+impl Default for TrackParams {
+    fn default() -> Self {
+        Self::unity()
+    }
+}
+
+/// A command that mutates the audio graph.
+///
+/// Deliberately a flat `Copy` enum so that sending one through a
+/// lock-free channel (added in 2B-1c) is a plain memcpy with no heap
+/// allocation, keeping the audio-thread cost of `try_recv` to a
+/// cache-friendly constant.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EngineCommand {
+    /// Mark a slot as occupied and seed its parameters. Out-of-range
+    /// slots are ignored. Idempotent: applying twice to the same slot
+    /// with the same params produces the same state.
+    AddTrack { slot: usize, params: TrackParams },
+
+    /// Clear a slot back to `Track::default()` (occupied=false,
+    /// volume=1, pan=0, mute=false, solo=false). Crucially this also
+    /// clears the `solo` flag, so `any_solo()` cannot be left stuck on
+    /// a stale bit after the soloed track is removed.
+    RemoveTrack { slot: usize },
+
+    /// Replace the parameters of an **already occupied** slot. Applied
+    /// only if the slot is currently occupied — a command that arrives
+    /// after the track was removed is silently dropped, which is the
+    /// safer default when commands can race with remove-then-re-add.
+    SetTrackParams { slot: usize, params: TrackParams },
+
+    /// Master-bus linear gain.
+    SetMasterVolume { volume: f32 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn track_params_default_is_unity() {
+        assert_eq!(TrackParams::default(), TrackParams::unity());
+        let p = TrackParams::default();
+        assert_eq!(p.volume, 1.0);
+        assert_eq!(p.pan, 0.0);
+        assert!(!p.mute);
+        assert!(!p.solo);
+    }
+
+    #[test]
+    fn engine_command_is_copy_and_small() {
+        // The whole point of making EngineCommand flat and Copy is
+        // that it can be sent through a lock-free channel without
+        // allocation. Assert the type is Copy at compile time and
+        // that its size is bounded.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<EngineCommand>();
+
+        // Regression guard: keep the enum from growing unboundedly as
+        // new variants are added. `AddTrack` is currently the largest
+        // variant (usize + f32*2 + bool*2 + discriminant). 64 bytes is
+        // a generous ceiling that still fits comfortably in a single
+        // cache line.
+        assert!(
+            std::mem::size_of::<EngineCommand>() <= 64,
+            "EngineCommand grew to {} bytes",
+            std::mem::size_of::<EngineCommand>()
+        );
+    }
+
+    #[test]
+    fn track_params_round_trips_through_serde() {
+        let p = TrackParams {
+            volume: 0.75,
+            pan: -0.3,
+            mute: false,
+            solo: true,
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: TrackParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, back);
+        // camelCase field names on the wire for the frontend.
+        assert!(json.contains("\"volume\":0.75"));
+        assert!(json.contains("\"pan\":-0.3"));
+        assert!(json.contains("\"solo\":true"));
+    }
+}

--- a/src-tauri/src/engine/graph.rs
+++ b/src-tauri/src/engine/graph.rs
@@ -1,4 +1,4 @@
-//! Audio processing graph — pure data structures.
+//! Audio processing graph — data structures and command application.
 //!
 //! # Why a fixed-capacity slab?
 //!
@@ -13,12 +13,14 @@
 //!
 //! # What's NOT in this module
 //!
-//! - The command queue (`EngineCommand`) that mutates tracks → 2B-1b
-//! - `AudioGraph::apply(cmd)` → 2B-1b
+//! - Channel / `Sender<EngineCommand>` wiring → 2B-1c
 //! - Integration with the CPAL audio callback → 2B-1c
 //!
-//! This file is intentionally leaf data: `Track`, `AudioGraph`, and
-//! simple queries. Nothing here is real-time sensitive yet.
+//! This file exposes leaf data (`Track`, `AudioGraph`) plus the pure
+//! `apply` mutator that the audio thread will call once the channel is
+//! plumbed in 2B-1c. Nothing here touches real-time audio yet.
+
+use super::command::{EngineCommand, TrackParams};
 
 /// Maximum number of simultaneously active tracks. Increase only after
 /// a memory / cache-line audit — contiguous iteration over the full
@@ -140,6 +142,60 @@ impl AudioGraph {
             *t = Track::default();
         }
     }
+
+    /// Apply a command to the graph in place.
+    ///
+    /// This is the **only** way the audio thread mutates the graph once
+    /// 2B-1c plumbs the channel — the main thread sends commands, the
+    /// audio callback drains them, and this method performs the actual
+    /// mutation. For now it is invoked directly by tests.
+    ///
+    /// # Command semantics
+    ///
+    /// - [`EngineCommand::AddTrack`] sets `occupied = true` and copies
+    ///   the params. Out-of-range slots are ignored.
+    /// - [`EngineCommand::RemoveTrack`] resets the slot to
+    ///   [`Track::default`]. Crucially this also clears `solo`, which
+    ///   guarantees [`Self::any_solo`] cannot report stale state after
+    ///   a soloed track is removed.
+    /// - [`EngineCommand::SetTrackParams`] updates params **only if**
+    ///   the slot is currently occupied. A command that arrives after
+    ///   the track was removed is silently dropped — safer than
+    ///   forcing a re-occupation that would surprise the main thread.
+    /// - [`EngineCommand::SetMasterVolume`] writes the master-bus gain.
+    pub fn apply(&mut self, cmd: EngineCommand) {
+        match cmd {
+            EngineCommand::AddTrack { slot, params } => {
+                if let Some(t) = self.tracks.get_mut(slot) {
+                    t.occupied = true;
+                    copy_params(t, &params);
+                }
+            }
+            EngineCommand::RemoveTrack { slot } => {
+                // Delegate to clear_slot so the full reset logic
+                // (including the stale-solo guard) stays in one place.
+                self.clear_slot(slot);
+            }
+            EngineCommand::SetTrackParams { slot, params } => {
+                if let Some(t) = self.tracks.get_mut(slot) {
+                    if t.occupied {
+                        copy_params(t, &params);
+                    }
+                }
+            }
+            EngineCommand::SetMasterVolume { volume } => {
+                self.master_volume = volume;
+            }
+        }
+    }
+}
+
+#[inline]
+fn copy_params(track: &mut Track, params: &TrackParams) {
+    track.volume = params.volume;
+    track.pan = params.pan;
+    track.mute = params.mute;
+    track.solo = params.solo;
 }
 
 impl Default for AudioGraph {
@@ -217,6 +273,8 @@ mod tests {
         assert!(g.track_mut(MAX_TRACKS + 1).is_none());
     }
 
+    // ── clear_slot() ────────────────────────────────────────────────
+
     #[test]
     fn clear_slot_wipes_all_fields_including_solo_and_pan() {
         // Regression guard for codex finding #2 on PR #1694.
@@ -269,14 +327,195 @@ mod tests {
             t.volume = 0.1;
         }
         g.clear_slot(0);
-        // Simulate a fresh "add" by re-flipping occupied (what
-        // 2B-1b's EngineCommand::AddTrack will do via apply()).
+        // Simulate a fresh "add" by re-flipping occupied.
         g.track_mut(0).unwrap().occupied = true;
         let t = g.track(0).unwrap();
         assert_eq!(t.volume, 1.0);
         assert_eq!(t.pan, 0.0);
         assert!(!t.mute);
         assert!(!t.solo);
+    }
+
+    // ── apply() semantics ───────────────────────────────────────────
+
+    fn solo_params() -> TrackParams {
+        TrackParams {
+            volume: 0.5,
+            pan: -0.25,
+            mute: false,
+            solo: true,
+        }
+    }
+
+    #[test]
+    fn apply_add_track_marks_slot_occupied_with_params() {
+        let mut g = AudioGraph::new();
+        g.apply(EngineCommand::AddTrack {
+            slot: 3,
+            params: solo_params(),
+        });
+        let t = g.track(3).unwrap();
+        assert!(t.occupied);
+        assert_eq!(t.volume, 0.5);
+        assert_eq!(t.pan, -0.25);
+        assert!(!t.mute);
+        assert!(t.solo);
+        assert_eq!(g.active_count(), 1);
+        assert!(g.any_solo());
+    }
+
+    #[test]
+    fn apply_add_track_out_of_range_is_noop() {
+        let mut g = AudioGraph::new();
+        g.apply(EngineCommand::AddTrack {
+            slot: MAX_TRACKS,
+            params: TrackParams::unity(),
+        });
+        assert_eq!(g.active_count(), 0);
+    }
+
+    #[test]
+    fn apply_remove_track_clears_all_fields_including_solo() {
+        // Regression guard for the `any_solo` stale-bit edge case from
+        // 2B-1a. After removing a soloed track, any_solo() must be
+        // false — i.e. RemoveTrack must zero the solo bit, not just
+        // the occupied bit.
+        let mut g = AudioGraph::new();
+        g.apply(EngineCommand::AddTrack {
+            slot: 0,
+            params: solo_params(),
+        });
+        assert!(g.any_solo());
+
+        g.apply(EngineCommand::RemoveTrack { slot: 0 });
+        assert!(!g.any_solo());
+        assert_eq!(g.active_count(), 0);
+        let t = g.track(0).unwrap();
+        assert_eq!(*t, Track::default());
+    }
+
+    #[test]
+    fn apply_set_track_params_updates_occupied_slot() {
+        let mut g = AudioGraph::new();
+        g.apply(EngineCommand::AddTrack {
+            slot: 5,
+            params: TrackParams::unity(),
+        });
+        g.apply(EngineCommand::SetTrackParams {
+            slot: 5,
+            params: TrackParams {
+                volume: 0.1,
+                pan: 0.9,
+                mute: true,
+                solo: false,
+            },
+        });
+        let t = g.track(5).unwrap();
+        assert_eq!(t.volume, 0.1);
+        assert_eq!(t.pan, 0.9);
+        assert!(t.mute);
+        assert!(!t.solo);
+        assert!(t.occupied, "SetTrackParams must not clear occupancy");
+    }
+
+    #[test]
+    fn apply_set_track_params_on_unoccupied_slot_is_dropped() {
+        // A SetTrackParams racing against a just-processed RemoveTrack
+        // must not silently re-occupy the slot. Otherwise a removed
+        // track would pop back into the mix after the user expected it
+        // gone.
+        let mut g = AudioGraph::new();
+        g.apply(EngineCommand::SetTrackParams {
+            slot: 7,
+            params: TrackParams {
+                volume: 2.0,
+                pan: 0.5,
+                mute: false,
+                solo: true,
+            },
+        });
+        let t = g.track(7).unwrap();
+        assert_eq!(*t, Track::default(), "slot must stay pristine");
+        assert!(!g.any_solo());
+    }
+
+    #[test]
+    fn apply_set_master_volume_writes_master_bus_gain() {
+        let mut g = AudioGraph::new();
+        g.apply(EngineCommand::SetMasterVolume { volume: 0.25 });
+        assert_eq!(g.master_volume, 0.25);
+
+        g.apply(EngineCommand::SetMasterVolume { volume: 1.5 });
+        assert_eq!(g.master_volume, 1.5);
+    }
+
+    #[test]
+    fn apply_sequence_add_remove_readd_is_clean() {
+        // End-to-end simulation: add track, mutate params, remove,
+        // re-add at the same slot with different params. Final state
+        // must reflect only the second add; no leakage from the first.
+        let mut g = AudioGraph::new();
+        g.apply(EngineCommand::AddTrack {
+            slot: 10,
+            params: solo_params(),
+        });
+        g.apply(EngineCommand::SetTrackParams {
+            slot: 10,
+            params: TrackParams {
+                volume: 0.8,
+                pan: 0.6,
+                mute: true,
+                solo: true,
+            },
+        });
+        g.apply(EngineCommand::RemoveTrack { slot: 10 });
+
+        g.apply(EngineCommand::AddTrack {
+            slot: 10,
+            params: TrackParams::unity(),
+        });
+        let t = g.track(10).unwrap();
+        assert!(t.occupied);
+        assert_eq!(t.volume, 1.0);
+        assert_eq!(t.pan, 0.0);
+        assert!(!t.mute);
+        assert!(!t.solo);
+        assert_eq!(g.active_count(), 1);
+        assert!(!g.any_solo());
+    }
+
+    #[test]
+    fn apply_does_not_allocate_on_hot_path() {
+        // Proxy check for allocation-free: `apply` is pure mutation on
+        // a pre-allocated slab, so the graph's storage pointer must be
+        // stable before and after a burst of commands.
+        let mut g = AudioGraph::new();
+        let ptr_before = g.all_tracks().as_ptr();
+        for slot in 0..128 {
+            g.apply(EngineCommand::AddTrack {
+                slot,
+                params: TrackParams::unity(),
+            });
+        }
+        for slot in 0..128 {
+            g.apply(EngineCommand::SetTrackParams {
+                slot,
+                params: TrackParams {
+                    volume: 0.5,
+                    pan: 0.1,
+                    mute: false,
+                    solo: false,
+                },
+            });
+        }
+        for slot in 0..128 {
+            g.apply(EngineCommand::RemoveTrack { slot });
+        }
+        g.apply(EngineCommand::SetMasterVolume { volume: 0.75 });
+        let ptr_after = g.all_tracks().as_ptr();
+        assert_eq!(ptr_before, ptr_after);
+        assert_eq!(g.active_count(), 0);
+        assert_eq!(g.master_volume, 0.75);
     }
 
     #[test]

--- a/src-tauri/src/engine/graph.rs
+++ b/src-tauri/src/engine/graph.rs
@@ -21,6 +21,7 @@
 //! plumbed in 2B-1c. Nothing here touches real-time audio yet.
 
 use super::command::{EngineCommand, TrackParams};
+use super::slot::SlotHandle;
 
 /// Maximum number of simultaneously active tracks. Increase only after
 /// a memory / cache-line audit — contiguous iteration over the full
@@ -36,9 +37,20 @@ pub const MAX_TRACKS: usize = 256;
 /// slots. Keeping occupancy inside the Track itself (rather than in a
 /// side-channel bitmap) simplifies the audio-thread read path to a
 /// single cache line per slot.
+///
+/// `generation` mirrors the [`super::slot::SlotHandle`] generation
+/// that last occupied this slot via [`AudioGraph::apply`]. Commands
+/// from stale owners (e.g. a `SetTrackParams` that raced against a
+/// `RemoveTrack` + re-add) carry the owner's handle; `apply` compares
+/// the handle's generation against the live one and silently drops
+/// mismatches. `0` is a sentinel "uninitialised" value —
+/// `SlotAllocator::acquire` never issues generation 0, so a fresh
+/// slot cannot accidentally match a live handle. Found by codex
+/// review on PR #1696.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Track {
     pub occupied: bool,
+    pub generation: u32,
     /// Linear gain (1.0 = unity, 0.0 = silent). UI-side dB values are
     /// converted to linear before being sent as a command.
     pub volume: f32,
@@ -53,6 +65,7 @@ impl Default for Track {
     fn default() -> Self {
         Self {
             occupied: false,
+            generation: 0,
             volume: 1.0,
             pan: 0.0,
             mute: false,
@@ -150,42 +163,73 @@ impl AudioGraph {
     /// audio callback drains them, and this method performs the actual
     /// mutation. For now it is invoked directly by tests.
     ///
+    /// # Generation checks
+    ///
+    /// Commands that target a specific slot carry a
+    /// [`super::slot::SlotHandle`], which bundles the slot index with
+    /// the generation assigned by `SlotAllocator` at acquisition time.
+    /// `apply` compares the handle's generation against the one
+    /// currently stored on the track before performing any mutation.
+    /// This closes the race where a `SetTrackParams` or `RemoveTrack`
+    /// from a previous owner, queued just before the main thread
+    /// released and re-acquired the slot, would otherwise overwrite
+    /// the new owner's state — found by codex review on PR #1696.
+    ///
     /// # Command semantics
     ///
-    /// - [`EngineCommand::AddTrack`] sets `occupied = true` and copies
-    ///   the params. Out-of-range slots are ignored.
-    /// - [`EngineCommand::RemoveTrack`] resets the slot to
-    ///   [`Track::default`]. Crucially this also clears `solo`, which
-    ///   guarantees [`Self::any_solo`] cannot report stale state after
-    ///   a soloed track is removed.
-    /// - [`EngineCommand::SetTrackParams`] updates params **only if**
-    ///   the slot is currently occupied. A command that arrives after
-    ///   the track was removed is silently dropped — safer than
-    ///   forcing a re-occupation that would surprise the main thread.
-    /// - [`EngineCommand::SetMasterVolume`] writes the master-bus gain.
+    /// - [`EngineCommand::AddTrack`] unconditionally seeds the slot:
+    ///   writes `occupied = true`, stores the handle's generation,
+    ///   and copies params. Out-of-range slots are ignored. Add is
+    ///   the *first* command for a new owner so there is nothing to
+    ///   validate against — it *establishes* the generation.
+    /// - [`EngineCommand::RemoveTrack`] validates the handle's
+    ///   generation matches the live one before calling
+    ///   [`Self::clear_slot`]. A stale remove is a no-op.
+    /// - [`EngineCommand::SetTrackParams`] validates the handle's
+    ///   generation matches, the slot is occupied, and then mutates.
+    ///   Stale commands are silently dropped.
+    /// - [`EngineCommand::SetMasterVolume`] writes the master-bus
+    ///   gain unconditionally (no slot targeting).
     pub fn apply(&mut self, cmd: EngineCommand) {
         match cmd {
-            EngineCommand::AddTrack { slot, params } => {
-                if let Some(t) = self.tracks.get_mut(slot) {
+            EngineCommand::AddTrack { handle, params } => {
+                if let Some(t) = self.tracks.get_mut(handle.index()) {
                     t.occupied = true;
+                    t.generation = handle.generation();
                     copy_params(t, &params);
                 }
             }
-            EngineCommand::RemoveTrack { slot } => {
-                // Delegate to clear_slot so the full reset logic
-                // (including the stale-solo guard) stays in one place.
-                self.clear_slot(slot);
+            EngineCommand::RemoveTrack { handle } => {
+                if self.handle_matches(handle) {
+                    // Delegate to clear_slot so the full-reset logic
+                    // (including the stale-solo guard) stays in one
+                    // place. clear_slot resets generation back to 0,
+                    // which can never match a live SlotHandle because
+                    // SlotAllocator::acquire never issues generation 0.
+                    self.clear_slot(handle.index());
+                }
             }
-            EngineCommand::SetTrackParams { slot, params } => {
-                if let Some(t) = self.tracks.get_mut(slot) {
-                    if t.occupied {
-                        copy_params(t, &params);
-                    }
+            EngineCommand::SetTrackParams { handle, params } => {
+                if self.handle_matches(handle) {
+                    // handle_matches already bounds-checked.
+                    let t = self.tracks.get_mut(handle.index()).unwrap();
+                    copy_params(t, &params);
                 }
             }
             EngineCommand::SetMasterVolume { volume } => {
                 self.master_volume = volume;
             }
+        }
+    }
+
+    /// True iff the handle's slot is in range, currently occupied,
+    /// and its generation matches the live value stored on the track.
+    /// Pulled into its own helper so every validating arm of `apply`
+    /// shares the exact same predicate.
+    fn handle_matches(&self, handle: SlotHandle) -> bool {
+        match self.tracks.get(handle.index()) {
+            Some(t) => t.occupied && t.generation == handle.generation(),
+            None => false,
         }
     }
 }
@@ -212,6 +256,7 @@ mod tests {
     fn default_track_is_unoccupied_unity_centered() {
         let t = Track::default();
         assert!(!t.occupied);
+        assert_eq!(t.generation, 0, "sentinel generation");
         assert_eq!(t.volume, 1.0);
         assert_eq!(t.pan, 0.0);
         assert!(!t.mute);
@@ -338,6 +383,8 @@ mod tests {
 
     // ── apply() semantics ───────────────────────────────────────────
 
+    use super::super::slot::SlotAllocator;
+
     fn solo_params() -> TrackParams {
         TrackParams {
             volume: 0.5,
@@ -347,15 +394,25 @@ mod tests {
         }
     }
 
+    /// Set up a graph + allocator, acquire one handle, and return both.
+    /// Tests that only need a single live track use this helper.
+    fn graph_with_one_track() -> (AudioGraph, SlotAllocator, SlotHandle) {
+        let g = AudioGraph::new();
+        let mut alloc = SlotAllocator::with_default_capacity();
+        let h = alloc.acquire().unwrap();
+        (g, alloc, h)
+    }
+
     #[test]
-    fn apply_add_track_marks_slot_occupied_with_params() {
-        let mut g = AudioGraph::new();
+    fn apply_add_track_marks_slot_occupied_with_params_and_generation() {
+        let (mut g, _alloc, h) = graph_with_one_track();
         g.apply(EngineCommand::AddTrack {
-            slot: 3,
+            handle: h,
             params: solo_params(),
         });
-        let t = g.track(3).unwrap();
+        let t = g.track(h.index()).unwrap();
         assert!(t.occupied);
+        assert_eq!(t.generation, h.generation());
         assert_eq!(t.volume, 0.5);
         assert_eq!(t.pan, -0.25);
         assert!(!t.mute);
@@ -365,10 +422,22 @@ mod tests {
     }
 
     #[test]
-    fn apply_add_track_out_of_range_is_noop() {
+    fn apply_add_track_on_clamped_graph_with_oor_slot_is_noop() {
+        // Construct a handle that points past the graph capacity by
+        // using a SlotAllocator with a deliberately larger capacity.
+        // Real code would never produce such a handle, but the guard
+        // has to exist — out-of-range slots must be silently ignored.
         let mut g = AudioGraph::new();
+        let mut alloc = SlotAllocator::new(MAX_TRACKS + 4);
+        // Drain the in-range slots so the next acquire returns an
+        // index past MAX_TRACKS.
+        for _ in 0..MAX_TRACKS {
+            alloc.acquire();
+        }
+        let h = alloc.acquire().unwrap();
+        assert!(h.index() >= MAX_TRACKS);
         g.apply(EngineCommand::AddTrack {
-            slot: MAX_TRACKS,
+            handle: h,
             params: TrackParams::unity(),
         });
         assert_eq!(g.active_count(), 0);
@@ -380,29 +449,29 @@ mod tests {
         // 2B-1a. After removing a soloed track, any_solo() must be
         // false — i.e. RemoveTrack must zero the solo bit, not just
         // the occupied bit.
-        let mut g = AudioGraph::new();
+        let (mut g, _alloc, h) = graph_with_one_track();
         g.apply(EngineCommand::AddTrack {
-            slot: 0,
+            handle: h,
             params: solo_params(),
         });
         assert!(g.any_solo());
 
-        g.apply(EngineCommand::RemoveTrack { slot: 0 });
+        g.apply(EngineCommand::RemoveTrack { handle: h });
         assert!(!g.any_solo());
         assert_eq!(g.active_count(), 0);
-        let t = g.track(0).unwrap();
+        let t = g.track(h.index()).unwrap();
         assert_eq!(*t, Track::default());
     }
 
     #[test]
     fn apply_set_track_params_updates_occupied_slot() {
-        let mut g = AudioGraph::new();
+        let (mut g, _alloc, h) = graph_with_one_track();
         g.apply(EngineCommand::AddTrack {
-            slot: 5,
+            handle: h,
             params: TrackParams::unity(),
         });
         g.apply(EngineCommand::SetTrackParams {
-            slot: 5,
+            handle: h,
             params: TrackParams {
                 volume: 0.1,
                 pan: 0.9,
@@ -410,23 +479,23 @@ mod tests {
                 solo: false,
             },
         });
-        let t = g.track(5).unwrap();
+        let t = g.track(h.index()).unwrap();
         assert_eq!(t.volume, 0.1);
         assert_eq!(t.pan, 0.9);
         assert!(t.mute);
         assert!(!t.solo);
         assert!(t.occupied, "SetTrackParams must not clear occupancy");
+        assert_eq!(t.generation, h.generation(), "generation unchanged");
     }
 
     #[test]
     fn apply_set_track_params_on_unoccupied_slot_is_dropped() {
-        // A SetTrackParams racing against a just-processed RemoveTrack
-        // must not silently re-occupy the slot. Otherwise a removed
-        // track would pop back into the mix after the user expected it
-        // gone.
-        let mut g = AudioGraph::new();
+        // A SetTrackParams that arrives without a prior AddTrack must
+        // not silently re-occupy the slot. Otherwise a removed track
+        // would pop back into the mix after the user expected it gone.
+        let (mut g, _alloc, h) = graph_with_one_track();
         g.apply(EngineCommand::SetTrackParams {
-            slot: 7,
+            handle: h,
             params: TrackParams {
                 volume: 2.0,
                 pan: 0.5,
@@ -434,9 +503,88 @@ mod tests {
                 solo: true,
             },
         });
-        let t = g.track(7).unwrap();
+        let t = g.track(h.index()).unwrap();
         assert_eq!(*t, Track::default(), "slot must stay pristine");
         assert!(!g.any_solo());
+    }
+
+    #[test]
+    fn apply_stale_set_track_params_from_previous_owner_is_dropped() {
+        // Regression guard for codex finding on PR #1696.
+        //
+        // Scenario:
+        //   1. Allocator hands handle_a to owner A (slot 0, gen 1)
+        //   2. Main thread queues SetTrackParams(handle_a, X) for A
+        //   3. Main thread removes owner A (RemoveTrack then release)
+        //   4. Main thread re-acquires → handle_b (slot 0, gen 2) for owner B
+        //   5. Main thread queues AddTrack(handle_b, Y) for B
+        //   6. Audio thread drains. BUT the stale SetTrackParams from
+        //      step 2 arrives BEFORE the RemoveTrack in a reordered
+        //      scenario — or alternatively the main thread compiled
+        //      SetTrackParams against handle_a after B was in place.
+        //
+        // Without generation checks, that stale SetTrackParams would
+        // mutate owner B's state with A's params. With generation
+        // checks, the handle's gen 1 doesn't match the live gen 2 on
+        // the slot, and the command is silently dropped.
+        let mut g = AudioGraph::new();
+        let mut alloc = SlotAllocator::with_default_capacity();
+
+        // Owner A acquires and is added.
+        let handle_a = alloc.acquire().unwrap();
+        g.apply(EngineCommand::AddTrack {
+            handle: handle_a,
+            params: TrackParams::unity(),
+        });
+
+        // Owner A is removed AND the slot released to the allocator.
+        g.apply(EngineCommand::RemoveTrack { handle: handle_a });
+        alloc.release(handle_a);
+
+        // Owner B acquires the same slot and is added with distinct
+        // params so we can observe whether a stale command mutates it.
+        let handle_b = alloc.acquire().unwrap();
+        assert_eq!(handle_a.index(), handle_b.index(), "slot reused");
+        assert_ne!(
+            handle_a.generation(),
+            handle_b.generation(),
+            "generation should advance"
+        );
+        let owner_b_params = TrackParams {
+            volume: 0.9,
+            pan: 0.3,
+            mute: false,
+            solo: false,
+        };
+        g.apply(EngineCommand::AddTrack {
+            handle: handle_b,
+            params: owner_b_params,
+        });
+
+        // A stale SetTrackParams from owner A arrives late. It must be
+        // silently dropped and leave owner B's state untouched.
+        g.apply(EngineCommand::SetTrackParams {
+            handle: handle_a,
+            params: TrackParams {
+                volume: 0.01,
+                pan: -0.99,
+                mute: true,
+                solo: true,
+            },
+        });
+
+        let t = g.track(handle_b.index()).unwrap();
+        assert_eq!(t.volume, owner_b_params.volume);
+        assert_eq!(t.pan, owner_b_params.pan);
+        assert!(!t.mute);
+        assert!(!t.solo);
+        assert_eq!(t.generation, handle_b.generation());
+
+        // A stale RemoveTrack from owner A must also be dropped.
+        g.apply(EngineCommand::RemoveTrack { handle: handle_a });
+        let t = g.track(handle_b.index()).unwrap();
+        assert!(t.occupied, "owner B must still be live");
+        assert_eq!(t.generation, handle_b.generation());
     }
 
     #[test]
@@ -455,12 +603,15 @@ mod tests {
         // re-add at the same slot with different params. Final state
         // must reflect only the second add; no leakage from the first.
         let mut g = AudioGraph::new();
+        let mut alloc = SlotAllocator::with_default_capacity();
+        let h1 = alloc.acquire().unwrap();
+
         g.apply(EngineCommand::AddTrack {
-            slot: 10,
+            handle: h1,
             params: solo_params(),
         });
         g.apply(EngineCommand::SetTrackParams {
-            slot: 10,
+            handle: h1,
             params: TrackParams {
                 volume: 0.8,
                 pan: 0.6,
@@ -468,18 +619,22 @@ mod tests {
                 solo: true,
             },
         });
-        g.apply(EngineCommand::RemoveTrack { slot: 10 });
+        g.apply(EngineCommand::RemoveTrack { handle: h1 });
+        alloc.release(h1);
 
+        let h2 = alloc.acquire().unwrap();
+        assert_eq!(h1.index(), h2.index());
         g.apply(EngineCommand::AddTrack {
-            slot: 10,
+            handle: h2,
             params: TrackParams::unity(),
         });
-        let t = g.track(10).unwrap();
+        let t = g.track(h2.index()).unwrap();
         assert!(t.occupied);
         assert_eq!(t.volume, 1.0);
         assert_eq!(t.pan, 0.0);
         assert!(!t.mute);
         assert!(!t.solo);
+        assert_eq!(t.generation, h2.generation());
         assert_eq!(g.active_count(), 1);
         assert!(!g.any_solo());
     }
@@ -490,16 +645,19 @@ mod tests {
         // a pre-allocated slab, so the graph's storage pointer must be
         // stable before and after a burst of commands.
         let mut g = AudioGraph::new();
+        let mut alloc = SlotAllocator::with_default_capacity();
+        let handles: Vec<SlotHandle> = (0..128).map(|_| alloc.acquire().unwrap()).collect();
+
         let ptr_before = g.all_tracks().as_ptr();
-        for slot in 0..128 {
+        for &h in &handles {
             g.apply(EngineCommand::AddTrack {
-                slot,
+                handle: h,
                 params: TrackParams::unity(),
             });
         }
-        for slot in 0..128 {
+        for &h in &handles {
             g.apply(EngineCommand::SetTrackParams {
-                slot,
+                handle: h,
                 params: TrackParams {
                     volume: 0.5,
                     pan: 0.1,
@@ -508,8 +666,8 @@ mod tests {
                 },
             });
         }
-        for slot in 0..128 {
-            g.apply(EngineCommand::RemoveTrack { slot });
+        for &h in &handles {
+            g.apply(EngineCommand::RemoveTrack { handle: h });
         }
         g.apply(EngineCommand::SetMasterVolume { volume: 0.75 });
         let ptr_after = g.all_tracks().as_ptr();

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -19,11 +19,13 @@
 //! tests drive the full state machine without any audio hardware.
 
 pub mod audio_io;
+pub mod command;
 pub mod config;
 pub mod graph;
 pub mod mixer;
 pub mod slot;
 
+pub use command::{EngineCommand, TrackParams};
 pub use config::{
     AudioDeviceInfo, ConfigError, EngineConfig, EngineStatus, VALID_BUFFER_SIZES,
     VALID_SAMPLE_RATES,


### PR DESCRIPTION
## Summary

Second atomic slice of Phase 2B (real-time mixer). Adds the command enum and the pure `AudioGraph::apply` mutator that the audio thread will call once the channel is plumbed in 2B-1c. **No audio callback changes, no channel wiring, no TypeScript** — this slice is dead code at runtime until 2B-1c lands, and is driven directly from tests in the meantime.

Closes #1695. Part of #1522 and epic #1519. Builds on 2B-1a (PR #1694).

## What's in the diff

### `src-tauri/src/engine/command.rs` (new)

- **`TrackParams { volume, pan, mute, solo }`** — flat POD, `Default = unity`, serde `camelCase` wire format ready for the frontend.
- **`EngineCommand`** enum with four variants:
  - `AddTrack { slot, params }`
  - `RemoveTrack { slot }`
  - `SetTrackParams { slot, params }`
  - `SetMasterVolume { volume }`

  Deliberately a flat `Copy` enum so that sending one through a lock-free channel in 2B-1c is a plain memcpy with zero heap allocation. A regression test asserts `sizeof::<EngineCommand>` stays ≤ 64 bytes — one cache line — so a future variant addition can't silently inflate the hot path.

### `src-tauri/src/engine/graph.rs` — `AudioGraph::apply(cmd)`

Single entry point by which the audio thread will mutate the graph once 2B-1c plumbs the channel. Semantics:

- **`AddTrack`** sets `occupied = true` and copies params. Out-of-range slots are silently ignored.
- **`RemoveTrack`** delegates to `clear_slot` (the primitive from 2B-1a). The full-reset logic — including the stale-solo-bit guard from the codex review on PR #1694 — lives in exactly one place. No duplication.
- **`SetTrackParams`** only mutates **occupied** slots. A command racing against a just-processed `RemoveTrack` is silently dropped rather than forcing a re-occupation that would surprise the main thread and resurrect a track the user thought was gone. The safer default when commands can race with remove-then-re-add.
- **`SetMasterVolume`** writes `master_volume`.

## Tests — 11 new, 76 total pass

### Apply semantics
- `apply_add_track_marks_slot_occupied_with_params`
- `apply_add_track_out_of_range_is_noop`
- `apply_remove_track_clears_all_fields_including_solo` — regression guard matching the 2B-1a `any_solo` stale-bit case
- `apply_set_track_params_updates_occupied_slot`
- `apply_set_track_params_on_unoccupied_slot_is_dropped` — the drop-on-race defense
- `apply_set_master_volume_writes_master_bus_gain`
- `apply_sequence_add_remove_readd_is_clean` — end-to-end: add, mutate, remove, re-add at the same slot with different params, asserts the final state reflects only the second add with zero leakage from the first
- `apply_does_not_allocate_on_hot_path` — proxy allocation guard: 128 `AddTrack` + 128 `SetTrackParams` + 128 `RemoveTrack` + 1 `SetMasterVolume` does not move the slab storage pointer

### Command type invariants
- `track_params_default_is_unity`
- `engine_command_is_copy_and_small` — compile-time `Copy` check + 64-byte size ceiling regression guard
- `track_params_round_trips_through_serde` — camelCase field names on the wire

## Quality gates

- `cargo test --lib` — **76 passed, 0 failed** (65 from main after 2B-1a + 11 new), finishes in 0.41 s
- Dead code at runtime: `apply` is only invoked from tests. 2B-1c will plumb a `Receiver<EngineCommand>` into the CPAL callback and drive `apply` from the drained commands. Zero regression risk for the running app or the Phase 2A CPAL lifecycle on main.

## Non-goals (for reviewer)

- Channel types (`Sender`/`Receiver`) exposed from the module → **2B-1c**
- Audio callback integration (drain commands, run graph per buffer) → **2B-1c**
- Tauri command handlers → **2B-1d**
- TypeScript wiring in `TauriBackend.ts` → **2B-1d**
- Metering / effects / sends → **2B-2 / 2B-3 / 2B-4**

🤖 Generated with [Claude Code](https://claude.com/claude-code)