### PR TITLE
feat: Phase 5C — migrate useAudioEngine.ts off direct Tone.js

### DIFF
--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -38,9 +38,12 @@ export function useAudioEngine() {
 
   const resumeOnGesture = useCallback(async () => {
     // AudioEngine.resume() resumes the underlying AudioContext that
-    // Tone.js also uses (configured via configureNativeDsp in
-    // AudioEngine construction), so a separate Tone.start() is
-    // redundant. Verified by codex review on PR #1723.
+    // Tone.js also uses — AudioEngine's constructor calls
+    // `Tone.setContext(ctx)` so `Tone.start()` (which is literally
+    // `globalContext.resume()` in tone@15.1.22) would resume the
+    // same context. The parallel `Promise.all([engine.resume(),
+    // Tone.start()])` was redundant work. Verified by codex review
+    // on PR #1727.
     await engineRef.current.resume();
     const latency = engineRef.current.refreshPlaybackLatencyCompensation();
     const store = (await import('../store/projectStore')).useProjectStore.getState();

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1,5 +1,4 @@
 import { useRef, useEffect, useCallback } from 'react';
-import * as Tone from 'tone';
 import { AudioEngine } from '../engine/AudioEngine';
 import { useTransportStore } from '../store/transportStore';
 import { useProjectStore } from '../store/projectStore';
@@ -38,10 +37,11 @@ export function useAudioEngine() {
   }, []);
 
   const resumeOnGesture = useCallback(async () => {
-    await Promise.all([
-      engineRef.current.resume(),
-      Tone.start(),
-    ]);
+    // AudioEngine.resume() resumes the underlying AudioContext that
+    // Tone.js also uses (configured via configureNativeDsp in
+    // AudioEngine construction), so a separate Tone.start() is
+    // redundant. Verified by codex review on PR #1723.
+    await engineRef.current.resume();
     const latency = engineRef.current.refreshPlaybackLatencyCompensation();
     const store = (await import('../store/projectStore')).useProjectStore.getState();
     store.detectPlaybackLatency(latency);

--- a/tests/unit/playbackLatencyCalibration.test.tsx
+++ b/tests/unit/playbackLatencyCalibration.test.tsx
@@ -188,9 +188,10 @@ describe('playback latency calibration', () => {
 
     expect(mockEngineResume).toHaveBeenCalledTimes(1);
     // Phase 5C: useAudioEngine no longer calls Tone.start() directly.
-    // AudioEngine.resume() resumes the shared AudioContext that Tone
-    // also uses, so Tone.start is redundant. toneStart mock should
-    // not have been invoked.
+    // This unit asserts only the direct API surface — the underlying
+    // shared-context contract (AudioEngine calls Tone.setContext on
+    // the same AudioContext, so resuming the context is sufficient)
+    // is verified elsewhere; here `AudioEngine` is mocked.
     expect(toneStart).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/playbackLatencyCalibration.test.tsx
+++ b/tests/unit/playbackLatencyCalibration.test.tsx
@@ -187,7 +187,11 @@ describe('playback latency calibration', () => {
     });
 
     expect(mockEngineResume).toHaveBeenCalledTimes(1);
-    expect(toneStart).toHaveBeenCalledTimes(1);
+    // Phase 5C: useAudioEngine no longer calls Tone.start() directly.
+    // AudioEngine.resume() resumes the shared AudioContext that Tone
+    // also uses, so Tone.start is redundant. toneStart mock should
+    // not have been invoked.
+    expect(toneStart).not.toHaveBeenCalled();
   });
 
   it('keeps the fallback state when the browser exposes no latency values on resume', async () => {


### PR DESCRIPTION
## Summary

Third atomic slice of Phase 5 (#1525). Removes the single `Tone.start()` call from `useAudioEngine.resumeOnGesture()` — redundant because `AudioEngine.resume()` already resumes the same underlying `AudioContext` (verified by codex review on PR #1723).

- `await Promise.all([engine.resume(), Tone.start()])` → `await engine.resume()`
- Removed `import * as Tone from 'tone'`
- Updated `playbackLatencyCalibration.test.tsx` to assert `toneStart` is NOT called (was `called 1 time`)

## Test plan

- [x] `npm test` — 7291 pass, same 2 pre-existing clipResizeModifiers failures
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean

Closes #1726
Part of #1525, #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)