### PR TITLE
feat: Phase 2B-4 — send/return routing + aux buses (#1706)

### DIFF
--- a/src-tauri/src/engine/audio_io.rs
+++ b/src-tauri/src/engine/audio_io.rs
@@ -154,6 +154,7 @@ pub fn run_cpal_output_stream(ctx: RuntimeContext) {
         stop_rx,
         meter_producers,
         track_effects,
+        routing,
     } = ctx;
 
     // Attempt to open the stream. Any error path short-circuits to
@@ -188,7 +189,7 @@ pub fn run_cpal_output_stream(ctx: RuntimeContext) {
         let stream = device
             .build_output_stream(
                 &stream_config,
-                make_audio_callback(graph, cmd_rx, meter_producers, track_effects, config.sample_rate as f32, channels),
+                make_audio_callback(graph, cmd_rx, meter_producers, track_effects, routing, config.sample_rate as f32, channels),
                 err_fn,
                 None,
             )
@@ -250,6 +251,7 @@ fn make_audio_callback(
     cmd_rx: Receiver<EngineCommand>,
     mut meters: MeterProducers,
     mut effects: Vec<super::effect_chain::TrackEffects>,
+    mut routing: super::routing::RoutingState,
     sample_rate: f32,
     channels: u16,
 ) -> impl FnMut(&mut [f32], &cpal::OutputCallbackInfo) + Send + 'static {
@@ -300,17 +302,36 @@ fn make_audio_callback(
                             );
                         }
                     }
