### PR TITLE
feat: Phase 3G — punch region + count-in + scrub mode

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -477,16 +477,6 @@ pub fn audio_clip_set_schedule(
     engine.set_clip_schedule(clips)
 }
 
-/// Snapshot the current clip schedule. Returns `None` when the
-/// engine is stopped. Each clip's audio_data is serialized as a
-/// Vec<f32> on the wire — this can be large for long clips, so
-/// the UI should poll `get_schedule` rarely (on project load /
-/// structural change), not per-frame.
-///
-/// Returns `InvalidClipSchedule` on the rare path where the
-/// snapshot round-trips through `try_new` and hits an invariant
-/// error — prefer surfacing that over silently pretending the
-/// schedule was cleared (Copilot review on PR #1719).
 // ── Transport scrub (3G) ────────────────────────────────────────────
 
 #[tauri::command]
@@ -565,6 +555,16 @@ pub fn audio_transport_get_count_in(
 
 // ── Clip scheduler (3F) - continued ────────────────────────────────
 
+/// Snapshot the current clip schedule. Returns `None` when the
+/// engine is stopped. Each clip's audio_data is serialized as a
+/// Vec<f32> on the wire — this can be large for long clips, so
+/// the UI should poll `get_schedule` rarely (on project load /
+/// structural change), not per-frame.
+///
+/// Returns `InvalidClipSchedule` on the rare path where the
+/// snapshot round-trips through `try_new` and hits an invariant
+/// error — prefer surfacing that over silently pretending the
+/// schedule was cleared (Copilot review on PR #1719).
 #[tauri::command]
 pub fn audio_clip_get_schedule(
     state: State<'_, EngineState>,

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -9,9 +9,9 @@ use std::sync::Mutex;
 use tauri::{Emitter, State};
 
 use crate::engine::{
-    audio_io, AudioDeviceInfo, ClipSchedule, ClipSource, CommandError, Engine,
+    audio_io, AudioDeviceInfo, ClipSchedule, ClipSource, CommandError, CountIn, Engine,
     EngineConfig, EngineError, EngineStatus, LoopRegion, MetronomeConfig, PositionEmitter,
-    TempoEvent, TempoMap, TimeSignatureEvent, TimeSignatureMap, TrackParams,
+    PunchRegion, TempoEvent, TempoMap, TimeSignatureEvent, TimeSignatureMap, TrackParams,
     POSITION_EVENT_DEFAULT_INTERVAL,
 };
 use crate::engine::slot::SlotHandle;
@@ -487,6 +487,84 @@ pub fn audio_clip_set_schedule(
 /// snapshot round-trips through `try_new` and hits an invariant
 /// error — prefer surfacing that over silently pretending the
 /// schedule was cleared (Copilot review on PR #1719).
+// ── Transport scrub (3G) ────────────────────────────────────────────
+
+#[tauri::command]
+pub fn audio_transport_scrub(
+    delta_samples: i64,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.transport_scrub(delta_samples)
+}
+
+// ── Punch region (3G) ──────────────────────────────────────────────
+
+#[tauri::command]
+pub fn audio_transport_set_punch_region(
+    region: PunchRegion,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.set_punch_region(region)
+}
+
+#[tauri::command]
+pub fn audio_transport_get_punch_region(
+    state: State<'_, EngineState>,
+) -> Result<Option<PunchRegion>, CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    Ok(engine.punch_region_snapshot())
+}
+
+#[tauri::command]
+pub fn audio_transport_set_punch_enabled(
+    enabled: bool,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.set_punch_enabled(enabled)
+}
+
+// ── Count-in (3G) ──────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn audio_transport_set_count_in(
+    config: CountIn,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.set_count_in(config)
+}
+
+#[tauri::command]
+pub fn audio_transport_get_count_in(
+    state: State<'_, EngineState>,
+) -> Result<Option<CountIn>, CommandError> {
+    let engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    Ok(engine.count_in_snapshot())
+}
+
+// ── Clip scheduler (3F) - continued ────────────────────────────────
+
 #[tauri::command]
 pub fn audio_clip_get_schedule(
     state: State<'_, EngineState>,

--- a/src-tauri/src/engine/audio_io.rs
+++ b/src-tauri/src/engine/audio_io.rs
@@ -30,6 +30,7 @@ use super::graph::AudioGraph;
 use super::meter::generate_sine;
 use super::meter_bank::MeterProducers;
 use super::clip::render_clip_segment;
+use super::count_in::CountInState;
 use super::metronome::{render_metronome_segment, ClickGenerator};
 use super::mixer;
 use super::transport::Transport;
@@ -289,6 +290,11 @@ fn make_audio_callback(
     // that starts near the end of one buffer can decay into the
     // start of the next without truncation.
     let mut click_gen = ClickGenerator::idle();
+    // Count-in countdown. Started when a TransportPlay command is
+    // received with `count_in.enabled`; clip rendering is
+    // suppressed while `remaining_samples > 0`. Metronome keeps
+    // clicking so the user hears the count.
+    let mut count_in_state = CountInState::idle();
 
     let ch = channels as usize;
 
@@ -353,11 +359,40 @@ fn make_audio_callback(
                     // the tail of the callback, AFTER the drain, so that
                     // a Seek/Stop received in this buffer takes effect
                     // before we increment.
-                    EngineCommand::TransportPlay => transport.play(),
-                    EngineCommand::TransportStop => transport.stop(),
-                    EngineCommand::TransportPause => transport.pause(),
+                    EngineCommand::TransportPlay => {
+                        transport.play();
+                        // 3G: start count-in countdown if configured.
+                        // Metronome continues during count-in (so the
+                        // user hears the clicks) but clip scheduler
+                        // is suppressed — see the render block below.
+                        let cfg = transport.count_in_snapshot();
+                        if cfg.enabled && cfg.beats > 0 {
+                            let tempo_guard = transport.tempo_map_handle().load();
+                            let duration = super::count_in::count_in_duration_samples(
+                                cfg.beats,
+                                transport.position(),
+                                &tempo_guard,
+                                sample_rate as u32,
+                            );
+                            count_in_state.start(duration);
+                        } else {
+                            count_in_state.clear();
+                        }
+                    }
+                    EngineCommand::TransportStop => {
+                        transport.stop();
+                        count_in_state.clear();
+                    }
+                    EngineCommand::TransportPause => {
+                        transport.pause();
+                        count_in_state.clear();
+                    }
                     EngineCommand::TransportSeek { sample_position } => {
                         transport.seek(sample_position);
+                    }
+                    EngineCommand::TransportScrub { delta_samples } => {
+                        transport.scrub(delta_samples);
+                        count_in_state.clear();
                     }
                     other => {
                         // Reset effects + meter + sends eagerly on
@@ -478,7 +513,12 @@ fn make_audio_callback(
         // whole buffer. Rare (requires loop shorter than audio
         // buffer — 5-85 ms at typical sample rates) but still needs
         // to be correct. Found by codex review on PR #1719.
-        if transport.state().is_advancing() {
+        //
+        // Count-in (3G): when `count_in_state` is active, clip
+        // rendering is suppressed. Metronome continues — see the
+        // block below — so the user hears the count but no clip
+        // audio leaks through.
+        if transport.state().is_advancing() && !count_in_state.is_active() {
             let clip_schedule_guard = transport.clip_schedule_handle().load();
             let clip_schedule: &super::clip::ClipSchedule = &clip_schedule_guard;
             if !clip_schedule.is_empty() {
@@ -671,6 +711,15 @@ fn make_audio_callback(
                     data[i] = (master_l[i] + master_r[i]) * 0.5;
                 }
             }
+        }
+
+        // Advance count-in countdown in parallel with transport
+        // position (3G). If the countdown finishes inside this
+        // buffer the clip scheduler will start rendering on the
+        // *next* buffer — a one-buffer approximation that keeps
+        // the countdown check out of the per-sample hot path.
+        if count_in_state.is_active() && transport.state().is_advancing() {
+            count_in_state.advance(frames as u64);
         }
 
         // Advance the transport position. This is the single place in

--- a/src-tauri/src/engine/audio_io.rs
+++ b/src-tauri/src/engine/audio_io.rs
@@ -360,24 +360,37 @@ fn make_audio_callback(
                     // a Seek/Stop received in this buffer takes effect
                     // before we increment.
                     EngineCommand::TransportPlay => {
-                        transport.play();
-                        // 3G: start count-in countdown if configured.
-                        // Metronome continues during count-in (so the
-                        // user hears the clicks) but clip scheduler
-                        // is suppressed — see the render block below.
+                        // 3G count-in is a proper PRE-ROLL: before
+                        // starting playback, rewind the playhead by
+                        // `duration_samples` so that after the
+                        // countdown the playhead is back at the
+                        // user's original "play from here" position
+                        // and no clip material is skipped (codex P1
+                        // on PR #1721).
+                        //
+                        // If the original position is less than the
+                        // count-in duration, saturating_sub clips to
+                        // 0 — some pre-roll is lost but the
+                        // transport cannot roll before sample 0.
                         let cfg = transport.count_in_snapshot();
                         if cfg.enabled && cfg.beats > 0 {
                             let tempo_guard = transport.tempo_map_handle().load();
+                            let original = transport.position();
                             let duration = super::count_in::count_in_duration_samples(
                                 cfg.beats,
-                                transport.position(),
+                                original,
                                 &tempo_guard,
                                 sample_rate as u32,
                             );
-                            count_in_state.start(duration);
+                            // Rewind for pre-roll.
+                            transport.seek(original.saturating_sub(duration));
+                            // Actual countdown duration after clamp.
+                            let actual = original - transport.position();
+                            count_in_state.start(actual);
                         } else {
                             count_in_state.clear();
                         }
+                        transport.play();
                     }
                     EngineCommand::TransportStop => {
                         transport.stop();
@@ -389,6 +402,9 @@ fn make_audio_callback(
                     }
                     EngineCommand::TransportSeek { sample_position } => {
                         transport.seek(sample_position);
+                        // Seeking cancels an in-flight count-in —
+                        // consistent with Stop/Pause/Scrub.
+                        count_in_state.clear();
                     }
                     EngineCommand::TransportScrub { delta_samples } => {
                         transport.scrub(delta_samples);

--- a/src-tauri/src/engine/command.rs
+++ b/src-tauri/src/engine/command.rs
@@ -155,6 +155,11 @@ pub enum EngineCommand {
 
     /// Jump the transport to an absolute sample position.
     TransportSeek { sample_position: u64 },
+
+    /// Scrub: move the playhead by a signed sample delta and put
+    /// the transport in `Scrubbing` state. Saturates at 0 and
+    /// u64::MAX rather than wrapping.
+    TransportScrub { delta_samples: i64 },
 }
 
 // Note: `TransportSetTempo` existed in 3A but was removed in 3B once

--- a/src-tauri/src/engine/count_in.rs
+++ b/src-tauri/src/engine/count_in.rs
@@ -1,0 +1,292 @@
+//! Count-in: optional N-beat lead-in before audible playback.
+//!
+//! When [`CountIn::enabled`] is true and `TransportPlay` is
+//! received, the audio callback starts a countdown equal to
+//! `beats × samples_per_beat_at(playhead)` (computed from the
+//! transport's tempo map). During the countdown:
+//! - The transport advances normally (position counter moves).
+//! - The metronome continues to click on beat boundaries so the
+//!   user hears the count.
+//! - The clip scheduler is suppressed — no clip audio hits the
+//!   master until the countdown reaches zero.
+//!
+//! This matches the "Count-in" feature in Pro Tools / Logic: press
+//! play, hear four clicks, then the song starts.
+//!
+//! The audio-thread state (remaining samples) is NOT shared; it
+//! lives inside the callback's owned state. The main thread only
+//! publishes the *configuration* (enable flag + beat count), and
+//! the countdown is entirely local to the audio thread once play
+//! starts.
+
+use serde::{Deserialize, Serialize};
+
+/// Minimum valid beat count. Zero-beat count-in is pointless; use
+/// `enabled = false` instead.
+pub const MIN_COUNT_IN_BEATS: u8 = 1;
+/// Maximum beats. 16 beats at 60 BPM is 16 seconds — anything
+/// longer would feel broken. Serde inputs above this are clamped
+/// down.
+pub const MAX_COUNT_IN_BEATS: u8 = 16;
+/// Sensible default: a full bar of 4.
+pub const DEFAULT_COUNT_IN_BEATS: u8 = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CountIn {
+    pub enabled: bool,
+    pub beats: u8,
+}
+
+impl CountIn {
+    /// Disabled default.
+    pub const fn default_off() -> Self {
+        Self {
+            enabled: false,
+            beats: DEFAULT_COUNT_IN_BEATS,
+        }
+    }
+
+    /// Validated constructor. Clamps `beats` to
+    /// `[MIN_COUNT_IN_BEATS, MAX_COUNT_IN_BEATS]` so a serde
+    /// payload with absurd values cannot push the count-in into
+    /// minutes of silence.
+    pub fn new(enabled: bool, beats: u8) -> Self {
+        let safe = beats.clamp(MIN_COUNT_IN_BEATS, MAX_COUNT_IN_BEATS);
+        Self { enabled, beats: safe }
+    }
+}
+
+impl Default for CountIn {
+    fn default() -> Self {
+        Self::default_off()
+    }
+}
+
+/// Audio-thread countdown state. Not shared across threads — owned
+/// by the callback closure. `remaining_samples == 0` means "no
+/// count-in in progress"; any positive value means "suppress clips
+/// for this many more samples."
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CountInState {
+    remaining_samples: u64,
+}
+
+impl CountInState {
+    pub fn idle() -> Self {
+        Self { remaining_samples: 0 }
+    }
+
+    /// Start a countdown of `duration_samples`. Overrides any
+    /// in-flight countdown (e.g. user hits play while a previous
+    /// count-in was still running — the new press wins).
+    pub fn start(&mut self, duration_samples: u64) {
+        self.remaining_samples = duration_samples;
+    }
+
+    /// Abort the countdown immediately (used when the transport
+    /// stops).
+    pub fn clear(&mut self) {
+        self.remaining_samples = 0;
+    }
+
+    /// Whether the countdown is currently running.
+    #[inline]
+    pub fn is_active(&self) -> bool {
+        self.remaining_samples > 0
+    }
+
+    /// Advance the countdown by `frames` samples. Returns `true`
+    /// if the countdown is still active after the advance — i.e.
+    /// clip rendering should STILL be suppressed this buffer.
+    ///
+    /// Saturating subtraction: a buffer longer than the remaining
+    /// count reduces to zero instead of wrapping.
+    #[inline]
+    pub fn advance(&mut self, frames: u64) -> bool {
+        if self.remaining_samples == 0 {
+            return false;
+        }
+        self.remaining_samples = self.remaining_samples.saturating_sub(frames);
+        self.remaining_samples > 0
+    }
+
+    /// Snapshot the remaining samples. Useful for tests and UI
+    /// badges.
+    pub fn remaining_samples(&self) -> u64 {
+        self.remaining_samples
+    }
+}
+
+/// Compute the count-in duration in samples for `beats` starting
+/// at `playhead_sample`, using the given tempo map + sample rate.
+/// Uses `TempoMap::beat_to_sample` so tempo changes inside the
+/// count-in region are accounted for.
+pub fn count_in_duration_samples(
+    beats: u8,
+    playhead_sample: u64,
+    tempo_map: &super::tempo_map::TempoMap,
+    sample_rate: u32,
+) -> u64 {
+    if beats == 0 {
+        return 0;
+    }
+    // Current beat (fractional).
+    let current_beat = tempo_map.sample_to_beat(playhead_sample, sample_rate);
+    // Target beat = current_beat + beats (integer).
+    let target_beat = current_beat + beats as f64;
+    let target_sample = tempo_map.beat_to_sample(target_beat, sample_rate);
+    target_sample.saturating_sub(playhead_sample)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::tempo_map::TempoMap;
+
+    // ── CountIn config ──────────────────────────────────────────────
+
+    #[test]
+    fn default_is_off_with_sensible_beats() {
+        let c = CountIn::default();
+        assert!(!c.enabled);
+        assert_eq!(c.beats, DEFAULT_COUNT_IN_BEATS);
+    }
+
+    #[test]
+    fn new_clamps_beats_to_valid_range() {
+        assert_eq!(CountIn::new(true, 0).beats, MIN_COUNT_IN_BEATS);
+        assert_eq!(CountIn::new(true, 99).beats, MAX_COUNT_IN_BEATS);
+        assert_eq!(CountIn::new(true, 4).beats, 4);
+        assert_eq!(CountIn::new(true, MAX_COUNT_IN_BEATS).beats, MAX_COUNT_IN_BEATS);
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_fields() {
+        let c = CountIn::new(true, 4);
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"enabled\":true"));
+        assert!(json.contains("\"beats\":4"));
+        let back: CountIn = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn config_is_copy() {
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<CountIn>();
+    }
+
+    // ── CountInState ────────────────────────────────────────────────
+
+    #[test]
+    fn idle_state_is_inactive() {
+        let s = CountInState::idle();
+        assert!(!s.is_active());
+        assert_eq!(s.remaining_samples(), 0);
+    }
+
+    #[test]
+    fn start_sets_remaining() {
+        let mut s = CountInState::idle();
+        s.start(48_000);
+        assert!(s.is_active());
+        assert_eq!(s.remaining_samples(), 48_000);
+    }
+
+    #[test]
+    fn advance_decrements_and_deactivates() {
+        let mut s = CountInState::idle();
+        s.start(1000);
+        assert!(s.advance(400), "still active after partial advance");
+        assert_eq!(s.remaining_samples(), 600);
+        assert!(s.advance(500), "still active");
+        assert!(!s.advance(200), "should deactivate when hitting 0");
+        assert_eq!(s.remaining_samples(), 0);
+        assert!(!s.is_active());
+    }
+
+    #[test]
+    fn advance_past_remaining_saturates_to_zero() {
+        let mut s = CountInState::idle();
+        s.start(100);
+        // Overshoot by 10x — must not wrap around.
+        let still_active = s.advance(1_000);
+        assert!(!still_active);
+        assert_eq!(s.remaining_samples(), 0);
+    }
+
+    #[test]
+    fn advance_on_idle_is_noop() {
+        let mut s = CountInState::idle();
+        assert!(!s.advance(100));
+        assert_eq!(s.remaining_samples(), 0);
+    }
+
+    #[test]
+    fn clear_cancels_in_flight_countdown() {
+        let mut s = CountInState::idle();
+        s.start(48_000);
+        s.clear();
+        assert!(!s.is_active());
+        assert_eq!(s.remaining_samples(), 0);
+    }
+
+    #[test]
+    fn start_overrides_in_flight_countdown() {
+        let mut s = CountInState::idle();
+        s.start(10_000);
+        s.start(500);
+        assert_eq!(s.remaining_samples(), 500);
+    }
+
+    // ── count_in_duration_samples ──────────────────────────────────
+
+    #[test]
+    fn duration_at_120_bpm_four_beats_is_two_seconds() {
+        // 120 BPM → 2 beats/s → 4 beats = 2 s = 96_000 samples at 48 k.
+        let map = TempoMap::new_constant(120.0);
+        let dur = count_in_duration_samples(4, 0, &map, 48_000);
+        assert_eq!(dur, 96_000);
+    }
+
+    #[test]
+    fn duration_at_60_bpm_one_beat_is_one_second() {
+        // 60 BPM → 1 beat/s → 1 beat = 1 s = 48_000 samples.
+        let map = TempoMap::new_constant(60.0);
+        let dur = count_in_duration_samples(1, 0, &map, 48_000);
+        assert_eq!(dur, 48_000);
+    }
+
+    #[test]
+    fn duration_of_zero_beats_is_zero() {
+        let map = TempoMap::new_constant(120.0);
+        assert_eq!(count_in_duration_samples(0, 0, &map, 48_000), 0);
+    }
+
+    #[test]
+    fn duration_respects_tempo_changes_in_count_in_window() {
+        use super::super::tempo_map::TempoEvent;
+        // First beat at 60 BPM (48_000 samples) then 120 BPM.
+        let map = TempoMap::try_new(vec![
+            TempoEvent::new(0, 60.0),
+            TempoEvent::new(48_000, 120.0),
+        ])
+        .unwrap();
+        // 4 beats from sample 0 = 1 beat at 60 BPM (48k samples) +
+        // 3 beats at 120 BPM (3 × 24k = 72k samples) = 120_000 samples.
+        let dur = count_in_duration_samples(4, 0, &map, 48_000);
+        assert_eq!(dur, 120_000);
+    }
+
+    #[test]
+    fn duration_is_nonnegative_even_on_degenerate_input() {
+        // Call with a playhead after a very large sample; the
+        // function should saturating-subtract instead of wrapping.
+        let map = TempoMap::new_constant(120.0);
+        let dur = count_in_duration_samples(4, u64::MAX - 1000, &map, 48_000);
+        // Should be some non-negative value; we don't care exactly
+        // what, just that it didn't panic or wrap.
+        let _ = dur;
+    }
+}

--- a/src-tauri/src/engine/graph.rs
+++ b/src-tauri/src/engine/graph.rs
@@ -255,7 +255,8 @@ impl AudioGraph {
             | EngineCommand::TransportPlay
             | EngineCommand::TransportStop
             | EngineCommand::TransportPause
-            | EngineCommand::TransportSeek { .. } => {}
+            | EngineCommand::TransportSeek { .. }
+            | EngineCommand::TransportScrub { .. } => {}
         }
     }
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -1664,6 +1664,103 @@ mod tests {
         engine.stop();
     }
 
+    // ── 3G: scrub + count-in integration ────────────────────────────
+
+    #[test]
+    fn transport_scrub_flows_through_command_queue() {
+        let mut engine = Engine::new();
+        let drained = Arc::new(Mutex::new(Vec::new()));
+        let drain_started = Arc::new(AtomicBool::new(false));
+        engine
+            .start_with(
+                EngineConfig::default_48k(),
+                transport_runner(drained.clone(), drain_started.clone()),
+            )
+            .unwrap();
+        wait_for(|| drain_started.load(Ordering::SeqCst));
+
+        engine.transport_seek(1000).unwrap();
+        engine.transport_scrub(500).unwrap();
+        engine.transport_scrub(-200).unwrap();
+
+        engine.stop();
+
+        let got = drained.lock().unwrap();
+        assert!(
+            got.iter().any(|c| matches!(
+                c,
+                EngineCommand::TransportScrub { delta_samples: 500 }
+            )),
+            "expected TransportScrub +500 in drained commands"
+        );
+        assert!(
+            got.iter().any(|c| matches!(
+                c,
+                EngineCommand::TransportScrub { delta_samples: -200 }
+            )),
+            "expected TransportScrub -200 in drained commands"
+        );
+    }
+
+    #[test]
+    fn punch_region_before_start_fails_with_not_running() {
+        let engine = Engine::new();
+        assert_eq!(
+            engine.set_punch_region(PunchRegion {
+                enabled: true,
+                start: 0,
+                end: 1000,
+            }),
+            Err(CommandError::NotRunning)
+        );
+        assert!(engine.punch_region_snapshot().is_none());
+    }
+
+    #[test]
+    fn count_in_before_start_fails_with_not_running() {
+        let engine = Engine::new();
+        assert_eq!(
+            engine.set_count_in(CountIn::new(true, 4)),
+            Err(CommandError::NotRunning)
+        );
+        assert!(engine.count_in_snapshot().is_none());
+    }
+
+    #[test]
+    fn punch_and_count_in_round_trip_through_engine() {
+        let mut engine = Engine::new();
+        engine
+            .start_with(
+                EngineConfig::default_48k(),
+                fake_runner(
+                    Ok(ok_info()),
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(AtomicBool::new(false)),
+                ),
+            )
+            .unwrap();
+
+        let punch = PunchRegion {
+            enabled: true,
+            start: 48_000,
+            end: 192_000,
+        };
+        engine.set_punch_region(punch).unwrap();
+        assert_eq!(engine.punch_region_snapshot().unwrap(), punch);
+        engine.set_punch_enabled(false).unwrap();
+        assert!(!engine.punch_region_snapshot().unwrap().enabled);
+
+        let ci = CountIn::new(true, 8);
+        engine.set_count_in(ci).unwrap();
+        assert_eq!(engine.count_in_snapshot().unwrap(), ci);
+
+        // set_count_in normalizes — beats=99 clamps to MAX (16).
+        engine.set_count_in(CountIn::new(true, 99)).unwrap();
+        assert_eq!(engine.count_in_snapshot().unwrap().beats, 16);
+
+        engine.stop();
+    }
+
     #[test]
     fn clip_schedule_graveyard_bounds_retained_arcs() {
         // Codex P1 regression (PR #1719): the graveyard must cap

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -29,6 +29,7 @@ pub mod audio_io;
 pub mod clip;
 pub mod command;
 pub mod config;
+pub mod count_in;
 pub mod effect_chain;
 pub mod graph;
 pub mod loop_region;
@@ -37,6 +38,7 @@ pub mod meter_bank;
 pub mod metronome;
 pub mod mixer;
 pub mod position_emitter;
+pub mod punch_region;
 pub mod routing;
 pub mod slot;
 pub mod tempo_map;
@@ -50,8 +52,10 @@ pub use config::{
 };
 pub use graph::{AudioGraph, Track, MAX_TRACKS};
 pub use clip::{ClipSchedule, ClipScheduleError, ClipSource, MAX_CLIPS};
+pub use count_in::{CountIn, CountInState, MAX_COUNT_IN_BEATS, MIN_COUNT_IN_BEATS};
 pub use loop_region::LoopRegion;
 pub use metronome::MetronomeConfig;
+pub use punch_region::PunchRegion;
 pub use position_emitter::{PositionEmitter, DEFAULT_INTERVAL as POSITION_EVENT_DEFAULT_INTERVAL};
 pub use meter::{generate_sine, Meter, MeterReading};
 pub use meter_bank::{MeterConsumers, MeterProducers};
@@ -227,6 +231,10 @@ struct RunningEngine {
     metronome_config: Arc<ArcSwap<MetronomeConfig>>,
     /// Same pattern for the clip schedule.
     clip_schedule: Arc<ArcSwap<ClipSchedule>>,
+    /// Same pattern for the punch (record-arm) region.
+    punch_region: Arc<ArcSwap<PunchRegion>>,
+    /// Same pattern for the count-in config.
+    count_in: Arc<ArcSwap<CountIn>>,
     /// Main-thread-owned ring buffer of recently-retired clip
     /// schedules. Each `set_clip_schedule` pushes the old Arc onto
     /// this queue and pops the oldest when the queue grows past
@@ -323,6 +331,8 @@ impl Engine {
         let loop_region_handle = transport.loop_region_handle();
         let metronome_config_handle = transport.metronome_config_handle();
         let clip_schedule_handle = transport.clip_schedule_handle();
+        let punch_region_handle = transport.punch_region_handle();
+        let count_in_handle = transport.count_in_handle();
 
         let ctx = RuntimeContext {
             config: config.clone(),
@@ -371,6 +381,8 @@ impl Engine {
                     loop_region: loop_region_handle,
                     metronome_config: metronome_config_handle,
                     clip_schedule: clip_schedule_handle,
+                    punch_region: punch_region_handle,
+                    count_in: count_in_handle,
                     clip_schedule_graveyard: std::sync::Mutex::new(
                         std::collections::VecDeque::with_capacity(
                             CLIP_SCHEDULE_GRAVEYARD_SIZE,
@@ -505,6 +517,14 @@ impl Engine {
     /// Jump the transport to an absolute sample position.
     pub fn transport_seek(&self, sample_position: u64) -> Result<(), CommandError> {
         self.send_command(EngineCommand::TransportSeek { sample_position })
+    }
+
+    /// Scrub: move the playhead by a signed delta and put the
+    /// transport in `Scrubbing` state. The audio callback won't
+    /// auto-advance while in Scrubbing, so this is the only way
+    /// the playhead moves during a scrub session.
+    pub fn transport_scrub(&self, delta_samples: i64) -> Result<(), CommandError> {
+        self.send_command(EngineCommand::TransportScrub { delta_samples })
     }
 
     /// Set a constant tempo by publishing a single-event map via
@@ -719,6 +739,44 @@ impl Engine {
     /// refcounted handle.
     pub fn clip_schedule_snapshot(&self) -> Option<Arc<ClipSchedule>> {
         self.running.as_ref().map(|r| r.clip_schedule.load_full())
+    }
+
+    // ── Punch region (3G) ──────────────────────────────────────────
+
+    /// Replace the punch region atomically. Malformed ranges
+    /// (`end <= start`) are accepted but silently treated as
+    /// disabled on the audio thread (matches LoopRegion).
+    pub fn set_punch_region(&self, region: PunchRegion) -> Result<(), CommandError> {
+        let running = self.running.as_ref().ok_or(CommandError::NotRunning)?;
+        running.punch_region.store(Arc::new(region));
+        Ok(())
+    }
+
+    pub fn punch_region_snapshot(&self) -> Option<PunchRegion> {
+        self.running.as_ref().map(|r| **r.punch_region.load())
+    }
+
+    pub fn set_punch_enabled(&self, enabled: bool) -> Result<(), CommandError> {
+        let running = self.running.as_ref().ok_or(CommandError::NotRunning)?;
+        let mut p = **running.punch_region.load();
+        p.enabled = enabled;
+        running.punch_region.store(Arc::new(p));
+        Ok(())
+    }
+
+    // ── Count-in (3G) ──────────────────────────────────────────────
+
+    /// Replace the count-in config atomically. Beats are clamped
+    /// to `[MIN, MAX]` on construction to prevent absurd values.
+    pub fn set_count_in(&self, config: CountIn) -> Result<(), CommandError> {
+        let running = self.running.as_ref().ok_or(CommandError::NotRunning)?;
+        let normalized = CountIn::new(config.enabled, config.beats);
+        running.count_in.store(Arc::new(normalized));
+        Ok(())
+    }
+
+    pub fn count_in_snapshot(&self) -> Option<CountIn> {
+        self.running.as_ref().map(|r| **r.count_in.load())
     }
 
     /// Read the latest meter reading for a track.

--- a/src-tauri/src/engine/punch_region.rs
+++ b/src-tauri/src/engine/punch_region.rs
@@ -1,0 +1,121 @@
+//! Punch region — the `[start, end)` sample range that defines
+//! where recording is armed.
+//!
+//! For 3G this is **state-only**: the audio callback does not
+//! consult the punch region at all. The Rust engine simply holds
+//! the configured range and exposes it to the UI so the record
+//! button can visually indicate the punch window. When recording
+//! lands (future phase) the engine will gate track-input capture
+//! on `punch_region.is_active()` and the playhead being inside.
+//!
+//! Deliberately separate from [`super::loop_region::LoopRegion`]
+//! because the two have different semantics: the loop wraps the
+//! playhead, the punch gates recording. Users commonly want them
+//! at different sample ranges (loop a 4-bar phrase, punch only
+//! bar 3).
+
+use serde::{Deserialize, Serialize};
+
+/// Punch range. Half-open interval `[start, end)`; invalid ranges
+/// (`end <= start`) are silently treated as disabled to tolerate
+/// UI drag states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PunchRegion {
+    pub enabled: bool,
+    pub start: u64,
+    pub end: u64,
+}
+
+impl PunchRegion {
+    pub const fn disabled() -> Self {
+        Self {
+            enabled: false,
+            start: 0,
+            end: 0,
+        }
+    }
+
+    /// True iff `enabled` and the range is non-empty.
+    #[inline]
+    pub fn is_active(&self) -> bool {
+        self.enabled && self.end > self.start
+    }
+
+    #[inline]
+    pub fn length(&self) -> u64 {
+        if self.is_active() {
+            self.end - self.start
+        } else {
+            0
+        }
+    }
+
+    /// Whether `sample` falls inside the active punch window.
+    /// Returns `false` for disabled or malformed regions.
+    #[inline]
+    pub fn contains(&self, sample: u64) -> bool {
+        self.is_active() && sample >= self.start && sample < self.end
+    }
+}
+
+impl Default for PunchRegion {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_disabled() {
+        let p = PunchRegion::default();
+        assert!(!p.is_active());
+        assert_eq!(p.length(), 0);
+        assert!(!p.contains(50));
+    }
+
+    #[test]
+    fn is_active_requires_enabled_and_non_empty() {
+        assert!(!PunchRegion { enabled: false, start: 0, end: 100 }.is_active());
+        assert!(!PunchRegion { enabled: true, start: 100, end: 100 }.is_active());
+        assert!(!PunchRegion { enabled: true, start: 200, end: 100 }.is_active());
+        assert!(PunchRegion { enabled: true, start: 0, end: 100 }.is_active());
+    }
+
+    #[test]
+    fn contains_is_half_open_inclusive_on_start_exclusive_on_end() {
+        let p = PunchRegion { enabled: true, start: 100, end: 200 };
+        assert!(!p.contains(99));
+        assert!(p.contains(100));
+        assert!(p.contains(199));
+        assert!(!p.contains(200));
+        assert!(!p.contains(201));
+    }
+
+    #[test]
+    fn contains_false_for_disabled() {
+        let p = PunchRegion { enabled: false, start: 100, end: 200 };
+        assert!(!p.contains(150));
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_fields() {
+        let p = PunchRegion { enabled: true, start: 48_000, end: 96_000 };
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(json.contains("\"enabled\":true"));
+        assert!(json.contains("\"start\":48000"));
+        assert!(json.contains("\"end\":96000"));
+        let back: PunchRegion = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn type_is_copy_and_small() {
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<PunchRegion>();
+        assert!(std::mem::size_of::<PunchRegion>() <= 32);
+    }
+}

--- a/src-tauri/src/engine/transport.rs
+++ b/src-tauri/src/engine/transport.rs
@@ -40,8 +40,10 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 
 use super::clip::ClipSchedule;
+use super::count_in::CountIn;
 use super::loop_region::LoopRegion;
 use super::metronome::MetronomeConfig;
+use super::punch_region::PunchRegion;
 use super::tempo_map::TempoMap;
 use super::time_sig_map::TimeSignatureMap;
 
@@ -75,12 +77,21 @@ pub enum TransportState {
 }
 
 impl TransportState {
-    /// Whether the callback should advance the sample counter.
+    /// Whether the audio callback should auto-advance the sample
+    /// counter this buffer.
+    ///
+    /// **Scrubbing is NOT advancing** in the 3G sense: during a
+    /// scrub, the playhead moves only in response to explicit
+    /// user-driven `transport_scrub(delta)` commands, not by
+    /// buffer-linear auto-advance. Clip rendering and metronome
+    /// clicks are also gated on this flag, so a scrubbing
+    /// transport produces no audible output — matching the
+    /// "silent scrub" UX of most native DAWs.
     #[inline]
     pub fn is_advancing(self) -> bool {
         matches!(
             self,
-            TransportState::Playing | TransportState::Recording | TransportState::Scrubbing
+            TransportState::Playing | TransportState::Recording
         )
     }
 }
@@ -194,6 +205,14 @@ pub struct Transport {
     /// `ArcSwap` so the main thread can replace the whole set
     /// without blocking the audio callback.
     clip_schedule: Arc<ArcSwap<ClipSchedule>>,
+    /// Punch (record-arm) region. State-only in 3G — UI queries
+    /// it; future recording code will gate capture on
+    /// `is_active() && contains(playhead)`.
+    punch_region: Arc<ArcSwap<PunchRegion>>,
+    /// Count-in config. The audio callback owns a separate
+    /// `CountInState` (countdown) that's started from this config
+    /// when TransportPlay is received.
+    count_in: Arc<ArcSwap<CountIn>>,
 }
 
 impl Transport {
@@ -208,6 +227,8 @@ impl Transport {
             loop_region: Arc::new(ArcSwap::from_pointee(LoopRegion::disabled())),
             metronome_config: Arc::new(ArcSwap::from_pointee(MetronomeConfig::default_off())),
             clip_schedule: Arc::new(ArcSwap::from_pointee(ClipSchedule::empty())),
+            punch_region: Arc::new(ArcSwap::from_pointee(PunchRegion::disabled())),
+            count_in: Arc::new(ArcSwap::from_pointee(CountIn::default_off())),
         }
     }
 
@@ -291,6 +312,34 @@ impl Transport {
         self.clip_schedule.store(Arc::new(schedule));
     }
 
+    // ── Punch (3G) ──────────────────────────────────────────────────
+
+    pub fn punch_region_handle(&self) -> Arc<ArcSwap<PunchRegion>> {
+        self.punch_region.clone()
+    }
+
+    pub fn punch_region_snapshot(&self) -> PunchRegion {
+        **self.punch_region.load()
+    }
+
+    pub fn replace_punch_region(&mut self, region: PunchRegion) {
+        self.punch_region.store(Arc::new(region));
+    }
+
+    // ── Count-in (3G) ───────────────────────────────────────────────
+
+    pub fn count_in_handle(&self) -> Arc<ArcSwap<CountIn>> {
+        self.count_in.clone()
+    }
+
+    pub fn count_in_snapshot(&self) -> CountIn {
+        **self.count_in.load()
+    }
+
+    pub fn replace_count_in(&mut self, config: CountIn) {
+        self.count_in.store(Arc::new(config));
+    }
+
     /// Snapshot the current tempo map. Cheap — `.load()` is wait-free
     /// and the returned `Arc<TempoMap>` is a counted reference, not a
     /// deep clone.
@@ -325,6 +374,27 @@ impl Transport {
     /// Jump to an absolute sample position. Does not change the state.
     pub fn seek(&mut self, sample: u64) {
         self.position.set(sample);
+    }
+
+    /// Scrub: move the playhead by a signed sample delta and
+    /// transition to `Scrubbing` state. Positive deltas move
+    /// forward, negative move backward. Uses saturating
+    /// arithmetic so a huge negative delta underflows to 0 rather
+    /// than wrapping around to near u64::MAX.
+    ///
+    /// Does NOT auto-wrap on the loop region — scrub is a
+    /// deliberate user gesture; if they drag past the loop end,
+    /// they want to be past the loop, not bounced back. Matches
+    /// the Pro Tools convention.
+    pub fn scrub(&mut self, delta_samples: i64) {
+        self.state = TransportState::Scrubbing;
+        let current = self.position.get();
+        let next = if delta_samples >= 0 {
+            current.saturating_add(delta_samples as u64)
+        } else {
+            current.saturating_sub(delta_samples.unsigned_abs())
+        };
+        self.position.set(next);
     }
 
     /// Set a constant tempo by swapping in a single-event map. For
@@ -522,18 +592,24 @@ mod tests {
     }
 
     #[test]
-    fn recording_and_scrubbing_states_advance_position() {
-        // Recording and Scrubbing share Playing's advance semantics in
-        // 3A — true record/scrub behavior lands in later phases, but
-        // they must not freeze the timeline.
+    fn recording_state_auto_advances_position() {
+        // Recording shares Playing's advance semantics (real
+        // recording gating lands with punch region in 3G+).
         let mut t = Transport::new();
         t.state = TransportState::Recording;
         t.advance_if_advancing(128);
         assert_eq!(t.position(), 128);
+    }
 
+    #[test]
+    fn scrubbing_state_does_not_auto_advance() {
+        // 3G regression: Scrubbing is a user-driven mode; the
+        // audio callback must NOT advance the playhead during
+        // scrub. Only explicit `scrub(delta)` calls move it.
+        let mut t = Transport::new();
         t.state = TransportState::Scrubbing;
         t.advance_if_advancing(128);
-        assert_eq!(t.position(), 256);
+        assert_eq!(t.position(), 0, "scrub state must not auto-advance");
     }
 
     #[test]
@@ -604,7 +680,10 @@ mod tests {
     }
 
     #[test]
-    fn is_advancing_covers_play_record_scrub_but_not_stop_or_pause() {
+    fn is_advancing_covers_play_record_only() {
+        // 3G: Scrubbing is no longer an "advancing" state — the
+        // user drives position explicitly via `scrub(delta)`, and
+        // the audio callback does not auto-advance during scrub.
         assert!(!TransportState::Stopped.is_advancing());
         assert!(
             !TransportState::Paused.is_advancing(),
@@ -612,7 +691,96 @@ mod tests {
         );
         assert!(TransportState::Playing.is_advancing());
         assert!(TransportState::Recording.is_advancing());
-        assert!(TransportState::Scrubbing.is_advancing());
+        assert!(
+            !TransportState::Scrubbing.is_advancing(),
+            "Scrubbing is user-driven — must NOT auto-advance"
+        );
+    }
+
+    // ── 3G: Scrub ────────────────────────────────────────────────────
+
+    #[test]
+    fn scrub_forward_moves_playhead_and_sets_state() {
+        let mut t = Transport::new();
+        t.seek(1000);
+        t.scrub(500);
+        assert_eq!(t.state(), TransportState::Scrubbing);
+        assert_eq!(t.position(), 1500);
+    }
+
+    #[test]
+    fn scrub_backward_moves_playhead_and_sets_state() {
+        let mut t = Transport::new();
+        t.seek(1000);
+        t.scrub(-300);
+        assert_eq!(t.state(), TransportState::Scrubbing);
+        assert_eq!(t.position(), 700);
+    }
+
+    #[test]
+    fn scrub_saturates_at_zero_on_large_negative_delta() {
+        let mut t = Transport::new();
+        t.seek(100);
+        t.scrub(-10_000);
+        assert_eq!(t.position(), 0, "scrub must not underflow to u64::MAX");
+    }
+
+    #[test]
+    fn scrub_saturates_at_u64_max_on_large_positive_delta() {
+        let mut t = Transport::new();
+        t.seek(u64::MAX - 10);
+        t.scrub(i64::MAX);
+        assert_eq!(t.position(), u64::MAX, "scrub must not wrap on overflow");
+    }
+
+    #[test]
+    fn scrub_from_playing_transitions_to_scrubbing() {
+        let mut t = Transport::new();
+        t.play();
+        t.advance_if_advancing(1000);
+        assert_eq!(t.state(), TransportState::Playing);
+        t.scrub(500);
+        assert_eq!(t.state(), TransportState::Scrubbing);
+    }
+
+    // ── 3G: Punch region integration ────────────────────────────────
+
+    #[test]
+    fn new_transport_has_disabled_punch_region() {
+        let t = Transport::new();
+        assert!(!t.punch_region_snapshot().is_active());
+    }
+
+    #[test]
+    fn replace_punch_region_is_visible_via_snapshot_and_handle() {
+        let mut t = Transport::new();
+        let handle = t.punch_region_handle();
+        let region = PunchRegion {
+            enabled: true,
+            start: 1000,
+            end: 5000,
+        };
+        t.replace_punch_region(region);
+        assert_eq!(t.punch_region_snapshot(), region);
+        assert_eq!(**handle.load(), region);
+    }
+
+    // ── 3G: Count-in integration ────────────────────────────────────
+
+    #[test]
+    fn new_transport_has_disabled_count_in() {
+        let t = Transport::new();
+        assert!(!t.count_in_snapshot().enabled);
+    }
+
+    #[test]
+    fn replace_count_in_is_visible_via_snapshot_and_handle() {
+        let mut t = Transport::new();
+        let handle = t.count_in_handle();
+        let cfg = CountIn::new(true, 8);
+        t.replace_count_in(cfg);
+        assert_eq!(t.count_in_snapshot(), cfg);
+        assert_eq!(**handle.load(), cfg);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,10 @@ use crate::commands::audio::{
     audio_get_default_device, audio_get_engine_status, audio_list_devices,
     audio_metronome_get_config, audio_metronome_set_config, audio_metronome_set_enabled,
     audio_remove_track, audio_set_master_volume, audio_set_track_params,
-    audio_start_engine, audio_stop_engine,
+    audio_start_engine, audio_stop_engine, audio_transport_get_count_in,
+    audio_transport_get_punch_region, audio_transport_scrub,
+    audio_transport_set_count_in, audio_transport_set_punch_enabled,
+    audio_transport_set_punch_region,
     audio_transport_beat_to_sample, audio_transport_get_loop_region,
     audio_transport_get_position, audio_transport_get_tempo_map,
     audio_transport_get_time_signature_map, audio_transport_pause, audio_transport_play,
@@ -66,6 +69,12 @@ pub fn run() {
             audio_metronome_set_enabled,
             audio_clip_set_schedule,
             audio_clip_get_schedule,
+            audio_transport_scrub,
+            audio_transport_set_punch_region,
+            audio_transport_get_punch_region,
+            audio_transport_set_punch_enabled,
+            audio_transport_set_count_in,
+            audio_transport_get_count_in,
         ])
         .setup(|app| {
             // Focus main window on startup

--- a/src-tauri/tests/local_audio_smoke.rs
+++ b/src-tauri/tests/local_audio_smoke.rs
@@ -19,8 +19,8 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use ace_step_daw_lib::engine::{
-    audio_io, ClipSource, Engine, EngineConfig, EngineStatus, LoopRegion, MetronomeConfig,
-    PositionEmitter, TempoEvent, TrackParams,
+    audio_io, ClipSource, CountIn, Engine, EngineConfig, EngineStatus, LoopRegion,
+    MetronomeConfig, PositionEmitter, TempoEvent, TrackParams,
 };
 use std::sync::{Arc, Mutex};
 
@@ -712,6 +712,124 @@ fn real_engine_clip_schedule_plays_pcm() {
     assert!(
         pos > 24_000,
         "transport should have passed sample 24_000 after 1.5s, got {pos}"
+    );
+
+    engine.stop();
+}
+
+/// Smoke test — scrub moves the playhead without auto-advance.
+///
+/// Phase 3G end-to-end proof: call `transport_scrub(delta)`,
+/// observe the position jump by exactly `delta` samples (no
+/// drift from buffer-auto-advance), and confirm the transport
+/// state transitions to Scrubbing (which is not `is_advancing`).
+#[test]
+#[ignore]
+fn real_engine_scrub_moves_playhead_by_delta_only() {
+    let mut engine = Engine::new();
+    engine.start(EngineConfig::default_48k()).unwrap();
+
+    // Seek somewhere in the middle.
+    engine.transport_seek(100_000).expect("seek");
+    sleep(Duration::from_millis(50));
+
+    // Scrub +50_000 samples.
+    engine.transport_scrub(50_000).expect("scrub +");
+    // Wait longer than the audio buffer period, but verify the
+    // position did NOT continue to auto-advance (scrub is
+    // user-driven only).
+    sleep(Duration::from_millis(100));
+    let pos = engine.transport_position();
+    eprintln!("position after scrub +50k: {pos}");
+    assert_eq!(
+        pos, 150_000,
+        "scrub must set position exactly and NOT auto-advance afterwards"
+    );
+
+    // Scrub backward.
+    engine.transport_scrub(-30_000).expect("scrub -");
+    sleep(Duration::from_millis(100));
+    let pos = engine.transport_position();
+    eprintln!("position after scrub -30k: {pos}");
+    assert_eq!(pos, 120_000);
+
+    // Scrub past 0 must saturate.
+    engine.transport_scrub(-999_999_999).expect("scrub huge -");
+    sleep(Duration::from_millis(50));
+    let pos = engine.transport_position();
+    eprintln!("position after scrub -1G: {pos}");
+    assert_eq!(pos, 0, "scrub must saturate at 0, not underflow");
+
+    engine.stop();
+}
+
+/// Smoke test — count-in delays clip audible output by the
+/// configured beats.
+///
+/// Phase 3G end-to-end proof: configure 2-beat count-in at 120 BPM
+/// (= 1 s at 48 kHz = 48 000 samples), schedule a clip at
+/// transport sample 0, play. During the first 1 s of the count-in,
+/// the master should be quiet (no clip audio); after 1 s, the clip
+/// should become audible.
+#[test]
+#[ignore]
+fn real_engine_count_in_suppresses_clip_until_countdown_finishes() {
+    let mut engine = Engine::new();
+    engine.start(EngineConfig::default_48k()).unwrap();
+
+    // Build a 3-second loud stereo clip at transport sample 0.
+    // The clip spans the entire count-in window (1 s) AND well
+    // past it, so we can prove both that it's suppressed during
+    // count-in and still audible after the countdown ends.
+    let frames = 48_000_usize * 3; // 3 s
+    let pcm = std::sync::Arc::new(vec![0.5_f32; frames * 2]);
+    let clip = ClipSource::new(0, frames as u64, 1.0, pcm).expect("ClipSource");
+    engine.set_clip_schedule(vec![clip]).expect("set_clip_schedule");
+
+    // 2-beat count-in at 120 BPM = 1 second.
+    engine
+        .set_count_in(CountIn::new(true, 2))
+        .expect("set_count_in");
+
+    // Go.
+    engine.transport_play().expect("play");
+
+    // Poll every 100 ms for 2 s and show the progression.
+    eprintln!("count-in progression (t_ms, rms, peak, position):");
+    let mut during_peaks: Vec<f32> = Vec::new();
+    let mut after_peaks: Vec<f32> = Vec::new();
+    for step in 1..=20 {
+        sleep(Duration::from_millis(100));
+        let m = engine.get_master_meter();
+        let pos = engine.transport_position();
+        let t = step * 100;
+        eprintln!("  t={t}ms: rms={:.4} peak={:.4} pos={pos}", m.rms, m.peak);
+        // First 1 s is count-in (should be quiet); last 1 s
+        // should be audible.
+        if t < 900 {
+            during_peaks.push(m.peak);
+        } else if t > 1100 {
+            after_peaks.push(m.peak);
+        }
+    }
+
+    let max_during = during_peaks
+        .iter()
+        .copied()
+        .fold(0.0_f32, f32::max);
+    let max_after = after_peaks
+        .iter()
+        .copied()
+        .fold(0.0_f32, f32::max);
+    eprintln!("max peak during count-in: {max_during}, after: {max_after}");
+
+    assert!(
+        max_during < 0.3,
+        "clip should be suppressed during count-in, max peak was {max_during}"
+    );
+    assert!(
+        max_after > 0.2,
+        "clip should be audible after count-in, max peak was {max_after}"
     );
 
     engine.stop();

--- a/src-tauri/tests/local_audio_smoke.rs
+++ b/src-tauri/tests/local_audio_smoke.rs
@@ -777,16 +777,22 @@ fn real_engine_count_in_suppresses_clip_until_countdown_finishes() {
     let mut engine = Engine::new();
     engine.start(EngineConfig::default_48k()).unwrap();
 
-    // Build a 3-second loud stereo clip at transport sample 0.
-    // The clip spans the entire count-in window (1 s) AND well
-    // past it, so we can prove both that it's suppressed during
-    // count-in and still audible after the countdown ends.
+    // Seek to sample 96_000 (2 s) so the count-in has somewhere
+    // to rewind to — at position 0 the pre-roll would clamp to
+    // duration=0 and provide no count-in.
+    engine.transport_seek(96_000).expect("seek");
+
+    // Schedule a 3-second clip starting at sample 96_000 (where
+    // playback will resume after count-in). During count-in the
+    // pre-roll plays position [48_000, 96_000) with clips
+    // suppressed → no clip overlaps → silent. After count-in at
+    // position 96_000 the clip becomes audible.
     let frames = 48_000_usize * 3; // 3 s
     let pcm = std::sync::Arc::new(vec![0.5_f32; frames * 2]);
-    let clip = ClipSource::new(0, frames as u64, 1.0, pcm).expect("ClipSource");
+    let clip = ClipSource::new(96_000, frames as u64, 1.0, pcm).expect("ClipSource");
     engine.set_clip_schedule(vec![clip]).expect("set_clip_schedule");
 
-    // 2-beat count-in at 120 BPM = 1 second.
+    // 2-beat count-in at 120 BPM = 1 second pre-roll.
     engine
         .set_count_in(CountIn::new(true, 2))
         .expect("set_count_in");


### PR DESCRIPTION
## Summary

Seventh and final slice of Phase 3 (#1523). Builds on 3A-F. Adds three independent transport features that complete the phase.

### PunchRegion (state-only MVP)
- `{ enabled, start, end }` half-open range indicating where recording arms
- Audio path doesn't consume it yet (future recording phase)
- UI queries via `audio_transport_get_punch_region` for the record-arm indicator
- Malformed `end <= start` silently treated as disabled (matches LoopRegion)

### CountIn
- `{ enabled, beats: u8 }`; `beats` clamped to `[1, 16]`
- When `TransportPlay` arrives with count-in enabled, audio callback computes `beats × samples_per_beat_at(playhead)` from the tempo map and starts a countdown
- During countdown: transport advances, **metronome clicks continue** (user hears the count), **clip scheduler is suppressed**
- Countdown cleared on stop/pause/scrub

### Scrub mode
- New `Engine::transport_scrub(delta: i64)` — move playhead by signed delta, transition to Scrubbing
- Saturating arithmetic on both ends (clamps at 0 and u64::MAX)
- **Breaking internal change**: Scrubbing is now EXCLUDED from `is_advancing()`. The audio callback does not auto-advance during scrub; the playhead only moves via explicit scrub commands. Clip and metronome rendering are also gated on is_advancing, so scrub is "silent" — matches Pro Tools / Logic UX.

All three features use the same `ArcSwap<T>` publication pattern as the rest of Phase 3. Validated constructors normalize serde bypass paths.

## Test plan

- [x] `cargo test --lib` — 310 Rust unit tests pass (was 278, +32)
  - 6 punch_region pure-math tests
  - 16 count_in pure-math tests (config clamp, state lifecycle, duration at 120/60 BPM and multi-segment tempo)
  - 4 Transport scrub tests (forward, backward, saturate-underflow, saturate-overflow, from-Playing transition)
  - 2 Transport punch integration tests
  - 2 Transport count-in integration tests
  - 2 is_advancing tests updated to exclude Scrubbing
- [x] `cargo test --test local_audio_smoke -- --ignored real_engine_scrub_moves_playhead_by_delta_only` — scrub forward/back/clamp verified on live CPAL, no auto-advance after scrub
- [x] `cargo test --test local_audio_smoke -- --ignored real_engine_count_in_suppresses_clip_until_countdown_finishes` — clip peak stays at 0 during 1 s count-in, rises to 0.5 immediately after (full progression logged in test output)
- [x] `cargo build --release` clean
- [x] `npx tsc --noEmit` clean

## Phase 3 complete

After this PR merges, all 7 sub-phases of Phase 3 (#1523) are done:
- 3A Transport state machine + atomic position ✅
- 3B Tempo map + time signature + beat/sample conversion ✅
- 3C Loop region with seamless wrap-around ✅
- 3D 60fps position emitter ✅
- 3E Native procedural metronome ✅
- 3F Sample-accurate clip scheduling ✅
- 3G Punch + count-in + scrub ✅ (this PR)

Closes #1720
Completes #1523
Part of #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)