### PR TITLE
feat: Phase 3C — loop region with seamless wrap-around

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -10,7 +10,8 @@ use tauri::State;
 
 use crate::engine::{
     audio_io, AudioDeviceInfo, CommandError, Engine, EngineConfig, EngineError,
-    EngineStatus, TempoEvent, TempoMap, TimeSignatureEvent, TimeSignatureMap, TrackParams,
+    EngineStatus, LoopRegion, TempoEvent, TempoMap, TimeSignatureEvent, TimeSignatureMap,
+    TrackParams,
 };
 use crate::engine::slot::SlotHandle;
 
@@ -285,6 +286,52 @@ pub fn audio_transport_sample_to_beat(
         .lock()
         .map_err(|_| CommandError::Disconnected)?;
     Ok(engine.sample_to_beat(sample))
+}
+
+// ── Transport loop region (3C) ──────────────────────────────────────
+
+/// Replace the transport loop region atomically. Malformed ranges
+/// (`end <= start`) are accepted but silently treated as disabled
+/// on the audio thread — this supports transient UI drag states
+/// where the handles briefly cross.
+#[tauri::command]
+pub fn audio_transport_set_loop_region(
+    region: LoopRegion,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.set_loop_region(region)
+}
+
+/// Snapshot the current loop region. Returns `None` when the
+/// engine is stopped.
+#[tauri::command]
+pub fn audio_transport_get_loop_region(
+    state: State<'_, EngineState>,
+) -> Result<Option<LoopRegion>, CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    Ok(engine.loop_region_snapshot())
+}
+
+/// Toggle just the `enabled` flag of the current loop region
+/// without changing its bounds. Convenience for the "Loop On/Off"
+/// UI control.
+#[tauri::command]
+pub fn audio_transport_set_loop_enabled(
+    enabled: bool,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.set_loop_enabled(enabled)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/engine/audio_io.rs
+++ b/src-tauri/src/engine/audio_io.rs
@@ -501,8 +501,13 @@ fn make_audio_callback(
         // Advance the transport position. This is the single place in
         // the engine that moves the timeline forward — no-op when
         // stopped/paused, otherwise bumps the shared atomic by
-        // `frames`. Downstream phases (3C loop wrap, 3F clip
-        // scheduling) read this counter to decide what to render.
+        // `frames` (or wraps mid-buffer when the advance crosses the
+        // active loop end). Downstream phases (3F clip scheduling)
+        // read this counter to decide what to render.
+        //
+        // `advance_with_loop_if_advancing` loads the latest loop
+        // region from its `ArcSwap` on every buffer — changes the
+        // main thread publishes take effect on the next buffer.
         //
         // The advance intentionally uses the *rendered* frame count
         // (already clamped to `max_frames`), not the raw buffer size.
@@ -512,7 +517,7 @@ fn make_audio_callback(
         // and leave the tail silent (one-time audible gap) while
         // position advances by the same amount — versus advancing by
         // the full buffer, which would desync UI from audio.
-        transport.advance_if_advancing(frames as u64);
+        transport.advance_with_loop_if_advancing(frames as u64);
     }
 }
 

--- a/src-tauri/src/engine/loop_region.rs
+++ b/src-tauri/src/engine/loop_region.rs
@@ -104,6 +104,17 @@ impl LoopRegion {
     ///   buffer, so the wrap still applies).
     /// - `frames > length` (pathological: buffer larger than loop) →
     ///   modulo handles multiple wraps safely.
+    ///
+    /// # Overflow caveat
+    ///
+    /// `saturating_add` prevents a panic on `current + frames`
+    /// overflow, but if `frames` is pathologically large (close to
+    /// `u64::MAX`) the saturated raw value collapses distinct
+    /// inputs onto the same sentinel, and the wrapped result can
+    /// disagree with the "mathematically ideal" value by up to
+    /// one loop length. Not reachable from the real audio callback,
+    /// where `frames` is bounded by `max_frames = 4096` (see
+    /// `audio_io.rs`). Found by codex review on PR #1713.
     #[inline]
     pub fn next_position(&self, current: u64, frames: u64) -> u64 {
         let raw = current.saturating_add(frames);
@@ -334,6 +345,52 @@ mod tests {
     fn next_position_saturates_on_overflow_when_inactive() {
         let l = LoopRegion::disabled();
         assert_eq!(l.next_position(u64::MAX - 10, 50), u64::MAX);
+    }
+
+    // ── Codex review regression: frames = 0 / length = 1 ────────────
+
+    #[test]
+    fn next_position_zero_frames_is_no_op_in_all_regimes() {
+        // Audio callback may deliver a zero-frame buffer on device
+        // resync; the advance must be a pure no-op regardless of
+        // loop state.
+        let disabled = LoopRegion::disabled();
+        assert_eq!(disabled.next_position(123, 0), 123);
+
+        let active = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 200,
+        };
+        // Inside the loop.
+        assert_eq!(active.next_position(150, 0), 150);
+        // Before the loop.
+        assert_eq!(active.next_position(50, 0), 50);
+        // At the end boundary — still no advance, stays AT end.
+        assert_eq!(active.next_position(200, 0), 200);
+        // Past the end.
+        assert_eq!(active.next_position(250, 0), 250);
+    }
+
+    #[test]
+    fn next_position_loop_length_one_holds_cursor_on_single_sample() {
+        // Degenerate but valid region: [100, 101) — exactly one
+        // sample in the loop. The wrap math must collapse every
+        // advance back to `start`.
+        let l = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 101,
+        };
+        assert_eq!(l.length(), 1);
+        // Advance from inside the single sample → wrap to start.
+        assert_eq!(l.next_position(100, 1), 100, "advance of 1 wraps to start");
+        assert_eq!(l.next_position(100, 2), 100, "advance of 2 still lands on start (over % 1 == 0)");
+        assert_eq!(
+            l.next_position(100, 1000),
+            100,
+            "large advance modulo-wraps to start"
+        );
     }
 
     #[test]

--- a/src-tauri/src/engine/loop_region.rs
+++ b/src-tauri/src/engine/loop_region.rs
@@ -1,0 +1,375 @@
+//! Loop region — the `[start, end)` sample range the transport
+//! wraps around when playback reaches the end boundary.
+//!
+//! # Why its own module?
+//!
+//! Loop state is small (3 fields) but interacts with every advancing
+//! state (`Playing`, `Recording`, `Scrubbing`) and is read on the hot
+//! path of every audio callback. Keeping it in a dedicated module
+//! with pure functions for the wrap math means the audio callback
+//! can pass a `&LoopRegion` to a bounded-cost `Transport::advance*`
+//! method — no branching on loop config inside the callback itself.
+//!
+//! # Invariants
+//!
+//! `LoopRegion` is a plain value type. Validity depends on the data:
+//! - `enabled && end > start` → active loop.
+//! - `enabled && end <= start` → the region is malformed; treated as
+//!   disabled on the hot path (no wrap). This keeps the data schema
+//!   tolerant of UI intermediate states (e.g. user dragging the end
+//!   handle across the start handle) without surfacing a "your loop
+//!   is invalid" error on every keystroke.
+//! - `!enabled` → no wrap regardless of range.
+//!
+//! # Wrap semantics
+//!
+//! `end` is **exclusive** — sample position `end` is not played; the
+//! transport wraps to `start` at that instant. This matches the
+//! "region length" convention every major DAW uses: a 4-beat loop
+//! covers samples `[0, 4 * samples_per_beat)`, and after `frames - 1`
+//! advances the playhead is still inside the region.
+//!
+//! # Thread safety
+//!
+//! `LoopRegion` is `Copy + Send + Sync`. Shared between threads by
+//! wrapping it in an `arc_swap::ArcSwap<LoopRegion>` at the call
+//! site (see `transport.rs`), so this module only needs to provide
+//! the pure math.
+
+use serde::{Deserialize, Serialize};
+
+/// The looping region of the transport.
+///
+/// `start` and `end` are absolute sample positions. When
+/// [`enabled`] is true and `end > start`, the transport wraps the
+/// playhead from `end` back to `start` on the sample immediately
+/// after `end - 1` — i.e. the half-open interval `[start, end)`
+/// is what actually plays.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoopRegion {
+    pub enabled: bool,
+    pub start: u64,
+    pub end: u64,
+}
+
+impl LoopRegion {
+    /// Disabled loop at position 0. Use as the default on engine
+    /// startup — no wrap until the user sets a region.
+    pub const fn disabled() -> Self {
+        Self {
+            enabled: false,
+            start: 0,
+            end: 0,
+        }
+    }
+
+    /// Whether the loop should actually influence playback. Both
+    /// `enabled` and a positive-length range must hold. Malformed
+    /// ranges (`end <= start`) are silently treated as disabled so
+    /// a UI intermediate state (user dragging the end handle
+    /// through the start handle) does not panic or hang the engine.
+    #[inline]
+    pub fn is_active(&self) -> bool {
+        self.enabled && self.end > self.start
+    }
+
+    /// Length of the active loop in samples. Returns 0 for a
+    /// disabled or malformed region, so callers can use it as a
+    /// divisor only after checking [`is_active`].
+    #[inline]
+    pub fn length(&self) -> u64 {
+        if self.is_active() {
+            self.end - self.start
+        } else {
+            0
+        }
+    }
+
+    /// Compute the post-advance position when the transport moves
+    /// from `current` by `frames`. If the advance crosses the loop
+    /// end boundary, the result is wrapped into the loop by modulo.
+    /// Otherwise the result is simply `current + frames` (saturating
+    /// on u64 overflow).
+    ///
+    /// Pulled into its own pure function so that unit tests can
+    /// cover every wrap case without needing a full `Transport`.
+    ///
+    /// # Edge cases
+    ///
+    /// - Loop inactive → return `current + frames` (saturating).
+    /// - Playhead already at or past `end` → no wrap; just advance.
+    /// - Playhead before `start` and advance crosses `end` →
+    ///   wrap (the transport entered and exited the loop in one
+    ///   buffer, so the wrap still applies).
+    /// - `frames > length` (pathological: buffer larger than loop) →
+    ///   modulo handles multiple wraps safely.
+    #[inline]
+    pub fn next_position(&self, current: u64, frames: u64) -> u64 {
+        let raw = current.saturating_add(frames);
+        if !self.is_active() {
+            return raw;
+        }
+        // No wrap if the playhead is already past (or exactly at) the
+        // end — the user sought out of the loop, so stay out.
+        if current >= self.end {
+            return raw;
+        }
+        // No wrap if the advance does not reach the end.
+        if raw < self.end {
+            return raw;
+        }
+        // Wrap: how far past end did we go?
+        let over = raw - self.end;
+        let len = self.end - self.start;
+        // Modulo for pathological long advances — never return a
+        // position outside the loop.
+        self.start + (over % len)
+    }
+}
+
+impl Default for LoopRegion {
+    /// Default: disabled.
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_disabled() {
+        let l = LoopRegion::default();
+        assert!(!l.enabled);
+        assert_eq!(l.start, 0);
+        assert_eq!(l.end, 0);
+        assert!(!l.is_active());
+        assert_eq!(l.length(), 0);
+    }
+
+    #[test]
+    fn is_active_requires_enabled_and_non_empty() {
+        assert!(!LoopRegion {
+            enabled: false,
+            start: 100,
+            end: 200,
+        }
+        .is_active());
+        assert!(!LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 100,
+        }
+        .is_active());
+        assert!(!LoopRegion {
+            enabled: true,
+            start: 200,
+            end: 100,
+        }
+        .is_active());
+        assert!(LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 200,
+        }
+        .is_active());
+    }
+
+    #[test]
+    fn length_returns_zero_for_inactive() {
+        let disabled = LoopRegion {
+            enabled: false,
+            start: 100,
+            end: 200,
+        };
+        assert_eq!(disabled.length(), 0);
+        let empty = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 100,
+        };
+        assert_eq!(empty.length(), 0);
+    }
+
+    #[test]
+    fn length_for_active_loop() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 200,
+        };
+        assert_eq!(l.length(), 100);
+    }
+
+    // ── next_position: inactive paths ────────────────────────────────
+
+    #[test]
+    fn next_position_no_wrap_when_disabled() {
+        let l = LoopRegion {
+            enabled: false,
+            start: 100,
+            end: 200,
+        };
+        assert_eq!(l.next_position(150, 100), 250);
+    }
+
+    #[test]
+    fn next_position_no_wrap_when_empty_range() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 100,
+        };
+        assert_eq!(l.next_position(50, 100), 150);
+    }
+
+    #[test]
+    fn next_position_no_wrap_when_inverted_range() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 200,
+            end: 100,
+        };
+        assert_eq!(
+            l.next_position(50, 100),
+            150,
+            "malformed region (start > end) must not wrap or panic"
+        );
+    }
+
+    // ── next_position: outside loop paths ────────────────────────────
+
+    #[test]
+    fn next_position_no_wrap_when_playhead_past_end() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 200,
+        };
+        // Position already past end → user sought out of the loop.
+        assert_eq!(l.next_position(250, 100), 350);
+    }
+
+    #[test]
+    fn next_position_no_wrap_at_exact_end_already() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 200,
+        };
+        // At sample 200 we're AT end (already wrapped last time).
+        // Advancing should not re-wrap — we're now outside.
+        assert_eq!(l.next_position(200, 50), 250);
+    }
+
+    #[test]
+    fn next_position_no_wrap_when_advance_stays_before_end() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 200,
+        };
+        assert_eq!(l.next_position(150, 40), 190, "stays inside loop");
+    }
+
+    // ── next_position: wrap paths ────────────────────────────────────
+
+    #[test]
+    fn next_position_wraps_exactly_at_end_boundary() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 200,
+        };
+        // Advance lands exactly on end → wrap to start with 0 over.
+        assert_eq!(
+            l.next_position(150, 50),
+            100,
+            "raw result = end → wrap to start"
+        );
+    }
+
+    #[test]
+    fn next_position_wraps_mid_buffer() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 200,
+        };
+        // From 180 advance 50 → raw 230; over = 30 → start + 30 = 130.
+        assert_eq!(l.next_position(180, 50), 130);
+    }
+
+    #[test]
+    fn next_position_wraps_when_entering_from_before_start() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 200,
+        };
+        // From 50 advance 200 → raw 250; 50 < end (200), so wrap
+        // applies. over = 50; 100 + (50 % 100) = 150.
+        assert_eq!(l.next_position(50, 200), 150);
+    }
+
+    #[test]
+    fn next_position_handles_multiple_wraps() {
+        // Very short loop with a large advance — must wrap multiple
+        // times without producing a position outside the loop.
+        let l = LoopRegion {
+            enabled: true,
+            start: 0,
+            end: 10,
+        };
+        // Advance 27 samples from 0: that's 2 full loops + 7 into
+        // the third → position 7.
+        let r = l.next_position(0, 27);
+        assert!(r >= l.start && r < l.end, "{} not in [0,10)", r);
+        assert_eq!(r, 7);
+    }
+
+    #[test]
+    fn next_position_saturates_on_overflow_when_inactive() {
+        let l = LoopRegion::disabled();
+        assert_eq!(l.next_position(u64::MAX - 10, 50), u64::MAX);
+    }
+
+    #[test]
+    fn next_position_wraps_cleanly_at_large_loop() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 48_000,
+            end: 96_000,
+        };
+        // 1 second at 48 kHz loop. From inside at 95_900, advance 256
+        // frames → raw 96_156; over 156 → 48_156.
+        assert_eq!(l.next_position(95_900, 256), 48_156);
+    }
+
+    // ── serde wire format ────────────────────────────────────────────
+
+    #[test]
+    fn serde_round_trip_preserves_fields() {
+        let l = LoopRegion {
+            enabled: true,
+            start: 48_000,
+            end: 96_000,
+        };
+        let json = serde_json::to_string(&l).unwrap();
+        assert!(json.contains("\"enabled\":true"), "json: {json}");
+        assert!(json.contains("\"start\":48000"));
+        assert!(json.contains("\"end\":96000"));
+        let back: LoopRegion = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, l);
+    }
+
+    #[test]
+    fn loop_region_is_copy_and_small() {
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<LoopRegion>();
+        // bool + u64 + u64 = 17 bytes, typically padded to 24.
+        assert!(std::mem::size_of::<LoopRegion>() <= 32);
+    }
+}

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -30,6 +30,7 @@ pub mod command;
 pub mod config;
 pub mod effect_chain;
 pub mod graph;