+                    // Routing commands — route to RoutingState.
+                    EngineCommand::SetTrackSendLevel {
+                        handle,
+                        bus_index,
+                        level,
+                    } => {
+                        if graph.handle_matches(handle) {
+                            routing.set_send_level(handle.index(), bus_index as usize, level);
+                        }
+                    }
+                    EngineCommand::SetAuxBusVolume { bus_index, volume } => {
+                        if let Some(bus) = routing.buses.get_mut(bus_index as usize) {
+                            bus.volume = volume;
+                        }
+                    }
+                    EngineCommand::SetAuxBusEnabled { bus_index, enabled } => {
+                        if let Some(bus) = routing.buses.get_mut(bus_index as usize) {
+                            bus.enabled = enabled;
+                        }
+                    }
                     other => {
-                        // Reset effects + meter eagerly on RemoveTrack
-                        // so that if AddTrack for the same slot follows
-                        // in the same drain batch, the new track starts
-                        // clean. Without this, the per-track loop finds
-                        // occupied=true (from the re-add) and skips the
-                        // reset. Found by codex review on PR #1705.
+                        // Reset effects + meter + sends eagerly on
+                        // RemoveTrack so that if AddTrack for the same
+                        // slot follows in the same drain batch, the new
+                        // track starts clean.
                         if let EngineCommand::RemoveTrack { handle } = other {
                             if graph.handle_matches(handle) {
                                 effects[handle.index()].reset();
                                 meters.track_meters[handle.index()].reset();
+                                routing.reset_track_sends(handle.index());
                             }
                         }
                         graph.apply(other);
@@ -324,9 +345,10 @@ fn make_audio_callback(
         let frames = if ch > 0 { data.len() / ch } else { data.len() };
         let frames = frames.min(max_frames);
 
-        // Zero the master accumulators for this buffer.
+        // Zero the master accumulators + aux bus buffers for this buffer.
         master_l[..frames].fill(0.0);
         master_r[..frames].fill(0.0);
+        routing.clear_buses(frames);
 
         let any_solo = graph.any_solo();
         let master_vol = graph.master_volume;
@@ -378,14 +400,33 @@ fn make_audio_callback(
             }
 
             // Apply volume + pan and accumulate into master L/R.
+            // Also compute per-frame track L/R for post-fader sends.
             let vol = track.volume;
             let (pan_l, pan_r) = mixer::equal_power_pan(track.pan);
             for i in 0..frames {
                 let s = scratch[i] * vol;
-                master_l[i] += s * pan_l;
-                master_r[i] += s * pan_r;
+                let l = s * pan_l;
+                let r = s * pan_r;
+                master_l[i] += l;
+                master_r[i] += r;
+                // Reuse scratch for the L channel and master_l
+                // contains the running sum, so we can't easily
+                // extract per-track L/R. Instead, compute the
+                // track's L/R contribution in scratch[i] and use
+                // a second pass for sends. (See below.)
             }
+
+            // Post-fader sends: tap the track's panned output and
+            // route to aux buses. We recompute the per-sample
+            // contribution rather than storing a separate buffer to
+            // avoid an extra MAX_FRAMES allocation per track.
+            // Since the send loop only runs for tracks with non-zero
+            // send levels and enabled buses, the cost is bounded.
+            routing.send_from_track_computed(slot, &scratch[..frames], vol, pan_l, pan_r, frames);
         }
+
+        // Mix aux return buses into master BEFORE master volume.
+        routing.mix_into_master(&mut master_l[..frames], &mut master_r[..frames], frames);
 
         // Apply master volume.
         for i in 0..frames {
@@ -474,7 +515,10 @@ mod tests {
         let (_cmd_tx, cmd_rx) = crossbeam_channel::bounded::<EngineCommand>(8);
         let (meter_prods, _meter_cons) = crate::engine::meter_bank::create_meter_pair(48_000.0);
         let track_fx = crate::engine::effect_chain::create_effect_chains(48_000.0);
-        let mut cb = make_audio_callback(graph, cmd_rx, meter_prods, track_fx, 48_000.0, 2);
+        let routing = crate::engine::routing::RoutingState::new(
+            crate::engine::graph::MAX_TRACKS, 1024,
+        );
+        let mut cb = make_audio_callback(graph, cmd_rx, meter_prods, track_fx, routing, 48_000.0, 2);
 
         // We can't easily synthesize a real `OutputCallbackInfo` — its
         // constructor is private inside cpal. The return type of

--- a/src-tauri/src/engine/command.rs
+++ b/src-tauri/src/engine/command.rs
@@ -127,6 +127,20 @@ pub enum EngineCommand {
         threshold_db: f32,
         ratio: f32,
     },
+
+    /// Set the send level from a track to an aux bus.
+    /// Generation-checked on the track handle.
+    SetTrackSendLevel {
+        handle: SlotHandle,
+        bus_index: u8,
+        level: f32,
+    },
+
+    /// Set the volume of an aux return bus.
+    SetAuxBusVolume { bus_index: u8, volume: f32 },
+
+    /// Enable or disable an aux return bus.
+    SetAuxBusEnabled { bus_index: u8, enabled: bool },
 }
 
 #[cfg(test)]

--- a/src-tauri/src/engine/graph.rs
+++ b/src-tauri/src/engine/graph.rs
@@ -242,11 +242,16 @@ impl AudioGraph {
                     t.test_signal = None;
                 }
             }
-            // Effect commands are handled by the audio callback's
-            // command router (which routes them to TrackEffects) rather
-            // than by AudioGraph::apply. They arrive here only if
-            // called directly in tests — ignore them.
-            EngineCommand::SetEqParams { .. } | EngineCommand::SetCompressorParams { .. } => {}
+            // Effect + routing commands are handled by the audio
+            // callback's command router (which routes them to
+            // TrackEffects / RoutingState) rather than by
+            // AudioGraph::apply. They arrive here only if called
+            // directly in tests — ignore them.
+            EngineCommand::SetEqParams { .. }
+            | EngineCommand::SetCompressorParams { .. }
+            | EngineCommand::SetTrackSendLevel { .. }
+            | EngineCommand::SetAuxBusVolume { .. }
+            | EngineCommand::SetAuxBusEnabled { .. } => {}
         }
     }
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -33,6 +33,7 @@ pub mod graph;
 pub mod meter;
 pub mod meter_bank;
 pub mod mixer;
+pub mod routing;
 pub mod slot;
 
 pub use command::{EngineCommand, TrackParams};
@@ -92,6 +93,8 @@ pub struct RuntimeContext {
     pub meter_producers: MeterProducers,
     /// Pre-allocated per-track effect chains.
     pub track_effects: Vec<effect_chain::TrackEffects>,
+    /// Pre-allocated aux send/return routing state.
+    pub routing: routing::RoutingState,
 }
 
 /// Errors surfaced to Tauri command handlers.
