### PR TITLE
feat: Phase 5I — migrate ModulationEngine off Tone.js

### DIFF
--- a/src/engine/ModulationEngine.ts
+++ b/src/engine/ModulationEngine.ts
@@ -11,7 +11,6 @@
  *                    (linear remap from [-1,1] to [0,1])
  */
 
-import type { InputNode as ToneInputNode } from 'tone';
 import { getAudioEngine } from '../hooks/useAudioEngine';
 import type {
   ModulationSettings,
@@ -20,19 +19,21 @@ import type {
 } from '../types/project';
 
 /**
- * Destination: given a track's audio nodes, an AudioParam / AudioNode
- * to modulate.
- *
- * The `ToneInputNode` branch is a transitional type-only shim — still
- * required because some upstream engines (Subtractive/Synth/etc.) are
- * Tone-wrapped during the 5-phase migration. Those engines' return
- * types flow through here untouched; at runtime we skip any target
- * that isn't a genuinely-native AudioParam/AudioNode instance, so
- * unmigrated routes degrade silently rather than crashing.
- *
- * This `tone` import is erased by TS at build time — no runtime dep.
+ * Destination: native AudioParam / AudioNode, or — transitionally —
+ * any object with a `connect` method. During the Tone migration some
+ * upstream engines (Subtractive/Synth/etc.) still hand back Tone
+ * wrappers; once those land on native-only, this union can shrink to
+ * just `AudioParam | AudioNode`. We intentionally don't import
+ * `tone`'s types here, even as a `type`-only import, so removing the
+ * `tone` package doesn't depend on finishing every engine first. At
+ * runtime the `.connect()` call is wrapped in try/catch, so any
+ * target that isn't compatible with native `AudioNode.connect`
+ * degrades silently.
  */
-export type ModulationTarget = AudioParam | AudioNode | ToneInputNode;
+// `any`-typed params so Tone's `ToneAudioNode.connect(destination: InputNode, …)`
+// structurally matches without dragging in Tone's `InputNode` type.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ModulationTarget = AudioParam | AudioNode | { connect: (target: any, ...rest: any[]) => any };
 
 export interface ModulationTargets {
   pitch?: ModulationTarget;
@@ -72,19 +73,24 @@ interface TrackModulation {
 }
 
 /**
- * Build a WaveShaper curve that linearly remaps its [-1, 1] input
- * range to [0, 1] — the unipolar fold Tone.Scale(0, 1) used to do.
+ * WaveShaper curve that linearly remaps its [-1, 1] input range to
+ * [0, 1] — the unipolar fold Tone.Scale(0, 1) used to do.
  *
- * Returns the strict `Float32Array<ArrayBuffer>` variant required by
- * `WaveShaperNode.curve` in TS 5.7's generic TypedArray typings.
+ * Hoisted to a module-level constant so `applyModulation` doesn't
+ * allocate a fresh 3-element Float32Array per unipolar LFO slot.
+ * The same curve buffer is safe to assign to many WaveShaperNodes —
+ * each node reads the values at assignment time.
+ *
+ * Typed as `Float32Array<ArrayBuffer>` to satisfy TS 5.7's strict
+ * generic TypedArray typings for `WaveShaperNode.curve`.
  */
-function buildUnipolarCurve(): Float32Array<ArrayBuffer> {
+const UNIPOLAR_CURVE: Float32Array<ArrayBuffer> = (() => {
   const curve = new Float32Array(3);
   curve[0] = 0;
   curve[1] = 0.5;
   curve[2] = 1;
   return curve;
-}
+})();
 
 /**
  * Connect a native AudioNode to `target`. The target can be a native
@@ -184,6 +190,19 @@ class ModulationEngine {
       const target = this.resolveTarget(slot.destination, targets);
       if (!target) continue;
 
+      // Try the downstream connection first — if the target is a
+      // still-Tone-wrapped value from an unmigrated engine, native
+      // `.connect()` will throw. In that case we bail before
+      // allocating the scaler / shaper and leaking nodes into the
+      // track's dispose queue.
+      const scaler = ctx.createGain();
+      scaler.gain.value = slot.amount;
+      const connected = connectToTarget(scaler, target);
+      if (!connected) {
+        try { scaler.disconnect(); } catch { /* already disconnected */ }
+        continue;
+      }
+
       // For unipolar (bipolar=false) LFO sources, fold output from
       // [-1, 1] to [0, 1] via a WaveShaper before the amount scaler.
       const isLfoSource = source.kind === 'lfo';
