### PR TITLE
feat: Phase 3D — 60fps position reporting via Tauri events

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -6,12 +6,12 @@
 //! affected by the mutex.
 
 use std::sync::Mutex;
-use tauri::State;
+use tauri::{Emitter, State};
 
 use crate::engine::{
     audio_io, AudioDeviceInfo, CommandError, Engine, EngineConfig, EngineError,
-    EngineStatus, LoopRegion, TempoEvent, TempoMap, TimeSignatureEvent, TimeSignatureMap,
-    TrackParams,
+    EngineStatus, LoopRegion, PositionEmitter, TempoEvent, TempoMap, TimeSignatureEvent,
+    TimeSignatureMap, TrackParams, POSITION_EVENT_DEFAULT_INTERVAL,
 };
 use crate::engine::slot::SlotHandle;
 
@@ -33,6 +33,32 @@ impl Default for EngineState {
     }
 }
 
+/// Holds the background thread that emits transport-position Tauri
+/// events at ~60 Hz while the engine is running. Split from
+/// [`EngineState`] so the existing 20+ command sites that lock
+/// `state.0` don't need to change shape.
+///
+/// The `None` case means "no emitter currently active" — i.e. the
+/// engine is stopped, or the app is still in first-open state.
+pub struct TransportEmitterState(pub Mutex<Option<PositionEmitter>>);
+
+impl TransportEmitterState {
+    pub fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+}
+
+impl Default for TransportEmitterState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Tauri event name for the 60 Hz transport-position push. Payload
+/// is a `u64` sample position. Kept as a constant so the UI test
+/// harness can reference it without hard-coding the string.
+pub const TRANSPORT_POSITION_EVENT: &str = "transport-position";
+
 // ── Device enumeration ──────────────────────────────────────────────
 
 #[tauri::command]