@@ -252,6 +255,7 @@ impl Engine {
             stop_rx,
             meter_producers: meter_prods,
             track_effects: effect_chain::create_effect_chains(config.sample_rate as f32),
+            routing: routing::RoutingState::new(MAX_TRACKS, 1024),
         };
 
         let boxed: Box<dyn StreamRunner> = Box::new(runner);

--- a/src-tauri/src/engine/routing.rs
+++ b/src-tauri/src/engine/routing.rs
@@ -1,0 +1,308 @@
+//! Aux send/return routing for the processing graph.
+//!
+//! Each track can send a configurable amount of its post-fader signal
+//! to up to [`MAX_AUX_BUSES`] return buses. Return buses accumulate
+//! contributions from all sending tracks, apply their own volume, and
+//! are mixed into the master output alongside regular tracks.
+//!
+//! # Topology
+//!
+//! Post-fader sends: the send taps AFTER volume/pan (matching
+//! Ableton and Logic default). Pre-fader sends can be added later as
+//! a per-send flag without changing the data structures.
+//!
+//! # Memory
+//!
+//! All buffers are pre-allocated at engine start. At 8 buses × 1024
+//! frames × 2 channels × 4 bytes ≈ 64 KiB. Trivial.
+
+/// Maximum number of aux send/return buses.
+pub const MAX_AUX_BUSES: usize = 8;
+
+/// Per-track send levels to each aux bus. Index by bus_index.
+/// 0.0 = no send, 1.0 = unity send.
+#[derive(Debug, Clone, Copy)]
+pub struct TrackSends {
+    pub levels: [f32; MAX_AUX_BUSES],
+}
+
+impl Default for TrackSends {
+    fn default() -> Self {
+        Self {
+            levels: [0.0; MAX_AUX_BUSES],
+        }
+    }
+}
+
+/// A single aux return bus.
+pub struct AuxBus {
+    pub enabled: bool,
+    pub volume: f32,
+    /// Pre-allocated stereo accumulation buffers. Zeroed at the start
+    /// of each audio callback, then tracks add their contributions.
+    pub buf_l: Vec<f32>,
+    pub buf_r: Vec<f32>,
+}
+
+impl AuxBus {
+    fn new(max_frames: usize) -> Self {
+        Self {
+            enabled: false,
+            volume: 1.0,
+            buf_l: vec![0.0; max_frames],
+            buf_r: vec![0.0; max_frames],
+        }
+    }
+
+    /// Zero the accumulation buffers for a new callback.
+    pub fn clear(&mut self, frames: usize) {
+        let n = frames.min(self.buf_l.len());
+        self.buf_l[..n].fill(0.0);
+        self.buf_r[..n].fill(0.0);
+    }
+}
+
+/// All aux buses for the engine. Pre-allocated at start.
+pub struct RoutingState {
+    pub buses: Vec<AuxBus>,
+    /// Per-track send levels. Indexed by [slot][bus].
+    pub track_sends: Vec<TrackSends>,
+}
+
+impl RoutingState {
+    /// Create routing state for `num_tracks` tracks and `MAX_AUX_BUSES`
+    /// buses with buffer capacity `max_frames`.
+    pub fn new(num_tracks: usize, max_frames: usize) -> Self {
+        Self {
+            buses: (0..MAX_AUX_BUSES).map(|_| AuxBus::new(max_frames)).collect(),
+            track_sends: vec![TrackSends::default(); num_tracks],
+        }
+    }
+
+    /// Zero all bus accumulation buffers. Call at the start of each
+    /// audio callback before per-track processing.
+    pub fn clear_buses(&mut self, frames: usize) {
+        for bus in &mut self.buses {
+            bus.clear(frames);
+        }
+    }
+
+    /// Add a track's post-fader contribution to all active sends.
+    /// `track_l` / `track_r` are the track's panned output for this
+    /// buffer. `slot` indexes into `track_sends`.
+    pub fn send_from_track(
+        &mut self,
+        slot: usize,
+        track_l: &[f32],
+        track_r: &[f32],
+        frames: usize,
+    ) {
+        let sends = match self.track_sends.get(slot) {
+            Some(s) => s,
+            None => return,
+        };
+        for (bus_idx, &level) in sends.levels.iter().enumerate() {
+            if level <= 0.0 {
+                continue;
+            }
+            let bus = &mut self.buses[bus_idx];
+            if !bus.enabled {
+                continue;
+            }
+            let n = frames.min(bus.buf_l.len());
+            for i in 0..n {
+                bus.buf_l[i] += track_l[i] * level;
+                bus.buf_r[i] += track_r[i] * level;
+            }
+        }
+    }
+
+    /// Mix all enabled aux buses into the master L/R accumulators.
+    /// Called after all tracks have been processed.
+    pub fn mix_into_master(
+        &self,
+        master_l: &mut [f32],
+        master_r: &mut [f32],
+        frames: usize,
+    ) {
+        for bus in &self.buses {
+            if !bus.enabled || bus.volume <= 0.0 {
+                continue;
+            }
+            let n = frames.min(bus.buf_l.len()).min(master_l.len());
+            for i in 0..n {
+                master_l[i] += bus.buf_l[i] * bus.volume;
+                master_r[i] += bus.buf_r[i] * bus.volume;
+            }
+        }
+    }
+
+    /// Set the send level for a specific track → bus pair.
+    pub fn set_send_level(&mut self, slot: usize, bus_index: usize, level: f32) {
+        if let Some(sends) = self.track_sends.get_mut(slot) {
+            if bus_index < MAX_AUX_BUSES {
+                sends.levels[bus_index] = level.max(0.0);
+            }
+        }
+    }
+
+    /// Send a track's post-fader contribution to aux buses, computing
+    /// the panned output on-the-fly from the mono scratch buffer +
+    /// volume + pan gains. Avoids allocating a separate per-track L/R
+    /// buffer.
+    pub fn send_from_track_computed(
+        &mut self,
+        slot: usize,
+        scratch: &[f32],
+        vol: f32,
+        pan_l: f32,
+        pan_r: f32,
+        frames: usize,
+    ) {
+        let sends = match self.track_sends.get(slot) {
+            Some(s) => *s, // Copy — levels is [f32; 8]
+            None => return,
+        };
+        for (bus_idx, level) in sends.levels.iter().enumerate() {
+            if *level <= 0.0 {
+                continue;
+            }
+            let bus = &mut self.buses[bus_idx];
+            if !bus.enabled {
+                continue;
+            }
+            let n = frames.min(bus.buf_l.len()).min(scratch.len());
+            let lv = *level;
+            for i in 0..n {
+                let s = scratch[i] * vol;
+                bus.buf_l[i] += s * pan_l * lv;
+                bus.buf_r[i] += s * pan_r * lv;
+            }
+        }
+    }
+
+    /// Reset sends for a track slot (called when the track is removed).
+    pub fn reset_track_sends(&mut self, slot: usize) {
+        if let Some(sends) = self.track_sends.get_mut(slot) {
+            *sends = TrackSends::default();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_send_contributes_nothing() {
+        let mut routing = RoutingState::new(4, 256);
+        routing.buses[0].enabled = true;
+        routing.clear_buses(256);
+
+        let track_l = vec![1.0_f32; 256];
+        let track_r = vec![1.0_f32; 256];
+        // Send level is 0 by default.
+        routing.send_from_track(0, &track_l, &track_r, 256);
+
+        assert!(routing.buses[0].buf_l.iter().all(|&s| s == 0.0));
+    }
+
+    #[test]
+    fn unity_send_forwards_full_signal() {
+        let mut routing = RoutingState::new(4, 256);
+        routing.buses[0].enabled = true;
+        routing.set_send_level(0, 0, 1.0);
+        routing.clear_buses(256);
+
+        let track_l = vec![0.5_f32; 256];
+        let track_r = vec![0.3_f32; 256];
+        routing.send_from_track(0, &track_l, &track_r, 256);
+
+        assert!((routing.buses[0].buf_l[0] - 0.5).abs() < 1e-5);
+        assert!((routing.buses[0].buf_r[0] - 0.3).abs() < 1e-5);
+    }
+
+    #[test]
+    fn half_send_scales_signal() {
+        let mut routing = RoutingState::new(4, 256);
+        routing.buses[0].enabled = true;
+        routing.set_send_level(0, 0, 0.5);
+        routing.clear_buses(256);
+
+        let track_l = vec![1.0_f32; 256];
+        let track_r = vec![1.0_f32; 256];
+        routing.send_from_track(0, &track_l, &track_r, 256);
+
+        assert!((routing.buses[0].buf_l[0] - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn multiple_tracks_sum_into_same_bus() {
+        let mut routing = RoutingState::new(4, 256);
+        routing.buses[0].enabled = true;
+        routing.set_send_level(0, 0, 1.0);
+        routing.set_send_level(1, 0, 1.0);
+        routing.clear_buses(256);
+
+        let t0 = vec![0.3_f32; 256];
+        let t1 = vec![0.4_f32; 256];
+        routing.send_from_track(0, &t0, &t0, 256);
+        routing.send_from_track(1, &t1, &t1, 256);
+
+        assert!((routing.buses[0].buf_l[0] - 0.7).abs() < 1e-5);
+    }
+
+    #[test]
+    fn aux_bus_volume_applied_on_mix_to_master() {
+        let mut routing = RoutingState::new(4, 256);
+        routing.buses[0].enabled = true;
+        routing.buses[0].volume = 0.5;
+        routing.set_send_level(0, 0, 1.0);
+        routing.clear_buses(256);
+
+        let track = vec![1.0_f32; 256];
+        routing.send_from_track(0, &track, &track, 256);
+
+        let mut master_l = vec![0.0_f32; 256];
+        let mut master_r = vec![0.0_f32; 256];
+        routing.mix_into_master(&mut master_l, &mut master_r, 256);
+
+        assert!((master_l[0] - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn disabled_bus_contributes_nothing() {
+        let mut routing = RoutingState::new(4, 256);
+        // Bus 0 disabled (default).
+        routing.set_send_level(0, 0, 1.0);
+        routing.clear_buses(256);
+
+        let track = vec![1.0_f32; 256];
+        routing.send_from_track(0, &track, &track, 256);
+
+        let mut master_l = vec![0.0_f32; 256];
+        let mut master_r = vec![0.0_f32; 256];
+        routing.mix_into_master(&mut master_l, &mut master_r, 256);
+
+        assert!(master_l[0] == 0.0, "disabled bus must not contribute");
+    }
+
+    #[test]
+    fn reset_track_sends_clears_all_levels() {
+        let mut routing = RoutingState::new(4, 256);
+        routing.set_send_level(2, 0, 0.8);
+        routing.set_send_level(2, 3, 0.5);
+        routing.reset_track_sends(2);
+
+        let sends = &routing.track_sends[2];
+        assert!(sends.levels.iter().all(|&l| l == 0.0));
+    }
+
+    #[test]
+    fn out_of_range_bus_index_is_ignored() {
+        let mut routing = RoutingState::new(4, 256);
+        routing.set_send_level(0, MAX_AUX_BUSES + 5, 1.0);
+        // Should not panic, and default sends should be 0.
+        assert!(routing.track_sends[0].levels.iter().all(|&l| l == 0.0));
+    }
+}


### PR DESCRIPTION
## Summary

Final slice of Phase 2B. Adds aux send/return routing: each track can send post-fader signal to up to 8 return buses, which mix into the master before master volume. **This completes the Phase 2 Rust audio engine core (#1522).**

Closes #1706. Part of #1522 and epic #1519.

## What's in the diff

- **\`routing.rs\` (new)** — \`RoutingState\` holding 8 \`AuxBus\` structs (pre-allocated stereo buffers) + per-track \`TrackSends\` (send levels). \`send_from_track_computed()\` routes post-fader panned output to aux buses on-the-fly. \`mix_into_master()\` sums enabled buses into master L/R.
- **\`command.rs\`** — 3 new commands: \`SetTrackSendLevel\`, \`SetAuxBusVolume\`, \`SetAuxBusEnabled\`.
- **\`audio_io.rs\`** — Command drain routes send/bus commands. Per-track loop now sends to aux buses after volume/pan. Aux returns mixed into master before master volume. Bus buffers cleared each callback.

## Audio callback flow (complete Phase 2B)

Signal → EQ → Compressor → meter → volume/pan → master + **aux sends** → **aux returns** → master volume → master meter → output

## Tests — 116 unit + 7 smoke

8 new routing tests covering: zero/unity/half send levels, multi-track sum, bus volume, disabled bus, send reset, out-of-range bus index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)