### PR TITLE
feat: Phase 5F — migrate AdditiveEngine off direct Tone.js

### DIFF
--- a/src/engine/AdditiveEngine.ts
+++ b/src/engine/AdditiveEngine.ts
@@ -1,5 +1,6 @@
-import * as Tone from 'tone';
 import type { AdditiveSettings, AdditivePartial, AdditivePreset, InstrumentEnvelope } from '../types/project';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+import { midiToFrequency } from '../utils/pitch';
 
 // ─── Preset Harmonic Profiles ──────────────────────────────────────────────
 
@@ -80,7 +81,7 @@ interface ActiveVoice {
 }
 
 interface AdditiveInstance {
-  output: Tone.Gain;
+  output: GainNode;
   settings: AdditiveSettings;
   activeVoices: Map<number, ActiveVoice>;
 }
@@ -95,15 +96,16 @@ class AdditiveEngine {
   private instances = new Map<string, AdditiveInstance>();
 
   async ensureStarted() {
-    if (Tone.getContext().state !== 'running') {
-      await Tone.start();
+    const engine = getAudioEngine();
+    if (engine.ctx.state !== 'running') {
+      await engine.resume();
     }
   }
 
   ensureTrack(
     trackId: string,
     settings: AdditiveSettings,
-    connectTo?: Tone.InputNode,
+    connectTo?: AudioNode,
   ): AdditiveInstance {
     const outputLevel = dBToLinear(settings.outputGain);
 
@@ -114,13 +116,10 @@ class AdditiveEngine {
       return existing;
     }
 
-    const output = new Tone.Gain(outputLevel);
-
-    if (connectTo) {
-      output.connect(connectTo);
-    } else {
-      output.toDestination();
-    }
+    const ctx = getAudioEngine().ctx;
+    const output = ctx.createGain();
+    output.gain.value = outputLevel;
+    output.connect(connectTo ?? ctx.destination);
 
     const instance: AdditiveInstance = {
       output,
@@ -139,9 +138,9 @@ class AdditiveEngine {
     this._stopVoice(instance, pitch);
 
     const { partials, ampEnvelope } = instance.settings;
-    const ctx = Tone.getContext().rawContext;
+    const ctx = getAudioEngine().ctx;
     const now = ctx.currentTime;
-    const fundamentalFreq = Tone.Frequency(pitch, 'midi').toFrequency();
+    const fundamentalFreq = midiToFrequency(pitch);
     const vel = Math.max(0, Math.min(127, velocity)) / 127;
 
     const masterGain = ctx.createGain();
@@ -151,7 +150,10 @@ class AdditiveEngine {
       vel * ampEnvelope.sustain,
       now + ampEnvelope.attack + ampEnvelope.decay,
     );
-    masterGain.connect((instance.output as unknown as { input: AudioNode }).input ?? ctx.destination);
+    // Route into the instance's output bus (native GainNode). The
+    // `.input` fallback from the prior Tone.Gain shape is no longer
+    // needed — native GainNodes connect directly.
+    masterGain.connect(instance.output);
 
     // Pre-compute active partial count once (avoid O(n²))
     const activeCount = partials.reduce((n, p) => n + (p.amplitude > 0 ? 1 : 0), 0);
@@ -193,7 +195,7 @@ class AdditiveEngine {
     const voice = instance.activeVoices.get(pitch);
     if (!voice) return;
 
-    const ctx = Tone.getContext().rawContext;
+    const ctx = getAudioEngine().ctx;
     const now = ctx.currentTime;
     const release = instance.settings.ampEnvelope.release;
 
@@ -265,7 +267,9 @@ class AdditiveEngine {
     for (const pitch of [...instance.activeVoices.keys()]) {
       this._stopVoice(instance, pitch);
     }
-    instance.output.dispose();
+    // Native GainNode has no `dispose` — `disconnect` releases the
+    // graph edge; GC reclaims the node itself.
+    try { instance.output.disconnect(); } catch { /* already disconnected */ }
     this.instances.delete(trackId);
   }
 

--- a/src/engine/AdditiveEngine.ts
+++ b/src/engine/AdditiveEngine.ts
@@ -119,6 +119,14 @@ class AdditiveEngine {
     const ctx = getAudioEngine().ctx;
     const output = ctx.createGain();
     output.gain.value = outputLevel;
+    // Connect to the supplied track node when available; otherwise
+    // route directly to ctx.destination. This bypasses Tone's
+    // DestinationClass wrapper (which had its own volume/mute) —
+    // no audible impact in this app because master gain is handled
+    // by AudioEngine's master bus on the connectTo path, and the
+    // fallback is reachable only from _lazyInit (notes triggered
+    // before ensureTrack was called with a connectTo). Codex P1 on
+    // PR #1733.
     output.connect(connectTo ?? ctx.destination);
 
     const instance: AdditiveInstance = {

--- a/src/engine/__tests__/AdditiveEngine.test.ts
+++ b/src/engine/__tests__/AdditiveEngine.test.ts
@@ -3,30 +3,34 @@ import { createPresetPartials, createDefaultAdditiveSettings } from '../Additive
 
 // Phase 5F migration: AdditiveEngine no longer imports Tone
 // directly — it pulls the AudioContext from `getAudioEngine().ctx`.
-// Mock that singleton accessor to return a minimal ctx with the
-// factories the engine uses (createGain / createOscillator).
-const makeMockGain = () => ({
-  gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
-  connect: vi.fn(),
-  disconnect: vi.fn(),
+// Use `vi.hoisted` so the mock factories don't close over
+// module-level consts that may be undefined at hoist time
+// (Copilot review on PR #1733, matching the GranularEngine test
+// pattern).
+const { mockCtx } = vi.hoisted(() => {
+  const makeMockGain = () => ({
+    gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  });
+  const makeMockOsc = () => ({
+    type: 'sine' as OscillatorType,
+    frequency: { value: 440 },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  });
+  return {
+    mockCtx: {
+      state: 'running' as AudioContextState,
+      currentTime: 0,
+      destination: {},
+      createGain: vi.fn(makeMockGain),
+      createOscillator: vi.fn(makeMockOsc),
+    },
+  };
 });
-
-const makeMockOsc = () => ({
-  type: 'sine' as OscillatorType,
-  frequency: { value: 440 },
-  connect: vi.fn(),
-  disconnect: vi.fn(),
-  start: vi.fn(),
-  stop: vi.fn(),
-});
-
-const mockCtx = {
-  state: 'running' as AudioContextState,
-  currentTime: 0,
-  destination: {},
-  createGain: vi.fn(makeMockGain),
-  createOscillator: vi.fn(makeMockOsc),
-};
 
 vi.mock('../../hooks/useAudioEngine', () => ({
   getAudioEngine: vi.fn(() => ({

--- a/src/engine/__tests__/AdditiveEngine.test.ts
+++ b/src/engine/__tests__/AdditiveEngine.test.ts
@@ -1,44 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createPresetPartials, createDefaultAdditiveSettings } from '../AdditiveEngine';
 
-// Mock Tone.js — additive engine uses raw AudioContext for partials
-const mockGainNode = {
+// Phase 5F migration: AdditiveEngine no longer imports Tone
+// directly — it pulls the AudioContext from `getAudioEngine().ctx`.
+// Mock that singleton accessor to return a minimal ctx with the
+// factories the engine uses (createGain / createOscillator).
+const makeMockGain = () => ({
   gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn(), cancelScheduledValues: vi.fn() },
   connect: vi.fn(),
   disconnect: vi.fn(),
-};
+});
 
-const mockOscNode = {
+const makeMockOsc = () => ({
   type: 'sine' as OscillatorType,
   frequency: { value: 440 },
   connect: vi.fn(),
   start: vi.fn(),
   stop: vi.fn(),
+});
+
+const mockCtx = {
+  state: 'running' as AudioContextState,
+  currentTime: 0,
+  destination: {},
+  createGain: vi.fn(makeMockGain),
+  createOscillator: vi.fn(makeMockOsc),
 };
 
-vi.mock('tone', () => ({
-  Gain: function MockGain() {
-    return {
-      connect: vi.fn(),
-      toDestination: vi.fn(),
-      dispose: vi.fn(),
-      gain: { value: 1 },
-      input: {},
-    };
-  },
-  Frequency: vi.fn((pitch: number, _type: string) => ({
-    toFrequency: () => 440 * Math.pow(2, (pitch - 69) / 12),
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(() => ({
+    ctx: mockCtx,
+    resume: vi.fn().mockResolvedValue(undefined),
   })),
-  getContext: vi.fn(() => ({
-    state: 'running',
-    rawContext: {
-      currentTime: 0,
-      destination: {},
-      createGain: () => ({ ...mockGainNode }),
-      createOscillator: () => ({ ...mockOscNode }),
-    },
-  })),
-  start: vi.fn(),
 }));
 
 async function createFreshEngine() {

--- a/src/engine/__tests__/AdditiveEngine.test.ts
+++ b/src/engine/__tests__/AdditiveEngine.test.ts
@@ -15,6 +15,7 @@ const makeMockOsc = () => ({
   type: 'sine' as OscillatorType,
   frequency: { value: 440 },
   connect: vi.fn(),
+  disconnect: vi.fn(),
   start: vi.fn(),
   stop: vi.fn(),
 });


### PR DESCRIPTION
Sixth slice of Phase 5 (#1525). 8 Tone refs → 0. Tone.Gain → native GainNode, Tone.getContext → getAudioEngine().ctx, Tone.Frequency → midiToFrequency, Tone.start → engine.resume. Test mock switched from 'tone' to 'useAudioEngine'. 15/15 additive tests + 7291 full-suite pass.

Closes #1732. Part of #1525, epic #1519.