+pub mod loop_region;
 pub mod meter;
 pub mod meter_bank;
 pub mod mixer;
@@ -45,6 +46,7 @@ pub use config::{
     VALID_SAMPLE_RATES,
 };
 pub use graph::{AudioGraph, Track, MAX_TRACKS};
+pub use loop_region::LoopRegion;
 pub use meter::{generate_sine, Meter, MeterReading};
 pub use meter_bank::{MeterConsumers, MeterProducers};
 pub use mixer::{equal_power_pan, is_audible};
@@ -209,6 +211,8 @@ struct RunningEngine {
     tempo_map: Arc<ArcSwap<TempoMap>>,
     /// Same pattern for time signature.
     time_sig_map: Arc<ArcSwap<TimeSignatureMap>>,
+    /// Same pattern for the loop region.
+    loop_region: Arc<ArcSwap<LoopRegion>>,
     /// Active sample rate — cached so beat↔sample conversion can
     /// run without re-parsing `EngineStatus`.
     sample_rate: u32,
@@ -285,6 +289,7 @@ impl Engine {
         let shared_position = transport.shared_position();
         let tempo_map_handle = transport.tempo_map_handle();
         let time_sig_map_handle = transport.time_sig_map_handle();
+        let loop_region_handle = transport.loop_region_handle();
 
         let ctx = RuntimeContext {
             config: config.clone(),
@@ -330,6 +335,7 @@ impl Engine {
                     shared_position,
                     tempo_map: tempo_map_handle,
                     time_sig_map: time_sig_map_handle,
+                    loop_region: loop_region_handle,
                     sample_rate: active_sample_rate,
                 });
                 Ok(status)
@@ -547,6 +553,36 @@ impl Engine {
             Some(r) => r.tempo_map.load().sample_to_beat(sample, r.sample_rate),
             None => 0.0,
         }
+    }
+
+    // ── Transport loop region (3C) ──────────────────────────────────
+
+    /// Replace the loop region atomically. The region is stored as
+    /// given — malformed regions (`end <= start`) are NOT rejected
+    /// here because the UI may be in a transient drag state where
+    /// the handles have briefly crossed. Such regions are silently
+    /// treated as disabled on the audio thread (see
+    /// [`LoopRegion::is_active`]).
+    pub fn set_loop_region(&self, region: LoopRegion) -> Result<(), CommandError> {
+        let running = self.running.as_ref().ok_or(CommandError::NotRunning)?;
+        running.loop_region.store(Arc::new(region));
+        Ok(())
+    }
+
+    /// Snapshot the current loop region. Returns `None` when the
+    /// engine is stopped.
+    pub fn loop_region_snapshot(&self) -> Option<LoopRegion> {
+        self.running.as_ref().map(|r| **r.loop_region.load())
+    }
+
+    /// Enable or disable the existing loop region without changing
+    /// its bounds. Convenience for the "Loop On/Off" UI toggle.
+    pub fn set_loop_enabled(&self, enabled: bool) -> Result<(), CommandError> {
+        let running = self.running.as_ref().ok_or(CommandError::NotRunning)?;
+        let mut region = **running.loop_region.load();
+        region.enabled = enabled;
+        running.loop_region.store(Arc::new(region));
+        Ok(())
     }
 
     /// Read the latest meter reading for a track.
@@ -1486,6 +1522,65 @@ mod tests {
         let snap = engine.tempo_map_snapshot().unwrap();
         assert_eq!(snap.events().len(), 2);
         assert_eq!(snap.events()[0].bpm, 77.0);
+
+        engine.stop();
+    }
+
+    // ── 3C: loop region via Engine ──────────────────────────────────
+
+    #[test]
+    fn loop_region_before_start_fails_with_not_running() {
+        let engine = Engine::new();
+        assert_eq!(
+            engine.set_loop_region(LoopRegion {
+                enabled: true,
+                start: 0,
+                end: 1_000,
+            }),
+            Err(CommandError::NotRunning)
+        );
+        assert!(engine.loop_region_snapshot().is_none());
+        assert_eq!(
+            engine.set_loop_enabled(true),
+            Err(CommandError::NotRunning)
+        );
+    }
+
+    #[test]
+    fn loop_region_publish_and_snapshot_round_trip() {
+        let mut engine = Engine::new();
+        engine
+            .start_with(
+                EngineConfig::default_48k(),
+                fake_runner(
+                    Ok(ok_info()),
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(AtomicBool::new(false)),
+                ),
+            )
+            .unwrap();
+
+        // Default is disabled.
+        let initial = engine.loop_region_snapshot().unwrap();
+        assert_eq!(initial, LoopRegion::disabled());
+
+        let region = LoopRegion {
+            enabled: true,
+            start: 48_000,
+            end: 96_000,
+        };
+        engine.set_loop_region(region).unwrap();
+        assert_eq!(engine.loop_region_snapshot().unwrap(), region);
+
+        // set_loop_enabled toggles without changing the bounds.
+        engine.set_loop_enabled(false).unwrap();
+        let after = engine.loop_region_snapshot().unwrap();
+        assert!(!after.enabled);
+        assert_eq!(after.start, 48_000);
+        assert_eq!(after.end, 96_000);
+
+        engine.set_loop_enabled(true).unwrap();
+        assert!(engine.loop_region_snapshot().unwrap().enabled);
 
         engine.stop();
     }

--- a/src-tauri/src/engine/transport.rs
+++ b/src-tauri/src/engine/transport.rs
@@ -39,6 +39,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 
+use super::loop_region::LoopRegion;
 use super::tempo_map::TempoMap;
 use super::time_sig_map::TimeSignatureMap;
 
@@ -177,16 +178,23 @@ pub struct Transport {
     /// `Transport` so that 3E's metronome and the UI can pull from a
     /// single source of truth.
     time_sig_map: Arc<ArcSwap<TimeSignatureMap>>,
+    /// Loop region. When active, the audio callback wraps the
+    /// playhead from `end` back to `start` as playback crosses the
+    /// end boundary. Shared via `ArcSwap` so the main thread can
+    /// toggle / move the region without blocking the audio thread
+    /// — the callback does a wait-free `.load()` on each buffer.
+    loop_region: Arc<ArcSwap<LoopRegion>>,
 }
 
 impl Transport {
-    /// Fresh transport: Stopped at sample 0, 120 BPM, 4/4.
+    /// Fresh transport: Stopped at sample 0, 120 BPM, 4/4, no loop.
     pub fn new() -> Self {
         Self {
             state: TransportState::Stopped,
             position: SharedPosition::new(),
             tempo_map: Arc::new(ArcSwap::from_pointee(TempoMap::new_constant(DEFAULT_BPM))),
             time_sig_map: Arc::new(ArcSwap::from_pointee(TimeSignatureMap::default())),
+            loop_region: Arc::new(ArcSwap::from_pointee(LoopRegion::disabled())),
         }
     }
 
@@ -224,6 +232,23 @@ impl Transport {
     /// [`tempo_map_handle`](Self::tempo_map_handle) for semantics.
     pub fn time_sig_map_handle(&self) -> Arc<ArcSwap<TimeSignatureMap>> {
         self.time_sig_map.clone()
+    }
+
+    /// Clone the loop-region handle. Read-only on the audio side;
+    /// main thread publishes via `.store(Arc::new(new))`.
+    pub fn loop_region_handle(&self) -> Arc<ArcSwap<LoopRegion>> {
+        self.loop_region.clone()
+    }
+
+    /// Snapshot the current loop region. Cheap — `ArcSwap::load` is
+    /// wait-free and returns a lightweight guard.
+    pub fn loop_region_snapshot(&self) -> LoopRegion {
+        **self.loop_region.load()
+    }
+
+    /// Replace the loop region atomically.
+    pub fn replace_loop_region(&mut self, region: LoopRegion) {
+        self.loop_region.store(Arc::new(region));
     }
 
     /// Snapshot the current tempo map. Cheap — `.load()` is wait-free
@@ -288,16 +313,34 @@ impl Transport {
     /// [`TransportState::is_advancing`]). No-op for `Stopped` and
     /// `Paused`.
     ///
-    /// Named `advance_if_advancing` rather than `advance_if_advancing`
-    /// because the condition is not just `Playing` — all three
-    /// advancing states share the same per-buffer increment in 3A.
-    /// Later phases (3G scrub) may split these paths; callers should
-    /// not assume the condition is equivalent to "state == Playing".
+    /// Kept for tests and for callers that explicitly want to ignore
+    /// the loop region. The production audio callback uses
+    /// [`advance_with_loop_if_advancing`] instead.
     #[inline]
     pub fn advance_if_advancing(&mut self, frames: u64) {
         if self.state.is_advancing() {
             self.position.advance(frames);
         }
+    }
+
+    /// Called by the audio callback once per buffer. Like
+    /// [`advance_if_advancing`] but reads the current loop region
+    /// snapshot and wraps the playhead if the advance crosses the
+    /// loop end boundary.
+    ///
+    /// The wrap math lives in [`LoopRegion::next_position`], so
+    /// this method is a thin audio-callback-friendly wrapper — no
+    /// allocation, no locks, one `ArcSwap::load` + one atomic
+    /// write. Safe to call from the audio thread.
+    #[inline]
+    pub fn advance_with_loop_if_advancing(&mut self, frames: u64) {
+        if !self.state.is_advancing() {
+            return;
+        }
+        let region = **self.loop_region.load();
+        let current = self.position.get();
+        let next = region.next_position(current, frames);
+        self.position.set(next);
     }
 }
 
@@ -586,5 +629,122 @@ mod tests {
             (3, 4),
             "handle must observe transport-side updates"
         );
+    }
+
+    // ── 3C: loop region integration ─────────────────────────────────
+
+    #[test]
+    fn new_transport_has_disabled_loop_region() {
+        let t = Transport::new();
+        let r = t.loop_region_snapshot();
+        assert_eq!(r, LoopRegion::disabled());
+        assert!(!r.is_active());
+    }
+
+    #[test]
+    fn replace_loop_region_is_visible_on_snapshot_and_handle() {
+        let mut t = Transport::new();
+        let handle = t.loop_region_handle();
+
+        let region = LoopRegion {
+            enabled: true,
+            start: 48_000,
+            end: 96_000,
+        };
+        t.replace_loop_region(region);
+
+        assert_eq!(t.loop_region_snapshot(), region);
+        // The external handle must observe the same cell.
+        let via_handle = **handle.load();
+        assert_eq!(via_handle, region);
+    }
+
+    #[test]
+    fn advance_with_loop_no_op_when_stopped() {
+        let mut t = Transport::new();
+        t.replace_loop_region(LoopRegion {
+            enabled: true,
+            start: 0,
+            end: 100,
+        });
+        t.advance_with_loop_if_advancing(50);
+        assert_eq!(t.position(), 0, "stopped transport must not advance");
+    }
+
+    #[test]
+    fn advance_with_loop_wraps_at_end_boundary() {
+        let mut t = Transport::new();
+        t.replace_loop_region(LoopRegion {
+            enabled: true,
+            start: 48_000,
+            end: 96_000,
+        });
+        t.seek(95_900);
+        t.play();
+        // Advance 256 → raw 96_156; over = 156 → start + 156 = 48_156.
+        t.advance_with_loop_if_advancing(256);
+        assert_eq!(t.position(), 48_156);
+    }
+
+    #[test]
+    fn advance_with_loop_no_wrap_when_region_disabled() {
+        let mut t = Transport::new();
+        // Region set but disabled.
+        t.replace_loop_region(LoopRegion {
+            enabled: false,
+            start: 0,
+            end: 1_000,
+        });
+        t.seek(900);
+        t.play();
+        t.advance_with_loop_if_advancing(256);
+        assert_eq!(
+            t.position(),
+            1_156,
+            "disabled loop must not wrap — position advances past end"
+        );
+    }
+
+    #[test]
+    fn advance_with_loop_no_wrap_when_outside_loop() {
+        let mut t = Transport::new();
+        t.replace_loop_region(LoopRegion {
+            enabled: true,
+            start: 0,
+            end: 1_000,
+        });
+        // Seek past end → outside the loop.
+        t.seek(5_000);
+        t.play();
+        t.advance_with_loop_if_advancing(256);
+        assert_eq!(
+            t.position(),
+            5_256,
+            "playhead past end → no wrap, just advance"
+        );
+    }
+
+    #[test]
+    fn advance_with_loop_reads_latest_region_each_buffer() {
+        // The audio callback loads the ArcSwap on every buffer, so a
+        // main-thread mutation mid-playback must take effect
+        // immediately.
+        let mut t = Transport::new();
+        t.seek(500);
+        t.play();
+
+        // No wrap yet — no region set.
+        t.advance_with_loop_if_advancing(100);
+        assert_eq!(t.position(), 600);
+
+        // Now install a loop that the next advance will cross.
+        t.replace_loop_region(LoopRegion {
+            enabled: true,
+            start: 100,
+            end: 700,
+        });
+        t.advance_with_loop_if_advancing(200);
+        // 600 + 200 = 800; over = 100; 100 + (100 % 600) = 200.
+        assert_eq!(t.position(), 200);
     }
 }

--- a/src-tauri/src/engine/transport.rs
+++ b/src-tauri/src/engine/transport.rs
@@ -330,17 +330,39 @@ impl Transport {
     ///
     /// The wrap math lives in [`LoopRegion::next_position`], so
     /// this method is a thin audio-callback-friendly wrapper — no
-    /// allocation, no locks, one `ArcSwap::load` + one atomic
-    /// write. Safe to call from the audio thread.
+    /// allocation, no locks, one `ArcSwap::load` + at most one
+    /// atomic read-modify-write. Safe to call from the audio thread.
+    ///
+    /// **Fast path** — when the loop is inactive (the common case
+    /// during single-shot playback), we delegate to
+    /// `SharedPosition::advance`, which uses a single `fetch_add`
+    /// atomic RMW. Only the active-loop path needs the more
+    /// expensive load + compute + store, because we have to re-read
+    /// the cursor to decide whether the advance crosses the end
+    /// boundary. Copilot review noted the inactive case was paying
+    /// extra atomics for nothing (PR #1713).
     #[inline]
     pub fn advance_with_loop_if_advancing(&mut self, frames: u64) {
         if !self.state.is_advancing() {
             return;
         }
         let region = **self.loop_region.load();
+        if !region.is_active() {
+            self.position.advance(frames);
+            return;
+        }
         let current = self.position.get();
         let next = region.next_position(current, frames);
-        self.position.set(next);
+        // Skip the store if the advance landed exactly where the
+        // non-wrap path would have, which is the 99% case when the
+        // playhead is outside the loop range entirely. `advance`
+        // does a single RMW and matches what the caller wants.
+        if next == current.saturating_add(frames) {
+            self.position.advance(frames);
+        } else {
+            // Wrap happened — need an absolute set, not a delta.
+            self.position.set(next);
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,11 +7,13 @@ use crate::commands::audio::{
     audio_add_track, audio_get_default_device, audio_get_engine_status,
     audio_list_devices, audio_remove_track, audio_set_master_volume,
     audio_set_track_params, audio_start_engine, audio_stop_engine,
-    audio_transport_beat_to_sample, audio_transport_get_position,
-    audio_transport_get_tempo_map, audio_transport_get_time_signature_map,
-    audio_transport_pause, audio_transport_play, audio_transport_sample_to_beat,
-    audio_transport_seek, audio_transport_set_tempo, audio_transport_set_tempo_map,
-    audio_transport_set_time_signature_map, audio_transport_stop, EngineState,
+    audio_transport_beat_to_sample, audio_transport_get_loop_region,
+    audio_transport_get_position, audio_transport_get_tempo_map,
+    audio_transport_get_time_signature_map, audio_transport_pause, audio_transport_play,
+    audio_transport_sample_to_beat, audio_transport_seek, audio_transport_set_loop_enabled,
+    audio_transport_set_loop_region, audio_transport_set_tempo,
+    audio_transport_set_tempo_map, audio_transport_set_time_signature_map,
+    audio_transport_stop, EngineState,
 };
 
 /// Greet command — placeholder to verify IPC works.
@@ -53,6 +55,9 @@ pub fn run() {
             audio_transport_get_time_signature_map,
             audio_transport_beat_to_sample,
             audio_transport_sample_to_beat,
+            audio_transport_set_loop_region,
+            audio_transport_get_loop_region,
+            audio_transport_set_loop_enabled,
         ])
         .setup(|app| {
             // Focus main window on startup

--- a/src-tauri/tests/local_audio_smoke.rs
+++ b/src-tauri/tests/local_audio_smoke.rs
@@ -19,7 +19,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use ace_step_daw_lib::engine::{
-    audio_io, Engine, EngineConfig, EngineStatus, TempoEvent, TrackParams,
+    audio_io, Engine, EngineConfig, EngineStatus, LoopRegion, TempoEvent, TrackParams,
 };
 
 /// Smoke test 1 — device enumeration returns at least one device on a
@@ -409,6 +409,84 @@ fn real_engine_tempo_map_round_trip() {
             "round trip drifted: {beats} → {s} → {b}"
         );
     }
+
+    engine.stop();
+}
+
+/// Smoke test — loop region wraps the transport position on live
+/// playback.
+///
+/// Phase 3C end-to-end proof: set a small loop [48_000, 96_000]
+/// (1 s at 48 kHz), seek just inside the region, start playback,
+/// wait long enough for multiple wraps, and assert that the
+/// observed position has wrapped (i.e. the counter is not
+/// monotonically advancing past `end`).
+#[test]
+#[ignore]
+fn real_engine_loop_wraps_position() {
+    let mut engine = Engine::new();
+    engine.start(EngineConfig::default_48k()).unwrap();
+
+    let region = LoopRegion {
+        enabled: true,
+        start: 48_000,
+        end: 96_000,
+    };
+    engine.set_loop_region(region).expect("set_loop_region");
+
+    // Seek to just inside the region's end so the very next buffer
+    // crosses the boundary.
+    engine.transport_seek(95_000).expect("seek");
+    engine.transport_play().expect("play");
+
+    // Wait for at least one wrap to happen. At 256 frames / 48 kHz
+    // ≈ 5.3 ms per buffer, 50 ms gives ~9 buffers worth, which is
+    // more than enough to cross the 1000-sample tail into the wrap.
+    sleep(Duration::from_millis(50));
+
+    let after_wrap = engine.transport_position();
+    eprintln!("position after first wrap window: {after_wrap}");
+    assert!(
+        after_wrap < region.end,
+        "position {after_wrap} should have wrapped below region.end = {}",
+        region.end
+    );
+    assert!(
+        after_wrap >= region.start,
+        "position {after_wrap} should be at or after region.start = {}",
+        region.start
+    );
+
+    // Continue for another 200 ms — the position must STILL be
+    // inside the loop (it keeps wrapping, not monotonically
+    // advancing).
+    sleep(Duration::from_millis(200));
+    let later = engine.transport_position();
+    eprintln!("position after 250 ms total: {later}");
+    assert!(
+        later >= region.start && later < region.end,
+        "position {later} drifted out of loop [{}, {})",
+        region.start,
+        region.end
+    );
+
+    // Disable the loop and verify the next advance goes past end
+    // without wrapping.
+    engine
+        .set_loop_enabled(false)
+        .expect("set_loop_enabled");
+    sleep(Duration::from_millis(50));
+    let after_disable = engine.transport_position();
+    eprintln!("position after loop disabled: {after_disable}");
+    // The position was inside [48_000, 96_000). After 50 ms ≈ 2400
+    // more samples and loop disabled, it should now exceed 96_000
+    // (assuming no wrap happened post-disable).
+    // Allow a small grace because there may be 1 in-flight buffer
+    // already partway through a wrap when we flipped the flag.
+    assert!(
+        after_disable >= region.start,
+        "position {after_disable} went backwards"
+    );
 
     engine.stop();
 }

--- a/src-tauri/tests/local_audio_smoke.rs
+++ b/src-tauri/tests/local_audio_smoke.rs
@@ -470,22 +470,35 @@ fn real_engine_loop_wraps_position() {
         region.end
     );
 
-    // Disable the loop and verify the next advance goes past end
-    // without wrapping.
+    // Disable the loop and verify the playhead leaves the region.
+    // This is the critical regression guard — without the assertion
+    // that `after_disable >= region.end`, a bug where wrapping kept
+    // happening after `set_loop_enabled(false)` would slip through
+    // (Copilot review on PR #1713).
     engine
         .set_loop_enabled(false)
         .expect("set_loop_enabled");
-    sleep(Duration::from_millis(50));
+    wait_until(
+        || engine.transport_position() >= region.end,
+        Duration::from_secs(2),
+        "position exits loop region once enabled=false",
+    );
     let after_disable = engine.transport_position();
     eprintln!("position after loop disabled: {after_disable}");
-    // The position was inside [48_000, 96_000). After 50 ms ≈ 2400
-    // more samples and loop disabled, it should now exceed 96_000
-    // (assuming no wrap happened post-disable).
-    // Allow a small grace because there may be 1 in-flight buffer
-    // already partway through a wrap when we flipped the flag.
     assert!(
-        after_disable >= region.start,
-        "position {after_disable} went backwards"
+        after_disable >= region.end,
+        "position {after_disable} still inside loop range \
+         [{}, {}) after set_loop_enabled(false) — wrap did not stop",
+        region.start,
+        region.end
+    );
+    // And the counter must keep advancing (not re-wrap).
+    let first = after_disable;
+    sleep(Duration::from_millis(50));
+    let second = engine.transport_position();
+    assert!(
+        second > first,
+        "position stuck at {first} — counter not advancing after loop disabled"
     );
 
     engine.stop();


### PR DESCRIPTION
## Summary

Third atomic slice of Phase 3 (#1523). Builds on 3A (PR #1709 transport) and 3B (PR #1711 tempo/timesig). Adds the loop region state machine and makes the audio callback wrap the transport position mid-buffer when playback crosses the loop end boundary.

- **`LoopRegion { enabled, start, end }`** — `Copy + Send + Sync` value type, no validated constructor. Malformed regions (`end <= start`) are silently treated as disabled on the audio thread to tolerate UI drag states.
- **Half-open interval `[start, end)`** — `end` is exclusive, matching the "region length" convention in every major DAW.
- **Pure wrap math** in `LoopRegion::next_position` — modulo-based, handles pathological cases (multiple wraps per buffer).
- **ArcSwap sharing** — same pattern as tempo/timesig maps. Main thread publishes, audio callback reads wait-free on every buffer.
- **Position-counter only** — 3C wraps the counter, audio-rendering wrap (crossfade at boundary) lands with clip scheduling in 3F.

### Engine + Tauri API
- `Engine::set_loop_region`, `loop_region_snapshot`, `set_loop_enabled`
- `audio_transport_set_loop_region`, `audio_transport_get_loop_region`, `audio_transport_set_loop_enabled`

## Test plan

- [x] `cargo test --lib` — 215 Rust unit tests pass (was 188, +27)
  - 18 loop_region pure-math tests (every wrap and no-wrap edge case)
  - 7 transport integration tests (ArcSwap aliasing, audio-thread read path)
  - 2 engine integration tests (set/get round-trip, enable toggle)
- [x] `cargo test --test local_audio_smoke -- --ignored real_engine_loop_wraps_position` — hardware smoke test passes: set `[48_000, 96_000)` loop, seek just inside the tail (95_000), play, position wraps cleanly below `end`, toggle `enabled=false` mid-playback and verify wrap stops
- [x] `cargo build --release` clean
- [x] `npx tsc --noEmit` clean

## Non-goals (later phases)

- Sample-accurate audio crossfade at wrap point → 3F (requires clip scheduler)
- Punch in/out markers → 3G
- Pre-roll before loop start → 3G
- UI event emission when wrap occurs → 3D

Closes #1712
Part of #1523, #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)