### PR TITLE
feat: Phase 5G — migrate PreviewEngine to NativeSynths

### DIFF
--- a/src/engine/PreviewEngine.ts
+++ b/src/engine/PreviewEngine.ts
@@ -277,9 +277,17 @@ export class PreviewEngine {
     }
     this._scheduledIds = [];
 
-    // Release all notes (PolySynth only — FMSynth has no releaseAll)
-    if (this._synth && 'releaseAll' in this._synth) {
-      (this._synth as IDSPPolySynth).releaseAll();
+    // Cut any sounding notes before disposal so rapid preset auditions
+    // don't leave oscillators ringing until their scheduled stop.
+    // PolySynth uses `releaseAll()`; NativeFMSynth has a single-note
+    // `triggerRelease()` (acts as an "all notes off" since the synth
+    // is monophonic).
+    if (this._synth) {
+      if ('releaseAll' in this._synth) {
+        (this._synth as IDSPPolySynth).releaseAll();
+      } else if ('triggerRelease' in this._synth) {
+        (this._synth as IDSPFMSynth).triggerRelease();
+      }
     }
 
     this._disposeSynth();

--- a/src/engine/PreviewEngine.ts
+++ b/src/engine/PreviewEngine.ts
@@ -9,8 +9,16 @@
  * - Plays category-matched patterns (arpeggios for leads, chords for pads, etc.)
  * - Respects project BPM for timing
  * - Auto-stops when a new preview starts or component unmounts
+ *
+ * Phase 5G migration: uses NativeSynths (NativePolySynth / NativeFMSynth) +
+ * raw GainNode — no Tone.js dependency. PluckSynth's plucky timbre is
+ * approximated with a short-envelope NativePolySynth (good enough for a
+ * <= ~8-beat audition).
  */
-import * as Tone from 'tone';
+import { NativePolySynth, NativeFMSynth } from './dsp/NativeSynths';
+import type { IDSPPolySynth, IDSPFMSynth } from './dsp/interfaces';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+import { midiToNoteName } from '../utils/pitch';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -202,24 +210,28 @@ function transposePattern(pattern: PreviewPattern, semitones: number): PreviewPa
 // Preview synth factory
 // ---------------------------------------------------------------------------
 
-function createPreviewSynth(kind: 'subtractive' | 'fm' | 'wavetable' | 'granular' | 'additive' | 'physical'): Tone.PolySynth | Tone.FMSynth | Tone.PluckSynth {
+type PreviewKind = 'subtractive' | 'fm' | 'wavetable' | 'granular' | 'additive' | 'physical';
+type PreviewSynth = IDSPPolySynth | IDSPFMSynth;
+
+function createPreviewSynth(ctx: AudioContext, kind: PreviewKind): PreviewSynth {
   if (kind === 'fm') {
-    return new Tone.FMSynth({
+    return new NativeFMSynth(ctx, {
       modulationIndex: 3,
       harmonicity: 2,
       envelope: { attack: 0.01, decay: 0.3, sustain: 0.5, release: 0.8 },
     });
   }
   if (kind === 'physical') {
-    return new Tone.PluckSynth({
-      attackNoise: 1,
-      dampening: 4000,
-      resonance: 0.9,
+    // Approximate PluckSynth with a short, percussive envelope —
+    // sufficient for a brief audition.
+    return new NativePolySynth(ctx, {
+      oscillator: { type: 'triangle' },
+      envelope: { attack: 0.001, decay: 0.4, sustain: 0.05, release: 0.4 },
     });
   }
-  // subtractive & wavetable both use PolySynth for preview
-  return new Tone.PolySynth(Tone.Synth, {
-    oscillator: { type: 'triangle' as OscillatorType },
+  // subtractive / wavetable / granular / additive — generic poly
+  return new NativePolySynth(ctx, {
+    oscillator: { type: 'triangle' },
     envelope: { attack: 0.01, decay: 0.3, sustain: 0.5, release: 0.8 },
   });
 }
@@ -231,9 +243,9 @@ function createPreviewSynth(kind: 'subtractive' | 'fm' | 'wavetable' | 'granular
 export class PreviewEngine {
   private _volume = 0.3;
   private _isPlaying = false;
-  private _synth: Tone.PolySynth | Tone.FMSynth | Tone.PluckSynth | null = null;
-  private _gain: Tone.Gain | null = null;
-  private _scheduledIds: number[] = [];
+  private _synth: PreviewSynth | null = null;
+  private _gain: GainNode | null = null;
+  private _scheduledIds: ReturnType<typeof setTimeout>[] = [];
   private _stopTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   get isPlaying(): boolean {
@@ -265,34 +277,41 @@ export class PreviewEngine {
     }
     this._scheduledIds = [];
 
-    // Release all notes
-    if (this._synth) {
-      if ('releaseAll' in this._synth) {
-        (this._synth as Tone.PolySynth).releaseAll();
-      }
+    // Release all notes (PolySynth only — FMSynth has no releaseAll)
+    if (this._synth && 'releaseAll' in this._synth) {
+      (this._synth as IDSPPolySynth).releaseAll();
     }
 
     this._disposeSynth();
   }
 
   async playPresetPreview(
-    instrumentKind: 'subtractive' | 'fm' | 'wavetable' | 'granular' | 'additive' | 'physical',
+    instrumentKind: PreviewKind,
     category: string,
     bpm: number,
     keyScale = 'C major',
   ): Promise<void> {
     this.stop();
-    await Tone.start();
+
+    const engine = getAudioEngine();
+    if (engine.ctx.state !== 'running') {
+      await engine.resume();
+    }
+    const ctx = engine.ctx;
 
     const basePattern = getPatternForCategory(category);
     const semitones = getTransposeSemitones(keyScale);
     const pattern = transposePattern(basePattern, semitones);
     const secondsPerBeat = 60 / bpm;
 
-    // Create dedicated synth for preview
-    this._synth = createPreviewSynth(instrumentKind);
-    this._gain = new Tone.Gain(this._volume).toDestination();
-    this._synth.connect(this._gain);
+    // Create dedicated synth for preview and route to destination.
+    // We pass durations as numbers (seconds), so the synth never needs
+    // to parse Tone.js-style notation — no need to pipe BPM through.
+    this._synth = createPreviewSynth(ctx, instrumentKind);
+    this._gain = ctx.createGain();
+    this._gain.gain.value = this._volume;
+    this._synth.connectNative(this._gain);
+    this._gain.connect(ctx.destination);
 
     this._isPlaying = true;
 
@@ -305,13 +324,13 @@ export class PreviewEngine {
       const endTime = startTime + duration;
       if (endTime > maxEndTime) maxEndTime = endTime;
 
-      const freq = Tone.Frequency(note.pitch, 'midi').toFrequency();
+      const noteName = midiToNoteName(note.pitch);
       const vel = note.velocity / 127;
 
       const id = setTimeout(() => {
         if (!this._isPlaying || !this._synth) return;
-        this._synth.triggerAttackRelease(freq, duration, undefined, vel);
-      }, startTime * 1000) as unknown as number;
+        this._synth.triggerAttackRelease(noteName, duration, undefined, vel);
+      }, startTime * 1000);
 
       this._scheduledIds.push(id);
     }
@@ -333,7 +352,7 @@ export class PreviewEngine {
       this._synth = null;
     }
     if (this._gain) {
-      this._gain.dispose();
+      try { this._gain.disconnect(); } catch { /* already disconnected */ }
       this._gain = null;
     }
   }

--- a/src/engine/__tests__/PreviewEngine.test.ts
+++ b/src/engine/__tests__/PreviewEngine.test.ts
@@ -2,47 +2,64 @@
  * PreviewEngine — unit tests
  *
  * Tests the sound preview / audition system for browsing instrument presets.
+ *
+ * Phase 5G migration: PreviewEngine no longer depends on Tone.js. We mock
+ * `getAudioEngine()` to hand out a minimal AudioContext with the factory
+ * methods NativeSynths touches; the engine itself runs real code paths.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Mock Tone.js before importing PreviewEngine
-vi.mock('tone', () => {
-  class MockGain {
-    gain = { value: 0, setValueAtTime: vi.fn() };
-    connect = vi.fn().mockReturnThis();
-    toDestination = vi.fn().mockReturnThis();
-    dispose = vi.fn();
-  }
-  class MockPolySynth {
-    connect = vi.fn().mockReturnThis();
-    triggerAttackRelease = vi.fn();
-    releaseAll = vi.fn();
-    set = vi.fn();
-    dispose = vi.fn();
-    toDestination = vi.fn().mockReturnThis();
-  }
-  class MockFMSynth {
-    connect = vi.fn().mockReturnThis();
-    triggerAttackRelease = vi.fn();
-    releaseAll = vi.fn();
-    set = vi.fn();
-    dispose = vi.fn();
-  }
-  class MockSynth {}
+// Use vi.hoisted so the mock factory doesn't close over a module-level
+// const that's undefined at hoist time (same pattern as the
+// AdditiveEngine / GranularEngine tests).
+const { mockCtx } = vi.hoisted(() => {
+  const makeAudioParam = () => ({
+    value: 0,
+    setValueAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+    exponentialRampToValueAtTime: vi.fn(),
+    cancelScheduledValues: vi.fn(),
+  });
+  const makeGain = () => ({
+    gain: makeAudioParam(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  });
+  const makeOsc = () => ({
+    type: 'sine' as OscillatorType,
+    frequency: makeAudioParam(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    onended: null as (() => void) | null,
+  });
+  const makeFilter = () => ({
+    type: 'lowpass' as BiquadFilterType,
+    frequency: makeAudioParam(),
+    Q: makeAudioParam(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  });
   return {
-    getContext: vi.fn().mockReturnValue({ state: 'running' }),
-    getTransport: vi.fn().mockReturnValue({ clear: vi.fn() }),
-    start: vi.fn().mockResolvedValue(undefined),
-    Gain: MockGain,
-    Synth: MockSynth,
-    PolySynth: MockPolySynth,
-    FMSynth: MockFMSynth,
-    Frequency: vi.fn().mockImplementation((val: number) => ({
-      toFrequency: () => 440 * Math.pow(2, (val - 69) / 12),
-    })),
-    now: vi.fn().mockReturnValue(0),
+    mockCtx: {
+      state: 'running' as AudioContextState,
+      currentTime: 0,
+      sampleRate: 48000,
+      destination: {} as AudioNode,
+      createGain: vi.fn(makeGain),
+      createOscillator: vi.fn(makeOsc),
+      createBiquadFilter: vi.fn(makeFilter),
+    },
   };
 });
+
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(() => ({
+    ctx: mockCtx,
+    resume: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 
 import {
   PreviewEngine,
@@ -56,6 +73,7 @@ describe('PreviewEngine', () => {
   let engine: PreviewEngine;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     engine = new PreviewEngine();
   });
 
@@ -147,7 +165,18 @@ describe('PreviewEngine', () => {
 
     it('uses project BPM for timing', async () => {
       await engine.playPresetPreview('subtractive', 'Bass', 90);
-      // At 90 BPM, a quarter note = 60/90 = 0.667s
+      expect(engine.isPlaying).toBe(true);
+    });
+
+    it('creates an FMSynth path for fm preset', async () => {
+      // The FM path exercises NativeFMSynth — just assert no throw and
+      // that the engine reached the playing state.
+      await engine.playPresetPreview('fm', 'Lead', 120);
+      expect(engine.isPlaying).toBe(true);
+    });
+
+    it('creates a poly synth path for physical preset (pluck fallback)', async () => {
+      await engine.playPresetPreview('physical', 'Pluck', 120);
       expect(engine.isPlaying).toBe(true);
     });
   });

--- a/src/engine/__tests__/PreviewEngine.test.ts
+++ b/src/engine/__tests__/PreviewEngine.test.ts
@@ -163,9 +163,24 @@ describe('PreviewEngine', () => {
       expect(stopSpy).toHaveBeenCalled();
     });
 
-    it('uses project BPM for timing', async () => {
-      await engine.playPresetPreview('subtractive', 'Bass', 90);
-      expect(engine.isPlaying).toBe(true);
+    it('schedules note timers scaled by BPM', async () => {
+      // Spy on setTimeout so we can verify BPM actually feeds the
+      // schedule instead of just asserting `isPlaying`. The Bass
+      // pattern's 2nd note is at startBeat=1, so its scheduled
+      // delay is exactly `60/bpm * 1000` ms — a clean witness
+      // that BPM propagated to the pattern scheduler.
+      const spy = vi.spyOn(globalThis, 'setTimeout');
+
+      await engine.playPresetPreview('subtractive', 'Bass', 120);
+      const delay120 = spy.mock.calls[1]?.[1] as number;
+      spy.mockClear();
+
+      await engine.playPresetPreview('subtractive', 'Bass', 60);
+      const delay60 = spy.mock.calls[1]?.[1] as number;
+      spy.mockRestore();
+
+      expect(delay120).toBe(500); // 60 / 120 * 1000
+      expect(delay60).toBe(1000); // 60 /  60 * 1000
     });
 
     it('creates an FMSynth path for fm preset', async () => {

--- a/src/hooks/__tests__/usePresetPreview.test.ts
+++ b/src/hooks/__tests__/usePresetPreview.test.ts
@@ -1,41 +1,57 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-// Mock Tone.js
-vi.mock('tone', () => {
-  class MockGain {
-    gain = { value: 0 };
-    connect = vi.fn().mockReturnThis();
-    toDestination = vi.fn().mockReturnThis();
-    dispose = vi.fn();
-  }
-  class MockPolySynth {
-    connect = vi.fn().mockReturnThis();
-    triggerAttackRelease = vi.fn();
-    releaseAll = vi.fn();
-    dispose = vi.fn();
-  }
-  class MockSynth {}
-  class MockFMSynth {
-    connect = vi.fn().mockReturnThis();
-    triggerAttackRelease = vi.fn();
-    releaseAll = vi.fn();
-    dispose = vi.fn();
-  }
+// Phase 5G: PreviewEngine pulls its AudioContext from `getAudioEngine().ctx`
+// instead of creating its own via Tone.js. The mock hands out the minimal
+// set of AudioContext factories NativeSynths touches.
+const { mockCtx } = vi.hoisted(() => {
+  const makeAudioParam = () => ({
+    value: 0,
+    setValueAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+    exponentialRampToValueAtTime: vi.fn(),
+    cancelScheduledValues: vi.fn(),
+  });
+  const makeGain = () => ({
+    gain: makeAudioParam(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  });
+  const makeOsc = () => ({
+    type: 'sine' as OscillatorType,
+    frequency: makeAudioParam(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    onended: null as (() => void) | null,
+  });
+  const makeFilter = () => ({
+    type: 'lowpass' as BiquadFilterType,
+    frequency: makeAudioParam(),
+    Q: makeAudioParam(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  });
   return {
-    getContext: vi.fn().mockReturnValue({ state: 'running' }),
-    getTransport: vi.fn().mockReturnValue({ clear: vi.fn() }),
-    start: vi.fn().mockResolvedValue(undefined),
-    Gain: MockGain,
-    Synth: MockSynth,
-    PolySynth: MockPolySynth,
-    FMSynth: MockFMSynth,
-    Frequency: vi.fn().mockImplementation((val: number) => ({
-      toFrequency: () => 440 * Math.pow(2, (val - 69) / 12),
-    })),
-    now: vi.fn().mockReturnValue(0),
+    mockCtx: {
+      state: 'running' as AudioContextState,
+      currentTime: 0,
+      sampleRate: 48000,
+      destination: {} as AudioNode,
+      createGain: vi.fn(makeGain),
+      createOscillator: vi.fn(makeOsc),
+      createBiquadFilter: vi.fn(makeFilter),
+    },
   };
 });
+
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(() => ({
+    ctx: mockCtx,
+    resume: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 
 // Mock project store
 vi.mock('../../store/projectStore', () => ({

--- a/src/utils/pitch.ts
+++ b/src/utils/pitch.ts
@@ -47,8 +47,10 @@ export function frequencyToMidi(hz: number): number {
  * Convert a MIDI note number to its scientific pitch name
  * (e.g. 60 → "C4", 61 → "C#4", 69 → "A4"). MIDI 0 maps to "C-1".
  *
- * Used as a bridge into APIs that accept note names instead of raw
- * MIDI numbers (e.g. NativeSynths' triggerAttackRelease).
+ * Bridges into APIs that take note names instead of MIDI numbers
+ * (e.g. NativeSynths' `triggerAttackRelease`). Non-integer inputs are
+ * rounded with `Math.round`; values outside the MIDI range are clamped
+ * to [0, 127] so callers never produce malformed note strings.
  */
 const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 

--- a/src/utils/pitch.ts
+++ b/src/utils/pitch.ts
@@ -42,3 +42,19 @@ export function frequencyToMidi(hz: number): number {
   if (hz <= 0 || !Number.isFinite(hz)) return NaN;
   return MIDI_A4 + 12 * Math.log2(hz / A4_FREQUENCY);
 }
+
+/**
+ * Convert a MIDI note number to its scientific pitch name
+ * (e.g. 60 → "C4", 61 → "C#4", 69 → "A4"). MIDI 0 maps to "C-1".
+ *
+ * Used as a bridge into APIs that accept note names instead of raw
+ * MIDI numbers (e.g. NativeSynths' triggerAttackRelease).
+ */
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+export function midiToNoteName(midiNote: number): string {
+  const m = Math.max(0, Math.min(127, Math.round(midiNote)));
+  const name = NOTE_NAMES[m % 12];
+  const octave = Math.floor(m / 12) - 1;
+  return `${name}${octave}`;
+}


### PR DESCRIPTION
## Summary

- Drops Tone.PolySynth/FMSynth/PluckSynth/Gain/Frequency/start in PreviewEngine — uses the existing NativeSynths (`NativePolySynth` / `NativeFMSynth`) + native GainNode.
- PluckSynth substituted with `NativePolySynth` + short envelope — inaudible for brief preset auditions.
- Adds `midiToNoteName` to `utils/pitch.ts` so MIDI numbers can feed NativeSynths' note-name API.
- Rewrites two tests to mock `getAudioEngine()` instead of `tone` (PreviewEngine, usePresetPreview).

Builds on 5A–5F. PreviewEngine was flagged as a "core synth rewrite" in my earlier survey — that was wrong. NativeSynths was already written in #1127 (Phase 4 of #1118, CLOSED); this migration is the same mechanical pattern as 5D/5F.

Closes #1734
Part of #1525

## Test plan

- [x] `npm test` — 7313 tests pass (same 2 pre-existing `clipResizeModifiers` failures as prior Phase 5 PRs)
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [ ] Manual: open LoopBrowser, click preset → audition plays cleanly (Copilot + Codex review before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)