### PR TITLE
feat: Phase 2B-3 — per-track EQ + Compressor via ace-dsp-core (#1704)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3,9 +3,17 @@
 version = 4
 
 [[package]]
+name = "ace-dsp-core"
+version = "0.1.0"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "ace-step-daw"
 version = "0.1.0"
 dependencies = [
+ "ace-dsp-core",
  "cpal",
  "crossbeam-channel",
  "ringbuf",
@@ -2111,6 +2119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2142,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2651,6 +2677,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2997,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -3360,6 +3409,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -4047,6 +4102,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+ace-dsp-core = { path = "../crates/ace-dsp-core" }
 cpal = "0.15"
 crossbeam-channel = "0.5"
 ringbuf = "0.4"

--- a/src-tauri/src/engine/audio_io.rs
+++ b/src-tauri/src/engine/audio_io.rs
@@ -300,7 +300,21 @@ fn make_audio_callback(
                             );
                         }
                     }
-                    other => graph.apply(other),
+                    other => {
+                        // Reset effects + meter eagerly on RemoveTrack
+                        // so that if AddTrack for the same slot follows
+                        // in the same drain batch, the new track starts
+                        // clean. Without this, the per-track loop finds
+                        // occupied=true (from the re-add) and skips the
+                        // reset. Found by codex review on PR #1705.
+                        if let EngineCommand::RemoveTrack { handle } = other {
+                            if graph.handle_matches(handle) {
+                                effects[handle.index()].reset();
+                                meters.track_meters[handle.index()].reset();
+                            }
+                        }
+                        graph.apply(other);
+                    }
                 },
                 Err(_) => break,
             }

--- a/src-tauri/src/engine/audio_io.rs
+++ b/src-tauri/src/engine/audio_io.rs
@@ -153,6 +153,7 @@ pub fn run_cpal_output_stream(ctx: RuntimeContext) {
         ready_tx,
         stop_rx,
         meter_producers,
+        track_effects,
     } = ctx;
 
     // Attempt to open the stream. Any error path short-circuits to
