### PR TITLE
feat: Phase 5J — migrate WavetableEngine off Tone.js

### DIFF
--- a/src/engine/WavetableEngine.ts
+++ b/src/engine/WavetableEngine.ts
@@ -144,9 +144,21 @@ export class NativeWavetableSynth {
 
     const t = time ?? this._ctx.currentTime;
     const env = this._envelope;
-    voice.gain.gain.cancelScheduledValues(t);
-    voice.gain.gain.setValueAtTime(voice.gain.gain.value, t);
-    voice.gain.gain.linearRampToValueAtTime(0, t + env.release);
+    // `AudioParam.value` reflects the current time's computed value,
+    // not the value at `t` — so naively anchoring via
+    // `setValueAtTime(value, t)` after `cancelScheduledValues` drops
+    // the scheduled ADSR mid-ramp. `cancelAndHoldAtTime(t)` is the
+    // correct primitive: it cancels future events while preserving
+    // whatever value the scheduled ramp would reach at `t`. Fall
+    // back to the old approach for environments that don't expose it.
+    const gainParam = voice.gain.gain;
+    if (typeof gainParam.cancelAndHoldAtTime === 'function') {
+      gainParam.cancelAndHoldAtTime(t);
+    } else {
+      gainParam.cancelScheduledValues(t);
+      gainParam.setValueAtTime(gainParam.value, t);
+    }
+    gainParam.linearRampToValueAtTime(0, t + env.release);
 
     const osc = voice.osc;
     osc.onended = () => {
@@ -259,10 +271,15 @@ class WavetableEngine {
     const instance = this.instances.get(trackId);
     if (!instance) return;
 
-    instance.settings = { ...settings };
-    instance.currentPosition = settings.position;
+    // Clamp here to match `setPosition` — an out-of-range value on a
+    // persisted project or a bad upstream call would otherwise be
+    // cached in `currentPosition` without clamping, even though
+    // `computePartialsAtPosition` clamps internally for the wave itself.
+    const clamped = Math.max(0, Math.min(1, settings.position));
+    instance.settings = { ...settings, position: clamped };
+    instance.currentPosition = clamped;
 
-    const partials = computePartialsAtPosition(settings.waveforms, settings.position);
+    const partials = computePartialsAtPosition(settings.waveforms, clamped);
     instance.synth.setPartials(partials);
     instance.synth.setEnvelope(settings.ampEnvelope);
     instance.gain.gain.value = settings.outputGain;

--- a/src/engine/WavetableEngine.ts
+++ b/src/engine/WavetableEngine.ts
@@ -1,26 +1,208 @@
-import * as Tone from 'tone';
-import type { WavetableSettings } from '../types/project';
-import { computePartialsAtPosition } from './wavetablePresets';
-
-interface WavetableInstance {
-  synth: Tone.PolySynth;
-  gain: Tone.Gain;
-  settings: WavetableSettings;
-  /** Current morph position (updated manually via setPosition). */
-  currentPosition: number;
-  /** The output node this instance is connected to; used to detect re-routing. */
-  connectTo: Tone.InputNode | undefined;
-}
-
 /**
- * Engine that manages wavetable synthesis instances per track.
- * Uses Tone.PolySynth with custom `partials` arrays and interpolates
- * between waveform tables based on position.
+ * WavetableEngine — manages wavetable synthesis instances per track.
+ *
+ * Phase 5J migration: replaced `Tone.PolySynth(Tone.Synth)` with
+ * `Tone.oscillator.type = 'custom'` with a local `NativeWavetableSynth`
+ * — a small polyphonic voice manager that drives each voice's
+ * OscillatorNode from a `PeriodicWave` built out of the partials
+ * array. This is the same wavetable wiring Tone does under the hood,
+ * but without the dependency.
  *
  * Note: `morphSpeed` is stored in settings for UI/persistence but automatic
  * real-time morphing requires a Transport-scheduled callback (not yet wired).
  * Use `setPosition()` to drive morphing from an external clock or automation lane.
  */
+
+import type { InstrumentEnvelope, WavetableSettings } from '../types/project';
+import { computePartialsAtPosition } from './wavetablePresets';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+import { midiToFrequency } from '../utils/pitch';
+
+// ─── NativeWavetableSynth ──────────────────────────────────────────────────
+
+interface WavetableVoice {
+  osc: OscillatorNode | null;
+  gain: GainNode;
+  /** The freq currently held in this voice slot (Hz) — doubles as the
+   *  identity for per-note release. null when idle. */
+  freq: number | null;
+}
+
+/**
+ * Small polyphonic wavetable synth. Each voice owns a GainNode (pre-
+ * connected to the output bus) and rents an OscillatorNode for the
+ * note's lifetime. The oscillator is driven by a PeriodicWave derived
+ * from the current partials — swapping partials at runtime doesn't
+ * affect voices already sounding (their oscillator captured the
+ * previous wave), matching Tone.PolySynth's behaviour.
+ */
+export class NativeWavetableSynth {
+  private readonly _ctx: AudioContext;
+  private readonly _output: GainNode;
+  private readonly _voices: WavetableVoice[] = [];
+  private readonly _maxPoly: number;
+  private _nextVoice = 0;
+  private readonly _freqToVoice = new Map<number, number>();
+  private _periodicWave: PeriodicWave;
+  private _envelope: InstrumentEnvelope = {
+    attack: 0.01,
+    decay: 0.1,
+    sustain: 0.7,
+    release: 0.3,
+  };
+
+  constructor(ctx: AudioContext, partials: number[], maxPolyphony = 8) {
+    this._ctx = ctx;
+    this._maxPoly = maxPolyphony;
+    this._output = ctx.createGain();
+    this._periodicWave = this._buildWave(partials);
+    for (let i = 0; i < this._maxPoly; i++) {
+      const gain = ctx.createGain();
+      gain.gain.value = 0;
+      gain.connect(this._output);
+      this._voices.push({ osc: null, gain, freq: null });
+    }
+  }
+
+  get outputNode(): GainNode {
+    return this._output;
+  }
+
+  private _buildWave(partials: number[]): PeriodicWave {
+    // partials[i] is the amplitude of the (i+1)th harmonic.
+    // `createPeriodicWave(real, imag)` uses imag[k] as the sine
+    // coefficient for the kth harmonic; index 0 is DC (ignored).
+    const len = partials.length + 1;
+    const real = new Float32Array(len);
+    const imag = new Float32Array(len);
+    for (let i = 0; i < partials.length; i++) {
+      imag[i + 1] = partials[i];
+    }
+    return this._ctx.createPeriodicWave(real, imag, { disableNormalization: false });
+  }
+
+  setPartials(partials: number[]): void {
+    this._periodicWave = this._buildWave(partials);
+  }
+
+  setEnvelope(env: InstrumentEnvelope): void {
+    this._envelope = { ...env };
+  }
+
+  private _allocVoice(freq: number): WavetableVoice {
+    const existing = this._freqToVoice.get(freq);
+    if (existing !== undefined) return this._voices[existing];
+
+    const idx = this._nextVoice % this._maxPoly;
+    this._nextVoice++;
+
+    // Evict any note currently occupying this slot
+    for (const [f, vi] of this._freqToVoice) {
+      if (vi === idx) {
+        this._freqToVoice.delete(f);
+        break;
+      }
+    }
+    this._freqToVoice.set(freq, idx);
+    return this._voices[idx];
+  }
+
+  triggerAttack(freq: number, time?: number, velocity = 1): void {
+    const t = time ?? this._ctx.currentTime;
+    const voice = this._allocVoice(freq);
+    const env = this._envelope;
+
+    // Stop & disconnect any lingering osc in this slot
+    if (voice.osc) {
+      try { voice.osc.stop(t); } catch { /* already stopped */ }
+      try { voice.osc.disconnect(); } catch { /* already disconnected */ }
+    }
+
+    const osc = this._ctx.createOscillator();
+    osc.setPeriodicWave(this._periodicWave);
+    osc.frequency.value = freq;
+    osc.connect(voice.gain);
+
+    voice.gain.gain.cancelScheduledValues(t);
+    voice.gain.gain.setValueAtTime(0, t);
+    voice.gain.gain.linearRampToValueAtTime(velocity, t + env.attack);
+    voice.gain.gain.linearRampToValueAtTime(
+      velocity * env.sustain,
+      t + env.attack + env.decay,
+    );
+
+    osc.start(t);
+    voice.osc = osc;
+    voice.freq = freq;
+  }
+
+  triggerRelease(freq: number, time?: number): void {
+    const idx = this._freqToVoice.get(freq);
+    if (idx === undefined) return;
+    const voice = this._voices[idx];
+    if (!voice.osc) return;
+
+    const t = time ?? this._ctx.currentTime;
+    const env = this._envelope;
+    voice.gain.gain.cancelScheduledValues(t);
+    voice.gain.gain.setValueAtTime(voice.gain.gain.value, t);
+    voice.gain.gain.linearRampToValueAtTime(0, t + env.release);
+
+    const osc = voice.osc;
+    osc.onended = () => {
+      try { osc.disconnect(); } catch { /* already disconnected */ }
+    };
+    try { osc.stop(t + env.release + 0.01); } catch { /* already stopped */ }
+
+    voice.osc = null;
+    voice.freq = null;
+    this._freqToVoice.delete(freq);
+  }
+
+  triggerAttackRelease(
+    freq: number,
+    duration: number,
+    time?: number,
+    velocity = 1,
+  ): void {
+    const t = time ?? this._ctx.currentTime;
+    this.triggerAttack(freq, t, velocity);
+    this.triggerRelease(freq, t + duration);
+  }
+
+  releaseAll(time?: number): void {
+    const t = time ?? this._ctx.currentTime;
+    const freqs = [...this._freqToVoice.keys()];
+    for (const f of freqs) {
+      this.triggerRelease(f, t);
+    }
+  }
+
+  dispose(): void {
+    for (const voice of this._voices) {
+      if (voice.osc) {
+        try { voice.osc.stop(); } catch { /* already stopped */ }
+        try { voice.osc.disconnect(); } catch { /* already disconnected */ }
+        voice.osc = null;
+      }
+      try { voice.gain.disconnect(); } catch { /* already disconnected */ }
+    }
+    this._voices.length = 0;
+    this._freqToVoice.clear();
+    try { this._output.disconnect(); } catch { /* already disconnected */ }
+  }
+}
+
+// ─── WavetableEngine ───────────────────────────────────────────────────────
+
+interface WavetableInstance {
+  synth: NativeWavetableSynth;
+  gain: GainNode;
+  settings: WavetableSettings;
+  currentPosition: number;
+  connectTo: AudioNode | undefined;
+}
+
 class WavetableEngine {
   private instances = new Map<string, WavetableInstance>();
 
@@ -31,39 +213,31 @@ class WavetableEngine {
   ensureTrackSynth(
     trackId: string,
     settings: WavetableSettings,
-    connectTo?: Tone.InputNode,
-  ): Tone.PolySynth {
+    connectTo?: AudioNode,
+  ): NativeWavetableSynth {
     const existing = this.instances.get(trackId);
     if (existing) {
       this.applySettings(trackId, settings);
-      // Reconnect gain if the output node has changed.
       if (connectTo && connectTo !== existing.connectTo) {
-        existing.gain.disconnect();
+        try { existing.gain.disconnect(); } catch { /* already disconnected */ }
         existing.gain.connect(connectTo);
         existing.connectTo = connectTo;
       }
       return existing.synth;
     }
 
-    // Create new instance
+    const ctx = getAudioEngine().ctx;
     const partials = computePartialsAtPosition(settings.waveforms, settings.position);
-    const synth = new Tone.PolySynth(Tone.Synth);
-    synth.set({
-      oscillator: { type: 'custom', partials },
-      envelope: {
-        attack: settings.ampEnvelope.attack,
-        decay: settings.ampEnvelope.decay,
-        sustain: settings.ampEnvelope.sustain,
-        release: settings.ampEnvelope.release,
-      },
-    });
+    const synth = new NativeWavetableSynth(ctx, partials);
+    synth.setEnvelope(settings.ampEnvelope);
 
-    const gain = new Tone.Gain(settings.outputGain);
-    synth.connect(gain);
+    const gain = ctx.createGain();
+    gain.gain.value = settings.outputGain;
+    synth.outputNode.connect(gain);
     if (connectTo) {
       gain.connect(connectTo);
     } else {
-      gain.toDestination();
+      gain.connect(ctx.destination);
     }
 
     const instance: WavetableInstance = {
@@ -89,16 +263,8 @@ class WavetableEngine {
     instance.currentPosition = settings.position;
 
     const partials = computePartialsAtPosition(settings.waveforms, settings.position);
-    instance.synth.set({
-      oscillator: { type: 'custom', partials },
-      envelope: {
-        attack: settings.ampEnvelope.attack,
-        decay: settings.ampEnvelope.decay,
-        sustain: settings.ampEnvelope.sustain,
-        release: settings.ampEnvelope.release,
-      },
-    });
-
+    instance.synth.setPartials(partials);
+    instance.synth.setEnvelope(settings.ampEnvelope);
     instance.gain.gain.value = settings.outputGain;
   }
 
@@ -112,7 +278,7 @@ class WavetableEngine {
     const clamped = Math.max(0, Math.min(1, position));
     instance.currentPosition = clamped;
     const partials = computePartialsAtPosition(instance.settings.waveforms, clamped);
-    instance.synth.set({ oscillator: { type: 'custom', partials } });
+    instance.synth.setPartials(partials);
   }
 
   /**
@@ -125,7 +291,7 @@ class WavetableEngine {
   /**
    * Get the synth instance for a track (for external note triggering).
    */
-  getSynth(trackId: string): Tone.PolySynth | null {
+  getSynth(trackId: string): NativeWavetableSynth | null {
     return this.instances.get(trackId)?.synth ?? null;
   }
 
@@ -139,12 +305,12 @@ class WavetableEngine {
     duration: number,
     settings: WavetableSettings,
   ): Promise<void> {
-    if (Tone.getContext().state !== 'running') {
-      await Tone.start();
+    const engine = getAudioEngine();
+    if (engine.ctx.state !== 'running') {
+      await engine.resume();
     }
     const synth = this.ensureTrackSynth(trackId, settings);
-    const freq = Tone.Frequency(pitch, 'midi').toFrequency();
-    synth.triggerAttackRelease(freq, duration, undefined, velocity / 127);
+    synth.triggerAttackRelease(midiToFrequency(pitch), duration, undefined, velocity / 127);
   }
 
   /**
@@ -153,8 +319,7 @@ class WavetableEngine {
   noteOn(trackId: string, pitch: number, velocity = 100): void {
     const instance = this.instances.get(trackId);
     if (!instance) return;
-    const freq = Tone.Frequency(pitch, 'midi').toFrequency();
-    instance.synth.triggerAttack(freq, undefined, velocity / 127);
+    instance.synth.triggerAttack(midiToFrequency(pitch), undefined, velocity / 127);
   }
 
   /**
@@ -163,8 +328,7 @@ class WavetableEngine {
   noteOff(trackId: string, pitch: number): void {
     const instance = this.instances.get(trackId);
     if (!instance) return;
-    const freq = Tone.Frequency(pitch, 'midi').toFrequency();
-    instance.synth.triggerRelease(freq);
+    instance.synth.triggerRelease(midiToFrequency(pitch));
   }
 
   /**
@@ -184,7 +348,7 @@ class WavetableEngine {
     if (!instance) return;
     instance.synth.releaseAll();
     instance.synth.dispose();
-    instance.gain.dispose();
+    try { instance.gain.disconnect(); } catch { /* already disconnected */ }
     this.instances.delete(trackId);
   }
 

--- a/src/engine/__tests__/WavetableEngine.test.ts
+++ b/src/engine/__tests__/WavetableEngine.test.ts
@@ -1,41 +1,63 @@
+/**
+ * WavetableEngine — unit tests
+ *
+ * Phase 5J migration: the engine now runs its own NativeWavetableSynth
+ * over `getAudioEngine().ctx`. Tests observe via the mocked context's
+ * factory spies; most behaviour that used to assert on Tone class
+ * calls becomes "did the right context method get invoked?".
+ */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const mockSynthSet = vi.fn();
-const mockSynthConnect = vi.fn();
-const mockSynthDispose = vi.fn();
-const mockSynthTriggerAttackRelease = vi.fn();
-const mockSynthTriggerAttack = vi.fn();
-const mockSynthTriggerRelease = vi.fn();
-const mockSynthReleaseAll = vi.fn();
-
-const mockGainConnect = vi.fn();
-const mockGainToDestination = vi.fn();
-const mockGainDispose = vi.fn();
-const mockGainValue = { value: 0 };
-
-vi.mock('tone', () => {
+const { mockCtx, mocks } = vi.hoisted(() => {
+  const makeAudioParam = () => ({
+    value: 0,
+    setValueAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+    cancelScheduledValues: vi.fn(),
+  });
+  const mocks = {
+    oscStart: vi.fn(),
+    oscStop: vi.fn(),
+    oscConnect: vi.fn(),
+    oscDisconnect: vi.fn(),
+    oscSetPeriodicWave: vi.fn(),
+    gainConnect: vi.fn(),
+    gainDisconnect: vi.fn(),
+    createPeriodicWave: vi.fn(),
+  };
+  const makeGain = () => ({
+    gain: makeAudioParam(),
+    connect: mocks.gainConnect,
+    disconnect: mocks.gainDisconnect,
+  });
+  const makeOsc = () => ({
+    frequency: makeAudioParam(),
+    start: mocks.oscStart,
+    stop: mocks.oscStop,
+    connect: mocks.oscConnect,
+    disconnect: mocks.oscDisconnect,
+    setPeriodicWave: mocks.oscSetPeriodicWave,
+    onended: null as (() => void) | null,
+  });
   return {
-    PolySynth: class MockPolySynth {
-      set = mockSynthSet;
-      connect = mockSynthConnect;
-      dispose = mockSynthDispose;
-      triggerAttackRelease = mockSynthTriggerAttackRelease;
-      triggerAttack = mockSynthTriggerAttack;
-      triggerRelease = mockSynthTriggerRelease;
-      releaseAll = mockSynthReleaseAll;
+    mockCtx: {
+      state: 'running' as AudioContextState,
+      currentTime: 0,
+      destination: {} as AudioNode,
+      createGain: vi.fn(makeGain),
+      createOscillator: vi.fn(makeOsc),
+      createPeriodicWave: mocks.createPeriodicWave.mockReturnValue({} as PeriodicWave),
     },
-    Synth: class MockSynth {},
-    Gain: class MockGain {
-      gain = mockGainValue;
-      connect = mockGainConnect;
-      toDestination = mockGainToDestination;
-      dispose = mockGainDispose;
-    },
-    Frequency: vi.fn().mockReturnValue({ toFrequency: () => 440 }),
-    getContext: vi.fn().mockReturnValue({ state: 'running' }),
-    start: vi.fn(),
+    mocks,
   };
 });
+
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(() => ({
+    ctx: mockCtx,
+    resume: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 
 import { wavetableEngine } from '../WavetableEngine';
 import type { WavetableSettings } from '../../types/project';
@@ -53,6 +75,9 @@ const makeSettings = (overrides?: Partial<WavetableSettings>): WavetableSettings
 describe('WavetableEngine', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // mockReturnValue is re-applied after clearAllMocks to keep the
+    // factory returning a valid PeriodicWave stand-in.
+    mocks.createPeriodicWave.mockReturnValue({} as PeriodicWave);
   });
 
   afterEach(() => {
@@ -60,15 +85,11 @@ describe('WavetableEngine', () => {
   });
 
   describe('ensureTrackSynth', () => {
-    it('creates a synth with custom partials', () => {
+    it('creates a synth built from partials (via createPeriodicWave)', () => {
       const settings = makeSettings();
       const synth = wavetableEngine.ensureTrackSynth('test-track', settings);
       expect(synth).not.toBeUndefined();
-      expect(mockSynthSet).toHaveBeenCalledWith(
-        expect.objectContaining({
-          oscillator: expect.objectContaining({ type: 'custom' }),
-        }),
-      );
+      expect(mocks.createPeriodicWave).toHaveBeenCalled();
     });
 
     it('returns existing synth on second call', () => {
@@ -80,24 +101,22 @@ describe('WavetableEngine', () => {
 
     it('connects to provided output node', () => {
       const settings = makeSettings();
-      const mockOutput = {} as unknown as import('tone').InputNode;
+      const mockOutput = {} as AudioNode;
       wavetableEngine.ensureTrackSynth('test-track', settings, mockOutput);
-      expect(mockGainConnect).toHaveBeenCalledWith(mockOutput);
+      // Last GainNode.connect() call should target the provided output.
+      expect(mocks.gainConnect).toHaveBeenCalledWith(mockOutput);
     });
   });
 
   describe('setPosition', () => {
-    it('updates partials when position changes', () => {
+    it('rebuilds the periodic wave when position changes', () => {
       const settings = makeSettings({ waveforms: [WAVEFORM_SINE, WAVEFORM_SAW, WAVEFORM_SQUARE] });
       wavetableEngine.ensureTrackSynth('test-track', settings);
-      vi.clearAllMocks();
+      mocks.createPeriodicWave.mockClear();
+      mocks.createPeriodicWave.mockReturnValue({} as PeriodicWave);
 
       wavetableEngine.setPosition('test-track', 0.5);
-      expect(mockSynthSet).toHaveBeenCalledWith(
-        expect.objectContaining({
-          oscillator: expect.objectContaining({ type: 'custom' }),
-        }),
-      );
+      expect(mocks.createPeriodicWave).toHaveBeenCalledTimes(1);
       expect(wavetableEngine.getPosition('test-track')).toBe(0.5);
     });
 
@@ -111,38 +130,44 @@ describe('WavetableEngine', () => {
     });
 
     it('is a no-op for unknown track', () => {
+      mocks.createPeriodicWave.mockClear();
       wavetableEngine.setPosition('nonexistent', 0.5);
-      expect(mockSynthSet).not.toHaveBeenCalled();
+      expect(mocks.createPeriodicWave).not.toHaveBeenCalled();
     });
   });
 
   describe('noteOn / noteOff', () => {
-    it('triggers attack on note-on', () => {
+    it('starts an oscillator on note-on', () => {
       wavetableEngine.ensureTrackSynth('test-track', makeSettings());
+      mocks.oscStart.mockClear();
       wavetableEngine.noteOn('test-track', 60, 100);
-      expect(mockSynthTriggerAttack).toHaveBeenCalled();
+      expect(mocks.oscStart).toHaveBeenCalled();
+      expect(mocks.oscSetPeriodicWave).toHaveBeenCalled();
     });
 
-    it('triggers release on note-off', () => {
+    it('stops the oscillator on note-off', () => {
       wavetableEngine.ensureTrackSynth('test-track', makeSettings());
+      wavetableEngine.noteOn('test-track', 60, 100);
+      mocks.oscStop.mockClear();
       wavetableEngine.noteOff('test-track', 60);
-      expect(mockSynthTriggerRelease).toHaveBeenCalled();
+      expect(mocks.oscStop).toHaveBeenCalled();
     });
 
     it('is a no-op for unknown track', () => {
+      mocks.oscStart.mockClear();
       wavetableEngine.noteOn('nonexistent', 60);
       wavetableEngine.noteOff('nonexistent', 60);
-      expect(mockSynthTriggerAttack).not.toHaveBeenCalled();
+      expect(mocks.oscStart).not.toHaveBeenCalled();
     });
   });
 
   describe('removeTrackSynth', () => {
-    it('disposes synth and gain', () => {
+    it('disposes the synth and gain', () => {
       wavetableEngine.ensureTrackSynth('test-track', makeSettings());
+      mocks.gainDisconnect.mockClear();
       wavetableEngine.removeTrackSynth('test-track');
-      expect(mockSynthReleaseAll).toHaveBeenCalled();
-      expect(mockSynthDispose).toHaveBeenCalled();
-      expect(mockGainDispose).toHaveBeenCalled();
+      // Per-voice gain disconnects + per-instance gain disconnect: at least one.
+      expect(mocks.gainDisconnect).toHaveBeenCalled();
     });
 
     it('makes getSynth return null after removal', () => {


### PR DESCRIPTION
## Summary

Drops Tone from WavetableEngine. Replaces \`Tone.PolySynth(Tone.Synth, { oscillator: 'custom', partials })\` with a local \`NativeWavetableSynth\` that manages 8 voices and drives each one's OscillatorNode via a \`PeriodicWave\` built from the partials array — the same approach Tone takes internally for custom-partial oscillators.

- \`setPartials()\` swaps the wave for *future* voices; active notes finish their tail on the captured wave (matches Tone).
- \`triggerAttackRelease(freq, duration, time, velocity)\` API preserved so \`useTransport.ts\` callers still compile.

Closes #1740
Part of #1525

## Test plan

- [x] \`npm test\` — 7313 pass, same 2 pre-existing \`clipResizeModifiers\` failures as prior phase PRs
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — succeeds
- [ ] Copilot + Codex review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)