### PR TITLE
feat: Phase 5E — migrate RecordingEngine off direct Tone.js

### DIFF
--- a/src/engine/RecordingEngine.ts
+++ b/src/engine/RecordingEngine.ts
@@ -3,10 +3,45 @@
  * input level metering, and real-time waveform capture.
  */
 
-import * as Tone from 'tone';
 import { createDebugLogger } from '../utils/debugLogger';
+import { getAudioEngine } from '../hooks/useAudioEngine';
 
 const log = createDebugLogger('recording-engine');
+
+/**
+ * Fire a short percussive click using only native Web Audio —
+ * drop-in replacement for the `Tone.MembraneSynth.triggerAttackRelease`
+ * pattern used by the count-in and metronome below.
+ *
+ * Models a kick-like click: starts at `startFreq`, exponentially
+ * sweeps to `endFreq` over `decayMs`, with a linear attack and
+ * exponential amplitude decay. Fresh nodes per trigger — the
+ * oscillator stops itself so there is nothing to dispose.
+ */
+function playClick(
+  ctx: AudioContext,
+  destination: AudioNode,
+  startFreq: number,
+  endFreq: number,
+  decayMs: number,
+  volume: number,
+): void {
+  const now = ctx.currentTime;
+  const endTime = now + decayMs / 1000;
+  const osc = ctx.createOscillator();
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(startFreq, now);
+  osc.frequency.exponentialRampToValueAtTime(Math.max(endFreq, 1), endTime);
+
+  const gain = ctx.createGain();
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.linearRampToValueAtTime(volume, now + 0.001);
+  gain.gain.exponentialRampToValueAtTime(0.0001, endTime);
+
+  osc.connect(gain).connect(destination);
+  osc.start(now);
+  osc.stop(endTime + 0.02);
+}
 
 export interface AudioInputDevice {
   deviceId: string;
@@ -404,21 +439,15 @@ class RecordingEngine {
     const totalBeats = bars * beatsPerBar;
     const beatDuration = 60 / bpm;
 
-    await Tone.start();
-
-    const clickHi = new Tone.MembraneSynth({
-      pitchDecay: 0.01,
-      octaves: 6,
-      oscillator: { type: 'sine' },
-      envelope: { attack: 0.001, decay: 0.05, sustain: 0, release: 0.01 },
-    }).toDestination();
-
-    const clickLo = new Tone.MembraneSynth({
-      pitchDecay: 0.01,
-      octaves: 4,
-      oscillator: { type: 'sine' },
-      envelope: { attack: 0.001, decay: 0.05, sustain: 0, release: 0.01 },
-    }).toDestination();
+    const engine = getAudioEngine();
+    await engine.resume();
+    const ctx = engine.ctx;
+    // Hi click (downbeat) and lo click (other beats) — pitch
+    // parameters picked to match the old Tone.MembraneSynth
+    // (pitchDecay 0.01, octaves 6/4 from C5/C4) closely enough to
+    // keep the perceptual "kick click" character.
+    const clickHi = () => playClick(ctx, ctx.destination, 800, 120, 60, 0.6);
+    const clickLo = () => playClick(ctx, ctx.destination, 400, 90, 60, 0.5);
 
     for (let i = 0; i < totalBeats; i++) {
       const bar = Math.floor(i / beatsPerBar);
@@ -426,17 +455,15 @@ class RecordingEngine {
       onBeat(bar, beat, totalBeats - i);
 
       if (beat === 0) {
-        clickHi.triggerAttackRelease('C5', '32n');
+        clickHi();
       } else {
-        clickLo.triggerAttackRelease('C4', '32n');
+        clickLo();
       }
 
       await new Promise<void>(resolve => setTimeout(resolve, beatDuration * 1000));
     }
 
     this.isCountingIn = false;
-    clickHi.dispose();
-    clickLo.dispose();
   }
 
   get countingIn() { return this.isCountingIn; }
@@ -444,36 +471,32 @@ class RecordingEngine {
   // --- Metronome ---
 
   startMetronome(bpm: number, beatsPerBar: number): () => void {
-    const clickHi = new Tone.MembraneSynth({
-      pitchDecay: 0.008,
-      octaves: 6,
-      oscillator: { type: 'sine' },
-      envelope: { attack: 0.001, decay: 0.05, sustain: 0, release: 0.01 },
-    }).toDestination();
-    clickHi.volume.value = -6;
-
-    const clickLo = new Tone.MembraneSynth({
-      pitchDecay: 0.008,
-      octaves: 4,
-      oscillator: { type: 'sine' },
-      envelope: { attack: 0.001, decay: 0.04, sustain: 0, release: 0.01 },
-    }).toDestination();
-    clickLo.volume.value = -10;
+    // Recording-time metronome. Not sample-accurate — the Rust
+    // engine owns the sample-accurate metronome in Phase 3E; this
+    // is the pre-roll clicker that plays wallclock-driven during
+    // a recording session.
+    const engine = getAudioEngine();
+    const ctx = engine.ctx;
+    // -6 dB ≈ 0.5 linear, -10 dB ≈ 0.316 linear (matches the old
+    // Tone.MembraneSynth volume.value settings).
+    const hiVolume = 0.5;
+    const loVolume = 0.316;
+    const clickHi = () => playClick(ctx, ctx.destination, 800, 120, 50, hiVolume);
+    const clickLo = () => playClick(ctx, ctx.destination, 400, 90, 40, loVolume);
 
     let beat = 0;
-    const id = Tone.getTransport().scheduleRepeat((time) => {
+    const beatInterval = (60 / bpm) * 1000;
+    const intervalId = setInterval(() => {
       if (beat % beatsPerBar === 0) {
-        clickHi.triggerAttackRelease('C5', '32n', time);
+        clickHi();
       } else {
-        clickLo.triggerAttackRelease('C4', '32n', time);
+        clickLo();
       }
       beat++;
-    }, `${beatsPerBar}n`);
+    }, beatInterval);
 
     return () => {
-      Tone.getTransport().clear(id);
-      clickHi.dispose();
-      clickLo.dispose();
+      clearInterval(intervalId);
     };
   }
 

--- a/src/engine/RecordingEngine.ts
+++ b/src/engine/RecordingEngine.ts
@@ -449,33 +449,39 @@ class RecordingEngine {
     const totalBeats = bars * beatsPerBar;
     const beatDuration = 60 / bpm;
 
-    const engine = getAudioEngine();
-    await engine.resume();
-    const ctx = engine.ctx;
-    // Hi click (downbeat) and lo click (other beats) — pitch
-    // sweeps match the old Tone.MembraneSynth character
-    // (pitchDecay 0.01, octaves 6/4 from C5/C4): ~3139 → 523 Hz
-    // over 10 ms for hi, ~1046 → 261 Hz for lo. Previous values
-    // (800→120, 400→90 over 60 ms) sounded too low and soft
-    // (codex P3 on PR #1731).
-    const clickHi = () => playClick(ctx, ctx.destination, 3139, 523, 10, 0.6);
-    const clickLo = () => playClick(ctx, ctx.destination, 1046, 261, 10, 0.5);
+    try {
+      const engine = getAudioEngine();
+      await engine.resume();
+      const ctx = engine.ctx;
+      // Hi click (downbeat) and lo click (other beats) — pitch
+      // sweeps match the old Tone.MembraneSynth character
+      // (pitchDecay 0.01, octaves 6/4 from C5/C4): ~3139 → 523 Hz
+      // over 10 ms for hi, ~1046 → 261 Hz for lo. Previous values
+      // (800→120, 400→90 over 60 ms) sounded too low and soft
+      // (codex P3 on PR #1731).
+      const clickHi = () => playClick(ctx, ctx.destination, 3139, 523, 10, 0.6);
+      const clickLo = () => playClick(ctx, ctx.destination, 1046, 261, 10, 0.5);
 
-    for (let i = 0; i < totalBeats; i++) {
-      const bar = Math.floor(i / beatsPerBar);
-      const beat = i % beatsPerBar;
-      onBeat(bar, beat, totalBeats - i);
+      for (let i = 0; i < totalBeats; i++) {
+        const bar = Math.floor(i / beatsPerBar);
+        const beat = i % beatsPerBar;
+        onBeat(bar, beat, totalBeats - i);
 
-      if (beat === 0) {
-        clickHi();
-      } else {
-        clickLo();
+        if (beat === 0) {
+          clickHi();
+        } else {
+          clickLo();
+        }
+
+        await new Promise<void>(resolve => setTimeout(resolve, beatDuration * 1000));
       }
-
-      await new Promise<void>(resolve => setTimeout(resolve, beatDuration * 1000));
+    } finally {
+      // Always reset isCountingIn, even if engine.resume() rejects
+      // or onBeat throws — otherwise the engine can get stuck
+      // reporting `countingIn === true` forever (Copilot review
+      // on PR #1731).
+      this.isCountingIn = false;
     }
-
-    this.isCountingIn = false;
   }
 
   get countingIn() { return this.isCountingIn; }
@@ -492,6 +498,11 @@ class RecordingEngine {
     // wallclock-driven click beneath the sample-accurate playback
     // metronome (codex P2 note on PR #1731).
     const engine = getAudioEngine();
+    // Fire-and-forget resume — if the user hasn't triggered a
+    // gesture yet the ctx may be suspended and clicks would be
+    // silent. `resume()` is a no-op when already running (Copilot
+    // review on PR #1731).
+    void engine.resume();
     const ctx = engine.ctx;
     // -6 dB ≈ 0.5 linear, -10 dB ≈ 0.316 linear (matches old
     // Tone.MembraneSynth volume.value settings).

--- a/src/engine/RecordingEngine.ts
+++ b/src/engine/RecordingEngine.ts
@@ -15,8 +15,13 @@ const log = createDebugLogger('recording-engine');
  *
  * Models a kick-like click: starts at `startFreq`, exponentially
  * sweeps to `endFreq` over `decayMs`, with a linear attack and
- * exponential amplitude decay. Fresh nodes per trigger — the
- * oscillator stops itself so there is nothing to dispose.
+ * exponential amplitude decay.
+ *
+ * Cleanup: oscillator `stop()` ends playback; the `onended` handler
+ * disconnects both nodes so the graph edges + closures are
+ * released deterministically instead of waiting for browser GC
+ * (codex P3 on PR #1731, matching the pattern in
+ * `LoopBrowser.playPreview`).
  */
 function playClick(
   ctx: AudioContext,
@@ -41,6 +46,11 @@ function playClick(
   osc.connect(gain).connect(destination);
   osc.start(now);
   osc.stop(endTime + 0.02);
+  osc.onended = () => {
+    try { osc.disconnect(); } catch { /* already disconnected */ }
+    try { gain.disconnect(); } catch { /* already disconnected */ }
+    osc.onended = null;
+  };
 }
 
 export interface AudioInputDevice {
@@ -443,11 +453,13 @@ class RecordingEngine {
     await engine.resume();
     const ctx = engine.ctx;
     // Hi click (downbeat) and lo click (other beats) — pitch
-    // parameters picked to match the old Tone.MembraneSynth
-    // (pitchDecay 0.01, octaves 6/4 from C5/C4) closely enough to
-    // keep the perceptual "kick click" character.
-    const clickHi = () => playClick(ctx, ctx.destination, 800, 120, 60, 0.6);
-    const clickLo = () => playClick(ctx, ctx.destination, 400, 90, 60, 0.5);
+    // sweeps match the old Tone.MembraneSynth character
+    // (pitchDecay 0.01, octaves 6/4 from C5/C4): ~3139 → 523 Hz
+    // over 10 ms for hi, ~1046 → 261 Hz for lo. Previous values
+    // (800→120, 400→90 over 60 ms) sounded too low and soft
+    // (codex P3 on PR #1731).
+    const clickHi = () => playClick(ctx, ctx.destination, 3139, 523, 10, 0.6);
+    const clickLo = () => playClick(ctx, ctx.destination, 1046, 261, 10, 0.5);
 
     for (let i = 0; i < totalBeats; i++) {
       const bar = Math.floor(i / beatsPerBar);
@@ -471,18 +483,22 @@ class RecordingEngine {
   // --- Metronome ---
 
   startMetronome(bpm: number, beatsPerBar: number): () => void {
-    // Recording-time metronome. Not sample-accurate — the Rust
-    // engine owns the sample-accurate metronome in Phase 3E; this
-    // is the pre-roll clicker that plays wallclock-driven during
-    // a recording session.
+    // Recording-time metronome. Not sample-accurate: clicks fire
+    // when the JS timer wakes up (subject to UI stall, GC,
+    // background-tab throttling). The app's sample-accurate
+    // metronome lives in the Rust engine (Phase 3E); this helper
+    // has no current call sites in `src/` as of Phase 5E, but is
+    // retained for future recording-session UX that may need
+    // wallclock-driven click beneath the sample-accurate playback
+    // metronome (codex P2 note on PR #1731).
     const engine = getAudioEngine();
     const ctx = engine.ctx;
-    // -6 dB ≈ 0.5 linear, -10 dB ≈ 0.316 linear (matches the old
+    // -6 dB ≈ 0.5 linear, -10 dB ≈ 0.316 linear (matches old
     // Tone.MembraneSynth volume.value settings).
     const hiVolume = 0.5;
     const loVolume = 0.316;
-    const clickHi = () => playClick(ctx, ctx.destination, 800, 120, 50, hiVolume);
-    const clickLo = () => playClick(ctx, ctx.destination, 400, 90, 40, loVolume);
+    const clickHi = () => playClick(ctx, ctx.destination, 3139, 523, 10, hiVolume);
+    const clickLo = () => playClick(ctx, ctx.destination, 1046, 261, 10, loVolume);
 
     let beat = 0;
     const beatInterval = (60 / bpm) * 1000;

--- a/src/engine/__tests__/RecordingEngine.test.ts
+++ b/src/engine/__tests__/RecordingEngine.test.ts
@@ -3,23 +3,36 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-// Mock Tone.js before importing RecordingEngine
-vi.mock('tone', () => {
-  class MockMembraneSynth {
-    volume = { value: 0 };
-    toDestination = vi.fn().mockReturnThis();
-    triggerAttackRelease = vi.fn();
-    dispose = vi.fn();
-  }
-  return {
-    start: vi.fn(),
-    MembraneSynth: MockMembraneSynth,
-    getTransport: vi.fn(() => ({
-      scheduleRepeat: vi.fn(() => 1),
-      clear: vi.fn(),
-    })),
-  };
-});
+// Mock getAudioEngine — RecordingEngine no longer imports Tone
+// directly (Phase 5E migration), but still calls getAudioEngine()
+// for the count-in / metronome clicks.
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(() => ({
+    resume: vi.fn().mockResolvedValue(undefined),
+    ctx: {
+      currentTime: 0,
+      createOscillator: vi.fn(() => ({
+        type: 'sine',
+        frequency: {
+          setValueAtTime: vi.fn(),
+          exponentialRampToValueAtTime: vi.fn(),
+        },
+        connect: vi.fn().mockReturnThis(),
+        start: vi.fn(),
+        stop: vi.fn(),
+      })),
+      createGain: vi.fn(() => ({
+        gain: {
+          setValueAtTime: vi.fn(),
+          linearRampToValueAtTime: vi.fn(),
+          exponentialRampToValueAtTime: vi.fn(),
+        },
+        connect: vi.fn().mockReturnThis(),
+      })),
+      destination: {},
+    },
+  })),
+}));
 
 import { recordingEngine } from '../RecordingEngine';
 


### PR DESCRIPTION
## Summary

Fifth atomic slice of Phase 5 (#1525). Removes 7 Tone.js refs from RecordingEngine — all count-in / recording-metronome click synthesis.

- `Tone.MembraneSynth` × 4 → native `playClick(ctx, dst, startFreq, endFreq, decayMs, volume)` helper: Osc + Gain with pitch sweep + expo envelope, fresh nodes per trigger, self-stopping
- `Tone.getTransport().scheduleRepeat` → `setInterval` (wallclock-driven; Rust engine owns sample-accurate metronome in 3E)
- `Tone.start()` → `engine.resume()`
- Click parameters mapped to match prior perceptual character (see commit message for the frequency/volume/decay table)

## Test plan

- 7291 tests pass, 37/37 RecordingEngine, same 2 pre-existing failures
- `npx tsc --noEmit` / `npm run build` clean

Closes #1730
Part of #1525, #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)