@@ -187,7 +188,7 @@ pub fn run_cpal_output_stream(ctx: RuntimeContext) {
         let stream = device
             .build_output_stream(
                 &stream_config,
-                make_audio_callback(graph, cmd_rx, meter_producers, config.sample_rate as f32, channels),
+                make_audio_callback(graph, cmd_rx, meter_producers, track_effects, config.sample_rate as f32, channels),
                 err_fn,
                 None,
             )
@@ -248,6 +249,7 @@ fn make_audio_callback(
     mut graph: AudioGraph,
     cmd_rx: Receiver<EngineCommand>,
     mut meters: MeterProducers,
+    mut effects: Vec<super::effect_chain::TrackEffects>,
     sample_rate: f32,
     channels: u16,
 ) -> impl FnMut(&mut [f32], &cpal::OutputCallbackInfo) + Send + 'static {
@@ -263,10 +265,43 @@ fn make_audio_callback(
     let ch = channels as usize;
 
     move |data: &mut [f32], _info: &cpal::OutputCallbackInfo| {
-        // 1. Drain up to COMMAND_DRAIN_BUDGET commands.
+        // 1. Drain up to COMMAND_DRAIN_BUDGET commands. Effect
+        //    commands are routed to the per-track effect chain rather
+        //    than to AudioGraph::apply, because effect state lives
+        //    outside the graph (in the pre-allocated Vec<TrackEffects>).
         for _ in 0..COMMAND_DRAIN_BUDGET {
             match cmd_rx.try_recv() {
-                Ok(cmd) => graph.apply(cmd),
+                Ok(cmd) => match cmd {
+                    EngineCommand::SetEqParams {
+                        handle,
+                        low_gain_db,
+                        mid_gain_db,
+                        high_gain_db,
+                    } => {
+                        if graph.handle_matches(handle) {
+                            effects[handle.index()].set_eq_params(
+                                low_gain_db,
+                                mid_gain_db,
+                                high_gain_db,
+                            );
+                        }
+                    }
+                    EngineCommand::SetCompressorParams {
+                        handle,
+                        enabled,
+                        threshold_db,
+                        ratio,
+                    } => {
+                        if graph.handle_matches(handle) {
+                            effects[handle.index()].set_compressor_params(
+                                enabled,
+                                threshold_db,
+                                ratio,
+                            );
+                        }
+                    }
+                    other => graph.apply(other),
+                },
                 Err(_) => break,
             }
         }
@@ -287,10 +322,11 @@ fn make_audio_callback(
         for slot in 0..super::graph::MAX_TRACKS {
             let track = &mut graph.all_tracks_mut()[slot];
             if !track.occupied {
-                // Reset stale meter state so a newly-added track at
-                // this slot doesn't inherit the previous occupant's
-                // RMS/peak/clip. Found by codex review on PR #1703.
+                // Reset stale meter + effect state so a newly-added
+                // track at this slot doesn't inherit the previous
+                // occupant's RMS/peak/clip or effect parameters.
                 meters.track_meters[slot].reset();
+                effects[slot].reset();
                 continue;
             }
 
@@ -304,9 +340,15 @@ fn make_audio_callback(
                 false
             };
 
-            // Feed per-track meter BEFORE volume/pan/mute so the
-            // meter shows the "raw" signal level, which is the
-            // standard DAW convention (pre-fader metering).
+            // Run per-track effect chain (EQ → Compressor) on the
+            // scratch buffer. Effects are post-signal, pre-fader —
+            // the standard DAW insert chain order.
+            if has_signal {
+                effects[slot].process(&mut scratch[..frames]);
+            }
+
+            // Feed per-track meter AFTER effects but BEFORE volume/pan
+            // (post-effect, pre-fader metering — standard DAW convention).
             if has_signal {
                 meters.track_meters[slot].process(&scratch[..frames]);
             }
@@ -417,7 +459,8 @@ mod tests {
         let graph = AudioGraph::new();
         let (_cmd_tx, cmd_rx) = crossbeam_channel::bounded::<EngineCommand>(8);
         let (meter_prods, _meter_cons) = crate::engine::meter_bank::create_meter_pair(48_000.0);
-        let mut cb = make_audio_callback(graph, cmd_rx, meter_prods, 48_000.0, 2);
+        let track_fx = crate::engine::effect_chain::create_effect_chains(48_000.0);
+        let mut cb = make_audio_callback(graph, cmd_rx, meter_prods, track_fx, 48_000.0, 2);
 
         // We can't easily synthesize a real `OutputCallbackInfo` — its
         // constructor is private inside cpal. The return type of

--- a/src-tauri/src/engine/command.rs
+++ b/src-tauri/src/engine/command.rs
@@ -110,6 +110,23 @@ pub enum EngineCommand {
 
     /// Stop any active test signal on a track. Generation-checked.
     StopTestSignal { handle: SlotHandle },
+
+    /// Set the 3-band EQ gains for a track. Generation-checked.
+    /// Gains are in dB: 0 = flat, positive = boost, negative = cut.
+    SetEqParams {
+        handle: SlotHandle,
+        low_gain_db: f32,
+        mid_gain_db: f32,
+        high_gain_db: f32,
+    },
+
+    /// Set compressor parameters for a track. Generation-checked.
+    SetCompressorParams {
+        handle: SlotHandle,
+        enabled: bool,
+        threshold_db: f32,
+        ratio: f32,
+    },
 }
 
 #[cfg(test)]

--- a/src-tauri/src/engine/effect_chain.rs
+++ b/src-tauri/src/engine/effect_chain.rs
@@ -1,0 +1,172 @@
+//! Per-track effect chain wrapping `ace-dsp-core` algorithms.
+//!
+//! Each track gets a pre-allocated `TrackEffects` holding one instance
+//! of each supported effect type. Effects are always present in memory
+//! but only processed when their `enabled` flag is true — this avoids
+//! any heap allocation on the audio thread when toggling effects.
+//!
+//! Processing order: **EQ → Compressor** (standard DAW insert chain).
+//!
+//! # Supported effects (2B-3)
+//!
+//! - 3-band EQ via `ace_dsp_core::eq::ParametricEq` (bands 0–2 mapped
+//!   to low/mid/high shelf/peak)
+//! - Compressor via `ace_dsp_core::dynamics::Compressor`
+//!
+//! Reverb and additional effects will be added in follow-up PRs.
+
+use ace_dsp_core::biquad::BiquadType;
+use ace_dsp_core::dynamics::Compressor;
+use ace_dsp_core::eq::ParametricEq;
+
+use super::graph::MAX_TRACKS;
+
+/// Default EQ frequencies for the 3-band layout matching the Web Audio
+/// bridge's `eqLowGain` / `eqMidGain` / `eqHighGain` params.
+const EQ_LOW_FREQ: f32 = 200.0;
+const EQ_MID_FREQ: f32 = 1000.0;
+const EQ_HIGH_FREQ: f32 = 5000.0;
+const EQ_Q: f32 = 0.707;
+
+/// Per-track effect instances.
+pub struct TrackEffects {
+    pub eq: ParametricEq,
+    pub eq_enabled: bool,
+    pub compressor: Compressor,
+    pub compressor_enabled: bool,
+}
+
+impl TrackEffects {
+    pub fn new(sample_rate: f32) -> Self {
+        Self {
+            eq: ParametricEq::new(sample_rate),
+            eq_enabled: false,
+            compressor: Compressor::new(
+                sample_rate,
+                -20.0, // threshold
+                4.0,   // ratio
+                10.0,  // attack ms
+                100.0, // release ms
+                3.0,   // knee dB
+                0.0,   // makeup gain
+            ),
+            compressor_enabled: false,
+        }
+    }
+
+    /// Set 3-band EQ gains. Enables the EQ if any gain is non-zero.
+    pub fn set_eq_params(&mut self, low_db: f32, mid_db: f32, high_db: f32) {
+        self.eq.set_band(0, BiquadType::LowShelf, EQ_LOW_FREQ, EQ_Q, low_db, low_db.abs() > 0.01);
+        self.eq.set_band(1, BiquadType::Peaking, EQ_MID_FREQ, EQ_Q, mid_db, mid_db.abs() > 0.01);
+        self.eq.set_band(2, BiquadType::HighShelf, EQ_HIGH_FREQ, EQ_Q, high_db, high_db.abs() > 0.01);
+        self.eq_enabled = low_db.abs() > 0.01 || mid_db.abs() > 0.01 || high_db.abs() > 0.01;
+    }
+
+    /// Set compressor parameters.
+    pub fn set_compressor_params(&mut self, enabled: bool, threshold_db: f32, ratio: f32) {
+        self.compressor_enabled = enabled;
+        self.compressor.set_threshold(threshold_db);
+        self.compressor.set_ratio(ratio);
+    }
+
+    /// Process a mono buffer through the enabled effects in series.
+    /// EQ → Compressor. Zero allocation.
+    #[inline]
+    pub fn process(&mut self, buffer: &mut [f32]) {
+        if self.eq_enabled {
+            self.eq.process_buffer(buffer);
+        }
+        if self.compressor_enabled {
+            self.compressor.process_buffer(buffer);
+        }
+    }
+
+    /// Reset all effect state (filter histories, envelope followers).
+    pub fn reset(&mut self) {
+        self.eq.reset();
+        self.eq_enabled = false;
+        self.compressor.reset();
+        self.compressor_enabled = false;
+    }
+}
+
+/// Pre-allocate `MAX_TRACKS` effect chains at engine start.
+pub fn create_effect_chains(sample_rate: f32) -> Vec<TrackEffects> {
+    (0..MAX_TRACKS)
+        .map(|_| TrackEffects::new(sample_rate))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SR: f32 = 48_000.0;
+
+    fn sine_buffer(freq: f32, amplitude: f32, samples: usize) -> Vec<f32> {
+        (0..samples)
+            .map(|i| amplitude * (std::f32::consts::TAU * freq * i as f32 / SR).sin())
+            .collect()
+    }
+
+    #[test]
+    fn disabled_effects_are_transparent() {
+        let mut fx = TrackEffects::new(SR);
+        let mut buf = vec![0.5_f32; 256];
+        let original = buf.clone();
+        fx.process(&mut buf);
+        assert_eq!(buf, original, "disabled effects must be transparent");
+    }
+
+    #[test]
+    fn eq_boost_increases_level() {
+        let mut fx = TrackEffects::new(SR);
+        fx.set_eq_params(0.0, 12.0, 0.0); // +12 dB mid
+
+        // Generate 1 kHz sine (center of mid band).
+        let mut buf = sine_buffer(1000.0, 0.5, 4096);
+        fx.process(&mut buf);
+
+        // RMS of the processed tail should be higher than input.
+        let rms: f32 = buf[2048..].iter().map(|x| x * x).sum::<f32>() / 2048.0;
+        let rms = rms.sqrt();
+        let input_rms = 0.5 / 2.0_f32.sqrt();
+        assert!(
+            rms > input_rms * 1.5,
+            "12 dB EQ boost should increase RMS: got {rms}, input {input_rms}"
+        );
+    }
+
+    #[test]
+    fn compressor_reduces_peak() {
+        let mut fx = TrackEffects::new(SR);
+        fx.set_compressor_params(true, -20.0, 8.0); // heavy compression
+
+        // Loud signal: 0.9 amplitude ≈ -1 dBFS, well above -20 threshold.
+        let mut buf = sine_buffer(440.0, 0.9, 8192);
+        fx.process(&mut buf);
+
+        // Peak of compressed output should be lower than input peak.
+        let peak = buf[4096..].iter().map(|s| s.abs()).fold(0.0_f32, f32::max);
+        assert!(
+            peak < 0.9,
+            "compressor should reduce peak: got {peak}, input was 0.9"
+        );
+    }
+
+    #[test]
+    fn eq_and_compressor_chain_runs_without_panic() {
+        let mut fx = TrackEffects::new(SR);
+        fx.set_eq_params(6.0, -3.0, 6.0);
+        fx.set_compressor_params(true, -10.0, 4.0);
+
+        let mut buf = sine_buffer(440.0, 0.7, 1024);
+        fx.process(&mut buf); // should not panic
+    }
+
+    #[test]
+    fn create_effect_chains_allocates_max_tracks() {
+        let chains = create_effect_chains(SR);
+        assert_eq!(chains.len(), MAX_TRACKS);
+    }
+}

--- a/src-tauri/src/engine/effect_chain.rs
+++ b/src-tauri/src/engine/effect_chain.rs
@@ -23,10 +23,14 @@ use super::graph::MAX_TRACKS;
 
 /// Default EQ frequencies for the 3-band layout matching the Web Audio
 /// bridge's `eqLowGain` / `eqMidGain` / `eqHighGain` params.
-const EQ_LOW_FREQ: f32 = 200.0;
+/// Aligned with the Web Audio mixer's TrackNode EQ (250 / 1k / 8k Hz,
+/// Q=1.0) so the same `eqLowGain/eqMidGain/eqHighGain` values produce
+/// matching sonic results across both backends. Found by codex review
+/// on PR #1705 — original constants (200/1000/5000, Q=0.707) diverged.
+const EQ_LOW_FREQ: f32 = 250.0;
 const EQ_MID_FREQ: f32 = 1000.0;
-const EQ_HIGH_FREQ: f32 = 5000.0;
-const EQ_Q: f32 = 0.707;
+const EQ_HIGH_FREQ: f32 = 8000.0;
+const EQ_Q: f32 = 1.0;
 
 /// Per-track effect instances.
 pub struct TrackEffects {

--- a/src-tauri/src/engine/graph.rs
+++ b/src-tauri/src/engine/graph.rs
@@ -242,6 +242,11 @@ impl AudioGraph {
                     t.test_signal = None;
                 }
             }
+            // Effect commands are handled by the audio callback's
+            // command router (which routes them to TrackEffects) rather
+            // than by AudioGraph::apply. They arrive here only if
+            // called directly in tests — ignore them.
+            EngineCommand::SetEqParams { .. } | EngineCommand::SetCompressorParams { .. } => {}
         }
     }
 
@@ -249,7 +254,7 @@ impl AudioGraph {
     /// and its generation matches the live value stored on the track.
     /// Pulled into its own helper so every validating arm of `apply`
     /// shares the exact same predicate.
-    fn handle_matches(&self, handle: SlotHandle) -> bool {
+    pub fn handle_matches(&self, handle: SlotHandle) -> bool {
         match self.tracks.get(handle.index()) {
             Some(t) => t.occupied && t.generation == handle.generation(),
             None => false,

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -28,6 +28,7 @@
 pub mod audio_io;
 pub mod command;
 pub mod config;
+pub mod effect_chain;
 pub mod graph;
 pub mod meter;
 pub mod meter_bank;
@@ -89,6 +90,8 @@ pub struct RuntimeContext {
     pub stop_rx: Receiver<()>,
     /// Audio-thread half of the metering ring buffers.
     pub meter_producers: MeterProducers,
+    /// Pre-allocated per-track effect chains.
+    pub track_effects: Vec<effect_chain::TrackEffects>,
 }
 
 /// Errors surfaced to Tauri command handlers.
@@ -248,6 +251,7 @@ impl Engine {
             ready_tx,
             stop_rx,
             meter_producers: meter_prods,
+            track_effects: effect_chain::create_effect_chains(config.sample_rate as f32),
         };
 
         let boxed: Box<dyn StreamRunner> = Box::new(runner);


### PR DESCRIPTION
## Summary

Wire `ace-dsp-core`'s `ParametricEq` and `Compressor` into the audio callback as a per-track effect chain. Effects are pre-allocated at engine start (256 × \`TrackEffects\`) and processed in insert order: **EQ → Compressor → meter → volume/pan**. Zero allocation on the audio thread.

Closes #1704. Part of #1522 and epic #1519.

## Changes

- **\`effect_chain.rs\` (new)** — \`TrackEffects\` struct holding 3-band EQ (low shelf 200 Hz, mid peak 1 kHz, high shelf 5 kHz) + Compressor. \`process(&mut [f32])\` runs them in series. Pre-allocated via \`create_effect_chains()\`.
- **\`command.rs\`** — \`SetEqParams\` + \`SetCompressorParams\` commands, generation-checked.
- **\`audio_io.rs\`** — Command drain routes effect commands to \`effects[slot]\`. Per-track processing now runs EQ → Compressor between signal generation and metering.
- **\`Cargo.toml\`** — \`ace-dsp-core = { path = "../crates/ace-dsp-core" }\` path dependency.

## Tests — 108 unit + 7 smoke, all pass

| Test | What it proves |
|---|---|
| \`disabled_effects_are_transparent\` | All effects off = pure passthrough |
| \`eq_boost_increases_level\` | +12 dB mid peak → RMS > 1.5× input |
| \`compressor_reduces_peak\` | 8:1 ratio → peak < input amplitude |
| \`eq_and_compressor_chain_runs_without_panic\` | Full chain at once |
| \`create_effect_chains_allocates_max_tracks\` | 256 instances |

🤖 Generated with [Claude Code](https://claude.com/claude-code)