@@ -51,16 +77,59 @@ pub fn audio_get_default_device() -> Option<AudioDeviceInfo> {
 pub fn audio_start_engine(
     config: EngineConfig,
     state: State<'_, EngineState>,
+    emitter_state: State<'_, TransportEmitterState>,
+    app: tauri::AppHandle,
 ) -> Result<EngineStatus, EngineError> {
     let mut engine = state
         .0
         .lock()
         .map_err(|_| EngineError::Open("engine mutex poisoned".into()))?;
-    engine.start(config)
+    let status = engine.start(config)?;
+
+    // Spawn the position emitter so the UI can animate the playhead
+    // from Tauri events instead of polling at 60 Hz. If an emitter
+    // from a previous start is still alive (should not happen under
+    // normal use, but stop_engine may have been skipped), stop it
+    // first so we never have two emitters pushing to the same event
+    // name.
+    if let Some(shared_pos) = engine.shared_position_handle() {
+        let mut slot = emitter_state
+            .0
+            .lock()
+            .map_err(|_| EngineError::Open("emitter mutex poisoned".into()))?;
+        if let Some(mut old) = slot.take() {
+            old.stop();
+        }
+        let app_handle = app.clone();
+        let emitter = PositionEmitter::start(
+            shared_pos,
+            POSITION_EVENT_DEFAULT_INTERVAL,
+            move |pos| {
+                // Deliberately ignore emit errors: the webview may
+                // not be alive on initial boot, and a dropped event
+                // is preferable to panicking the emitter thread.
+                let _ = app_handle.emit(TRANSPORT_POSITION_EVENT, pos);
+            },
+        );
+        *slot = Some(emitter);
+    }
+
+    Ok(status)
 }
 
 #[tauri::command]
-pub fn audio_stop_engine(state: State<'_, EngineState>) -> Result<(), EngineError> {
+pub fn audio_stop_engine(
+    state: State<'_, EngineState>,
+    emitter_state: State<'_, TransportEmitterState>,
+) -> Result<(), EngineError> {
+    // Stop the emitter BEFORE the engine so it doesn't tick one
+    // more event carrying a stale (pre-rewind) position after
+    // `engine.stop()` resets the counter.
+    if let Ok(mut slot) = emitter_state.0.lock() {
+        if let Some(mut e) = slot.take() {
+            e.stop();
+        }
+    }
     let mut engine = state
         .0
         .lock()

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -73,6 +73,17 @@ pub fn audio_get_default_device() -> Option<AudioDeviceInfo> {
 
 // ── Engine lifecycle ────────────────────────────────────────────────
 
+// Locking protocol for start/stop (addresses codex P1 on PR #1715):
+//
+// - ALWAYS take `EngineState` FIRST, then `TransportEmitterState`.
+//   The reverse order in any command would risk a deadlock if two
+//   commands overlap.
+// - HOLD BOTH LOCKS through the entire emitter lifecycle transition
+//   (old stopped → new stopped, or old running → new running).
+//   Otherwise a `stop_engine` that sees `None` can race a concurrent
+//   `start_engine` that installs a new emitter between the check and
+//   the engine stop, leaving a stale emitter behind.
+
 #[tauri::command]
 pub fn audio_start_engine(
     config: EngineConfig,
@@ -80,26 +91,26 @@ pub fn audio_start_engine(
     emitter_state: State<'_, TransportEmitterState>,
     app: tauri::AppHandle,
 ) -> Result<EngineStatus, EngineError> {
+    // Take locks in canonical order and hold both.
     let mut engine = state
         .0
         .lock()
         .map_err(|_| EngineError::Open("engine mutex poisoned".into()))?;
+    let mut emitter_slot = emitter_state
+        .0
+        .lock()
+        .map_err(|_| EngineError::Open("emitter mutex poisoned".into()))?;
+
+    // Stop any leftover emitter BEFORE starting the new engine — so
+    // we never have two emitters pushing to the same event name, and
+    // we don't leak a thread if `start` fails.
+    if let Some(mut old) = emitter_slot.take() {
+        old.stop();
+    }
+
     let status = engine.start(config)?;
 
-    // Spawn the position emitter so the UI can animate the playhead
-    // from Tauri events instead of polling at 60 Hz. If an emitter
-    // from a previous start is still alive (should not happen under
-    // normal use, but stop_engine may have been skipped), stop it
-    // first so we never have two emitters pushing to the same event
-    // name.
     if let Some(shared_pos) = engine.shared_position_handle() {
-        let mut slot = emitter_state
-            .0
-            .lock()
-            .map_err(|_| EngineError::Open("emitter mutex poisoned".into()))?;
-        if let Some(mut old) = slot.take() {
-            old.stop();
-        }
         let app_handle = app.clone();
         let emitter = PositionEmitter::start(
             shared_pos,
@@ -111,7 +122,7 @@ pub fn audio_start_engine(
                 let _ = app_handle.emit(TRANSPORT_POSITION_EVENT, pos);
             },
         );
-        *slot = Some(emitter);
+        *emitter_slot = Some(emitter);
     }
 
     Ok(status)
@@ -122,18 +133,24 @@ pub fn audio_stop_engine(
     state: State<'_, EngineState>,
     emitter_state: State<'_, TransportEmitterState>,
 ) -> Result<(), EngineError> {
-    // Stop the emitter BEFORE the engine so it doesn't tick one
-    // more event carrying a stale (pre-rewind) position after
-    // `engine.stop()` resets the counter.
-    if let Ok(mut slot) = emitter_state.0.lock() {
-        if let Some(mut e) = slot.take() {
-            e.stop();
-        }
-    }
+    // Canonical order: engine first, emitter second — matches
+    // start_engine so the two commands can never deadlock each
+    // other.
     let mut engine = state
         .0
         .lock()
         .map_err(|_| EngineError::Open("engine mutex poisoned".into()))?;
+    let mut emitter_slot = emitter_state
+        .0
+        .lock()
+        .map_err(|_| EngineError::Open("emitter mutex poisoned".into()))?;
+
+    // Stop the emitter BEFORE the engine so it doesn't tick one
+    // more event carrying a stale (pre-rewind) position after
+    // `engine.stop()` resets the counter.
+    if let Some(mut e) = emitter_slot.take() {
+        e.stop();
+    }
     engine.stop();
     Ok(())
 }

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -34,6 +34,7 @@ pub mod loop_region;
 pub mod meter;
 pub mod meter_bank;
 pub mod mixer;
+pub mod position_emitter;
 pub mod routing;
 pub mod slot;
 pub mod tempo_map;
@@ -47,6 +48,7 @@ pub use config::{
 };
 pub use graph::{AudioGraph, Track, MAX_TRACKS};
 pub use loop_region::LoopRegion;
+pub use position_emitter::{PositionEmitter, DEFAULT_INTERVAL as POSITION_EVENT_DEFAULT_INTERVAL};
 pub use meter::{generate_sine, Meter, MeterReading};
 pub use meter_bank::{MeterConsumers, MeterProducers};
 pub use mixer::{equal_power_pan, is_audible};
@@ -496,6 +498,15 @@ impl Engine {
             .as_ref()
             .map(|r| r.shared_position.get())
             .unwrap_or(0)
+    }
+
+    /// Clone the shared-position handle. External readers (the
+    /// [`position_emitter::PositionEmitter`] background thread, UI
+    /// poller, Tauri event pusher) use this to observe the atomic
+    /// counter without going through the engine mutex or the
+    /// command queue. Returns `None` when the engine is stopped.
+    pub fn shared_position_handle(&self) -> Option<SharedPosition> {
+        self.running.as_ref().map(|r| r.shared_position.clone())
     }
 
     // ── Transport tempo / time-signature maps (3B) ──────────────────

--- a/src-tauri/src/engine/position_emitter.rs
+++ b/src-tauri/src/engine/position_emitter.rs
@@ -81,6 +81,14 @@ impl PositionEmitter {
         let thread = thread::Builder::new()
             .name("ace-position-emitter".into())
             .spawn(move || {
+                // Re-check the flag BEFORE the initial emit so that
+                // a caller who does `start()` immediately followed
+                // by `stop()` — before the thread's first wake —
+                // doesn't see one stale tick. Found by codex review
+                // on PR #1715.
+                if !running_clone.load(Ordering::Relaxed) {
+                    return;
+                }
                 // Emit once immediately so the UI sees a value on
                 // the very first frame, not `clamped` ms later.
                 notify(shared_position.get());
@@ -299,6 +307,32 @@ mod tests {
         // Right at the boundaries: preserve exactly.
         assert_eq!(clamp_interval(MIN_INTERVAL), MIN_INTERVAL);
         assert_eq!(clamp_interval(MAX_INTERVAL), MAX_INTERVAL);
+    }
+
+    #[test]
+    fn stop_immediately_after_start_fires_no_ticks() {
+        // Codex P2 regression (PR #1715): the constructor spawns a
+        // thread that emits immediately before checking the running
+        // flag. If a caller does `start(...)` then `stop()` before
+        // the thread's first wake, the flag check must suppress the
+        // initial emit too — not just subsequent loop iterations.
+        let (sink, cb) = make_sink();
+        let pos = SharedPosition::new();
+        pos.set(99);
+        let mut emitter = PositionEmitter::start(pos, Duration::from_millis(50), cb);
+        // Stop *immediately*. On a fast machine the thread may not
+        // have even been scheduled yet; the flag flip + join must
+        // still prevent the stale tick.
+        emitter.stop();
+        // Give the thread a generous window to (incorrectly) tick
+        // if it were going to.
+        thread::sleep(Duration::from_millis(50));
+        assert_eq!(
+            sink.len(),
+            0,
+            "emitter fired {} stale ticks after an immediate stop",
+            sink.len()
+        );
     }
 
     #[test]

--- a/src-tauri/src/engine/position_emitter.rs
+++ b/src-tauri/src/engine/position_emitter.rs
@@ -1,0 +1,312 @@
+//! Background-thread poller that reads the transport's shared
+//! sample-position counter at a fixed interval and invokes a
+//! user-supplied callback with the current value.
+//!
+//! # Why a separate thread?
+//!
+//! The audio callback already updates the
+//! [`super::transport::SharedPosition`] atomically every buffer, so
+//! any reader can snapshot it with a single atomic load. Rather than
+//! asking the UI to poll the Tauri command for position at 60 Hz
+//! (which would serialize through the engine mutex and add IPC
+//! latency to every frame), we push the value from a background
+//! thread that owns the polling loop.
+//!
+//! # Real-time safety
+//!
+//! **This thread is NOT the audio callback.** It is a plain
+//! `std::thread`, so it is free to allocate, emit events, log,
+//! block on `thread::sleep`, etc. The audio thread is not involved
+//! — it only writes the atomic counter; the emitter only reads it.
+//!
+//! # Typical use
+//!
+//! The Tauri command layer constructs a `PositionEmitter` whose
+//! callback emits a `transport-position` event to the webview, so
+//! the UI can animate the playhead without querying the engine on
+//! every frame.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use super::transport::SharedPosition;
+
+/// Minimum polling interval. Faster than 200 Hz is pointless for a
+/// visual playhead and starts costing real CPU (wake-ups, Tauri
+/// event serialization).
+pub const MIN_INTERVAL: Duration = Duration::from_millis(5);
+
+/// Maximum polling interval. Slower than 1 Hz is effectively a
+/// "no emit" state and should be modeled with an explicit stop
+/// instead — clamping here ensures a bogus caller config doesn't
+/// make the UI look frozen.
+pub const MAX_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Default polling interval — 16 ms ≈ 60 Hz, which matches typical
+/// browser `requestAnimationFrame` cadence and is smooth for a
+/// playhead animation.
+pub const DEFAULT_INTERVAL: Duration = Duration::from_millis(16);
+
+/// Background polling thread that repeatedly snapshots a
+/// `SharedPosition` and hands the value to a callback.
+///
+/// Lifecycle: `start` spawns the thread, `stop` (or `Drop`) joins
+/// it. `stop` is idempotent.
+pub struct PositionEmitter {
+    running: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl PositionEmitter {
+    /// Spawn the polling thread. The callback is invoked on every
+    /// tick with the current sample position; the thread sleeps
+    /// for `interval` between ticks. `interval` is clamped to
+    /// `[MIN_INTERVAL, MAX_INTERVAL]` so pathological inputs
+    /// (zero, NaN via `Duration::ZERO` / `Duration::MAX`) cannot
+    /// produce a hot-spin loop or a hung UI.
+    pub fn start<F>(
+        shared_position: SharedPosition,
+        interval: Duration,
+        mut notify: F,
+    ) -> Self
+    where
+        F: FnMut(u64) + Send + 'static,
+    {
+        let clamped = clamp_interval(interval);
+        let running = Arc::new(AtomicBool::new(true));
+        let running_clone = running.clone();
+
+        let thread = thread::Builder::new()
+            .name("ace-position-emitter".into())
+            .spawn(move || {
+                // Emit once immediately so the UI sees a value on
+                // the very first frame, not `clamped` ms later.
+                notify(shared_position.get());
+                while running_clone.load(Ordering::Relaxed) {
+                    thread::sleep(clamped);
+                    // Re-check after the sleep in case `stop` was
+                    // called during the sleep window — otherwise
+                    // we'd fire one extra event after shutdown.
+                    if !running_clone.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    notify(shared_position.get());
+                }
+            })
+            .expect("spawn position emitter thread");
+
+        Self {
+            running,
+            thread: Some(thread),
+        }
+    }
+
+    /// Stop the thread and wait for it to exit. Idempotent.
+    pub fn stop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+
+    /// Whether the thread is currently spinning. Returns `false`
+    /// after `stop` or if the thread exited on its own (which
+    /// should not happen in normal flow).
+    pub fn is_running(&self) -> bool {
+        self.thread.is_some() && self.running.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for PositionEmitter {
+    fn drop(&mut self) {
+        // Ensure the thread is joined even if the caller forgets
+        // to call `stop`. Joining inside `Drop` is important
+        // because a leaked thread would keep a clone of the
+        // `SharedPosition` alive and continue ticking into a
+        // callback whose captured state may have been torn down.
+        self.stop();
+    }
+}
+
+#[inline]
+fn clamp_interval(d: Duration) -> Duration {
+    if d < MIN_INTERVAL {
+        MIN_INTERVAL
+    } else if d > MAX_INTERVAL {
+        MAX_INTERVAL
+    } else {
+        d
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Instant;
+
+    /// A test sink that records every position the emitter pushed,
+    /// so tests can assert on the sequence without waiting for a
+    /// real Tauri event round-trip.
+    #[derive(Clone, Default)]
+    struct Sink(Arc<Mutex<Vec<u64>>>);
+    impl Sink {
+        fn len(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+        fn values(&self) -> Vec<u64> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    fn make_sink() -> (Sink, impl FnMut(u64) + Send + 'static) {
+        let sink = Sink::default();
+        let sink_clone = sink.clone();
+        let cb = move |pos: u64| {
+            sink_clone.0.lock().unwrap().push(pos);
+        };
+        (sink, cb)
+    }
+
+    #[test]
+    fn start_immediately_emits_first_sample() {
+        // The constructor guarantees the first `notify` fires
+        // before the first sleep, so UI sees a value on frame 0.
+        let (sink, cb) = make_sink();
+        let pos = SharedPosition::new();
+        pos.set(42);
+        let mut emitter = PositionEmitter::start(pos, Duration::from_millis(50), cb);
+        // Wait briefly for the thread to schedule its first tick.
+        let deadline = Instant::now() + Duration::from_millis(200);
+        while sink.len() < 1 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(2));
+        }
+        assert!(sink.len() >= 1, "expected at least one tick");
+        assert_eq!(sink.values()[0], 42);
+        emitter.stop();
+    }
+
+    #[test]
+    fn emits_approximately_at_configured_rate() {
+        // At 20 ms interval over ~200 ms, expect ~10 ticks (first
+        // tick is immediate, then ~9 more). Use a wide window to
+        // absorb CI jitter.
+        let (sink, cb) = make_sink();
+        let pos = SharedPosition::new();
+        let mut emitter = PositionEmitter::start(pos.clone(), Duration::from_millis(20), cb);
+        thread::sleep(Duration::from_millis(220));
+        emitter.stop();
+        let n = sink.len();
+        assert!(
+            (5..=20).contains(&n),
+            "expected ~10 ticks over 220 ms at 20 ms interval, got {n}"
+        );
+    }
+
+    #[test]
+    fn callback_sees_live_shared_position_updates() {
+        // Changes the main thread makes to SharedPosition must be
+        // visible on the next emitter tick.
+        let (sink, cb) = make_sink();
+        let pos = SharedPosition::new();
+        let mut emitter = PositionEmitter::start(pos.clone(), Duration::from_millis(20), cb);
+        // Let the first tick land.
+        thread::sleep(Duration::from_millis(40));
+        pos.set(1234);
+        thread::sleep(Duration::from_millis(60));
+        emitter.stop();
+
+        let values = sink.values();
+        assert!(
+            values.iter().any(|&v| v == 1234),
+            "emitter should have observed the main-thread update; saw {:?}",
+            values
+        );
+    }
+
+    #[test]
+    fn stop_is_idempotent_and_joins_thread() {
+        let (_, cb) = make_sink();
+        let pos = SharedPosition::new();
+        let mut emitter = PositionEmitter::start(pos, Duration::from_millis(50), cb);
+        assert!(emitter.is_running());
+        emitter.stop();
+        assert!(!emitter.is_running());
+        // Second stop must be a no-op, not a panic.
+        emitter.stop();
+    }
+
+    #[test]
+    fn drop_stops_thread() {
+        let (sink, cb) = make_sink();
+        let pos = SharedPosition::new();
+        {
+            let _emitter = PositionEmitter::start(pos.clone(), Duration::from_millis(10), cb);
+            thread::sleep(Duration::from_millis(30));
+        } // drop here — thread must join
+        let after_drop = sink.len();
+        thread::sleep(Duration::from_millis(60));
+        assert_eq!(
+            sink.len(),
+            after_drop,
+            "no ticks should land after the emitter is dropped"
+        );
+    }
+
+    #[test]
+    fn interval_clamps_to_min() {
+        let (sink, cb) = make_sink();
+        let pos = SharedPosition::new();
+        // Ask for 0 ms → must be clamped to MIN_INTERVAL.
+        let mut emitter = PositionEmitter::start(pos.clone(), Duration::ZERO, cb);
+        thread::sleep(Duration::from_millis(100));
+        emitter.stop();
+        let n = sink.len();
+        // At MIN_INTERVAL (5 ms) over 100 ms, ~20 ticks expected;
+        // at no clamp, we'd see 20_000+ ticks on a modern machine.
+        // A 200-tick ceiling catches the "didn't clamp" regression.
+        assert!(
+            n < 200,
+            "emitter did not clamp interval — {} ticks in 100 ms",
+            n
+        );
+    }
+
+    #[test]
+    fn interval_clamps_to_max() {
+        let (sink, cb) = make_sink();
+        let pos = SharedPosition::new();
+        // Ask for 10 s → must be clamped to MAX_INTERVAL (1 s).
+        // Initial emit fires immediately, so we still see 1 tick.
+        let mut emitter =
+            PositionEmitter::start(pos.clone(), Duration::from_secs(10), cb);
+        thread::sleep(Duration::from_millis(50));
+        emitter.stop();
+        // Only the immediate initial tick should have fired in
+        // this window — subsequent ticks are deferred to the
+        // clamped max-interval wait, which is 1 s away.
+        assert_eq!(sink.len(), 1);
+    }
+
+    #[test]
+    fn clamp_interval_rounds_up_and_down() {
+        assert_eq!(clamp_interval(Duration::ZERO), MIN_INTERVAL);
+        assert_eq!(clamp_interval(Duration::from_millis(2)), MIN_INTERVAL);
+        assert_eq!(clamp_interval(Duration::from_millis(10)), Duration::from_millis(10));
+        assert_eq!(clamp_interval(Duration::from_secs(5)), MAX_INTERVAL);
+        // Right at the boundaries: preserve exactly.
+        assert_eq!(clamp_interval(MIN_INTERVAL), MIN_INTERVAL);
+        assert_eq!(clamp_interval(MAX_INTERVAL), MAX_INTERVAL);
+    }
+
+    #[test]
+    fn defaults_are_sensible() {
+        assert!(DEFAULT_INTERVAL >= MIN_INTERVAL);
+        assert!(DEFAULT_INTERVAL <= MAX_INTERVAL);
+        // 60 fps target → between 14 and 18 ms is defensible.
+        assert!(DEFAULT_INTERVAL >= Duration::from_millis(14));
+        assert!(DEFAULT_INTERVAL <= Duration::from_millis(20));
+    }
+}

--- a/src-tauri/src/engine/position_emitter.rs
+++ b/src-tauri/src/engine/position_emitter.rs
@@ -63,9 +63,10 @@ impl PositionEmitter {
     /// Spawn the polling thread. The callback is invoked on every
     /// tick with the current sample position; the thread sleeps
     /// for `interval` between ticks. `interval` is clamped to
-    /// `[MIN_INTERVAL, MAX_INTERVAL]` so pathological inputs
-    /// (zero, NaN via `Duration::ZERO` / `Duration::MAX`) cannot
-    /// produce a hot-spin loop or a hung UI.
+    /// `[MIN_INTERVAL, MAX_INTERVAL]` so pathological inputs — in
+    /// particular `Duration::ZERO` (would hot-spin) and unbounded
+    /// durations like `Duration::MAX` (would make the UI look
+    /// frozen) — cannot poison the emitter loop.
     pub fn start<F>(
         shared_position: SharedPosition,
         interval: Duration,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ use crate::commands::audio::{
     audio_transport_sample_to_beat, audio_transport_seek, audio_transport_set_loop_enabled,
     audio_transport_set_loop_region, audio_transport_set_tempo,
     audio_transport_set_tempo_map, audio_transport_set_time_signature_map,
-    audio_transport_stop, EngineState,
+    audio_transport_stop, EngineState, TransportEmitterState,
 };
 
 /// Greet command — placeholder to verify IPC works.
@@ -31,6 +31,7 @@ fn is_desktop() -> bool {
 pub fn run() {
     tauri::Builder::default()
         .manage(EngineState::new())
+        .manage(TransportEmitterState::new())
         .invoke_handler(tauri::generate_handler![
             greet,
             is_desktop,

--- a/src-tauri/tests/local_audio_smoke.rs
+++ b/src-tauri/tests/local_audio_smoke.rs
@@ -19,8 +19,10 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use ace_step_daw_lib::engine::{
-    audio_io, Engine, EngineConfig, EngineStatus, LoopRegion, TempoEvent, TrackParams,
+    audio_io, Engine, EngineConfig, EngineStatus, LoopRegion, PositionEmitter, TempoEvent,
+    TrackParams,
 };
+use std::sync::{Arc, Mutex};
 
 /// Smoke test 1 — device enumeration returns at least one device on a
 /// machine that has audio hardware. Also exercises the tolerant error
@@ -502,6 +504,78 @@ fn real_engine_loop_wraps_position() {
     );
 
     engine.stop();
+}
+
+/// Smoke test — PositionEmitter pushes ~60 ticks/second with a
+/// live engine running.
+///
+/// Phase 3D end-to-end proof: start the real CPAL engine, use the
+/// exposed `shared_position_handle()` to feed a `PositionEmitter`,
+/// play for 500 ms, and assert:
+///   - tick count is in a sane range for 60 fps (20..60 ticks)
+///   - tick values are monotonically non-decreasing
+///   - at least one value is > 0 (i.e. the engine actually advanced)
+#[test]
+#[ignore]
+fn real_engine_position_emitter_ticks_and_tracks_playback() {
+    let mut engine = Engine::new();
+    engine.start(EngineConfig::default_48k()).unwrap();
+
+    let shared = engine
+        .shared_position_handle()
+        .expect("running engine must expose shared position");
+
+    let samples: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+    let samples_clone = samples.clone();
+    let mut emitter = PositionEmitter::start(
+        shared,
+        Duration::from_millis(16),
+        move |pos| {
+            samples_clone.lock().unwrap().push(pos);
+        },
+    );
+
+    // Play for 500 ms — ~31 ticks at 16 ms interval.
+    engine.transport_play().expect("play");
+    sleep(Duration::from_millis(500));
+
+    emitter.stop();
+    engine.stop();
+
+    let captured = samples.lock().unwrap().clone();
+    let n = captured.len();
+    eprintln!(
+        "captured {n} ticks; first={:?} last={:?}",
+        captured.first(),
+        captured.last()
+    );
+
+    // Tick-count window: 16 ms interval × 500 ms ≈ 31 ticks. Accept
+    // 20..60 to absorb OS scheduler jitter + the "emit immediately
+    // on start" first tick.
+    assert!(
+        (20..=60).contains(&n),
+        "expected ~31 ticks over 500 ms at 16 ms interval, got {n}"
+    );
+
+    // Monotonically non-decreasing (during linear playback without
+    // loop the position only advances).
+    for pair in captured.windows(2) {
+        assert!(
+            pair[1] >= pair[0],
+            "position went backwards: {} → {}",
+            pair[0],
+            pair[1]
+        );
+    }
+
+    // At least one tick must have observed a non-zero position
+    // (proving the engine actually advanced while the emitter was
+    // ticking).
+    assert!(
+        captured.iter().any(|&v| v > 0),
+        "emitter only saw zeros — engine did not advance"
+    );
 }
 
 /// Smoke test — starting with an unknown device name surfaces a


### PR DESCRIPTION
## Summary

Fourth atomic slice of Phase 3 (#1523). Builds on 3A/B/C. Adds a background `std::thread` poller that pushes the transport sample position to the UI as Tauri events, so the playhead can animate without the UI querying the engine on every frame.

- **`PositionEmitter`** — callback-based, NOT the audio thread. Unit-testable via mock closure.
- **Interval clamping**: 5 ms floor / 1 s cap / 16 ms default (~60 fps)
- **Emit-on-start**: first tick fires immediately so UI sees a value on frame 0
- **`TransportEmitterState`** sibling state — no shape change to existing `EngineState`
- **Drop-safe**: `Drop` joins the thread so leaked emitters can't tick into stale callbacks
- **Event**: `transport-position`, payload: `u64` sample position
- **Engine API**: `Engine::shared_position_handle()` for external readers

## Test plan

- [x] `cargo test --lib` — 226 Rust unit tests pass (was 217, +9)
  - emit-immediately-on-start, ticks at configured rate, live SharedPosition tracking, idempotent stop, Drop stops thread, MIN/MAX/default interval clamping, boundary clamp
- [x] `cargo test --test local_audio_smoke -- --ignored real_engine_position_emitter_ticks_and_tracks_playback` — hardware smoke test passes: captures ~31 ticks over 500 ms at 16 ms interval, positions monotonically non-decreasing, at least one non-zero position confirming engine-emitter integration
- [x] `cargo build --release` clean

## Non-goals (later phases)

- Transport state events (Stopped/Paused/Playing) → could add when UI needs
- Adjustable rate via Tauri command → follow-up if needed
- UI-side interpolation with monotonic timestamps → follow-up if 60 Hz appears choppy
- TS-side subscription wiring → 3E/later work

Closes #1714
Part of #1523, #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)