@@ -191,7 +210,7 @@ class ModulationEngine {
 
       if (!slot.bipolar && isLfoSource) {
         const shaper = ctx.createWaveShaper();
-        shaper.curve = buildUnipolarCurve();
+        shaper.curve = UNIPOLAR_CURVE;
         source.output.connect(shaper);
         upstream = shaper;
         connections.push({
@@ -203,18 +222,8 @@ class ModulationEngine {
       }
 
       // Scaling node: upstream × amount → destination.
-      const scaler = ctx.createGain();
-      scaler.gain.value = slot.amount;
       const slotUpstream = upstream;
       slotUpstream.connect(scaler);
-      const connected = connectToTarget(scaler, target);
-      // If the target wasn't a native connectable, leave the scaler
-      // orphaned but registered for disposal — cheaper than rolling
-      // back the upstream chain above, and its dispose path will
-      // disconnect everything cleanly on removeTrack.
-      if (!connected) {
-        // No target connection made — nothing more to do for this slot.
-      }
 
       connections.push({
         dispose: () => {

--- a/src/engine/ModulationEngine.ts
+++ b/src/engine/ModulationEngine.ts
@@ -1,48 +1,67 @@
 /**
- * Modulation Matrix Engine
+ * Modulation Matrix Engine — routes LFO / macro sources to synth
+ * parameters. Each track has up to 8 modulation slots.
  *
- * Manages Tone.js LFO and Signal nodes for flexible modulation routing.
- * Each track can have up to 8 modulation slots routing sources (LFOs,
- * envelopes, macros) to destinations (synth parameters).
- *
- * Architecture:
- * - Source nodes (LFO1, LFO2, macros) are Tone.Signal or Tone.LFO instances
- * - Each slot creates a Tone.Multiply (amount) node between source and destination
- * - Destinations are AudioParam references obtained from the synth engine
+ * Phase 5I migration: replaced Tone.LFO / Signal / Multiply / Scale
+ * with native Web Audio primitives. Mapping:
+ *   Tone.LFO       → OscillatorNode (native sine/square/triangle/sawtooth)
+ *   Tone.Signal(v) → ConstantSourceNode with offset.value = v
+ *   Tone.Multiply  → GainNode (gain = factor)
+ *   Tone.Scale(0,1)→ WaveShaperNode with curve [0, 0.5, 1]
+ *                    (linear remap from [-1,1] to [0,1])
  */
 
-import * as Tone from 'tone';
+import type { InputNode as ToneInputNode } from 'tone';
+import { getAudioEngine } from '../hooks/useAudioEngine';
 import type {
   ModulationSettings,
-  ModulationSlot,
   ModulationSource,
   ModulationDestination,
 } from '../types/project';
 
 /**
- * Destination resolver: given a track's audio nodes, returns the AudioParam references to modulate.
- * Uses Tone.InputNode as the common type since Tone.js Param/Signal generics are complex.
+ * Destination: given a track's audio nodes, an AudioParam / AudioNode
+ * to modulate.
+ *
+ * The `ToneInputNode` branch is a transitional type-only shim — still
+ * required because some upstream engines (Subtractive/Synth/etc.) are
+ * Tone-wrapped during the 5-phase migration. Those engines' return
+ * types flow through here untouched; at runtime we skip any target
+ * that isn't a genuinely-native AudioParam/AudioNode instance, so
+ * unmigrated routes degrade silently rather than crashing.
+ *
+ * This `tone` import is erased by TS at build time — no runtime dep.
  */
+export type ModulationTarget = AudioParam | AudioNode | ToneInputNode;
+
 export interface ModulationTargets {
-  pitch?: Tone.InputNode;
-  filterCutoff?: Tone.InputNode;
-  filterResonance?: Tone.InputNode;
-  amp?: Tone.InputNode;
-  pan?: Tone.InputNode;
-  oscLevel?: Tone.InputNode;
-  lfo1Rate?: Tone.InputNode;
-  lfo2Rate?: Tone.InputNode;
-  fmIndex?: Tone.InputNode;
-  wtPosition?: Tone.InputNode;
+  pitch?: ModulationTarget;
+  filterCutoff?: ModulationTarget;
+  filterResonance?: ModulationTarget;
+  amp?: ModulationTarget;
+  pan?: ModulationTarget;
+  oscLevel?: ModulationTarget;
+  lfo1Rate?: ModulationTarget;
+  lfo2Rate?: ModulationTarget;
+  fmIndex?: ModulationTarget;
+  wtPosition?: ModulationTarget;
 }
 
-interface SourceNode {
-  node: Tone.LFO | Tone.Signal;
-  dispose: () => void;
-}
+type LfoSourceNode = {
+  kind: 'lfo';
+  osc: OscillatorNode;
+  output: AudioNode;
+};
+
+type SignalSourceNode = {
+  kind: 'signal';
+  constant: ConstantSourceNode;
+  output: AudioNode;
+};
+
+type SourceNode = LfoSourceNode | SignalSourceNode;
 
 interface SlotConnection {
-  scaler: Tone.Multiply;
   dispose: () => void;
 }
 
@@ -50,6 +69,47 @@ interface TrackModulation {
   sources: Map<ModulationSource, SourceNode>;
   connections: SlotConnection[];
   settings: ModulationSettings;
+}
+
+/**
+ * Build a WaveShaper curve that linearly remaps its [-1, 1] input
+ * range to [0, 1] — the unipolar fold Tone.Scale(0, 1) used to do.
+ *
+ * Returns the strict `Float32Array<ArrayBuffer>` variant required by
+ * `WaveShaperNode.curve` in TS 5.7's generic TypedArray typings.
+ */
+function buildUnipolarCurve(): Float32Array<ArrayBuffer> {
+  const curve = new Float32Array(3);
+  curve[0] = 0;
+  curve[1] = 0.5;
+  curve[2] = 1;
+  return curve;
+}
+
+/**
+ * Connect a native AudioNode to `target`. The target can be a native
+ * AudioParam / AudioNode, or — during the Tone migration — a Tone
+ * wrapper that native `.connect()` doesn't understand. We `try` the
+ * connection and silently drop it on failure so an unmigrated engine
+ * doesn't crash the audio graph; the scaler node still gets created,
+ * just with no downstream. Returns `true` iff the connect succeeded.
+ */
+function connectToTarget(output: AudioNode, target: ModulationTarget): boolean {
+  try {
+    // The union type defeats TS's overload resolution here; cast to
+    // `never` to let the runtime's overload handling pick the right
+    // signature (AudioParam vs AudioNode).
+    output.connect(target as never);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function disconnectFromTarget(output: AudioNode, target: ModulationTarget): void {
+  try {
+    output.disconnect(target as never);
+  } catch { /* already disconnected or never connected */ }
 }
 
 class ModulationEngine {
@@ -69,36 +129,31 @@ class ModulationEngine {
 
     if (settings.slots.length === 0) return;
 
+    const ctx = getAudioEngine().ctx;
     const sources = new Map<ModulationSource, SourceNode>();
     const connections: SlotConnection[] = [];
 
-    // Create source nodes on demand
     const getSource = (source: ModulationSource): SourceNode | null => {
-      if (sources.has(source)) return sources.get(source)!;
+      const cached = sources.get(source);
+      if (cached) return cached;
 
       let sourceNode: SourceNode | null = null;
 
       switch (source) {
         case 'lfo1': {
-          const lfo = new Tone.LFO({
-            frequency: settings.lfo1.rateHz,
-            type: settings.lfo1.waveform as Tone.ToneOscillatorType,
-            min: -1,
-            max: 1,
-          });
-          lfo.start();
-          sourceNode = { node: lfo, dispose: () => { lfo.stop(); lfo.dispose(); } };
+          const osc = ctx.createOscillator();
+          osc.type = settings.lfo1.waveform as OscillatorType;
+          osc.frequency.value = settings.lfo1.rateHz;
+          osc.start();
+          sourceNode = { kind: 'lfo', osc, output: osc };
           break;
         }
         case 'lfo2': {
-          const lfo = new Tone.LFO({
-            frequency: settings.lfo2.rateHz,
-            type: settings.lfo2.waveform as Tone.ToneOscillatorType,
-            min: -1,
-            max: 1,
-          });
-          lfo.start();
-          sourceNode = { node: lfo, dispose: () => { lfo.stop(); lfo.dispose(); } };
+          const osc = ctx.createOscillator();
+          osc.type = settings.lfo2.waveform as OscillatorType;
+          osc.frequency.value = settings.lfo2.rateHz;
+          osc.start();
+          sourceNode = { kind: 'lfo', osc, output: osc };
           break;
         }
         case 'macro1':
@@ -106,8 +161,10 @@ class ModulationEngine {
         case 'macro3':
         case 'macro4': {
           const idx = parseInt(source.replace('macro', '')) - 1;
-          const sig = new Tone.Signal(settings.macros[idx] ?? 0);
-          sourceNode = { node: sig, dispose: () => sig.dispose() };
+          const constant = ctx.createConstantSource();
+          constant.offset.value = settings.macros[idx] ?? 0;
+          constant.start();
+          sourceNode = { kind: 'signal', constant, output: constant };
           break;
         }
         // Velocity, modWheel, envelope sources need per-note triggering — defer to future
@@ -115,9 +172,7 @@ class ModulationEngine {
           return null;
       }
 
-      if (sourceNode) {
-        sources.set(source, sourceNode);
-      }
+      sources.set(source, sourceNode);
       return sourceNode;
     };
 
@@ -129,39 +184,43 @@ class ModulationEngine {
       const target = this.resolveTarget(slot.destination, targets);
       if (!target) continue;
 
-      // For unipolar (bipolar=false) LFO sources, remap LFO output from [-1,1] to [0,1]
-      // using Tone.Scale before the amount scaler.
-      const isLfoSource = slot.source === 'lfo1' || slot.source === 'lfo2';
-      // sourceNode is the raw source output (LFO or Signal); captured for explicit disconnect on dispose.
-      const sourceNode = source.node as unknown as Tone.ToneAudioNode;
-      let upstream: Tone.ToneAudioNode = sourceNode;
+      // For unipolar (bipolar=false) LFO sources, fold output from
+      // [-1, 1] to [0, 1] via a WaveShaper before the amount scaler.
+      const isLfoSource = source.kind === 'lfo';
+      let upstream: AudioNode = source.output;
+
       if (!slot.bipolar && isLfoSource) {
-        const scaleNode = new Tone.Scale(0, 1); // maps [-1,1] → [0,1]
-        sourceNode.connect(scaleNode as unknown as Tone.InputNode);
-        upstream = scaleNode as unknown as Tone.ToneAudioNode;
+        const shaper = ctx.createWaveShaper();
+        shaper.curve = buildUnipolarCurve();
+        source.output.connect(shaper);
+        upstream = shaper;
         connections.push({
-          scaler: scaleNode as unknown as Tone.Multiply,
           dispose: () => {
-            // Disconnect source → scaleNode before disposal to avoid dangling connections.
-            try { sourceNode.disconnect(scaleNode as unknown as Tone.InputNode); } catch { /* already disconnected */ }
-            scaleNode.dispose();
+            try { source.output.disconnect(shaper); } catch { /* already disconnected */ }
+            try { shaper.disconnect(); } catch { /* already disconnected */ }
           },
         });
       }
 
-      // Create scaling node: upstream * amount → destination.
-      // Capture upstream in a const for the dispose closure.
+      // Scaling node: upstream × amount → destination.
+      const scaler = ctx.createGain();
+      scaler.gain.value = slot.amount;
       const slotUpstream = upstream;
-      const scaler = new Tone.Multiply(slot.amount);
       slotUpstream.connect(scaler);
-      scaler.connect(target);
+      const connected = connectToTarget(scaler, target);
+      // If the target wasn't a native connectable, leave the scaler
+      // orphaned but registered for disposal — cheaper than rolling
+      // back the upstream chain above, and its dispose path will
+      // disconnect everything cleanly on removeTrack.
+      if (!connected) {
+        // No target connection made — nothing more to do for this slot.
+      }
 
       connections.push({
-        scaler,
         dispose: () => {
-          // Disconnect upstream → scaler before disposal.
           try { slotUpstream.disconnect(scaler); } catch { /* already disconnected */ }
-          scaler.dispose();
+          disconnectFromTarget(scaler, target);
+          try { scaler.disconnect(); } catch { /* already disconnected */ }
         },
       });
     }
@@ -178,8 +237,8 @@ class ModulationEngine {
 
     const sourceKey = `macro${macroIndex + 1}` as ModulationSource;
     const source = track.sources.get(sourceKey);
-    if (source && source.node instanceof Tone.Signal) {
-      source.node.value = Math.max(0, Math.min(1, value));
+    if (source && source.kind === 'signal') {
+      source.constant.offset.value = Math.max(0, Math.min(1, value));
     }
   }
 
@@ -192,8 +251,8 @@ class ModulationEngine {
 
     const sourceKey = lfoIndex === 0 ? 'lfo1' : 'lfo2';
     const source = track.sources.get(sourceKey);
-    if (source && source.node instanceof Tone.LFO) {
-      source.node.frequency.value = rateHz;
+    if (source && source.kind === 'lfo') {
+      source.osc.frequency.value = rateHz;
     }
   }
 
@@ -208,7 +267,13 @@ class ModulationEngine {
       conn.dispose();
     }
     for (const source of track.sources.values()) {
-      source.dispose();
+      if (source.kind === 'lfo') {
+        try { source.osc.stop(); } catch { /* already stopped */ }
+        try { source.osc.disconnect(); } catch { /* already disconnected */ }
+      } else {
+        try { source.constant.stop(); } catch { /* already stopped */ }
+        try { source.constant.disconnect(); } catch { /* already disconnected */ }
+      }
     }
     this.tracks.delete(trackId);
   }
@@ -225,7 +290,7 @@ class ModulationEngine {
   private resolveTarget(
     dest: ModulationDestination,
     targets: ModulationTargets,
-  ): Tone.InputNode | null {
+  ): ModulationTarget | null {
     switch (dest) {
       case 'pitch': return targets.pitch ?? null;
       case 'filterCutoff': return targets.filterCutoff ?? null;

--- a/src/engine/SubtractiveEngine.ts
+++ b/src/engine/SubtractiveEngine.ts
@@ -2,7 +2,7 @@ import * as Tone from 'tone';
 import type {
   SubtractiveInstrumentSettings,
 } from '../types/project';
-import type { ModulationTargets } from './ModulationEngine';
+import type { ModulationTarget, ModulationTargets } from './ModulationEngine';
 
 interface SubtractiveInstance {
   synth: Tone.PolySynth;
@@ -138,15 +138,20 @@ class SubtractiveEngine {
     const instance = this.instances.get(trackId);
     if (!instance) return null;
 
+    // These are all Tone.Param wrappers; they carry `.connect()` that
+    // works within Tone's graph but isn't a direct AudioParam/AudioNode
+    // match. The ModulationEngine's runtime try/catch handles the
+    // mismatch — until SubtractiveEngine itself goes native (Phase 5K),
+    // modulation routes involving this engine will degrade silently.
     return {
-      amp: instance.output.gain as unknown as Tone.InputNode,
-      pitch: (instance.synth as unknown as { detune: Tone.InputNode }).detune ?? undefined,
-      pan: instance.panner.pan as unknown as Tone.InputNode,
+      amp: instance.output.gain as unknown as ModulationTarget,
+      pitch: (instance.synth as unknown as { detune: ModulationTarget }).detune ?? undefined,
+      pan: instance.panner.pan as unknown as ModulationTarget,
       filterCutoff: instance.filter
-        ? (instance.filter.frequency as unknown as Tone.InputNode)
+        ? (instance.filter.frequency as unknown as ModulationTarget)
         : undefined,
       filterResonance: instance.filter
-        ? (instance.filter.Q as unknown as Tone.InputNode)
+        ? (instance.filter.Q as unknown as ModulationTarget)
         : undefined,
     };
   }

--- a/src/engine/__tests__/ModulationEngine.test.ts
+++ b/src/engine/__tests__/ModulationEngine.test.ts
@@ -1,54 +1,105 @@
+/**
+ * ModulationEngine — unit tests
+ *
+ * Phase 5I migration: engine pulls its AudioContext from
+ * `getAudioEngine().ctx` instead of creating Tone nodes. We mock that
+ * context and track the native nodes via vi spies.
+ */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const mockLfoStart = vi.fn();
-const mockLfoStop = vi.fn();
-const mockLfoDispose = vi.fn();
-const mockLfoConnect = vi.fn();
-const mockLfoFrequency = { value: 1 };
+// We expose the mock factories via hoisted refs so individual tests
+// can reach in and assert behaviour on the most-recently-created node.
+const {
+  mockCtx,
+  makeMockAudioParam,
+  mocks,
+} = vi.hoisted(() => {
+  type MockParam = {
+    value: number;
+    setValueAtTime: ReturnType<typeof vi.fn>;
+  };
+  const makeMockAudioParam = (): MockParam => ({
+    value: 0,
+    setValueAtTime: vi.fn(),
+  });
 
-const mockSignalDispose = vi.fn();
-const mockSignalConnect = vi.fn();
-let mockSignalValue = 0;
+  // Shared mock handles — cleared between tests via vi.clearAllMocks().
+  const mocks = {
+    oscStart: vi.fn(),
+    oscStop: vi.fn(),
+    oscConnect: vi.fn(),
+    oscDisconnect: vi.fn(),
+    constantStart: vi.fn(),
+    constantStop: vi.fn(),
+    constantConnect: vi.fn(),
+    constantDisconnect: vi.fn(),
+    gainConnect: vi.fn(),
+    gainDisconnect: vi.fn(),
+    shaperConnect: vi.fn(),
+    shaperDisconnect: vi.fn(),
+    // Handles kept in mutable slots so tests can inspect them.
+    lastOsc: null as any,
+    lastConstant: null as any,
+  };
 
-const mockMultiplyConnect = vi.fn();
-const mockMultiplyDispose = vi.fn();
+  const makeOsc = () => {
+    const osc = {
+      type: 'sine',
+      frequency: makeMockAudioParam(),
+      start: mocks.oscStart,
+      stop: mocks.oscStop,
+      connect: mocks.oscConnect,
+      disconnect: mocks.oscDisconnect,
+    };
+    mocks.lastOsc = osc;
+    return osc;
+  };
+  const makeConstant = () => {
+    const c = {
+      offset: makeMockAudioParam(),
+      start: mocks.constantStart,
+      stop: mocks.constantStop,
+      connect: mocks.constantConnect,
+      disconnect: mocks.constantDisconnect,
+    };
+    mocks.lastConstant = c;
+    return c;
+  };
+  const makeGain = () => ({
+    gain: makeMockAudioParam(),
+    connect: mocks.gainConnect,
+    disconnect: mocks.gainDisconnect,
+  });
+  const makeShaper = () => ({
+    curve: null as Float32Array | null,
+    connect: mocks.shaperConnect,
+    disconnect: mocks.shaperDisconnect,
+  });
 
-const mockScaleConnect = vi.fn();
-const mockScaleDispose = vi.fn();
-
-vi.mock('tone', () => {
   return {
-    LFO: class MockLFO {
-      frequency = mockLfoFrequency;
-      start = mockLfoStart;
-      stop = mockLfoStop;
-      dispose = mockLfoDispose;
-      connect = mockLfoConnect;
+    mockCtx: {
+      state: 'running' as AudioContextState,
+      currentTime: 0,
+      createOscillator: vi.fn(makeOsc),
+      createConstantSource: vi.fn(makeConstant),
+      createGain: vi.fn(makeGain),
+      createWaveShaper: vi.fn(makeShaper),
     },
-    Signal: class MockSignal {
-      constructor(v: number) { mockSignalValue = v; }
-      get value() { return mockSignalValue; }
-      set value(v: number) { mockSignalValue = v; }
-      dispose = mockSignalDispose;
-      connect = mockSignalConnect;
-    },
-    Multiply: class MockMultiply {
-      constructor(public factor: number) {}
-      connect = mockMultiplyConnect;
-      dispose = mockMultiplyDispose;
-    },
-    Scale: class MockScale {
-      constructor(public outputMin: number, public outputMax: number) {}
-      connect = mockScaleConnect;
-      dispose = mockScaleDispose;
-    },
-    Param: class MockParam {},
+    makeMockAudioParam,
+    mocks,
   };
 });
 
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(() => ({
+    ctx: mockCtx,
+    resume: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 import { modulationEngine } from '../ModulationEngine';
 import type { ModulationSettings } from '../../types/project';
-import type { ModulationTargets } from '../ModulationEngine';
+import type { ModulationTargets, ModulationTarget } from '../ModulationEngine';
 
 function makeSettings(overrides?: Partial<ModulationSettings>): ModulationSettings {
   return {
@@ -62,39 +113,43 @@ function makeSettings(overrides?: Partial<ModulationSettings>): ModulationSettin
 }
 
 function makeMockTargets(): ModulationTargets {
+  // We use plain objects as AudioParam/AudioNode stand-ins. The
+  // engine only ever connects nodes into these — it doesn't read
+  // properties off them — so opaque object identity is enough.
   return {
-    filterCutoff: {} as ModulationTargets['filterCutoff'],
-    amp: {} as ModulationTargets['amp'],
+    filterCutoff: {} as unknown as ModulationTarget,
+    amp: {} as unknown as ModulationTarget,
   };
 }
 
 describe('ModulationEngine', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSignalValue = 0;
-    // re-assign arrow fn refs so vi.clearAllMocks doesn't break them
+    mocks.lastOsc = null;
+    mocks.lastConstant = null;
   });
 
   afterEach(() => {
     modulationEngine.removeTrack('test-track');
+    modulationEngine.removeTrack('track-1');
+    modulationEngine.removeTrack('track-2');
   });
 
   describe('applyModulation', () => {
     it('does nothing with empty slots', () => {
       const settings = makeSettings({ slots: [] });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
-      // No LFOs should be created
-      expect(mockLfoStart).not.toHaveBeenCalled();
+      expect(mocks.oscStart).not.toHaveBeenCalled();
     });
 
-    it('creates LFO1 source and connects to filter cutoff', () => {
+    it('creates LFO1 source and wires it through a gain scaler to the target', () => {
       const settings = makeSettings({
         slots: [{ source: 'lfo1', destination: 'filterCutoff', amount: 0.5, bipolar: true }],
       });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
-      expect(mockLfoStart).toHaveBeenCalled();
-      expect(mockLfoConnect).toHaveBeenCalled();
-      expect(mockMultiplyConnect).toHaveBeenCalled();
+      expect(mocks.oscStart).toHaveBeenCalledTimes(1);
+      expect(mocks.oscConnect).toHaveBeenCalled();       // osc → scaler
+      expect(mocks.gainConnect).toHaveBeenCalled();      // scaler → target
     });
 
     it('creates LFO2 source when used', () => {
@@ -102,20 +157,24 @@ describe('ModulationEngine', () => {
         slots: [{ source: 'lfo2', destination: 'amp', amount: 0.3, bipolar: false }],
       });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
-      expect(mockLfoStart).toHaveBeenCalled();
+      expect(mocks.oscStart).toHaveBeenCalledTimes(1);
+      // bipolar=false + LFO source → WaveShaper is created to fold [-1,1]→[0,1]
+      expect(mockCtx.createWaveShaper).toHaveBeenCalledTimes(1);
     });
 
-    it('creates macro source as Signal', () => {
+    it('creates macro source as ConstantSourceNode with initial offset', () => {
       const settings = makeSettings({
         macros: [0.75, 0, 0, 0],
         slots: [{ source: 'macro1', destination: 'filterCutoff', amount: 1, bipolar: false }],
       });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
-      expect(mockSignalValue).toBe(0.75);
-      expect(mockSignalConnect).toHaveBeenCalled();
+      expect(mockCtx.createConstantSource).toHaveBeenCalledTimes(1);
+      expect(mocks.lastConstant.offset.value).toBe(0.75);
+      expect(mocks.constantStart).toHaveBeenCalled();
+      expect(mocks.constantConnect).toHaveBeenCalled();
     });
 
-    it('reuses same source for multiple slots', () => {
+    it('reuses the same source for multiple slots', () => {
       const settings = makeSettings({
         slots: [
           { source: 'lfo1', destination: 'filterCutoff', amount: 0.5, bipolar: true },
@@ -123,19 +182,19 @@ describe('ModulationEngine', () => {
         ],
       });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
-      // LFO should only be created once, but connected twice via two scalers
-      expect(mockLfoStart).toHaveBeenCalledTimes(1);
-      expect(mockMultiplyConnect).toHaveBeenCalledTimes(2);
+      // Only one OscillatorNode is created — the second slot reuses it.
+      expect(mockCtx.createOscillator).toHaveBeenCalledTimes(1);
+      // Two scaler gains though — one per slot.
+      expect(mockCtx.createGain).toHaveBeenCalledTimes(2);
     });
 
     it('skips slots with unavailable targets', () => {
       const settings = makeSettings({
         slots: [{ source: 'lfo1', destination: 'pan', amount: 0.5, bipolar: true }],
       });
-      // Targets don't include 'pan'
-      modulationEngine.applyModulation('test-track', settings, { filterCutoff: {} as never });
-      // LFO created but no Multiply connected to target
-      expect(mockMultiplyConnect).not.toHaveBeenCalled();
+      modulationEngine.applyModulation('test-track', settings, { filterCutoff: {} as ModulationTarget });
+      // No scaler gain created because we bailed before that step.
+      expect(mockCtx.createGain).not.toHaveBeenCalled();
     });
 
     it('skips unsupported sources (velocity, modWheel, envelopes)', () => {
@@ -143,52 +202,50 @@ describe('ModulationEngine', () => {
         slots: [{ source: 'velocity', destination: 'filterCutoff', amount: 0.5, bipolar: false }],
       });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
-      // No source created, no connection
-      expect(mockLfoStart).not.toHaveBeenCalled();
-      expect(mockMultiplyConnect).not.toHaveBeenCalled();
+      expect(mockCtx.createOscillator).not.toHaveBeenCalled();
+      expect(mockCtx.createGain).not.toHaveBeenCalled();
     });
   });
 
   describe('setMacro', () => {
-    it('updates macro signal value', () => {
+    it('updates the macro source offset', () => {
       const settings = makeSettings({
         macros: [0.5, 0, 0, 0],
         slots: [{ source: 'macro1', destination: 'filterCutoff', amount: 1, bipolar: false }],
       });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
       modulationEngine.setMacro('test-track', 0, 0.8);
-      expect(mockSignalValue).toBe(0.8);
+      expect(mocks.lastConstant.offset.value).toBe(0.8);
     });
 
-    it('clamps macro value to 0-1', () => {
+    it('clamps macro value to [0, 1]', () => {
       const settings = makeSettings({
         macros: [0, 0, 0, 0],
         slots: [{ source: 'macro1', destination: 'filterCutoff', amount: 1, bipolar: false }],
       });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
       modulationEngine.setMacro('test-track', 0, 1.5);
-      expect(mockSignalValue).toBe(1);
+      expect(mocks.lastConstant.offset.value).toBe(1);
     });
 
     it('is a no-op for unknown track', () => {
-      modulationEngine.setMacro('nonexistent', 0, 0.5);
-      // Should not throw
+      expect(() => modulationEngine.setMacro('nonexistent', 0, 0.5)).not.toThrow();
     });
   });
 
   describe('setLfoRate', () => {
-    it('updates LFO frequency', () => {
+    it('updates the LFO oscillator frequency', () => {
       const settings = makeSettings({
         slots: [{ source: 'lfo1', destination: 'filterCutoff', amount: 0.5, bipolar: true }],
       });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
       modulationEngine.setLfoRate('test-track', 0, 5);
-      expect(mockLfoFrequency.value).toBe(5);
+      expect(mocks.lastOsc.frequency.value).toBe(5);
     });
   });
 
   describe('removeTrack', () => {
-    it('disposes all sources and connections', () => {
+    it('stops and disconnects all sources', () => {
       const settings = makeSettings({
         slots: [
           { source: 'lfo1', destination: 'filterCutoff', amount: 0.5, bipolar: true },
@@ -197,15 +254,18 @@ describe('ModulationEngine', () => {
       });
       modulationEngine.applyModulation('test-track', settings, makeMockTargets());
       modulationEngine.removeTrack('test-track');
-      expect(mockLfoStop).toHaveBeenCalled();
-      expect(mockLfoDispose).toHaveBeenCalled();
-      expect(mockSignalDispose).toHaveBeenCalled();
-      expect(mockMultiplyDispose).toHaveBeenCalledTimes(2);
+      // Each source is `stop()`ed exactly once (per source, not per slot).
+      expect(mocks.oscStop).toHaveBeenCalledTimes(1);
+      expect(mocks.constantStop).toHaveBeenCalledTimes(1);
+      // Disconnect assertions are "at least once" — the slot's dispose
+      // path and the source's dispose path both ask the upstream node
+      // to disconnect, which is fine (native disconnect is idempotent).
+      expect(mocks.oscDisconnect).toHaveBeenCalled();
+      expect(mocks.constantDisconnect).toHaveBeenCalled();
     });
 
     it('is a no-op for unknown track', () => {
-      modulationEngine.removeTrack('nonexistent');
-      // Should not throw
+      expect(() => modulationEngine.removeTrack('nonexistent')).not.toThrow();
     });
   });
 
@@ -217,7 +277,7 @@ describe('ModulationEngine', () => {
       modulationEngine.applyModulation('track-1', settings, makeMockTargets());
       modulationEngine.applyModulation('track-2', settings, makeMockTargets());
       modulationEngine.releaseAll();
-      expect(mockLfoStop).toHaveBeenCalledTimes(2);
+      expect(mocks.oscStop).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

Mechanical swap to native Web Audio primitives:
- \`Tone.LFO\` → \`OscillatorNode\`
- \`Tone.Signal(v)\` → \`ConstantSourceNode\` with \`offset.value = v\`
- \`Tone.Multiply(factor)\` → \`GainNode\` (gain = factor → multiplies incoming signal)
- \`Tone.Scale(0, 1)\` → \`WaveShaperNode\` with curve \`[0, 0.5, 1]\` (linear remap [-1,1]→[0,1])

**Transitional quirk**: \`ModulationTarget\` still accepts Tone's \`InputNode\` as a *type-only* import (erased at build time). Runtime uses a try/catch guard so unmigrated upstream engines (Subtractive/Synth/etc.) whose modulation targets are still Tone wrappers degrade silently rather than crashing the graph. This type branch will drop naturally once 5K/5L land.

Closes #1738
Part of #1525

## Test plan

- [x] \`npm test\` — 7311 pass, same 2 pre-existing \`clipResizeModifiers\` failures as prior phase PRs
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — succeeds
- [ ] Copilot + Codex review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)