### PR TITLE
feat: Phase 5H — migrate SamplerEngine off Tone.js

### DIFF
--- a/src/engine/SamplerEngine.ts
+++ b/src/engine/SamplerEngine.ts
@@ -1,26 +1,38 @@
-import * as Tone from 'tone';
+/**
+ * SamplerEngine — chromatic sample playback per track.
+ *
+ * Phase 5H migration: removed Tone.js dependency. Tone was being used
+ * purely as a thin wrapper over native Web Audio nodes —
+ * `Tone.Gain`/`Tone.Panner`/`Tone.BufferSource`/`Tone.ToneAudioBuffer`
+ * all map 1:1 onto native `GainNode`/`StereoPannerNode`/`AudioBufferSourceNode`/
+ * `AudioBuffer`, so this is a mechanical swap rather than a DSP rewrite.
+ */
 import type { SamplerConfig, Track } from '../types/project';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { getAudioEngine } from '../hooks/useAudioEngine';
 import { resolveZonePlayback, type ZonePlaybackInfo } from './samplerZoneResolver';
 
 interface SamplerVoice {
-  gain: Tone.Gain;
-  panner: Tone.Panner | null;
+  gain: GainNode;
+  panner: StereoPannerNode | null;
   pitch: number;
   releaseTimeoutId: ReturnType<typeof setTimeout> | null;
-  source: Tone.ToneBufferSource;
+  source: AudioBufferSourceNode;
+  /** Cached because AudioBufferSourceNode.playbackRate is an AudioParam,
+   *  but downstream timing math only needs the scalar. */
+  playbackRate: number;
+  /** Disposal timer — cleared in `_disposeVoice` so we don't drop nodes twice. */
+  disposeTimeoutId: ReturnType<typeof setTimeout> | null;
 }
 
 interface SamplerInstance {
   audioBuffer: AudioBuffer;
   audioKey: string;
-  buffer: Tone.ToneAudioBuffer;
   config: SamplerConfig;
-  output: Tone.Gain;
+  output: GainNode;
   voices: Map<number, SamplerVoice[]>;
   /** Cached zone buffers keyed by zone audioKey. */
-  zoneBuffers: Map<string, Tone.ToneAudioBuffer>;
+  zoneBuffers: Map<string, AudioBuffer>;
 }
 
 /** Default ADSR values for new sampler configs. */
