### PR TITLE
feat: Phase 3F — sample-accurate clip scheduling

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -9,9 +9,10 @@ use std::sync::Mutex;
 use tauri::{Emitter, State};
 
 use crate::engine::{
-    audio_io, AudioDeviceInfo, CommandError, Engine, EngineConfig, EngineError,
-    EngineStatus, LoopRegion, MetronomeConfig, PositionEmitter, TempoEvent, TempoMap,
-    TimeSignatureEvent, TimeSignatureMap, TrackParams, POSITION_EVENT_DEFAULT_INTERVAL,
+    audio_io, AudioDeviceInfo, ClipSchedule, ClipSource, CommandError, Engine,
+    EngineConfig, EngineError, EngineStatus, LoopRegion, MetronomeConfig, PositionEmitter,
+    TempoEvent, TempoMap, TimeSignatureEvent, TimeSignatureMap, TrackParams,
+    POSITION_EVENT_DEFAULT_INTERVAL,
 };
 use crate::engine::slot::SlotHandle;
 
@@ -455,6 +456,46 @@ pub fn audio_metronome_set_enabled(
         .lock()
         .map_err(|_| CommandError::Disconnected)?;
     engine.set_metronome_enabled(enabled)
+}
+
+// ── Clip scheduler (3F) ─────────────────────────────────────────────
+
+/// Replace the full clip schedule atomically. Validated on the
+/// Rust side via `ClipSchedule::try_new` before publishing, so a
+/// malformed payload (too many clips, empty audio_data, length
+/// exceeding PCM frames) returns a typed error to the UI instead
+/// of reaching the audio thread.
+#[tauri::command]
+pub fn audio_clip_set_schedule(
+    clips: Vec<ClipSource>,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.set_clip_schedule(clips)
+}
+
+/// Snapshot the current clip schedule. Returns `None` when the
+/// engine is stopped. Each clip's audio_data is serialized as a
+/// Vec<f32> on the wire — this can be large for long clips, so
+/// the UI should poll `get_schedule` rarely (on project load /
+/// structural change), not per-frame.
+#[tauri::command]
+pub fn audio_clip_get_schedule(
+    state: State<'_, EngineState>,
+) -> Result<Option<ClipSchedule>, CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    Ok(engine.clip_schedule_snapshot().map(|arc| {
+        // Rebuild an owned ClipSchedule for the wire. The clip
+        // audio_data is still shared Arc<Vec<f32>> so there is no
+        // deep copy of the PCM.
+        ClipSchedule::try_new(arc.clips().to_vec()).unwrap_or_else(|_| ClipSchedule::empty())
+    }))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -482,6 +482,11 @@ pub fn audio_clip_set_schedule(
 /// Vec<f32> on the wire — this can be large for long clips, so
 /// the UI should poll `get_schedule` rarely (on project load /
 /// structural change), not per-frame.
+///
+/// Returns `InvalidClipSchedule` on the rare path where the
+/// snapshot round-trips through `try_new` and hits an invariant
+/// error — prefer surfacing that over silently pretending the
+/// schedule was cleared (Copilot review on PR #1719).
 #[tauri::command]
 pub fn audio_clip_get_schedule(
     state: State<'_, EngineState>,
@@ -490,12 +495,15 @@ pub fn audio_clip_get_schedule(
         .0
         .lock()
         .map_err(|_| CommandError::Disconnected)?;
-    Ok(engine.clip_schedule_snapshot().map(|arc| {
-        // Rebuild an owned ClipSchedule for the wire. The clip
-        // audio_data is still shared Arc<Vec<f32>> so there is no
-        // deep copy of the PCM.
-        ClipSchedule::try_new(arc.clips().to_vec()).unwrap_or_else(|_| ClipSchedule::empty())
-    }))
+    let Some(arc) = engine.clip_schedule_snapshot() else {
+        return Ok(None);
+    };
+    // Rebuild an owned ClipSchedule for the wire. The clip
+    // audio_data is still shared Arc<Vec<f32>> so there is no
+    // deep copy of the PCM.
+    let rebuilt = ClipSchedule::try_new(arc.clips().to_vec())
+        .map_err(|e| CommandError::InvalidClipSchedule(e.to_string()))?;
+    Ok(Some(rebuilt))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/engine/audio_io.rs
+++ b/src-tauri/src/engine/audio_io.rs
@@ -465,83 +465,74 @@ fn make_audio_callback(
         // Mix aux return buses into master BEFORE master volume.
         routing.mix_into_master(&mut master_l[..frames], &mut master_r[..frames], frames);
 
-        // Clip scheduler render (3F). Same wrap-split pattern as
-        // the metronome. Reads a borrowed guard from the ArcSwap
-        // so no Arc clone / drop on the audio thread. Each clip
-        // is bounds-checked (`intersects_buffer`) before any PCM
-        // access to cap per-buffer cost at O(N) comparisons even
-        // when most clips are outside the current buffer window.
+        // Clip scheduler render (3F). Reads a borrowed guard from
+        // the ArcSwap so no Arc clone / drop on the audio thread.
+        // Each clip is bounds-checked (`intersects_buffer`) before
+        // any PCM access to cap per-buffer cost at O(N) comparisons
+        // even when most clips are outside the current buffer
+        // window.
+        //
+        // Handles multiple loop wraps per buffer: if `frames > loop.length`,
+        // we iterate rendering one segment at a time, advancing the
+        // "virtual playhead" past each wrap, until we've covered the
+        // whole buffer. Rare (requires loop shorter than audio
+        // buffer — 5-85 ms at typical sample rates) but still needs
+        // to be correct. Found by codex review on PR #1719.
         if transport.state().is_advancing() {
             let clip_schedule_guard = transport.clip_schedule_handle().load();
             let clip_schedule: &super::clip::ClipSchedule = &clip_schedule_guard;
             if !clip_schedule.is_empty() {
                 let loop_region = **transport.loop_region_handle().load();
                 let playhead_start = transport.position();
-                let playhead_end = playhead_start.saturating_add(frames as u64);
+                let clips = clip_schedule.clips();
 
-                // Wrap split: same logic as the metronome.
-                let wrap_offset: Option<usize> = if loop_region.is_active()
-                    && playhead_start < loop_region.end
-                {
-                    let to_end = loop_region.end - playhead_start;
-                    if to_end < frames as u64 {
-                        Some(to_end as usize)
+                // Walk the buffer segment-by-segment. `buffer_offset`
+                // is where the next segment will start in the
+                // master output, `virt_playhead` is the absolute
+                // transport sample at that offset.
+                let mut buffer_offset: usize = 0;
+                let mut virt_playhead: u64 = playhead_start;
+
+                while buffer_offset < frames {
+                    // How many samples until either end of buffer
+                    // or the next loop-end wrap?
+                    let remaining = (frames - buffer_offset) as u64;
+                    let to_wrap: Option<u64> = if loop_region.is_active()
+                        && virt_playhead < loop_region.end
+                    {
+                        Some(loop_region.end - virt_playhead)
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
+                    let seg_len = match to_wrap {
+                        Some(dist) if dist < remaining => dist,
+                        _ => remaining,
+                    } as usize;
+                    let seg_end_offset = buffer_offset + seg_len;
 
-                let clips = clip_schedule.clips();
-                match wrap_offset {
-                    Some(w) => {
-                        // Pre-wrap segment: [0..w), absolute
-                        // [playhead_start..loop_region.end).
-                        for clip in clips {
-                            if clip.intersects_buffer(playhead_start, loop_region.end) {
-                                render_clip_segment(
-                                    clip,
-                                    &mut master_l[..frames],
-                                    &mut master_r[..frames],
-                                    0,
-                                    w,
-                                    playhead_start,
-                                );
-                            }
-                        }
-                        // Post-wrap segment: [w..frames), absolute
-                        // [loop_region.start..loop_region.start + (frames - w)).
-                        let post_end_abs = loop_region
-                            .start
-                            .saturating_add((frames - w) as u64);
-                        for clip in clips {
-                            if clip.intersects_buffer(loop_region.start, post_end_abs) {
-                                render_clip_segment(
-                                    clip,
-                                    &mut master_l[..frames],
-                                    &mut master_r[..frames],
-                                    w,
-                                    frames,
-                                    loop_region.start,
-                                );
-                            }
+                    // Render every intersecting clip into this segment.
+                    let seg_end_abs = virt_playhead.saturating_add(seg_len as u64);
+                    for clip in clips {
+                        if clip.intersects_buffer(virt_playhead, seg_end_abs) {
+                            render_clip_segment(
+                                clip,
+                                &mut master_l[..frames],
+                                &mut master_r[..frames],
+                                buffer_offset,
+                                seg_end_offset,
+                                virt_playhead,
+                            );
                         }
                     }
-                    None => {
-                        for clip in clips {
-                            if clip.intersects_buffer(playhead_start, playhead_end) {
-                                render_clip_segment(
-                                    clip,
-                                    &mut master_l[..frames],
-                                    &mut master_r[..frames],
-                                    0,
-                                    frames,
-                                    playhead_start,
-                                );
-                            }
-                        }
+
+                    // Advance the virtual playhead — wrap if we just
+                    // finished a wrap segment, otherwise linear.
+                    if to_wrap.map_or(false, |dist| (dist as usize) == seg_len) {
+                        virt_playhead = loop_region.start;
+                    } else {
+                        virt_playhead = seg_end_abs;
                     }
+                    buffer_offset = seg_end_offset;
                 }
             }
         }

--- a/src-tauri/src/engine/audio_io.rs
+++ b/src-tauri/src/engine/audio_io.rs
@@ -29,6 +29,7 @@ use super::config::{AudioDeviceInfo, VALID_SAMPLE_RATES};
 use super::graph::AudioGraph;
 use super::meter::generate_sine;
 use super::meter_bank::MeterProducers;
+use super::clip::render_clip_segment;
 use super::metronome::{render_metronome_segment, ClickGenerator};
 use super::mixer;
 use super::transport::Transport;
@@ -463,6 +464,87 @@ fn make_audio_callback(
 
         // Mix aux return buses into master BEFORE master volume.
         routing.mix_into_master(&mut master_l[..frames], &mut master_r[..frames], frames);
+
+        // Clip scheduler render (3F). Same wrap-split pattern as
+        // the metronome. Reads a borrowed guard from the ArcSwap
+        // so no Arc clone / drop on the audio thread. Each clip
+        // is bounds-checked (`intersects_buffer`) before any PCM
+        // access to cap per-buffer cost at O(N) comparisons even
+        // when most clips are outside the current buffer window.
+        if transport.state().is_advancing() {
+            let clip_schedule_guard = transport.clip_schedule_handle().load();
+            let clip_schedule: &super::clip::ClipSchedule = &clip_schedule_guard;
+            if !clip_schedule.is_empty() {
+                let loop_region = **transport.loop_region_handle().load();
+                let playhead_start = transport.position();
+                let playhead_end = playhead_start.saturating_add(frames as u64);
+
+                // Wrap split: same logic as the metronome.
+                let wrap_offset: Option<usize> = if loop_region.is_active()
+                    && playhead_start < loop_region.end
+                {
+                    let to_end = loop_region.end - playhead_start;
+                    if to_end < frames as u64 {
+                        Some(to_end as usize)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                let clips = clip_schedule.clips();
+                match wrap_offset {
+                    Some(w) => {
+                        // Pre-wrap segment: [0..w), absolute
+                        // [playhead_start..loop_region.end).
+                        for clip in clips {
+                            if clip.intersects_buffer(playhead_start, loop_region.end) {
+                                render_clip_segment(
+                                    clip,
+                                    &mut master_l[..frames],
+                                    &mut master_r[..frames],
+                                    0,
+                                    w,
+                                    playhead_start,
+                                );
+                            }
+                        }
+                        // Post-wrap segment: [w..frames), absolute
+                        // [loop_region.start..loop_region.start + (frames - w)).
+                        let post_end_abs = loop_region
+                            .start
+                            .saturating_add((frames - w) as u64);
+                        for clip in clips {
+                            if clip.intersects_buffer(loop_region.start, post_end_abs) {
+                                render_clip_segment(
+                                    clip,
+                                    &mut master_l[..frames],
+                                    &mut master_r[..frames],
+                                    w,
+                                    frames,
+                                    loop_region.start,
+                                );
+                            }
+                        }
+                    }
+                    None => {
+                        for clip in clips {
+                            if clip.intersects_buffer(playhead_start, playhead_end) {
+                                render_clip_segment(
+                                    clip,
+                                    &mut master_l[..frames],
+                                    &mut master_r[..frames],
+                                    0,
+                                    frames,
+                                    playhead_start,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         // Metronome render (3E). Runs AFTER track/aux mixing but
         // BEFORE master volume so the click respects master gain

--- a/src-tauri/src/engine/clip.rs
+++ b/src-tauri/src/engine/clip.rs
@@ -1,0 +1,531 @@
+//! Sample-accurate clip scheduler.
+//!
+//! # Shape
+//!
+//! A [`ClipSchedule`] is a bounded-capacity set of [`ClipSource`]
+//! values, each holding:
+//!
+//! - an absolute transport sample position where the clip starts,
+//! - a length in samples,
+//! - an owned linear gain (pre-clamped), and
+//! - a reference-counted handle to the raw stereo-interleaved PCM
+//!   (`Arc<Vec<f32>>`).
+//!
+//! Schedules are published from the main thread via an
+//! [`arc_swap::ArcSwap`] held on the
+//! [`super::transport::Transport`]. The audio callback reads the
+//! schedule via wait-free `.load()` guards on every buffer and
+//! mixes every clip that intersects the current buffer range into
+//! the master bus.
+//!
+//! # Ownership of audio data
+//!
+//! `audio_data: Arc<Vec<f32>>` lets multiple clips share a single
+//! PCM buffer (think "drag the same sample onto two lanes without
+//! doubling memory"). The audio callback only reads through the
+//! `Arc`, so publication is wait-free and deallocation happens on
+//! whichever thread drops the last reference — typically the main
+//! thread when a schedule is replaced.
+//!
+//! # Real-time safety
+//!
+//! - No allocation inside the render loop: the schedule is
+//!   pre-allocated by the main thread and referenced via a borrow.
+//! - Bounded work: the mix loop iterates every clip in the slab
+//!   (capped at [`MAX_CLIPS`]), but for each clip the
+//!   `intersects_buffer` check is O(1), so the per-buffer cost is
+//!   `O(MAX_CLIPS)` comparisons + `O(rendered_samples)` reads for
+//!   the intersecting subset.
+//! - Interleaved PCM layout matches CPAL's output layout, so the
+//!   mixer is a plain two-channel read-and-sum — no channel
+//!   deinterleaving needed.
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Maximum number of clips a single [`ClipSchedule`] can hold. This
+/// bounds worst-case per-buffer scan cost; 1024 is an
+/// order-of-magnitude more tracks × bars than a typical song.
+pub const MAX_CLIPS: usize = 1024;
+
+/// Errors from constructing a [`ClipSchedule`] or [`ClipSource`]
+/// with invalid input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClipScheduleError {
+    /// Schedule exceeded [`MAX_CLIPS`].
+    TooManyClips(usize),
+    /// Clip's audio_data was empty — would trigger division-by-zero
+    /// in the channel-interleave calculation.
+    EmptyAudio,
+    /// Clip's `length_samples` is longer than the PCM frames
+    /// available in `audio_data`.
+    LengthExceedsAudio { length: u64, available_frames: u64 },
+}
+
+/// A single audio clip scheduled at an absolute sample position.
+///
+/// Public fields are writable but values flow through
+/// [`ClipSource::new`] before reaching the schedule so the audio
+/// thread only ever sees clamped / validated state.
+///
+/// Serde: camelCase on the wire to match every other engine type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClipSource {
+    /// Absolute transport sample position at which the clip's
+    /// first frame plays.
+    pub start_sample: u64,
+    /// Length in frames (NOT samples-of-interleaved-channels).
+    /// The PCM buffer should hold at least `length_samples * 2`
+    /// floats in stereo-interleaved layout.
+    pub length_samples: u64,
+    /// Linear gain applied while mixing, clamped to [0, 1] on
+    /// construction.
+    pub gain: f32,
+    /// Stereo-interleaved PCM at the engine's sample rate. Shared
+    /// via `Arc` so multiple `ClipSource`s can reference the same
+    /// underlying audio without doubling memory.
+    pub audio_data: Arc<Vec<f32>>,
+}
+
+impl ClipSource {
+    /// Validated constructor. Clamps `gain` to `[0.0, 1.0]` and
+    /// rejects clips whose requested length exceeds what the PCM
+    /// buffer actually holds (prevents out-of-bounds reads on the
+    /// audio thread).
+    pub fn new(
+        start_sample: u64,
+        length_samples: u64,
+        gain: f32,
+        audio_data: Arc<Vec<f32>>,
+    ) -> Result<Self, ClipScheduleError> {
+        if audio_data.is_empty() {
+            return Err(ClipScheduleError::EmptyAudio);
+        }
+        // Stereo-interleaved: 2 floats per frame.
+        let available_frames = (audio_data.len() as u64) / 2;
+        if length_samples > available_frames {
+            return Err(ClipScheduleError::LengthExceedsAudio {
+                length: length_samples,
+                available_frames,
+            });
+        }
+        let safe_gain = if gain.is_finite() { gain.clamp(0.0, 1.0) } else { 0.0 };
+        Ok(Self {
+            start_sample,
+            length_samples,
+            gain: safe_gain,
+            audio_data,
+        })
+    }
+
+    /// Returns `true` if the clip overlaps the half-open buffer
+    /// range `[buf_start, buf_end)`. Zero-length clips never
+    /// intersect — they span no samples by definition.
+    #[inline]
+    pub fn intersects_buffer(&self, buf_start: u64, buf_end: u64) -> bool {
+        if self.length_samples == 0 {
+            return false;
+        }
+        let clip_end = self.start_sample.saturating_add(self.length_samples);
+        self.start_sample < buf_end && clip_end > buf_start
+    }
+
+    /// End sample (exclusive) — the first sample past the clip.
+    #[inline]
+    pub fn end_sample(&self) -> u64 {
+        self.start_sample.saturating_add(self.length_samples)
+    }
+}
+
+/// Fixed-capacity clip schedule. Construction validates the slab
+/// fits into [`MAX_CLIPS`] and every contained clip is valid.
+///
+/// Intentionally `Deserialize` is NOT derived — deserializing a
+/// `ClipSchedule` directly would bypass the validated
+/// [`ClipSchedule::try_new`] constructor. Tauri commands accept
+/// `Vec<ClipSource>` and route through `try_new` on the Rust side.
+#[derive(Debug, Serialize)]
+pub struct ClipSchedule {
+    clips: Vec<ClipSource>,
+}
+
+impl ClipSchedule {
+    /// Empty schedule. Default for a freshly-started engine.
+    pub fn empty() -> Self {
+        Self { clips: Vec::new() }
+    }
+
+    /// Validated constructor.
+    pub fn try_new(clips: Vec<ClipSource>) -> Result<Self, ClipScheduleError> {
+        if clips.len() > MAX_CLIPS {
+            return Err(ClipScheduleError::TooManyClips(clips.len()));
+        }
+        // Clips are validated individually by `ClipSource::new`, but
+        // allow callers who constructed them manually (e.g. via
+        // serde) to still fail fast if audio_data was emptied or
+        // length was extended out of bounds after construction.
+        for c in &clips {
+            if c.audio_data.is_empty() {
+                return Err(ClipScheduleError::EmptyAudio);
+            }
+            let available = (c.audio_data.len() as u64) / 2;
+            if c.length_samples > available {
+                return Err(ClipScheduleError::LengthExceedsAudio {
+                    length: c.length_samples,
+                    available_frames: available,
+                });
+            }
+        }
+        Ok(Self { clips })
+    }
+
+    pub fn clips(&self) -> &[ClipSource] {
+        &self.clips
+    }
+
+    pub fn len(&self) -> usize {
+        self.clips.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.clips.is_empty()
+    }
+}
+
+impl Default for ClipSchedule {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// Render a single clip's contribution into the given stereo
+/// master buffers over a segment `[out_start_offset, out_end_offset)`
+/// whose samples correspond to absolute transport positions
+/// `[seg_start_sample, seg_start_sample + (end - start))`.
+///
+/// The function computes the intersection of the clip's absolute
+/// range with the segment's absolute range and mixes PCM from
+/// `clip.audio_data` into `out_l` / `out_r`. If there is no
+/// intersection this is a no-op.
+///
+/// Pulled into its own function so the audio callback can call it
+/// twice per buffer when the transport wraps mid-buffer via the
+/// loop region — the pre-wrap and post-wrap segments each have
+/// their own linear mapping but the same clip set applies.
+#[allow(clippy::too_many_arguments)]
+pub fn render_clip_segment(
+    clip: &ClipSource,
+    out_l: &mut [f32],
+    out_r: &mut [f32],
+    out_start_offset: usize,
+    out_end_offset: usize,
+    seg_start_sample: u64,
+) {
+    // Segment range in absolute transport samples.
+    let seg_len = (out_end_offset - out_start_offset) as u64;
+    let seg_end_sample = seg_start_sample.saturating_add(seg_len);
+
+    // Clip range in absolute transport samples.
+    let clip_start = clip.start_sample;
+    let clip_end = clip.end_sample();
+
+    // Intersection — the overlap we actually render.
+    let overlap_start = clip_start.max(seg_start_sample);
+    let overlap_end = clip_end.min(seg_end_sample);
+    if overlap_start >= overlap_end {
+        return; // no overlap
+    }
+
+    // Map overlap to positions inside the clip's PCM and inside
+    // the output buffer.
+    let pcm_offset_frames = (overlap_start - clip_start) as usize; // position inside clip
+    let out_offset = out_start_offset + (overlap_start - seg_start_sample) as usize;
+    let render_frames = (overlap_end - overlap_start) as usize;
+
+    let pcm: &[f32] = &clip.audio_data;
+    let gain = clip.gain;
+
+    // Stereo-interleaved reads. Each frame is 2 floats: L then R.
+    for i in 0..render_frames {
+        let src = (pcm_offset_frames + i) * 2;
+        // Bounds-check defensively — the validated constructor
+        // should have made this unreachable, but the audio thread
+        // must NEVER panic.
+        if src + 1 >= pcm.len() {
+            break;
+        }
+        let l = pcm[src] * gain;
+        let r = pcm[src + 1] * gain;
+        let dst = out_offset + i;
+        if dst >= out_l.len() || dst >= out_r.len() {
+            break;
+        }
+        out_l[dst] += l;
+        out_r[dst] += r;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pcm(frames: usize, l_val: f32, r_val: f32) -> Arc<Vec<f32>> {
+        let mut v = Vec::with_capacity(frames * 2);
+        for _ in 0..frames {
+            v.push(l_val);
+            v.push(r_val);
+        }
+        Arc::new(v)
+    }
+
+    // ── ClipSource ──────────────────────────────────────────────────
+
+    #[test]
+    fn new_clamps_gain_to_unit_range() {
+        let pcm = make_pcm(100, 1.0, 1.0);
+        let a = ClipSource::new(0, 100, -5.0, pcm.clone()).unwrap();
+        let b = ClipSource::new(0, 100, 99.0, pcm.clone()).unwrap();
+        let c = ClipSource::new(0, 100, f32::NAN, pcm).unwrap();
+        assert_eq!(a.gain, 0.0);
+        assert_eq!(b.gain, 1.0);
+        assert_eq!(c.gain, 0.0, "NaN snaps to 0");
+    }
+
+    #[test]
+    fn new_rejects_empty_audio() {
+        let empty = Arc::new(Vec::<f32>::new());
+        assert_eq!(
+            ClipSource::new(0, 10, 1.0, empty),
+            Err(ClipScheduleError::EmptyAudio)
+        );
+    }
+
+    #[test]
+    fn new_rejects_length_exceeding_audio() {
+        let pcm = make_pcm(10, 1.0, 1.0); // 10 frames = 20 floats
+        match ClipSource::new(0, 100, 1.0, pcm) {
+            Err(ClipScheduleError::LengthExceedsAudio { length, available_frames }) => {
+                assert_eq!(length, 100);
+                assert_eq!(available_frames, 10);
+            }
+            other => panic!("expected LengthExceedsAudio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn intersects_buffer_true_for_overlap() {
+        let pcm = make_pcm(1_000, 1.0, 1.0);
+        let clip = ClipSource::new(100, 500, 1.0, pcm).unwrap();
+        // Buffer straddles clip start.
+        assert!(clip.intersects_buffer(50, 200));
+        // Buffer inside clip.
+        assert!(clip.intersects_buffer(200, 400));
+        // Buffer straddles clip end.
+        assert!(clip.intersects_buffer(500, 700));
+    }
+
+    #[test]
+    fn intersects_buffer_false_outside_clip() {
+        let pcm = make_pcm(1_000, 1.0, 1.0);
+        let clip = ClipSource::new(100, 500, 1.0, pcm).unwrap();
+        // Buffer entirely before clip.
+        assert!(!clip.intersects_buffer(0, 100));
+        // Buffer entirely after clip.
+        assert!(!clip.intersects_buffer(600, 800));
+    }
+
+    #[test]
+    fn intersects_buffer_edge_case_zero_length_clip() {
+        let pcm = make_pcm(10, 1.0, 1.0);
+        // 0-length clip is degenerate — should not intersect anything.
+        let clip = ClipSource::new(100, 0, 1.0, pcm).unwrap();
+        assert!(!clip.intersects_buffer(0, 200));
+    }
+
+    #[test]
+    fn end_sample_is_start_plus_length() {
+        let pcm = make_pcm(1_000, 1.0, 1.0);
+        let clip = ClipSource::new(100, 500, 1.0, pcm).unwrap();
+        assert_eq!(clip.end_sample(), 600);
+    }
+
+    #[test]
+    fn end_sample_saturates_on_overflow() {
+        let pcm = make_pcm(1_000, 1.0, 1.0);
+        let clip = ClipSource::new(u64::MAX - 10, 100, 1.0, pcm).unwrap();
+        // Would overflow without saturating_add.
+        assert_eq!(clip.end_sample(), u64::MAX);
+    }
+
+    // ── ClipSchedule ────────────────────────────────────────────────
+
+    #[test]
+    fn empty_schedule_has_zero_clips() {
+        let s = ClipSchedule::empty();
+        assert_eq!(s.len(), 0);
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn try_new_accepts_valid_clips() {
+        let pcm = make_pcm(100, 1.0, 1.0);
+        let clips = vec![
+            ClipSource::new(0, 50, 1.0, pcm.clone()).unwrap(),
+            ClipSource::new(100, 50, 0.8, pcm).unwrap(),
+        ];
+        let s = ClipSchedule::try_new(clips).unwrap();
+        assert_eq!(s.len(), 2);
+    }
+
+    #[test]
+    fn try_new_rejects_too_many_clips() {
+        let pcm = make_pcm(10, 1.0, 1.0);
+        let clips: Vec<_> = (0..MAX_CLIPS + 1)
+            .map(|i| ClipSource::new(i as u64, 5, 1.0, pcm.clone()).unwrap())
+            .collect();
+        match ClipSchedule::try_new(clips) {
+            Err(ClipScheduleError::TooManyClips(n)) => assert_eq!(n, MAX_CLIPS + 1),
+            other => panic!("expected TooManyClips, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_new_accepts_max_clips_exactly() {
+        let pcm = make_pcm(10, 1.0, 1.0);
+        let clips: Vec<_> = (0..MAX_CLIPS)
+            .map(|i| ClipSource::new(i as u64, 5, 1.0, pcm.clone()).unwrap())
+            .collect();
+        assert!(ClipSchedule::try_new(clips).is_ok());
+    }
+
+    // ── render_clip_segment ─────────────────────────────────────────
+
+    #[test]
+    fn render_no_overlap_leaves_output_unchanged() {
+        let pcm = make_pcm(100, 0.5, 0.5);
+        let clip = ClipSource::new(1000, 50, 1.0, pcm).unwrap();
+        let mut l = vec![0.0_f32; 10];
+        let mut r = vec![0.0_f32; 10];
+        // Segment [0..10) at abs 0..10 — clip is at 1000, no overlap.
+        render_clip_segment(&clip, &mut l, &mut r, 0, 10, 0);
+        assert!(l.iter().all(|&s| s == 0.0));
+        assert!(r.iter().all(|&s| s == 0.0));
+    }
+
+    #[test]
+    fn render_clip_aligned_to_buffer_start() {
+        let pcm = make_pcm(10, 0.25, 0.75);
+        let clip = ClipSource::new(100, 10, 1.0, pcm).unwrap();
+        let mut l = vec![0.0_f32; 10];
+        let mut r = vec![0.0_f32; 10];
+        // Segment [0..10) at abs 100..110 — clip fits exactly.
+        render_clip_segment(&clip, &mut l, &mut r, 0, 10, 100);
+        assert!(l.iter().all(|&s| (s - 0.25).abs() < 1e-6));
+        assert!(r.iter().all(|&s| (s - 0.75).abs() < 1e-6));
+    }
+
+    #[test]
+    fn render_clip_straddling_buffer_boundary_plays_both_halves() {
+        let pcm = make_pcm(20, 0.5, 0.5);
+        let clip = ClipSource::new(100, 20, 1.0, pcm).unwrap();
+        // First buffer: [100..110) — expects first 10 frames of clip.
+        let mut l = vec![0.0_f32; 10];
+        let mut r = vec![0.0_f32; 10];
+        render_clip_segment(&clip, &mut l, &mut r, 0, 10, 100);
+        assert!(l.iter().all(|&s| (s - 0.5).abs() < 1e-6));
+        // Second buffer: [110..120) — expects last 10 frames.
+        let mut l2 = vec![0.0_f32; 10];
+        let mut r2 = vec![0.0_f32; 10];
+        render_clip_segment(&clip, &mut l2, &mut r2, 0, 10, 110);
+        assert!(l2.iter().all(|&s| (s - 0.5).abs() < 1e-6));
+    }
+
+    #[test]
+    fn render_applies_gain() {
+        let pcm = make_pcm(10, 1.0, 1.0);
+        let clip = ClipSource::new(0, 10, 0.5, pcm).unwrap();
+        let mut l = vec![0.0_f32; 10];
+        let mut r = vec![0.0_f32; 10];
+        render_clip_segment(&clip, &mut l, &mut r, 0, 10, 0);
+        assert!(l.iter().all(|&s| (s - 0.5).abs() < 1e-6));
+        assert!(r.iter().all(|&s| (s - 0.5).abs() < 1e-6));
+    }
+
+    #[test]
+    fn render_accumulates_into_existing_buffer_contents() {
+        // Mixer is additive — existing non-zero content must be
+        // preserved and the clip's contribution added on top.
+        let pcm = make_pcm(5, 0.25, 0.25);
+        let clip = ClipSource::new(0, 5, 1.0, pcm).unwrap();
+        let mut l = vec![0.1_f32; 5];
+        let mut r = vec![0.2_f32; 5];
+        render_clip_segment(&clip, &mut l, &mut r, 0, 5, 0);
+        assert!(l.iter().all(|&s| (s - 0.35).abs() < 1e-6));
+        assert!(r.iter().all(|&s| (s - 0.45).abs() < 1e-6));
+    }
+
+    #[test]
+    fn render_clip_partially_before_segment_only_renders_inside() {
+        // Clip starts at 50, length 100 → [50, 150). Segment [100, 110)
+        // at abs [100..110) should render PCM frames 50..60 of the clip.
+        let mut pcm_data = Vec::new();
+        for i in 0..100 {
+            pcm_data.push(i as f32 * 0.01); // L
+            pcm_data.push(i as f32 * 0.02); // R
+        }
+        let clip = ClipSource::new(50, 100, 1.0, Arc::new(pcm_data)).unwrap();
+        let mut l = vec![0.0_f32; 10];
+        let mut r = vec![0.0_f32; 10];
+        render_clip_segment(&clip, &mut l, &mut r, 0, 10, 100);
+        // At abs sample 100 we're 50 frames into the clip.
+        // L[0] should be pcm L at frame 50 = 0.5.
+        assert!((l[0] - 0.50).abs() < 1e-6, "expected 0.50 got {}", l[0]);
+        // L[9] should be pcm L at frame 59 = 0.59.
+        assert!((l[9] - 0.59).abs() < 1e-6, "expected 0.59 got {}", l[9]);
+    }
+
+    #[test]
+    fn render_is_defensive_against_out_of_bounds_pcm_read() {
+        // If a caller mutated audio_data after ClipSource::new (via
+        // Arc::make_mut shenanigans) so length_samples now exceeds
+        // the PCM, the renderer must NOT panic.
+        let pcm = Arc::new(vec![1.0; 2]); // 1 frame = 2 floats
+        // Construct bypassing try_new-style check — but ClipSource::new
+        // validates too, so build manually.
+        let clip = ClipSource {
+            start_sample: 0,
+            length_samples: 100, // way more than 1 frame of PCM
+            gain: 1.0,
+            audio_data: pcm,
+        };
+        let mut l = vec![0.0_f32; 10];
+        let mut r = vec![0.0_f32; 10];
+        render_clip_segment(&clip, &mut l, &mut r, 0, 10, 0);
+        // Should render only 1 frame (the one that's actually in the
+        // PCM), then bail.
+        assert!((l[0] - 1.0).abs() < 1e-6);
+        // Frame 1 onward should be untouched (still 0).
+        for v in &l[1..] {
+            assert_eq!(*v, 0.0);
+        }
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_clip() {
+        let pcm = Arc::new(vec![0.1, 0.2, 0.3, 0.4]);
+        let clip = ClipSource::new(48_000, 2, 0.7, pcm).unwrap();
+        let json = serde_json::to_string(&clip).unwrap();
+        assert!(
+            json.contains("\"startSample\":48000"),
+            "wire format must be camelCase; got {json}"
+        );
+        assert!(json.contains("\"lengthSamples\":2"));
+        assert!(json.contains("\"gain\":0.7"));
+        let back: ClipSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.start_sample, clip.start_sample);
+        assert_eq!(back.length_samples, clip.length_samples);
+        assert_eq!(back.gain, clip.gain);
+        assert_eq!(&*back.audio_data, &*clip.audio_data);
+    }
+}

--- a/src-tauri/src/engine/clip.rs
+++ b/src-tauri/src/engine/clip.rs
@@ -245,24 +245,37 @@ pub fn render_clip_segment(
 
     let pcm: &[f32] = &clip.audio_data;
     let gain = clip.gain;
+    let pcm_len = pcm.len();
+    let out_l_len = out_l.len();
+    let out_r_len = out_r.len();
 
     // Stereo-interleaved reads. Each frame is 2 floats: L then R.
+    //
+    // Defensive bounds checks use `checked_mul`/`checked_add` so a
+    // manually-constructed `ClipSource` with a forged length can't
+    // wrap `usize` arithmetic and turn an out-of-range read into
+    // an in-range one (found by codex review on PR #1719).
     for i in 0..render_frames {
-        let src = (pcm_offset_frames + i) * 2;
-        // Bounds-check defensively — the validated constructor
-        // should have made this unreachable, but the audio thread
-        // must NEVER panic.
-        if src + 1 >= pcm.len() {
+        let Some(frame_idx) = pcm_offset_frames.checked_add(i) else {
+            break;
+        };
+        let Some(src) = frame_idx.checked_mul(2) else {
+            break;
+        };
+        let Some(src_r) = src.checked_add(1) else {
+            break;
+        };
+        if src_r >= pcm_len {
             break;
         }
-        let l = pcm[src] * gain;
-        let r = pcm[src + 1] * gain;
-        let dst = out_offset + i;
-        if dst >= out_l.len() || dst >= out_r.len() {
+        let Some(dst) = out_offset.checked_add(i) else {
+            break;
+        };
+        if dst >= out_l_len || dst >= out_r_len {
             break;
         }
-        out_l[dst] += l;
-        out_r[dst] += r;
+        out_l[dst] += pcm[src] * gain;
+        out_r[dst] += pcm[src_r] * gain;
     }
 }
 
@@ -483,6 +496,30 @@ mod tests {
         assert!((l[0] - 0.50).abs() < 1e-6, "expected 0.50 got {}", l[0]);
         // L[9] should be pcm L at frame 59 = 0.59.
         assert!((l[9] - 0.59).abs() < 1e-6, "expected 0.59 got {}", l[9]);
+    }
+
+    #[test]
+    fn render_rejects_forged_length_that_would_overflow_usize() {
+        // Codex P2 regression (PR #1719): if a caller constructs
+        // ClipSource by struct literal (bypassing new) with a
+        // forged length_samples approaching u64::MAX, the
+        // `pcm_offset_frames * 2` arithmetic could overflow
+        // usize and wrap. Checked_mul prevents that.
+        let pcm = Arc::new(vec![1.0_f32; 4]); // 2 frames of PCM
+        let clip = ClipSource {
+            start_sample: 0,
+            length_samples: u64::MAX, // forged
+            gain: 1.0,
+            audio_data: pcm,
+        };
+        let mut l = vec![0.0_f32; 10];
+        let mut r = vec![0.0_f32; 10];
+        // Segment at an offset that would overflow with a
+        // non-checked `pcm_offset_frames * 2`.
+        render_clip_segment(&clip, &mut l, &mut r, 0, 10, usize::MAX as u64 - 100);
+        // Audio thread must NOT panic. We don't assert on output
+        // content because there is no correct mapping for a
+        // forged-length clip — we just need to survive.
     }
 
     #[test]

--- a/src-tauri/src/engine/clip.rs
+++ b/src-tauri/src/engine/clip.rs
@@ -41,6 +41,7 @@
 //!   deinterleaving needed.
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::sync::Arc;
 
 /// Maximum number of clips a single [`ClipSchedule`] can hold. This
@@ -60,7 +61,36 @@ pub enum ClipScheduleError {
     /// Clip's `length_samples` is longer than the PCM frames
     /// available in `audio_data`.
     LengthExceedsAudio { length: u64, available_frames: u64 },
+    /// Clip's `audio_data` length is odd — stereo-interleaved PCM
+    /// must have `2 * frames` samples.
+    OddAudioLength(usize),
 }
+
+impl fmt::Display for ClipScheduleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ClipScheduleError::TooManyClips(n) => {
+                write!(f, "too many clips ({n}, max {MAX_CLIPS})")
+            }
+            ClipScheduleError::EmptyAudio => {
+                f.write_str("clip audio data is empty")
+            }
+            ClipScheduleError::LengthExceedsAudio {
+                length,
+                available_frames,
+            } => write!(
+                f,
+                "length_samples ({length}) exceeds available PCM frames ({available_frames})"
+            ),
+            ClipScheduleError::OddAudioLength(n) => write!(
+                f,
+                "audio data has {n} samples, which is odd; stereo-interleaved PCM must have 2×frames samples"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ClipScheduleError {}
 
 /// A single audio clip scheduled at an absolute sample position.
 ///
@@ -89,10 +119,10 @@ pub struct ClipSource {
 }
 
 impl ClipSource {
-    /// Validated constructor. Clamps `gain` to `[0.0, 1.0]` and
-    /// rejects clips whose requested length exceeds what the PCM
-    /// buffer actually holds (prevents out-of-bounds reads on the
-    /// audio thread).
+    /// Validated constructor. Clamps `gain` to `[0.0, 1.0]`,
+    /// rejects empty or odd-length PCM (stereo-interleaved must be
+    /// a multiple of 2), and rejects clips whose requested length
+    /// exceeds what the PCM buffer actually holds.
     pub fn new(
         start_sample: u64,
         length_samples: u64,
@@ -102,7 +132,13 @@ impl ClipSource {
         if audio_data.is_empty() {
             return Err(ClipScheduleError::EmptyAudio);
         }
-        // Stereo-interleaved: 2 floats per frame.
+        // Stereo-interleaved: 2 floats per frame. Odd length means
+        // the caller handed us the wrong channel layout; reject it
+        // here so the audio thread never has to handle a partial
+        // trailing sample (found by Copilot review on PR #1719).
+        if audio_data.len() % 2 != 0 {
+            return Err(ClipScheduleError::OddAudioLength(audio_data.len()));
+        }
         let available_frames = (audio_data.len() as u64) / 2;
         if length_samples > available_frames {
             return Err(ClipScheduleError::LengthExceedsAudio {
@@ -110,11 +146,10 @@ impl ClipSource {
                 available_frames,
             });
         }
-        let safe_gain = if gain.is_finite() { gain.clamp(0.0, 1.0) } else { 0.0 };
         Ok(Self {
             start_sample,
             length_samples,
-            gain: safe_gain,
+            gain: normalize_gain(gain),
             audio_data,
         })
     }
@@ -157,17 +192,23 @@ impl ClipSchedule {
     }
 
     /// Validated constructor.
-    pub fn try_new(clips: Vec<ClipSource>) -> Result<Self, ClipScheduleError> {
+    /// Validated constructor.
+    ///
+    /// Normalizes every incoming clip's `gain` via
+    /// [`normalize_gain`] so that a payload arriving via serde
+    /// (which can set public fields directly) cannot inject NaN,
+    /// ±∞, or out-of-range gain into the mix. Found by Copilot
+    /// review on PR #1719.
+    pub fn try_new(mut clips: Vec<ClipSource>) -> Result<Self, ClipScheduleError> {
         if clips.len() > MAX_CLIPS {
             return Err(ClipScheduleError::TooManyClips(clips.len()));
         }
-        // Clips are validated individually by `ClipSource::new`, but
-        // allow callers who constructed them manually (e.g. via
-        // serde) to still fail fast if audio_data was emptied or
-        // length was extended out of bounds after construction.
-        for c in &clips {
+        for c in &mut clips {
             if c.audio_data.is_empty() {
                 return Err(ClipScheduleError::EmptyAudio);
+            }
+            if c.audio_data.len() % 2 != 0 {
+                return Err(ClipScheduleError::OddAudioLength(c.audio_data.len()));
             }
             let available = (c.audio_data.len() as u64) / 2;
             if c.length_samples > available {
@@ -176,6 +217,9 @@ impl ClipSchedule {
                     available_frames: available,
                 });
             }
+            // Normalize gain — closes the serde-bypass hole where a
+            // raw ClipSource literal skipped ClipSource::new.
+            c.gain = normalize_gain(c.gain);
         }
         Ok(Self { clips })
     }
@@ -196,6 +240,18 @@ impl ClipSchedule {
 impl Default for ClipSchedule {
     fn default() -> Self {
         Self::empty()
+    }
+}
+
+/// Clamp gain to the valid unit range, snapping non-finite inputs
+/// (NaN / ±∞) to 0. Used by both `ClipSource::new` and
+/// `ClipSchedule::try_new` so there is one canonical definition.
+#[inline]
+pub fn normalize_gain(gain: f32) -> f32 {
+    if gain.is_finite() {
+        gain.clamp(0.0, 1.0)
+    } else {
+        0.0
     }
 }
 
@@ -303,6 +359,81 @@ mod tests {
         assert_eq!(a.gain, 0.0);
         assert_eq!(b.gain, 1.0);
         assert_eq!(c.gain, 0.0, "NaN snaps to 0");
+    }
+
+    #[test]
+    fn new_rejects_odd_length_audio() {
+        let odd = Arc::new(vec![1.0_f32, 2.0, 3.0]); // 3 samples
+        match ClipSource::new(0, 1, 1.0, odd) {
+            Err(ClipScheduleError::OddAudioLength(n)) => assert_eq!(n, 3),
+            other => panic!("expected OddAudioLength, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_new_normalizes_nan_gain_in_bypass_path() {
+        // Codex+Copilot regression: serde / struct-literal
+        // construction of ClipSource can set gain to NaN, bypassing
+        // ClipSource::new's clamp. try_new must re-normalize so the
+        // audio thread never sees NaN.
+        let pcm = make_pcm(10, 1.0, 1.0);
+        let bad = ClipSource {
+            start_sample: 0,
+            length_samples: 10,
+            gain: f32::NAN,
+            audio_data: pcm,
+        };
+        let schedule = ClipSchedule::try_new(vec![bad]).unwrap();
+        assert_eq!(schedule.clips()[0].gain, 0.0, "NaN snaps to 0");
+    }
+
+    #[test]
+    fn try_new_normalizes_out_of_range_gain_in_bypass_path() {
+        let pcm = make_pcm(10, 1.0, 1.0);
+        let bad = ClipSource {
+            start_sample: 0,
+            length_samples: 10,
+            gain: 99.0,
+            audio_data: pcm,
+        };
+        let schedule = ClipSchedule::try_new(vec![bad]).unwrap();
+        assert_eq!(schedule.clips()[0].gain, 1.0);
+    }
+
+    #[test]
+    fn try_new_rejects_odd_length_in_bypass_path() {
+        let odd = Arc::new(vec![0.5_f32; 7]);
+        // Cannot use ClipSource::new (it would reject); build by
+        // struct literal to bypass.
+        let bad = ClipSource {
+            start_sample: 0,
+            length_samples: 3,
+            gain: 1.0,
+            audio_data: odd,
+        };
+        match ClipSchedule::try_new(vec![bad]) {
+            Err(ClipScheduleError::OddAudioLength(_)) => {}
+            other => panic!("expected OddAudioLength, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn error_display_is_human_readable() {
+        // Copilot regression: use Display not Debug for user-facing
+        // errors.
+        let e = ClipScheduleError::TooManyClips(9999);
+        assert!(format!("{e}").contains("9999"));
+        let e = ClipScheduleError::EmptyAudio;
+        assert_eq!(format!("{e}"), "clip audio data is empty");
+        let e = ClipScheduleError::OddAudioLength(5);
+        assert!(format!("{e}").contains("5"));
+        let e = ClipScheduleError::LengthExceedsAudio {
+            length: 100,
+            available_frames: 50,
+        };
+        let s = format!("{e}");
+        assert!(s.contains("100"));
+        assert!(s.contains("50"));
     }
 
     #[test]

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -689,7 +689,7 @@ impl Engine {
     pub fn set_clip_schedule(&self, clips: Vec<ClipSource>) -> Result<(), CommandError> {
         let running = self.running.as_ref().ok_or(CommandError::NotRunning)?;
         let schedule = ClipSchedule::try_new(clips)
-            .map_err(|e| CommandError::InvalidClipSchedule(format!("{e:?}")))?;
+            .map_err(|e| CommandError::InvalidClipSchedule(e.to_string()))?;
         let new_arc = Arc::new(schedule);
         // Snapshot the outgoing schedule on the MAIN thread so the
         // Arc's refcount doesn't hit zero on the audio side.

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -227,10 +227,27 @@ struct RunningEngine {
     metronome_config: Arc<ArcSwap<MetronomeConfig>>,
     /// Same pattern for the clip schedule.
     clip_schedule: Arc<ArcSwap<ClipSchedule>>,
+    /// Main-thread-owned ring buffer of recently-retired clip
+    /// schedules. Each `set_clip_schedule` pushes the old Arc onto
+    /// this queue and pops the oldest when the queue grows past
+    /// `CLIP_SCHEDULE_GRAVEYARD_SIZE`. The drop of the evicted
+    /// Arc happens on the main thread (the caller of
+    /// `set_clip_schedule`) — which prevents the audio callback,
+    /// which may transiently hold a guard referencing the old
+    /// schedule, from being the last owner and ending up
+    /// deallocating PCM buffers on the RT thread. Found by codex
+    /// review on PR #1719.
+    clip_schedule_graveyard: std::sync::Mutex<std::collections::VecDeque<Arc<ClipSchedule>>>,
     /// Active sample rate — cached so beat↔sample conversion can
     /// run without re-parsing `EngineStatus`.
     sample_rate: u32,
 }
+
+/// How many past clip schedules to keep alive on the main thread
+/// after a swap. With audio buffers in the 1-10 ms range, 16 is
+/// 16-160 ms of audio processing — orders of magnitude more than
+/// the audio callback's window for a single guard hold.
+pub const CLIP_SCHEDULE_GRAVEYARD_SIZE: usize = 16;
 
 impl RunningEngine {
     fn shutdown(mut self) {
@@ -354,6 +371,11 @@ impl Engine {
                     loop_region: loop_region_handle,
                     metronome_config: metronome_config_handle,
                     clip_schedule: clip_schedule_handle,
+                    clip_schedule_graveyard: std::sync::Mutex::new(
+                        std::collections::VecDeque::with_capacity(
+                            CLIP_SCHEDULE_GRAVEYARD_SIZE,
+                        ),
+                    ),
                     sample_rate: active_sample_rate,
                 });
                 Ok(status)
@@ -654,11 +676,41 @@ impl Engine {
     /// Replace the clip schedule atomically. Validates via
     /// [`ClipSchedule::try_new`] before publishing so a malformed
     /// payload never reaches the audio thread.
+    ///
+    /// Uses a main-thread graveyard to defer the drop of the
+    /// *previous* schedule: the audio callback may be holding a
+    /// `load()` guard referencing it, and when that guard drops
+    /// (end of callback) we don't want the RT thread to be the
+    /// last owner and trigger allocator work on itself. By
+    /// retaining each retired Arc here for
+    /// [`CLIP_SCHEDULE_GRAVEYARD_SIZE`] swaps, the eviction drop
+    /// always happens on the main thread. Found by codex review
+    /// on PR #1719.
     pub fn set_clip_schedule(&self, clips: Vec<ClipSource>) -> Result<(), CommandError> {
         let running = self.running.as_ref().ok_or(CommandError::NotRunning)?;
         let schedule = ClipSchedule::try_new(clips)
             .map_err(|e| CommandError::InvalidClipSchedule(format!("{e:?}")))?;
-        running.clip_schedule.store(Arc::new(schedule));
+        let new_arc = Arc::new(schedule);
+        // Snapshot the outgoing schedule on the MAIN thread so the
+        // Arc's refcount doesn't hit zero on the audio side.
+        let old_arc = running.clip_schedule.load_full();
+        running.clip_schedule.store(new_arc);
+        // Push into the graveyard; drop the oldest eviction here
+        // (main thread) rather than letting the audio callback
+        // become the last owner.
+        let mut graveyard = running
+            .clip_schedule_graveyard
+            .lock()
+            .map_err(|_| CommandError::Disconnected)?;
+        graveyard.push_back(old_arc);
+        while graveyard.len() > CLIP_SCHEDULE_GRAVEYARD_SIZE {
+            // `pop_front` returns Some(Arc<...>) — dropped HERE
+            // on the main thread. If no other references exist
+            // (including no audio-thread guard), deallocation of
+            // the ClipSchedule's `Vec<ClipSource>` and each
+            // clip's `Vec<f32>` PCM happens on this thread.
+            graveyard.pop_front();
+        }
         Ok(())
     }
 
@@ -1550,6 +1602,50 @@ mod tests {
         let snap = engine.time_signature_map_snapshot().unwrap();
         assert_eq!(snap.signature_at(0), (4, 4));
         assert_eq!(snap.signature_at(96_000), (3, 4));
+
+        engine.stop();
+    }
+
+    #[test]
+    fn clip_schedule_graveyard_bounds_retained_arcs() {
+        // Codex P1 regression (PR #1719): the graveyard must cap
+        // retained Arc<ClipSchedule>s at CLIP_SCHEDULE_GRAVEYARD_SIZE
+        // so rapid-fire schedule swaps don't leak memory forever.
+        use std::sync::Arc;
+
+        let mut engine = Engine::new();
+        engine
+            .start_with(
+                EngineConfig::default_48k(),
+                fake_runner(
+                    Ok(ok_info()),
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(AtomicBool::new(false)),
+                ),
+            )
+            .unwrap();
+
+        // Build a tiny PCM so each ClipSource is cheap.
+        let pcm = Arc::new(vec![0.5_f32; 4]);
+
+        // Swap 3× the graveyard capacity — the queue must cap.
+        for i in 0..(CLIP_SCHEDULE_GRAVEYARD_SIZE * 3) {
+            let clip = ClipSource::new(i as u64 * 1000, 2, 1.0, pcm.clone()).unwrap();
+            engine.set_clip_schedule(vec![clip]).unwrap();
+        }
+
+        let graveyard_len = engine
+            .running
+            .as_ref()
+            .unwrap()
+            .clip_schedule_graveyard
+            .lock()
+            .unwrap()
+            .len();
+        assert!(
+            graveyard_len <= CLIP_SCHEDULE_GRAVEYARD_SIZE,
+            "graveyard grew past cap: {graveyard_len} > {CLIP_SCHEDULE_GRAVEYARD_SIZE}"
+        );
 
         engine.stop();
     }

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -26,6 +26,7 @@
 //! command receiver, ready signal, and stop signal.
 
 pub mod audio_io;
+pub mod clip;
 pub mod command;
 pub mod config;
 pub mod effect_chain;
@@ -48,6 +49,7 @@ pub use config::{
     VALID_SAMPLE_RATES,
 };
 pub use graph::{AudioGraph, Track, MAX_TRACKS};
+pub use clip::{ClipSchedule, ClipScheduleError, ClipSource, MAX_CLIPS};
 pub use loop_region::LoopRegion;
 pub use metronome::MetronomeConfig;
 pub use position_emitter::{PositionEmitter, DEFAULT_INTERVAL as POSITION_EVENT_DEFAULT_INTERVAL};
@@ -160,6 +162,10 @@ pub enum CommandError {
     /// Same as `InvalidTempoMap` but for the time-signature map.
     #[error("invalid time signature map: {0}")]
     InvalidTimeSignatureMap(String),
+    /// Caller sent a clip-schedule payload that violated invariants
+    /// (too many clips, empty audio_data, length > PCM frames).
+    #[error("invalid clip schedule: {0}")]
+    InvalidClipSchedule(String),
 }
 
 /// Contract for the function that owns a CPAL stream.
@@ -219,6 +225,8 @@ struct RunningEngine {
     loop_region: Arc<ArcSwap<LoopRegion>>,
     /// Same pattern for the metronome config.
     metronome_config: Arc<ArcSwap<MetronomeConfig>>,
+    /// Same pattern for the clip schedule.
+    clip_schedule: Arc<ArcSwap<ClipSchedule>>,
     /// Active sample rate — cached so beat↔sample conversion can
     /// run without re-parsing `EngineStatus`.
     sample_rate: u32,
@@ -297,6 +305,7 @@ impl Engine {
         let time_sig_map_handle = transport.time_sig_map_handle();
         let loop_region_handle = transport.loop_region_handle();
         let metronome_config_handle = transport.metronome_config_handle();
+        let clip_schedule_handle = transport.clip_schedule_handle();
 
         let ctx = RuntimeContext {
             config: config.clone(),
@@ -344,6 +353,7 @@ impl Engine {
                     time_sig_map: time_sig_map_handle,
                     loop_region: loop_region_handle,
                     metronome_config: metronome_config_handle,
+                    clip_schedule: clip_schedule_handle,
                     sample_rate: active_sample_rate,
                 });
                 Ok(status)
@@ -637,6 +647,26 @@ impl Engine {
         cfg.enabled = enabled;
         running.metronome_config.store(Arc::new(cfg));
         Ok(())
+    }
+
+    // ── Clip schedule (3F) ──────────────────────────────────────────
+
+    /// Replace the clip schedule atomically. Validates via
+    /// [`ClipSchedule::try_new`] before publishing so a malformed
+    /// payload never reaches the audio thread.
+    pub fn set_clip_schedule(&self, clips: Vec<ClipSource>) -> Result<(), CommandError> {
+        let running = self.running.as_ref().ok_or(CommandError::NotRunning)?;
+        let schedule = ClipSchedule::try_new(clips)
+            .map_err(|e| CommandError::InvalidClipSchedule(format!("{e:?}")))?;
+        running.clip_schedule.store(Arc::new(schedule));
+        Ok(())
+    }
+
+    /// Snapshot the current clip schedule. Returns `None` when the
+    /// engine is stopped. Cheap — wait-free `load_full` produces a
+    /// refcounted handle.
+    pub fn clip_schedule_snapshot(&self) -> Option<Arc<ClipSchedule>> {
+        self.running.as_ref().map(|r| r.clip_schedule.load_full())
     }
 
     /// Read the latest meter reading for a track.

--- a/src-tauri/src/engine/transport.rs
+++ b/src-tauri/src/engine/transport.rs
@@ -39,6 +39,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 
+use super::clip::ClipSchedule;
 use super::loop_region::LoopRegion;
 use super::metronome::MetronomeConfig;
 use super::tempo_map::TempoMap;
@@ -188,6 +189,11 @@ pub struct Transport {
     /// Metronome config (enable/volume/frequency). Audio-thread
     /// click state lives separately — only the config is shared.
     metronome_config: Arc<ArcSwap<MetronomeConfig>>,
+    /// Clip schedule — the set of PCM clips to mix into the master
+    /// bus at their scheduled sample positions. Shared via
+    /// `ArcSwap` so the main thread can replace the whole set
+    /// without blocking the audio callback.
+    clip_schedule: Arc<ArcSwap<ClipSchedule>>,
 }
 
 impl Transport {
@@ -201,6 +207,7 @@ impl Transport {
             time_sig_map: Arc::new(ArcSwap::from_pointee(TimeSignatureMap::default())),
             loop_region: Arc::new(ArcSwap::from_pointee(LoopRegion::disabled())),
             metronome_config: Arc::new(ArcSwap::from_pointee(MetronomeConfig::default_off())),
+            clip_schedule: Arc::new(ArcSwap::from_pointee(ClipSchedule::empty())),
         }
     }
 
@@ -271,6 +278,17 @@ impl Transport {
     /// Replace the metronome config atomically.
     pub fn replace_metronome_config(&mut self, config: MetronomeConfig) {
         self.metronome_config.store(Arc::new(config));
+    }
+
+    /// Clone the clip-schedule handle. Audio thread reads via
+    /// wait-free `.load()`, main thread publishes via `.store`.
+    pub fn clip_schedule_handle(&self) -> Arc<ArcSwap<ClipSchedule>> {
+        self.clip_schedule.clone()
+    }
+
+    /// Replace the clip schedule atomically.
+    pub fn replace_clip_schedule(&mut self, schedule: ClipSchedule) {
+        self.clip_schedule.store(Arc::new(schedule));
     }
 
     /// Snapshot the current tempo map. Cheap — `.load()` is wait-free

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,10 +4,11 @@ pub mod engine;
 use tauri::Manager;
 
 use crate::commands::audio::{
-    audio_add_track, audio_get_default_device, audio_get_engine_status,
-    audio_list_devices, audio_metronome_get_config, audio_metronome_set_config,
-    audio_metronome_set_enabled, audio_remove_track, audio_set_master_volume,
-    audio_set_track_params, audio_start_engine, audio_stop_engine,
+    audio_add_track, audio_clip_get_schedule, audio_clip_set_schedule,
+    audio_get_default_device, audio_get_engine_status, audio_list_devices,
+    audio_metronome_get_config, audio_metronome_set_config, audio_metronome_set_enabled,
+    audio_remove_track, audio_set_master_volume, audio_set_track_params,
+    audio_start_engine, audio_stop_engine,
     audio_transport_beat_to_sample, audio_transport_get_loop_region,
     audio_transport_get_position, audio_transport_get_tempo_map,
     audio_transport_get_time_signature_map, audio_transport_pause, audio_transport_play,
@@ -63,6 +64,8 @@ pub fn run() {
             audio_metronome_set_config,
             audio_metronome_get_config,
             audio_metronome_set_enabled,
+            audio_clip_set_schedule,
+            audio_clip_get_schedule,
         ])
         .setup(|app| {
             // Focus main window on startup

--- a/src-tauri/tests/local_audio_smoke.rs
+++ b/src-tauri/tests/local_audio_smoke.rs
@@ -19,7 +19,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use ace_step_daw_lib::engine::{
-    audio_io, Engine, EngineConfig, EngineStatus, LoopRegion, MetronomeConfig,
+    audio_io, ClipSource, Engine, EngineConfig, EngineStatus, LoopRegion, MetronomeConfig,
     PositionEmitter, TempoEvent, TrackParams,
 };
 use std::sync::{Arc, Mutex};
@@ -637,6 +637,81 @@ fn real_engine_metronome_renders_audible_clicks() {
     assert!(
         !cfg_after.enabled,
         "disable command did not propagate to the ArcSwap"
+    );
+
+    engine.stop();
+}
+
+/// Smoke test — clip scheduler mixes scheduled PCM into master
+/// during live playback.
+///
+/// Phase 3F end-to-end proof: build a 24_000-sample (0.5 s at
+/// 48 kHz) ramp PCM, schedule it at sample 24_000 (0.5 s into the
+/// transport), start playback, and observe the master meter RMS
+/// during the clip's window.
+#[test]
+#[ignore]
+fn real_engine_clip_schedule_plays_pcm() {
+    let mut engine = Engine::new();
+    engine.start(EngineConfig::default_48k()).unwrap();
+
+    // Build a 0.5 s stereo ramp that goes from 0 to 0.5 amplitude.
+    // Arc-wrap so the schedule can share it.
+    let frames = 24_000_usize;
+    let mut pcm = Vec::with_capacity(frames * 2);
+    for i in 0..frames {
+        let amp = (i as f32 / frames as f32) * 0.5;
+        pcm.push(amp); // L
+        pcm.push(amp); // R
+    }
+    let pcm = std::sync::Arc::new(pcm);
+
+    // Schedule it at transport sample 24_000 (0.5 s delay from
+    // playback start), 0.8 gain.
+    let clip = ClipSource::new(24_000, frames as u64, 0.8, pcm).expect("ClipSource::new");
+    engine
+        .set_clip_schedule(vec![clip])
+        .expect("set_clip_schedule");
+
+    engine.transport_play().expect("play");
+
+    // Poll meter at 50ms intervals for 1.5 seconds, sampling peak.
+    // The clip is at 500-1000ms of transport time; its amplitude
+    // ramps from 0 to 0.4 (after 0.8 gain), so peak should rise
+    // during that window.
+    let mut peaks = Vec::new();
+    for step in 0..30 {
+        sleep(Duration::from_millis(50));
+        let m = engine.get_master_meter();
+        peaks.push((step * 50, m.peak));
+    }
+    eprintln!("peak progression (ms, peak):");
+    for (t, p) in &peaks {
+        eprintln!("  t={t}: peak={p}");
+    }
+
+    // Verify that at least one sample during the clip's expected
+    // playback window (500-1000ms = steps 10-20) shows an audible
+    // peak. The ramp starts at 0 and grows, so later steps should
+    // be higher than earlier steps.
+    let max_peak_during_clip = peaks[10..20]
+        .iter()
+        .map(|(_, p)| *p)
+        .fold(0.0_f32, f32::max);
+    eprintln!("max peak during clip window: {max_peak_during_clip}");
+    assert!(
+        max_peak_during_clip > 0.05,
+        "clip should have produced audible output, max peak was {max_peak_during_clip}"
+    );
+
+    // Also verify that transport.position actually advanced past
+    // the clip start — rules out the "transport never played"
+    // hypothesis.
+    let pos = engine.transport_position();
+    eprintln!("final transport position: {pos}");
+    assert!(
+        pos > 24_000,
+        "transport should have passed sample 24_000 after 1.5s, got {pos}"
     );
 
     engine.stop();


### PR DESCRIPTION
## Summary

Sixth atomic slice of Phase 3 (#1523). The payoff for the whole transport rewrite: the engine can now read PCM data from clips positioned at arbitrary sample offsets and mix them into the master bus, respecting transport state, loop wrap-around, and tempo map.

- **`ClipSource`** — `start_sample`, `length_samples`, clamped `gain`, `Arc<Vec<f32>>` stereo-interleaved PCM
- **`ClipSchedule`** — fixed-capacity slab (`MAX_CLIPS = 1024`) with validated constructor
- **`ArcSwap<ClipSchedule>`** on `Transport` — wait-free audio-thread reads, lock-free main-thread writes. Serialize-only (not Deserialize) — UI sends `Vec<ClipSource>` and Rust validates
- **Audio callback** reads via borrowed `.load()` guard, no Arc clone on RT thread
- **Loop wrap-around** split-render pattern (same as metronome)
- **Mix behavior**: additive, runs after aux-return mix, before master volume, so clips respect master gain
- **Defensive PCM bounds checks** — re-check `audio_data.len()` per frame; audio thread never panics
- **Engine + Tauri API**: `set_clip_schedule`, `clip_schedule_snapshot`, 2 Tauri commands

## Test plan

- [x] `cargo test --lib` — 271 Rust unit tests pass (was 251, +20)
  - gain clamp, empty-audio reject, length-exceeds-audio reject
  - intersection edges (zero-length clip, partial overlap)
  - PCM alignment (buffer start, straddling, partial-before)
  - defensive out-of-bounds handling
  - slab capacity (MAX_CLIPS + 1 rejected)
  - serde round-trip with camelCase wire format
- [x] `cargo test --test local_audio_smoke -- --ignored real_engine_clip_schedule_plays_pcm` — hardware smoke: 0.5 s stereo ramp at transport sample 24 000 produces audible master peak (> 0.05) in the expected 500-1000 ms window; transport advances past clip start confirming playback
- [x] `cargo build --release` clean

## Non-goals (later)

- Sample-rate conversion if clip SR != engine SR (caller pre-resamples)
- Time-stretching (warp markers) — large feature, future phase
- Fade in/out (envelope automation) — follow-up

Closes #1718
Part of #1523, #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)