### PR TITLE
feat: Phase 5D — migrate GranularEngine off direct Tone.js

### DIFF
--- a/src/engine/GranularEngine.ts
+++ b/src/engine/GranularEngine.ts
@@ -136,9 +136,12 @@ class GranularEngine {
   }
 
   async ensureStarted(): Promise<void> {
-    const ctx = getAudioEngine().ctx;
-    if (ctx.state !== 'running') {
-      await getAudioEngine().resume();
+    // Cache the engine handle into a local — `getAudioEngine()` is
+    // a singleton accessor today but taking it once is cheaper and
+    // robust against future changes (Copilot review on PR #1729).
+    const engine = getAudioEngine();
+    if (engine.ctx.state !== 'running') {
+      await engine.resume();
     }
   }
 

--- a/src/engine/GranularEngine.ts
+++ b/src/engine/GranularEngine.ts
@@ -1,4 +1,3 @@
-import * as Tone from 'tone';
 import type { GranularSettings, GrainEnvelopeShape, Track } from '../types/project';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { getAudioEngine } from '../hooks/useAudioEngine';
@@ -128,12 +127,18 @@ class GranularEngine {
   private readonly bufferCache = new Map<string, AudioBuffer>();
 
   private getContext(): AudioContext {
-    return Tone.getContext().rawContext as AudioContext;
+    // Route through AudioEngine rather than Tone.getContext() —
+    // both return the same underlying AudioContext (AudioEngine's
+    // constructor calls Tone.setContext(ctx) on its own Web Audio
+    // context). Codex verified the shared-context invariant in
+    // PR #1727. Phase 5D migration.
+    return getAudioEngine().ctx;
   }
 
   async ensureStarted(): Promise<void> {
-    if (Tone.getContext().state !== 'running') {
-      await Tone.start();
+    const ctx = getAudioEngine().ctx;
+    if (ctx.state !== 'running') {
+      await getAudioEngine().resume();
     }
   }
 

--- a/src/engine/__tests__/GranularEngine.test.ts
+++ b/src/engine/__tests__/GranularEngine.test.ts
@@ -9,6 +9,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // `vi.hoisted` so the hoisted `vi.mock(...)` factories can see it.
 const { _mockCtx } = vi.hoisted(() => {
   const ctx = {
+    // `state: 'running'` mirrors the old `Tone.getContext()` mock
+    // and keeps `GranularEngine.ensureStarted()` from always calling
+    // `resume()` in future tests that exercise the start path.
+    // Codex P3 on PR #1729.
+    state: 'running' as AudioContextState,
     currentTime: 0,
     destination: {},
     createGain: vi.fn(() => ({

--- a/src/engine/__tests__/GranularEngine.test.ts
+++ b/src/engine/__tests__/GranularEngine.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Mocks must be hoisted — no top-level variable references ─────────────────
 
-vi.mock('tone', () => {
-  const _mockCtx = {
+// Shared mock AudioContext used by both the `tone` mock (for
+// `Tone.getContext().rawContext`, only read by test assertions now)
+// and the `useAudioEngine` mock (for `getAudioEngine().ctx`, the
+// real code path after the 5D migration). Must be defined via
+// `vi.hoisted` so the hoisted `vi.mock(...)` factories can see it.
+const { _mockCtx } = vi.hoisted(() => {
+  const ctx = {
     currentTime: 0,
     destination: {},
     createGain: vi.fn(() => ({
@@ -39,6 +44,10 @@ vi.mock('tone', () => {
       };
     }),
   };
+  return { _mockCtx: ctx };
+});
+
+vi.mock('tone', () => {
   return {
     getContext: vi.fn().mockReturnValue({
       state: 'running',
@@ -55,6 +64,7 @@ vi.mock('../../services/audioFileManager', () => ({
 
 vi.mock('../../hooks/useAudioEngine', () => ({
   getAudioEngine: vi.fn().mockReturnValue({
+    ctx: _mockCtx,
     resume: vi.fn(),
     decodeAudioData: vi.fn(),
   }),


### PR DESCRIPTION
## Summary

Fourth atomic slice of Phase 5 (#1525). Smallest remaining Tone.js footprint in the engine directory (3 refs in GranularEngine, all context helpers).

- `Tone.getContext().rawContext as AudioContext` → `getAudioEngine().ctx`
- `Tone.getContext().state` → `getAudioEngine().ctx.state`
- `Tone.start()` → `getAudioEngine().resume()`

Same net no-op: codex already verified in PR #1727 that `AudioEngine.ctx` IS the AudioContext Tone.js uses (via `Tone.setContext(ctx)` in AudioEngine's constructor).

Test update: moved the shared mock AudioContext into `vi.hoisted` so both the `tone` mock and the new `useAudioEngine` mock can share it. 36/36 granular tests pass.

## Originally scoped, deferred

- `offlineRender.ts` — uses `Tone.Offline` + Tone-based synths. Full migration requires migrating SynthEngine first.
- `ToneAdapter.ts` — DSP factory fallback. Deletion requires an audit of the factory pattern.

Both addressed in later sub-phases.

## Test plan

- [x] `npm test` — 7291 tests pass, 2 pre-existing failures
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` green

Closes #1728
Part of #1525, #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)