### PR TITLE
feat: Phase 2B-1d — wire Tauri commands to Engine track/master API (#1699)

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -9,8 +9,10 @@ use std::sync::Mutex;
 use tauri::State;
 
 use crate::engine::{
-    audio_io, AudioDeviceInfo, Engine, EngineConfig, EngineError, EngineStatus,
+    audio_io, AudioDeviceInfo, CommandError, Engine, EngineConfig, EngineError,
+    EngineStatus, TrackParams,
 };
+use crate::engine::slot::SlotHandle;
 
 /// State wrapper around the engine. Tauri requires `Send + Sync`, and
 /// `Engine` itself is `!Sync` because it holds a channel sender; the
@@ -30,6 +32,8 @@ impl Default for EngineState {
     }
 }
 
+// ── Device enumeration ──────────────────────────────────────────────
+
 #[tauri::command]
 pub fn audio_list_devices() -> Vec<AudioDeviceInfo> {
     audio_io::list_output_devices()
@@ -39,6 +43,8 @@ pub fn audio_list_devices() -> Vec<AudioDeviceInfo> {
 pub fn audio_get_default_device() -> Option<AudioDeviceInfo> {
     audio_io::get_default_output_device_info()
 }
+
+// ── Engine lifecycle ────────────────────────────────────────────────
 
 #[tauri::command]
 pub fn audio_start_engine(
@@ -71,6 +77,57 @@ pub fn audio_get_engine_status(
         .lock()
         .map_err(|_| EngineError::Open("engine mutex poisoned".into()))?;
     Ok(engine.status())
+}
+
+// ── Track management (2B-1d) ────────────────────────────────────────
+
+#[tauri::command]
+pub fn audio_add_track(
+    params: TrackParams,
+    state: State<'_, EngineState>,
+) -> Result<SlotHandle, CommandError> {
+    let mut engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.add_track(params)
+}
+
+#[tauri::command]
+pub fn audio_remove_track(
+    handle: SlotHandle,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let mut engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.remove_track(handle)
+}
+
+#[tauri::command]
+pub fn audio_set_track_params(
+    handle: SlotHandle,
+    params: TrackParams,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.set_track_params(handle, params)
+}
+
+#[tauri::command]
+pub fn audio_set_master_volume(
+    volume: f32,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.set_master_volume(volume)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -108,8 +108,10 @@ pub enum EngineError {
 /// user would accept as "instant" stop.
 const STOP_GRACE_PERIOD: Duration = Duration::from_millis(100);
 
-/// Errors returned from the command-sending API.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+/// Errors returned from the command-sending API. Serializable for
+/// Tauri IPC error responses.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, thiserror::Error)]
+#[serde(rename_all = "camelCase", tag = "kind", content = "message")]
 pub enum CommandError {
     #[error("engine is not running; start it before sending commands")]
     NotRunning,

--- a/src-tauri/src/engine/slot.rs
+++ b/src-tauri/src/engine/slot.rs
@@ -32,7 +32,7 @@ use super::graph::MAX_TRACKS;
 ///
 /// Handles are `Copy` so they can be stored alongside track metadata
 /// without shared-ownership concerns.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SlotHandle {
     slot: usize,
     generation: u32,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,8 +4,10 @@ pub mod engine;
 use tauri::Manager;
 
 use crate::commands::audio::{
-    audio_get_default_device, audio_get_engine_status, audio_list_devices,
-    audio_start_engine, audio_stop_engine, EngineState,
+    audio_add_track, audio_get_default_device, audio_get_engine_status,
+    audio_list_devices, audio_remove_track, audio_set_master_volume,
+    audio_set_track_params, audio_start_engine, audio_stop_engine,
+    EngineState,
 };
 
 /// Greet command — placeholder to verify IPC works.
@@ -31,6 +33,10 @@ pub fn run() {
             audio_start_engine,
             audio_stop_engine,
             audio_get_engine_status,
+            audio_add_track,
+            audio_remove_track,
+            audio_set_track_params,
+            audio_set_master_volume,
         ])
         .setup(|app| {
             // Focus main window on startup

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -1,26 +1,28 @@
 /**
  * TauriBackend — delegates audio operations to the Rust engine via Tauri IPC.
  *
- * This is a stub implementation for Phase 1. Methods are wired to
- * `invoke()` and `listen()` calls but the Rust handlers do not exist yet.
- * The backend will be fleshed out in Phase 2 (Rust audio engine core)
- * and Phase 3 (native transport + clip scheduling).
+ * Phase 2B-1d: track management and master volume are now wired to
+ * the real Rust audio engine. The backend maintains an internal
+ * `trackId → SlotHandle` map to bridge the AudioBridge's string-based
+ * track IDs to the native engine's slot-generation handles.
  *
- * Until the Rust engine is ready, the WebAudioBackend is used instead.
+ * Remaining stubs (metering, clip scheduling, transport callbacks)
+ * will be fleshed out in Phase 2B-2, Phase 3, etc.
+ *
+ * Until the full Rust engine is ready, the WebAudioBackend is the
+ * default in browser mode.
  */
+import { invoke } from '@tauri-apps/api/core';
 import type {
   AudioBridge,
   BridgeClipInfo,
   MasterMeterData,
   MeterData,
+  NativeSlotHandle,
+  NativeTrackParams,
   TrackParams,
 } from './types';
 import type { MasteringState } from '../../types/project';
-
-// Placeholder — will use @tauri-apps/api/core when Rust handlers exist
-async function invoke<T>(_cmd: string, _args?: Record<string, unknown>): Promise<T> {
-  throw new Error('TauriBackend: Rust audio engine not yet implemented');
-}
 
 const ZERO_METER: MeterData = { level: -Infinity, leftLevel: -Infinity, rightLevel: -Infinity, clipped: false };
 const ZERO_MASTER: MasterMeterData = { level: -Infinity, clipped: false };
@@ -32,14 +34,24 @@ export class TauriBackend implements AudioBridge {
   private _timeUpdateCb: ((time: number) => void) | null = null;
   private _onEndedCb: (() => void) | null = null;
 
+  /**
+   * Maps the AudioBridge's string `trackId` to the native engine's
+   * `SlotHandle`. Populated by `ensureTrack`, consumed by
+   * `removeTrack` / `setTrackParams`.
+   */
+  private _trackHandles = new Map<string, NativeSlotHandle>();
+
   // ── Lifecycle ─────────────────────────────────────────────────────
 
   async resume(): Promise<void> {
-    await invoke('audio_resume');
+    await invoke('audio_start_engine', {
+      config: { sampleRate: 48000, bufferSize: 256, deviceName: null },
+    });
   }
 
   dispose(): void {
-    invoke('audio_dispose').catch(() => {});
+    invoke('audio_stop_engine').catch(() => {});
+    this._trackHandles.clear();
   }
 
   // ── Transport ─────────────────────────────────────────────────────
@@ -69,23 +81,56 @@ export class TauriBackend implements AudioBridge {
   // ── Track Management ──────────────────────────────────────────────
 
   ensureTrack(trackId: string): void {
-    invoke('track_ensure', { trackId }).catch(() => {});
+    if (this._trackHandles.has(trackId)) return;
+    // Fire-and-forget: the bridge interface is synchronous but the
+    // IPC is async. We store a pending promise result in the map
+    // once it resolves.
+    const defaultParams: NativeTrackParams = {
+      volume: 1,
+      pan: 0,
+      mute: false,
+      solo: false,
+    };
+    invoke<NativeSlotHandle>('audio_add_track', { params: defaultParams })
+      .then((handle) => {
+        this._trackHandles.set(trackId, handle);
+      })
+      .catch(() => {});
   }
 
   removeTrack(trackId: string): void {
-    invoke('track_remove', { trackId }).catch(() => {});
+    const handle = this._trackHandles.get(trackId);
+    if (!handle) return;
+    this._trackHandles.delete(trackId);
+    invoke('audio_remove_track', { handle }).catch(() => {});
   }
 
   setTrackParams(trackId: string, params: TrackParams): void {
-    invoke('track_set_params', { trackId, params }).catch(() => {});
+    const handle = this._trackHandles.get(trackId);
+    if (!handle) return;
+    // Extract only the fields the Rust mixer supports (volume,
+    // pan, mute, solo). Effect parameters (EQ, compressor, reverb)
+    // will be forwarded once the effect chain lands in 2B-3.
+    const nativeParams: NativeTrackParams = {
+      volume: params.volume ?? 1,
+      pan: params.pan ?? 0,
+      mute: params.muted ?? false,
+      solo: params.soloed ?? false,
+    };
+    invoke('audio_set_track_params', { handle, params: nativeParams }).catch(() => {});
   }
 
   setTrackGroupRouting(trackId: string, groupId: string | null): void {
-    invoke('track_set_group', { trackId, groupId }).catch(() => {});
+    // Group routing will be wired in Phase 2B-4 (send/return).
+    void trackId;
+    void groupId;
   }
 
   updateSoloState(): void {
-    invoke('tracks_update_solo').catch(() => {});
+    // Solo state is resolved per-buffer inside the audio callback
+    // via `AudioGraph::any_solo()`. No explicit command needed — the
+    // individual `setTrackParams` calls with `solo: true/false`
+    // already propagate through the command queue.
   }
 
   // ── Metering ──────────────────────────────────────────────────────
@@ -98,8 +143,8 @@ export class TauriBackend implements AudioBridge {
     return -Infinity;
   }
 
-  resetTrackClip(trackId: string): void {
-    invoke('track_reset_clip', { trackId }).catch(() => {});
+  resetTrackClip(_trackId: string): void {
+    // Will be wired in Phase 2B-2 (metering)
   }
 
   getTrackSpectrum(_trackId: string): Float32Array | null {
@@ -114,8 +159,8 @@ export class TauriBackend implements AudioBridge {
     return -Infinity;
   }
 
-  resetMasterClip(stage: 'input' | 'output'): void {
-    invoke('master_reset_clip', { stage }).catch(() => {});
+  resetMasterClip(_stage: 'input' | 'output'): void {
+    // Will be wired in Phase 2B-2 (metering)
   }
 
   getMasterSpectrum(): Float32Array {
@@ -129,11 +174,11 @@ export class TauriBackend implements AudioBridge {
   }
 
   setMasterVolume(volume: number): void {
-    invoke('master_set_volume', { volume }).catch(() => {});
+    invoke('audio_set_master_volume', { volume }).catch(() => {});
   }
 
-  applyMastering(mastering: MasteringState | null | undefined): void {
-    invoke('master_apply_mastering', { mastering }).catch(() => {});
+  applyMastering(_mastering: MasteringState | null | undefined): void {
+    // Will invoke Rust command when effect chain lands (2B-3)
   }
 
   // ── Clip Scheduling ───────────────────────────────────────────────
@@ -147,13 +192,13 @@ export class TauriBackend implements AudioBridge {
   }
 
   stopAllSources(): void {
-    invoke('transport_stop_sources').catch(() => {});
+    // Will invoke Rust command in Phase 3
   }
 
   // ── Audio Data ────────────────────────────────────────────────────
 
   async decodeAudioData(_blob: Blob): Promise<AudioBuffer> {
-    // Rust backend will decode audio natively; for now throw
+    // Rust backend will decode audio natively in Phase 2C
     throw new Error('TauriBackend: decodeAudioData not yet implemented');
   }
 

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -36,10 +36,16 @@ export class TauriBackend implements AudioBridge {
 
   /**
    * Maps the AudioBridge's string `trackId` to the native engine's
-   * `SlotHandle`. Populated by `ensureTrack`, consumed by
-   * `removeTrack` / `setTrackParams`.
+   * `SlotHandle` + last-known mixer params. The handle may be `null`
+   * while the `audio_add_track` IPC is in-flight — this sentinel
+   * prevents double-allocation if `ensureTrack` is called twice
+   * before the first invoke resolves. Found by codex review on
+   * PR #1700.
    */
-  private _trackHandles = new Map<string, NativeSlotHandle>();
+  private _trackEntries = new Map<string, {
+    handle: NativeSlotHandle | null;
+    params: NativeTrackParams;
+  }>();
 
   // ── Lifecycle ─────────────────────────────────────────────────────
 
@@ -51,7 +57,7 @@ export class TauriBackend implements AudioBridge {
 
   dispose(): void {
     invoke('audio_stop_engine').catch(() => {});
-    this._trackHandles.clear();
+    this._trackEntries.clear();
   }
 
   // ── Transport ─────────────────────────────────────────────────────
@@ -81,43 +87,65 @@ export class TauriBackend implements AudioBridge {
   // ── Track Management ──────────────────────────────────────────────
 
   ensureTrack(trackId: string): void {
-    if (this._trackHandles.has(trackId)) return;
-    // Fire-and-forget: the bridge interface is synchronous but the
-    // IPC is async. We store a pending promise result in the map
-    // once it resolves.
+    if (this._trackEntries.has(trackId)) return;
+    // Insert a sentinel entry synchronously so a second ensureTrack
+    // call before the IPC resolves sees it and returns early — codex
+    // found that without this, two rapid calls would allocate two
+    // native slots for the same logical track. PR #1700.
     const defaultParams: NativeTrackParams = {
       volume: 1,
       pan: 0,
       mute: false,
       solo: false,
     };
+    this._trackEntries.set(trackId, { handle: null, params: defaultParams });
     invoke<NativeSlotHandle>('audio_add_track', { params: defaultParams })
       .then((handle) => {
-        this._trackHandles.set(trackId, handle);
+        const entry = this._trackEntries.get(trackId);
+        if (entry) {
+          entry.handle = handle;
+        }
+        // If removeTrack was called while the IPC was in-flight, the
+        // entry has already been deleted — send a compensating remove
+        // so the native side doesn't leak the slot.
+        if (!this._trackEntries.has(trackId)) {
+          invoke('audio_remove_track', { handle }).catch(() => {});
+        }
       })
-      .catch(() => {});
+      .catch(() => {
+        // IPC failed — remove the sentinel so the caller can retry.
+        this._trackEntries.delete(trackId);
+      });
   }
 
   removeTrack(trackId: string): void {
-    const handle = this._trackHandles.get(trackId);
-    if (!handle) return;
-    this._trackHandles.delete(trackId);
-    invoke('audio_remove_track', { handle }).catch(() => {});
+    const entry = this._trackEntries.get(trackId);
+    if (!entry) return;
+    this._trackEntries.delete(trackId);
+    // If the handle hasn't resolved yet (null), the then() handler
+    // above will detect the missing entry and send a compensating
+    // remove. If it has resolved, we remove immediately.
+    if (entry.handle) {
+      invoke('audio_remove_track', { handle: entry.handle }).catch(() => {});
+    }
   }
 
   setTrackParams(trackId: string, params: TrackParams): void {
-    const handle = this._trackHandles.get(trackId);
-    if (!handle) return;
-    // Extract only the fields the Rust mixer supports (volume,
-    // pan, mute, solo). Effect parameters (EQ, compressor, reverb)
-    // will be forwarded once the effect chain lands in 2B-3.
-    const nativeParams: NativeTrackParams = {
-      volume: params.volume ?? 1,
-      pan: params.pan ?? 0,
-      mute: params.muted ?? false,
-      solo: params.soloed ?? false,
-    };
-    invoke('audio_set_track_params', { handle, params: nativeParams }).catch(() => {});
+    const entry = this._trackEntries.get(trackId);
+    if (!entry || !entry.handle) return;
+    // Merge incoming partial params into the cached full state so
+    // omitted fields preserve their existing values — codex found
+    // that defaulting omitted fields to 1/0/false clobbers prior
+    // user settings (e.g. `{ muted: true }` would reset volume to
+    // 1.0 and pan to center). PR #1700.
+    if (params.volume !== undefined) entry.params.volume = params.volume;
+    if (params.pan !== undefined) entry.params.pan = params.pan;
+    if (params.muted !== undefined) entry.params.mute = params.muted;
+    if (params.soloed !== undefined) entry.params.solo = params.soloed;
+    invoke('audio_set_track_params', {
+      handle: entry.handle,
+      params: entry.params,
+    }).catch(() => {});
   }
 
   setTrackGroupRouting(trackId: string, groupId: string | null): void {

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -108,8 +108,12 @@ describe('TauriBackend', () => {
 
   // ── Methods that should throw (not yet implemented) ───────────────
 
-  it('resume throws (Rust engine not ready)', async () => {
-    await expect(backend.resume()).rejects.toThrow('not yet implemented');
+  it('resume rejects without Tauri runtime', async () => {
+    // resume() now calls invoke('audio_start_engine', ...) which
+    // rejects in a test environment because no Tauri webview
+    // context is available. The specific error message depends on
+    // the @tauri-apps/api internals — we only assert it rejects.
+    await expect(backend.resume()).rejects.toThrow();
   });
 
   it('decodeAudioData throws (Rust engine not ready)', async () => {

--- a/src/engine/bridge/types.ts
+++ b/src/engine/bridge/types.ts
@@ -166,3 +166,37 @@ export type NativeEngineError =
   | { kind: 'config'; message: { kind: 'invalidSampleRate' | 'invalidBufferSize'; message: number } }
   | { kind: 'open'; message: string }
   | { kind: 'openTimeout'; message: { secs: number; nanos: number } };
+
+// ── Track management (Tauri / Phase 2B-1d) ──────────────────────────
+
+/**
+ * Opaque handle to a track slot in the native audio engine. Returned
+ * by `audio_add_track` and passed back to `audio_remove_track` /
+ * `audio_set_track_params`. Contains a slot index + generation counter
+ * so stale handles from a previous owner are silently rejected by the
+ * audio thread.
+ */
+export interface NativeSlotHandle {
+  slot: number;
+  generation: number;
+}
+
+/**
+ * Per-track parameters for the native mixer. Mirrors Rust `TrackParams`
+ * with serde `camelCase` field names.
+ */
+export interface NativeTrackParams {
+  volume: number;
+  pan: number;
+  mute: boolean;
+  solo: boolean;
+}
+
+/**
+ * Shape of Rust `CommandError` when surfaced through Tauri `invoke`.
+ */
+export type NativeCommandError =
+  | { kind: 'notRunning' }
+  | { kind: 'queueFull'; message: number }
+  | { kind: 'disconnected' }
+  | { kind: 'slotAllocatorFull'; message: number };


### PR DESCRIPTION
## Summary

Final slice of Phase 2B-1. Connects the Tauri IPC layer to the Rust audio engine's track management API, and updates \`TauriBackend.ts\` so the frontend can drive the native mixer over IPC.

Closes #1699. Part of #1522 and epic #1519. Completes the 2B-1 sub-series (a/b/c/d).

## Changes

### Rust — 4 new Tauri commands

| Command | Maps to | Returns |
|---|---|---|
| \`audio_add_track(params)\` | \`engine.add_track(params)\` | \`SlotHandle\` |
| \`audio_remove_track(handle)\` | \`engine.remove_track(handle)\` | \`()\` |
| \`audio_set_track_params(handle, params)\` | \`engine.set_track_params\` | \`()\` |
| \`audio_set_master_volume(volume)\` | \`engine.set_master_volume\` | \`()\` |

- **\`SlotHandle\`** gains \`Serialize + Deserialize\` so Tauri can pass it across the IPC boundary. Fields remain private — external callers receive and pass back handles but cannot forge them. TS sees \`{ slot: number, generation: number }\`.
- **\`CommandError\`** gains \`Serialize\` for Tauri error responses. Same \`{ kind, message }\` tagged-union shape as \`EngineError\`.

### TypeScript — real IPC wiring

- **\`NativeSlotHandle\`**, **\`NativeTrackParams\`**, **\`NativeCommandError\`** types added to \`types.ts\`.
- **\`TauriBackend.ts\`** replaces the Phase 1 placeholder \`invoke()\` function with the real \`@tauri-apps/api/core\` import. Track management methods now call the real Rust commands:
  - \`ensureTrack(trackId)\` → \`invoke('audio_add_track')\`, stores the returned \`SlotHandle\` in a private \`Map<string, NativeSlotHandle>\` for subsequent calls.
  - \`removeTrack(trackId)\` → looks up handle from the map, calls \`audio_remove_track\`, clears the entry.
  - \`setTrackParams(trackId, params)\` → extracts volume/pan/mute/solo (effect params deferred to 2B-3), calls \`audio_set_track_params\`.
  - \`setMasterVolume(volume)\` → \`invoke('audio_set_master_volume')\`.
  - \`resume()\` → \`invoke('audio_start_engine')\` with default 48 kHz / 256 frame config.
  - \`dispose()\` → \`invoke('audio_stop_engine')\` + clears the handle map.

## Quality gates

- \`cargo test --lib\` — **87 passed, 0 failed** (0.45 s)
- \`npx tsc --noEmit\` — **0 errors**
- No React component changes — zero UI regression risk

## Non-goals

- Metering → **2B-2**
- Effect chain (EQ, compressor, reverb params) → **2B-3**
- Send/return routing → **2B-4**
- Clip scheduling / transport → **Phase 3** (#1523)

🤖 Generated with [Claude Code](https://claude.com/claude-code)