@@ -91,8 +103,9 @@ class SamplerEngine {
   private readonly bufferCache = new Map<string, AudioBuffer>();
 
   async ensureStarted() {
-    if (Tone.getContext().state !== 'running') {
-      await Tone.start();
+    const engine = getAudioEngine();
+    if (engine.ctx.state !== 'running') {
+      await engine.resume();
     }
   }
 
@@ -100,16 +113,14 @@ class SamplerEngine {
     trackId: string,
     config: SamplerConfig,
     audioBuffer: AudioBuffer,
-    connectTo?: Tone.InputNode,
+    connectTo?: AudioNode,
   ) {
     const nextConfig = buildPlaybackConfig(config, audioBuffer.duration);
     const existing = this.samplers.get(trackId);
     if (existing && existing.audioKey === config.audioKey) {
       existing.audioBuffer = audioBuffer;
-      existing.buffer = new Tone.ToneAudioBuffer(audioBuffer);
       existing.config = nextConfig;
       this.bufferCache.set(config.audioKey, audioBuffer);
-      // Refresh zone buffers if zones changed; prune stale entries
       this._pruneZoneBuffers(existing, nextConfig);
       if (nextConfig.zones && nextConfig.zones.length > 0) {
         void this._loadZoneBuffers(trackId, nextConfig);
@@ -121,17 +132,18 @@ class SamplerEngine {
       this._disposeInstance(existing);
     }
 
-    const output = new Tone.Gain(0.55);
+    const ctx = getAudioEngine().ctx;
+    const output = ctx.createGain();
+    output.gain.value = 0.55;
     if (connectTo) {
       output.connect(connectTo);
     } else {
-      output.toDestination();
+      output.connect(ctx.destination);
     }
 
     this.samplers.set(trackId, {
       audioBuffer,
       audioKey: config.audioKey,
-      buffer: new Tone.ToneAudioBuffer(audioBuffer),
       config: nextConfig,
       output,
       voices: new Map(),
@@ -139,7 +151,6 @@ class SamplerEngine {
     });
     this.bufferCache.set(config.audioKey, audioBuffer);
 
-    // Preload zone buffers asynchronously
     if (nextConfig.zones && nextConfig.zones.length > 0) {
       void this._loadZoneBuffers(trackId, nextConfig);
     }
@@ -167,14 +178,12 @@ class SamplerEngine {
     await engine.resume();
 
     for (const zone of zones) {
-      // Skip zones with empty audioKey (e.g., unresolved SFZ imports)
       if (!zone.audioKey) continue;
       if (instance.zoneBuffers.has(zone.audioKey)) continue;
 
-      // Check the global buffer cache first
       const cached = this.bufferCache.get(zone.audioKey);
       if (cached) {
-        instance.zoneBuffers.set(zone.audioKey, new Tone.ToneAudioBuffer(cached));
+        instance.zoneBuffers.set(zone.audioKey, cached);
         continue;
       }
 
@@ -183,10 +192,9 @@ class SamplerEngine {
 
       const buffer = await engine.decodeAudioData(blob);
       this.bufferCache.set(zone.audioKey, buffer);
-      // Re-check instance in case it was removed while loading
       const current = this.samplers.get(trackId);
       if (current) {
-        current.zoneBuffers.set(zone.audioKey, new Tone.ToneAudioBuffer(buffer));
+        current.zoneBuffers.set(zone.audioKey, buffer);
       }
     }
   }
@@ -229,13 +237,12 @@ class SamplerEngine {
 
     const previewConfig = buildPlaybackConfig(config, buffer.duration);
     const vel01 = velocity / 127;
-    const toneBuffer = new Tone.ToneAudioBuffer(buffer);
     const zoneInfos = resolveZonePlayback(previewConfig, pitch, velocity);
+    const ctx = getAudioEngine().ctx;
 
     for (const info of zoneInfos) {
-      // Preview always uses primary buffer (zone buffers may not be loaded in preview context)
-      const voice = this._createVoice(toneBuffer, previewConfig, pitch, vel01, info);
-      voice.gain.connect(Tone.getDestination());
+      const voice = this._createVoice(buffer, previewConfig, pitch, vel01, info);
+      voice.gain.connect(ctx.destination);
       this.previewVoices.push(voice);
       this._startVoice(voice, previewConfig, duration);
       break; // Preview plays first matching zone only
@@ -256,9 +263,8 @@ class SamplerEngine {
       this._startVoice(voice, instance.config, duration);
       played = true;
     }
-    // Fallback to primary sample if no zone buffers were available
     if (!played) {
-      const voice = this._createVoice(instance.buffer, instance.config, pitch, velocity);
+      const voice = this._createVoice(instance.audioBuffer, instance.config, pitch, velocity);
       this._registerVoice(instance, voice);
       this._startVoice(voice, instance.config, duration);
     }
@@ -285,9 +291,8 @@ class SamplerEngine {
       this._startVoice(voice, instance.config, Number.POSITIVE_INFINITY);
       played = true;
     }
-    // Fallback to primary sample if no zone buffers were available
     if (!played) {
-      const voice = this._createVoice(instance.buffer, instance.config, pitch, vel01);
+      const voice = this._createVoice(instance.audioBuffer, instance.config, pitch, vel01);
       this._registerVoice(instance, voice);
       this._startVoice(voice, instance.config, Number.POSITIVE_INFINITY);
     }
@@ -354,44 +359,45 @@ class SamplerEngine {
   }
 
   /** Get the buffer for a zone audioKey, falling back to primary. */
-  private _getZoneBuffer(instance: SamplerInstance, audioKey: string): Tone.ToneAudioBuffer | null {
-    if (audioKey === instance.audioKey) return instance.buffer;
+  private _getZoneBuffer(instance: SamplerInstance, audioKey: string): AudioBuffer | null {
+    if (audioKey === instance.audioKey) return instance.audioBuffer;
     return instance.zoneBuffers.get(audioKey) ?? null;
   }
 
   private _createVoice(
-    buffer: Tone.ToneAudioBuffer,
+    buffer: AudioBuffer,
     config: SamplerConfig,
     pitch: number,
     velocity: number,
     zoneInfo?: ZonePlaybackInfo,
   ): SamplerVoice {
+    const ctx = getAudioEngine().ctx;
     const rootNote = zoneInfo?.rootNote ?? config.rootNote;
     const tuneOffsetSemitones = (zoneInfo?.tuneOffsetCents ?? 0) / 100;
     const playbackRate = Math.pow(2, (pitch - rootNote + tuneOffsetSemitones) / 12);
     const zoneGain = zoneInfo?.gain ?? 1;
     const zonePan = zoneInfo?.pan ?? 0;
 
-    const source = new Tone.BufferSource({
-      url: buffer,
-      loop: config.playbackMode === 'loop',
-      loopStart: config.loopStart,
-      loopEnd: config.loopEnd,
-      playbackRate,
-    });
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.loop = config.playbackMode === 'loop';
+    source.loopStart = config.loopStart;
+    source.loopEnd = config.loopEnd;
+    source.playbackRate.value = playbackRate;
 
-    const gain = new Tone.Gain(0);
-    let panner: Tone.Panner | null = null;
+    const gain = ctx.createGain();
+    let panner: StereoPannerNode | null = null;
 
     if (zonePan !== 0) {
-      panner = new Tone.Panner(zonePan);
+      panner = ctx.createStereoPanner();
+      panner.pan.value = zonePan;
       source.connect(panner);
       panner.connect(gain);
     } else {
       source.connect(gain);
     }
 
-    const now = Tone.now();
+    const now = ctx.currentTime;
     const attackEnd = now + Math.max(0.001, config.attack);
     const peakLevel = clamp(velocity * zoneGain, 0, 1);
     const sustainLevel = clamp(peakLevel * config.sustain, 0, 1);
@@ -405,6 +411,8 @@ class SamplerEngine {
       pitch,
       releaseTimeoutId: null,
       source,
+      playbackRate,
+      disposeTimeoutId: null,
     };
   }
 
@@ -415,9 +423,10 @@ class SamplerEngine {
   }
 
   private _startVoice(voice: SamplerVoice, config: SamplerConfig, requestedDuration: number) {
-    const startTime = Tone.now();
+    const ctx = getAudioEngine().ctx;
+    const startTime = ctx.currentTime;
     const trimmedDuration = Math.max(0.01, config.trimEnd - config.trimStart);
-    const playbackRate = Math.max(0.001, voice.source.playbackRate.value);
+    const playbackRate = Math.max(0.001, voice.playbackRate);
     const naturalDuration = trimmedDuration / playbackRate;
 
     if (config.playbackMode === 'loop') {
@@ -451,27 +460,43 @@ class SamplerEngine {
       voice.releaseTimeoutId = null;
     }
 
-    const now = Tone.now();
+    const ctx = getAudioEngine().ctx;
+    const now = ctx.currentTime;
     const releaseEnd = now + Math.max(0.01, release);
+    const currentGain = voice.gain.gain.value;
     voice.gain.gain.cancelScheduledValues(now);
-    voice.gain.gain.setValueAtTime(Math.max(0.0001, voice.gain.gain.value), now);
+    voice.gain.gain.setValueAtTime(Math.max(0.0001, currentGain), now);
     voice.gain.gain.linearRampToValueAtTime(0.0001, releaseEnd);
-    voice.source.stop(releaseEnd + 0.005);
-    globalThis.setTimeout(() => {
-      voice.source.dispose();
-      voice.gain.dispose();
-      voice.panner?.dispose();
+    try { voice.source.stop(releaseEnd + 0.005); } catch { /* already stopped */ }
+
+    if (voice.disposeTimeoutId !== null) {
+      globalThis.clearTimeout(voice.disposeTimeoutId);
+    }
+    voice.disposeTimeoutId = globalThis.setTimeout(() => {
+      this._disposeVoice(voice);
     }, Math.max(20, Math.ceil((release + 0.05) * 1000)));
+  }
+
+  private _disposeVoice(voice: SamplerVoice): void {
+    if (voice.releaseTimeoutId !== null) {
+      globalThis.clearTimeout(voice.releaseTimeoutId);
+      voice.releaseTimeoutId = null;
+    }
+    if (voice.disposeTimeoutId !== null) {
+      globalThis.clearTimeout(voice.disposeTimeoutId);
+      voice.disposeTimeoutId = null;
+    }
+    try { voice.source.stop(); } catch { /* already stopped */ }
+    try { voice.source.disconnect(); } catch { /* already disconnected */ }
+    try { voice.gain.disconnect(); } catch { /* already disconnected */ }
+    if (voice.panner) {
+      try { voice.panner.disconnect(); } catch { /* already disconnected */ }
+    }
   }
 
   private _disposeVoices(voices: SamplerVoice[]) {
     for (const voice of voices) {
-      if (voice.releaseTimeoutId !== null) {
-        globalThis.clearTimeout(voice.releaseTimeoutId);
-      }
-      voice.source.dispose();
-      voice.gain.dispose();
-      voice.panner?.dispose();
+      this._disposeVoice(voice);
     }
   }
 
@@ -481,7 +506,7 @@ class SamplerEngine {
     }
     instance.voices.clear();
     instance.zoneBuffers.clear();
-    instance.output.dispose();
+    try { instance.output.disconnect(); } catch { /* already disconnected */ }
   }
 }
 


### PR DESCRIPTION
## Summary

Mechanical swap — Tone classes used in SamplerEngine were all thin wrappers over native Web Audio nodes:
- `Tone.Gain` → `GainNode`
- `Tone.Panner` → `StereoPannerNode`
- `Tone.BufferSource` / `ToneBufferSource` → `AudioBufferSourceNode`
- `Tone.ToneAudioBuffer` → native `AudioBuffer` (wrapper dropped wholesale)
- `Tone.now()` → `ctx.currentTime`
- `Tone.start/getContext/getDestination` → `getAudioEngine().ctx`

Also tightened voice cleanup: consolidated `_disposeVoice`, tracked the release-tail disposal timer so hard-disposing a voice (track removal) doesn't leak it.

Closes #1736
Part of #1525

## Test plan

- [x] `npm test` — 7311 pass, same 2 pre-existing `clipResizeModifiers` failures as prior Phase 5 PRs
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [ ] Copilot + Codex review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)