### PR TITLE
feat: Phase 5L — migrate SynthEngine off Tone.js

### DIFF
--- a/src/engine/SynthEngine.ts
+++ b/src/engine/SynthEngine.ts
@@ -1,74 +1,476 @@
-import * as Tone from 'tone';
-import type { SynthPreset, FilterEnvelope, FmInstrumentSettings, UnisonSettings } from '../types/project';
+/**
+ * @deprecated Use {@link InstrumentEngine} via {@link getEngineForInstrument} instead.
+ * This module will be removed once all call-sites migrate to the unified interface.
+ *
+ * Phase 5L migration: swapped Tone wrappers for native Web Audio
+ * primitives. Mapping:
+ *   Tone.PolySynth(Tone.Synth, …)   → NativeBasicPolySynth (local class)
+ *   Tone.FMSynth                    → NativeFmSynth (local class)
+ *   Tone.Filter                     → BiquadFilterNode
+ *   Tone.FrequencyEnvelope          → NativeFrequencyEnvelope (local helper)
+ *   Tone.Panner                     → StereoPannerNode
+ *   Tone.Gain                       → GainNode
+ *   Tone.Frequency(midi).toFrequency → midiToFrequency
+ *
+ * The local synth classes overlap with 5K's `NativeSubtractiveSynth`
+ * but intentionally stay inline — this file is deprecated, and
+ * consolidating before deletion would just churn.
+ */
+import type {
+  SynthPreset,
+  FilterEnvelope,
+  FmInstrumentSettings,
+  UnisonSettings,
+  InstrumentEnvelope,
+} from '../types/project';
+import { getAudioEngine } from '../hooks/useAudioEngine';
+import { midiToFrequency } from '../utils/pitch';
 
-interface UnisonVoice {
-  synth: Tone.PolySynth;
-  panner: Tone.Panner;
-  gain: Tone.Gain;
+// ─── NativeBasicPolySynth ────────────────────────────────────────────────
+
+interface BasicVoice {
+  osc: OscillatorNode | null;
+  gain: GainNode;
+  freq: number | null;
 }
 
-interface SynthInstance {
-  synth: Tone.PolySynth;
-  preset: SynthPreset;
-  gain: Tone.Gain;
-  filter?: Tone.Filter;
-  filterEnvelope?: Tone.FrequencyEnvelope;
+interface BasicEnvelope {
+  attack: number;
+  decay: number;
+  sustain: number;
+  release: number;
 }
 
-interface FmSynthInstance {
-  synth: Tone.FMSynth;
-  params: FmInstrumentSettings;
-  gain: Tone.Gain;
-  connectTo: Tone.InputNode | undefined;
+interface BasicSynthOptions {
+  oscillator?: { type?: OscillatorType };
+  envelope?: Partial<BasicEnvelope>;
+  portamento?: number;
+  detune?: number;
+}
+
+class NativeBasicPolySynth {
+  private readonly _ctx: AudioContext;
+  private readonly _output: GainNode;
+  private readonly _voices: BasicVoice[] = [];
+  private readonly _maxPoly: number;
+  private _nextVoice = 0;
+  private readonly _freqToVoice = new Map<number, number>();
+  private _envelope: BasicEnvelope = { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 };
+  private _oscType: OscillatorType = 'triangle';
+  private _portamento = 0;
+  private _detuneCents = 0;
+  private _lastFreq: number | null = null;
+
+  constructor(ctx: AudioContext, maxPolyphony = 8) {
+    this._ctx = ctx;
+    this._maxPoly = maxPolyphony;
+    this._output = ctx.createGain();
+    for (let i = 0; i < this._maxPoly; i++) {
+      const gain = ctx.createGain();
+      gain.gain.value = 0;
+      gain.connect(this._output);
+      this._voices.push({ osc: null, gain, freq: null });
+    }
+  }
+
+  get outputNode(): GainNode {
+    return this._output;
+  }
+
+  /**
+   * Convenience forwarder — offlineRender.ts (still on Tone in 5L)
+   * calls `synth.connect(gain)` expecting the engine-style API. Once
+   * offlineRender migrates in 5O this can go away.
+   */
+  connect(dest: AudioNode): AudioNode {
+    this._output.connect(dest);
+    return dest;
+  }
+
+  disconnect(): void {
+    try { this._output.disconnect(); } catch { /* already disconnected */ }
+  }
+
+  set(options: BasicSynthOptions): void {
+    if (options.oscillator?.type) {
+      this._oscType = options.oscillator.type;
+      for (const voice of this._voices) {
+        if (voice.osc) voice.osc.type = this._oscType;
+      }
+    }
+    if (options.envelope) {
+      this._envelope = { ...this._envelope, ...options.envelope };
+    }
+    if (options.portamento !== undefined) {
+      this._portamento = Math.max(0, options.portamento);
+    }
+    if (options.detune !== undefined) {
+      this._detuneCents = options.detune;
+      for (const voice of this._voices) {
+        if (voice.osc) voice.osc.detune.value = options.detune;
+      }
+    }
+  }
+
+  private _allocVoice(freq: number): BasicVoice {
+    const existing = this._freqToVoice.get(freq);
+    if (existing !== undefined) return this._voices[existing];
+    const idx = this._nextVoice % this._maxPoly;
+    this._nextVoice++;
+    for (const [f, vi] of this._freqToVoice) {
+      if (vi === idx) { this._freqToVoice.delete(f); break; }
+    }
+    this._freqToVoice.set(freq, idx);
+    return this._voices[idx];
+  }
+
+  triggerAttack(freq: number, time?: number, velocity = 1): void {
+    const t = time ?? this._ctx.currentTime;
+    const voice = this._allocVoice(freq);
+    const env = this._envelope;
+
+    if (voice.osc) {
+      try { voice.osc.stop(t); } catch { /* already stopped */ }
+      try { voice.osc.disconnect(); } catch { /* already disconnected */ }
+    }
+
+    const osc = this._ctx.createOscillator();
+    // 'triangle8' isn't a native OscillatorType; fall back to 'triangle'.
+    osc.type = (this._oscType as string) === 'triangle8' ? 'triangle' : this._oscType;
+    osc.detune.value = this._detuneCents;
+
+    if (this._portamento > 0 && this._lastFreq !== null && this._lastFreq !== freq) {
+      osc.frequency.setValueAtTime(this._lastFreq, t);
+      osc.frequency.linearRampToValueAtTime(freq, t + this._portamento);
+    } else {
+      osc.frequency.setValueAtTime(freq, t);
+    }
+    osc.connect(voice.gain);
+
+    voice.gain.gain.cancelScheduledValues(t);
+    voice.gain.gain.setValueAtTime(0, t);
+    voice.gain.gain.linearRampToValueAtTime(velocity, t + env.attack);
+    voice.gain.gain.linearRampToValueAtTime(velocity * env.sustain, t + env.attack + env.decay);
+
+    osc.start(t);
+    voice.osc = osc;
+    voice.freq = freq;
+    this._lastFreq = freq;
+  }
+
+  triggerRelease(freq: number, time?: number): void {
+    const idx = this._freqToVoice.get(freq);
+    if (idx === undefined) return;
+    const voice = this._voices[idx];
+    if (!voice.osc) return;
+
+    const t = time ?? this._ctx.currentTime;
+    const env = this._envelope;
+    const gainParam = voice.gain.gain;
+    if (typeof gainParam.cancelAndHoldAtTime === 'function') {
+      gainParam.cancelAndHoldAtTime(t);
+    } else {
+      gainParam.cancelScheduledValues(t);
+      gainParam.setValueAtTime(gainParam.value, t);
+    }
+    gainParam.linearRampToValueAtTime(0, t + env.release);
+
+    const osc = voice.osc;
+    osc.onended = () => { try { osc.disconnect(); } catch { /* already disconnected */ } };
+    try { osc.stop(t + env.release + 0.01); } catch { /* already stopped */ }
+
+    voice.osc = null;
+    voice.freq = null;
+    this._freqToVoice.delete(freq);
+  }
+
+  triggerAttackRelease(freq: number, duration: number, time?: number, velocity = 1): void {
+    const t = time ?? this._ctx.currentTime;
+    this.triggerAttack(freq, t, velocity);
+    this.triggerRelease(freq, t + duration);
+  }
+
+  releaseAll(time?: number): void {
+    const t = time ?? this._ctx.currentTime;
+    for (const f of [...this._freqToVoice.keys()]) {
+      this.triggerRelease(f, t);
+    }
+  }
+
+  dispose(): void {
+    for (const voice of this._voices) {
+      if (voice.osc) {
+        try { voice.osc.stop(); } catch { /* already stopped */ }
+        try { voice.osc.disconnect(); } catch { /* already disconnected */ }
+        voice.osc = null;
+      }
+      try { voice.gain.disconnect(); } catch { /* already disconnected */ }
+    }
+    try { this._output.disconnect(); } catch { /* already disconnected */ }
+    this._voices.length = 0;
+    this._freqToVoice.clear();
+  }
+}
+
+// ─── NativeFmSynth ───────────────────────────────────────────────────────
+
+interface NativeFmOptions {
+  modulationIndex?: number;
+  harmonicity?: number;
+  oscillator?: { type?: OscillatorType };
+  modulation?: { type?: OscillatorType };
+  envelope?: Partial<BasicEnvelope>;
 }
 
 /**
- * Build a Tone.FMSynth configuration from FmInstrumentSettings.
- * Different algorithms map to different harmonicity / modulationIndex / envelope shapes.
+ * Simple single-operator FM synth (monophonic — matches Tone.FMSynth's
+ * mono-by-default behaviour). Modulator frequency is `carrierFreq *
+ * harmonicity`, modulator output scaled by `carrierFreq *
+ * modulationIndex` and routed to the carrier's `frequency` param.
  */
-function buildFmSynthOptions(params: FmInstrumentSettings): Partial<Tone.FMSynthOptions> {
-  const { carrier, modulator, modulationIndex, harmonicity, feedback, algorithm, ampEnvelope } = params;
+class NativeFmSynth {
+  private readonly _ctx: AudioContext;
+  private readonly _output: GainNode;
+  private _carrier: OscillatorNode | null = null;
+  private _modulator: OscillatorNode | null = null;
+  private _modGain: GainNode | null = null;
+  private _envGain: GainNode | null = null;
+  private _oscType: OscillatorType = 'sine';
+  private _modType: OscillatorType = 'sine';
+  private _modIndex = 10;
+  private _harmonicity = 3;
+  private _envelope: BasicEnvelope = { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 };
 
-  const base: Partial<Tone.FMSynthOptions> = {
-    modulationIndex,
-    harmonicity,
-    oscillator: { type: carrier.waveform } as Tone.FMSynthOptions['oscillator'],
-    modulation: { type: modulator.waveform } as Tone.FMSynthOptions['modulation'],
-    envelope: {
-      attack: ampEnvelope.attack,
-      decay: ampEnvelope.decay,
-      sustain: ampEnvelope.sustain,
-      release: ampEnvelope.release,
-    } as Tone.FMSynthOptions['envelope'],
-  };
-
-  // Algorithm-specific parameter mapping
-  switch (algorithm) {
-    case 'serial':
-      // Classic: Modulator -> Carrier, standard FM
-      break;
-
-    case 'parallel':
-      // Both operators as carriers: reduce modulation, boost harmonicity
-      base.modulationIndex = modulationIndex * 0.3;
-      break;
-
-    case 'stack':
-      // Two modulators feeding one carrier: increase modulation depth
-      base.modulationIndex = modulationIndex * 1.5;
-      base.harmonicity = harmonicity * 0.5;
-      break;
-
-    case 'feedback':
-      // Modulator self-feedback: boost modulation with feedback factor
-      base.modulationIndex = modulationIndex * (1 + feedback);
-      break;
+  constructor(ctx: AudioContext) {
+    this._ctx = ctx;
+    this._output = ctx.createGain();
   }
 
-  return base;
+  get outputNode(): GainNode {
+    return this._output;
+  }
+
+  set(options: NativeFmOptions): void {
+    if (options.oscillator?.type) this._oscType = options.oscillator.type;
+    if (options.modulation?.type) this._modType = options.modulation.type;
+    if (options.modulationIndex !== undefined) this._modIndex = options.modulationIndex;
+    if (options.harmonicity !== undefined) this._harmonicity = options.harmonicity;
+    if (options.envelope) this._envelope = { ...this._envelope, ...options.envelope };
+  }
+
+  private _stopActive(t: number): void {
+    if (this._carrier) {
+      try { this._carrier.stop(t); } catch { /* already stopped */ }
+      try { this._carrier.disconnect(); } catch { /* already disconnected */ }
+      this._carrier = null;
+    }
+    if (this._modulator) {
+      try { this._modulator.stop(t); } catch { /* already stopped */ }
+      try { this._modulator.disconnect(); } catch { /* already disconnected */ }
+      this._modulator = null;
+    }
+    if (this._modGain) {
+      try { this._modGain.disconnect(); } catch { /* already disconnected */ }
+      this._modGain = null;
+    }
+    if (this._envGain) {
+      try { this._envGain.disconnect(); } catch { /* already disconnected */ }
+      this._envGain = null;
+    }
+  }
+
+  triggerAttack(freq: number, time?: number, velocity = 1): void {
+    const t = time ?? this._ctx.currentTime;
+    this._stopActive(t);
+
+    const carrier = this._ctx.createOscillator();
+    carrier.type = this._oscType;
+    carrier.frequency.value = freq;
+
+    const modulator = this._ctx.createOscillator();
+    modulator.type = this._modType;
+    modulator.frequency.value = freq * this._harmonicity;
+
+    const modGain = this._ctx.createGain();
+    modGain.gain.value = freq * this._modIndex;
+    modulator.connect(modGain);
+    modGain.connect(carrier.frequency);
+
+    const envGain = this._ctx.createGain();
+    carrier.connect(envGain);
+    envGain.connect(this._output);
+
+    const env = this._envelope;
+    envGain.gain.setValueAtTime(0, t);
+    envGain.gain.linearRampToValueAtTime(velocity, t + env.attack);
+    envGain.gain.linearRampToValueAtTime(velocity * env.sustain, t + env.attack + env.decay);
+
+    carrier.start(t);
+    modulator.start(t);
+    this._carrier = carrier;
+    this._modulator = modulator;
+    this._modGain = modGain;
+    this._envGain = envGain;
+  }
+
+  triggerRelease(time?: number): void {
+    const t = time ?? this._ctx.currentTime;
+    const env = this._envelope;
+    if (this._envGain) {
+      const g = this._envGain.gain;
+      if (typeof g.cancelAndHoldAtTime === 'function') {
+        g.cancelAndHoldAtTime(t);
+      } else {
+        g.cancelScheduledValues(t);
+        g.setValueAtTime(g.value, t);
+      }
+      g.linearRampToValueAtTime(0, t + env.release);
+    }
+    if (this._carrier) {
+      try { this._carrier.stop(t + env.release + 0.01); } catch { /* already stopped */ }
+      this._carrier = null;
+    }
+    if (this._modulator) {
+      try { this._modulator.stop(t + env.release + 0.01); } catch { /* already stopped */ }
+      this._modulator = null;
+    }
+  }
+
+  triggerAttackRelease(freq: number, duration: number, time?: number, velocity = 1): void {
+    const t = time ?? this._ctx.currentTime;
+    this.triggerAttack(freq, t, velocity);
+    this.triggerRelease(t + duration);
+  }
+
+  dispose(): void {
+    this._stopActive(this._ctx.currentTime);
+    try { this._output.disconnect(); } catch { /* already disconnected */ }
+  }
 }
 
-/** Check whether two FmInstrumentSettings are identical. */
+// ─── NativeFrequencyEnvelope ─────────────────────────────────────────────
+
+/**
+ * Schedules ramps on an `AudioParam` to mimic Tone.FrequencyEnvelope:
+ * filter freq = baseFrequency at rest, attacks up to
+ * `baseFrequency * 2^octaves`, decays to a sustain fraction of that
+ * peak, and releases back to baseFrequency.
+ */
+class NativeFrequencyEnvelope {
+  private readonly _param: AudioParam;
+  private readonly _ctx: AudioContext;
+  private readonly _options: FilterEnvelope;
+
+  constructor(ctx: AudioContext, param: AudioParam, options: FilterEnvelope) {
+    this._ctx = ctx;
+    this._param = param;
+    this._options = options;
+    param.value = options.baseFrequency;
+  }
+
+  triggerAttack(time?: number): void {
+    const t = time ?? this._ctx.currentTime;
+    const { baseFrequency, octaves, attack, decay, sustain } = this._options;
+    const peak = baseFrequency * Math.pow(2, octaves);
+    const sustained = baseFrequency * Math.pow(2, octaves * sustain);
+    const g = this._param;
+    if (typeof g.cancelAndHoldAtTime === 'function') {
+      g.cancelAndHoldAtTime(t);
+    } else {
+      g.cancelScheduledValues(t);
+      g.setValueAtTime(g.value, t);
+    }
+    g.linearRampToValueAtTime(peak, t + attack);
+    g.linearRampToValueAtTime(sustained, t + attack + decay);
+  }
+
+  triggerRelease(time?: number): void {
+    const t = time ?? this._ctx.currentTime;
+    const { baseFrequency, release } = this._options;
+    const g = this._param;
+    if (typeof g.cancelAndHoldAtTime === 'function') {
+      g.cancelAndHoldAtTime(t);
+    } else {
+      g.cancelScheduledValues(t);
+      g.setValueAtTime(g.value, t);
+    }
+    g.linearRampToValueAtTime(baseFrequency, t + release);
+  }
+
+  triggerAttackRelease(duration: number, time?: number): void {
+    const t = time ?? this._ctx.currentTime;
+    this.triggerAttack(t);
+    this.triggerRelease(t + duration);
+  }
+
+  dispose(): void {
+    // No persistent nodes to tear down — this helper just automates
+    // the caller-owned AudioParam.
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function getPresetEnvelope(preset: SynthPreset): InstrumentEnvelope {
+  switch (preset) {
+    case 'piano':   return { attack: 0.005, decay: 0.3,  sustain: 0.2, release: 1.2 };
+    case 'strings': return { attack: 0.4,   decay: 0.2,  sustain: 0.8, release: 1.5 };
+    case 'pad':     return { attack: 0.8,   decay: 0.5,  sustain: 0.9, release: 2.0 };
+    case 'lead':    return { attack: 0.01,  decay: 0.1,  sustain: 0.6, release: 0.3 };
+    case 'bass':    return { attack: 0.01,  decay: 0.2,  sustain: 0.4, release: 0.5 };
+    case 'organ':   return { attack: 0.01,  decay: 0.01, sustain: 1,   release: 0.1 };
+    default:        return { attack: 0.01,  decay: 0.1,  sustain: 0.7, release: 0.3 };
+  }
+}
+
+function getPresetOscType(preset: SynthPreset): OscillatorType {
+  switch (preset) {
+    case 'piano':   return 'triangle';  // 'triangle8' is Tone-only; triangle is closest native
+    case 'strings': return 'sawtooth';
+    case 'pad':     return 'sine';
+    case 'lead':    return 'square';
+    case 'bass':    return 'sawtooth';
+    case 'organ':   return 'sine';
+    default:        return 'triangle';
+  }
+}
+
+/**
+ * @deprecated Use {@link InstrumentEngine} via {@link getEngineForInstrument} instead.
+ *
+ * Accepts an optional context so offline-render callers (which use an
+ * `OfflineAudioContext`) can opt out of the default live engine ctx.
+ */
+export function createSynthForPreset(
+  preset: SynthPreset,
+  ctx?: BaseAudioContext,
+): NativeBasicPolySynth {
+  const audioCtx = (ctx ?? getAudioEngine().ctx) as AudioContext;
+  const synth = new NativeBasicPolySynth(audioCtx);
+  synth.set({
+    oscillator: { type: getPresetOscType(preset) },
+    envelope: getPresetEnvelope(preset),
+  });
+  return synth;
+}
+
+// ─── Unison helpers ──────────────────────────────────────────────────────
+
+function computeUnisonOffsets(
+  extraVoiceCount: number,
+  detuneCents: number,
+  spread: number,
+): Array<{ detune: number; pan: number }> {
+  if (extraVoiceCount <= 0) return [];
+  const offsets: Array<{ detune: number; pan: number }> = [];
+  for (let i = 0; i < extraVoiceCount; i++) {
+    const t = extraVoiceCount === 1 ? 0 : (2 * i) / (extraVoiceCount - 1) - 1;
+    offsets.push({ detune: t * detuneCents, pan: t * spread });
+  }
+  return offsets;
+}
+
+/** FmParamsEqual — check if two FmInstrumentSettings are identical. */
 function fmParamsEqual(a: FmInstrumentSettings, b: FmInstrumentSettings): boolean {
   return (
     a.modulationIndex === b.modulationIndex &&
@@ -89,114 +491,102 @@ function fmParamsEqual(a: FmInstrumentSettings, b: FmInstrumentSettings): boolea
   );
 }
 
-/**
- * @deprecated Use {@link InstrumentEngine} via {@link getEngineForInstrument} instead.
- * This function will be removed once all call-sites migrate to the unified interface.
- */
-export function createSynthForPreset(preset: SynthPreset): Tone.PolySynth {
-  const synth = new Tone.PolySynth(Tone.Synth);
+export function buildFmSynthOptions(params: FmInstrumentSettings): NativeFmOptions {
+  const { carrier, modulator, modulationIndex, harmonicity, feedback, algorithm, ampEnvelope } = params;
+  const base: NativeFmOptions = {
+    modulationIndex,
+    harmonicity,
+    oscillator: { type: carrier.waveform as OscillatorType },
+    modulation: { type: modulator.waveform as OscillatorType },
+    envelope: {
+      attack: ampEnvelope.attack,
+      decay: ampEnvelope.decay,
+      sustain: ampEnvelope.sustain,
+      release: ampEnvelope.release,
+    },
+  };
 
-  switch (preset) {
-    case 'piano':
-      synth.set({
-        oscillator: { type: 'triangle8' },
-        envelope: { attack: 0.005, decay: 0.3, sustain: 0.2, release: 1.2 },
-      });
+  switch (algorithm) {
+    case 'serial':
       break;
-    case 'strings':
-      synth.set({
-        oscillator: { type: 'sawtooth' },
-        envelope: { attack: 0.4, decay: 0.2, sustain: 0.8, release: 1.5 },
-      });
+    case 'parallel':
+      base.modulationIndex = modulationIndex * 0.3;
       break;
-    case 'pad':
-      synth.set({
-        oscillator: { type: 'sine' },
-        envelope: { attack: 0.8, decay: 0.5, sustain: 0.9, release: 2.0 },
-      });
+    case 'stack':
+      base.modulationIndex = modulationIndex * 1.5;
+      base.harmonicity = harmonicity * 0.5;
       break;
-    case 'lead':
-      synth.set({
-        oscillator: { type: 'square' },
-        envelope: { attack: 0.01, decay: 0.1, sustain: 0.6, release: 0.3 },
-      });
-      break;
-    case 'bass':
-      synth.set({
-        oscillator: { type: 'sawtooth' },
-        envelope: { attack: 0.01, decay: 0.2, sustain: 0.4, release: 0.5 },
-      });
-      break;
-    case 'organ':
-      synth.set({
-        oscillator: { type: 'sine' },
-        envelope: { attack: 0.01, decay: 0.01, sustain: 1, release: 0.1 },
-      });
+    case 'feedback':
+      base.modulationIndex = modulationIndex * (1 + feedback);
       break;
   }
 
-  return synth;
+  return base;
 }
 
-/**
- * Compute the detune and pan offsets for each extra unison voice.
- * Voices are spread symmetrically: e.g. for 4 total voices (3 extra),
- * detune offsets are [-detune, 0, +detune] and pan is spread accordingly.
- */
-function computeUnisonOffsets(
-  extraVoiceCount: number,
-  detuneCents: number,
-  spread: number,
-): Array<{ detune: number; pan: number }> {
-  if (extraVoiceCount <= 0) return [];
-  const offsets: Array<{ detune: number; pan: number }> = [];
-  for (let i = 0; i < extraVoiceCount; i++) {
-    // Map i to a position in [-1, 1] across extra voices
-    const t = extraVoiceCount === 1 ? 0 : (2 * i) / (extraVoiceCount - 1) - 1;
-    offsets.push({
-      detune: t * detuneCents,
-      pan: t * spread,
-    });
-  }
-  return offsets;
+// ─── SynthEngine instance types ──────────────────────────────────────────
+
+interface UnisonVoice {
+  synth: NativeBasicPolySynth;
+  panner: StereoPannerNode;
+  gain: GainNode;
 }
+
+interface SynthInstance {
+  synth: NativeBasicPolySynth;
+  preset: SynthPreset;
+  gain: GainNode;
+  filter?: BiquadFilterNode;
+  filterEnvelope?: NativeFrequencyEnvelope;
+}
+
+interface FmSynthInstance {
+  synth: NativeFmSynth;
+  params: FmInstrumentSettings;
+  gain: GainNode;
+  connectTo: AudioNode | undefined;
+}
+
+// ─── SynthEngine ─────────────────────────────────────────────────────────
 
 /**
  * @deprecated Use {@link InstrumentEngine} via {@link getEngineForInstrument} instead.
- * This class will be removed once all call-sites migrate to the unified interface.
  */
 class SynthEngine {
   private synths = new Map<string, SynthInstance>();
   private fmSynths = new Map<string, FmSynthInstance>();
   private unisonVoices = new Map<string, UnisonVoice[]>();
-  private previewSynth: Tone.PolySynth | null = null;
-  private previewGain: Tone.Gain | null = null;
+  private previewSynth: NativeBasicPolySynth | null = null;
+  private previewGain: GainNode | null = null;
 
   async ensureStarted() {
-    if (Tone.getContext().state !== 'running') {
-      await Tone.start();
+    const engine = getAudioEngine();
+    if (engine?.ctx?.state && engine.ctx.state !== 'running') {
+      await engine.resume();
     }
   }
 
-  ensureTrackSynth(trackId: string, preset: SynthPreset, connectTo?: Tone.InputNode): Tone.PolySynth {
+  ensureTrackSynth(trackId: string, preset: SynthPreset, connectTo?: AudioNode): NativeBasicPolySynth {
     const existing = this.synths.get(trackId);
     if (existing && existing.preset === preset) return existing.synth;
 
     if (existing) {
       existing.synth.releaseAll();
       existing.synth.dispose();
-      existing.gain.dispose();
-      existing.filter?.dispose();
+      try { existing.gain.disconnect(); } catch { /* already disconnected */ }
+      existing.filter && (() => { try { existing.filter!.disconnect(); } catch { /* noop */ } })();
       existing.filterEnvelope?.dispose();
     }
 
+    const ctx = getAudioEngine().ctx;
     const synth = createSynthForPreset(preset);
-    const gain = new Tone.Gain(0.55);
-    synth.connect(gain);
+    const gain = ctx.createGain();
+    gain.gain.value = 0.55;
+    synth.outputNode.connect(gain);
     if (connectTo) {
       gain.connect(connectTo);
     } else {
-      gain.toDestination();
+      gain.connect(ctx.destination);
     }
     this.synths.set(trackId, { synth, preset, gain });
     return synth;
@@ -204,72 +594,55 @@ class SynthEngine {
 
   /**
    * Apply a filter envelope to a track's synth signal chain.
-   * Inserts a Tone.Filter between synth and gain, controlled by a FrequencyEnvelope.
+   * Inserts a BiquadFilter between synth and gain, controlled by a NativeFrequencyEnvelope.
    * Pass null to remove the filter envelope.
    */
   setFilterEnvelope(trackId: string, envelope: FilterEnvelope | null): void {
     const instance = this.synths.get(trackId);
     if (!instance) return;
+    const ctx = getAudioEngine().ctx;
 
-    // Clean up existing filter envelope
     if (instance.filterEnvelope) {
       instance.filterEnvelope.dispose();
       instance.filterEnvelope = undefined;
     }
     if (instance.filter) {
-      // Reconnect synth directly to gain
-      instance.synth.disconnect();
-      instance.filter.dispose();
+      try { instance.synth.outputNode.disconnect(); } catch { /* noop */ }
+      try { instance.filter.disconnect(); } catch { /* noop */ }
       instance.filter = undefined;
-      instance.synth.connect(instance.gain);
+      instance.synth.outputNode.connect(instance.gain);
     }
 
     if (!envelope) return;
 
-    // Create filter and frequency envelope
-    const filter = new Tone.Filter({
-      type: 'lowpass',
-      frequency: envelope.baseFrequency,
-      Q: 2,
-    });
+    const filter = ctx.createBiquadFilter();
+    filter.type = 'lowpass';
+    filter.frequency.value = envelope.baseFrequency;
+    filter.Q.value = 2;
 
-    const freqEnv = new Tone.FrequencyEnvelope({
-      attack: envelope.attack,
-      decay: envelope.decay,
-      sustain: envelope.sustain,
-      release: envelope.release,
-      baseFrequency: envelope.baseFrequency,
-      octaves: envelope.octaves,
-    });
+    const freqEnv = new NativeFrequencyEnvelope(ctx, filter.frequency, envelope);
 
-    // Connect frequency envelope output to the filter's frequency param
-    freqEnv.connect(filter.frequency);
-
-    // Re-route: synth -> filter -> gain
-    instance.synth.disconnect();
-    instance.synth.connect(filter);
+    try { instance.synth.outputNode.disconnect(); } catch { /* noop */ }
+    instance.synth.outputNode.connect(filter);
     filter.connect(instance.gain);
 
     instance.filter = filter;
     instance.filterEnvelope = freqEnv;
   }
 
-  /** Get the filter envelope node for a track (for triggering). */
-  getFilterEnvelope(trackId: string): Tone.FrequencyEnvelope | undefined {
+  getFilterEnvelope(trackId: string): NativeFrequencyEnvelope | undefined {
     return this.synths.get(trackId)?.filterEnvelope;
   }
 
-  getSynth(trackId: string): Tone.PolySynth | null {
+  getSynth(trackId: string): NativeBasicPolySynth | null {
     return this.synths.get(trackId)?.synth ?? null;
   }
 
-  /** Create or retrieve an FM synth for a track. Reuses existing instance when params match. */
-  ensureFmSynth(trackId: string, params: FmInstrumentSettings, connectTo?: Tone.InputNode): Tone.FMSynth {
+  ensureFmSynth(trackId: string, params: FmInstrumentSettings, connectTo?: AudioNode): NativeFmSynth {
     const existing = this.fmSynths.get(trackId);
     if (existing && fmParamsEqual(existing.params, params)) {
-      // Reconnect gain if the output node has changed.
       if (connectTo && connectTo !== existing.connectTo) {
-        existing.gain.disconnect();
+        try { existing.gain.disconnect(); } catch { /* noop */ }
         existing.gain.connect(connectTo);
         existing.connectTo = connectTo;
       }
@@ -278,72 +651,67 @@ class SynthEngine {
 
     if (existing) {
       existing.synth.dispose();
-      existing.gain.dispose();
+      try { existing.gain.disconnect(); } catch { /* noop */ }
     }
 
-    const synth = new Tone.FMSynth();
-    const options = buildFmSynthOptions(params);
-    synth.set(options);
+    const ctx = getAudioEngine().ctx;
+    const synth = new NativeFmSynth(ctx);
+    synth.set(buildFmSynthOptions(params));
 
-    const gain = new Tone.Gain(params.outputGain ?? 0.55);
-    synth.connect(gain);
+    const gain = ctx.createGain();
+    gain.gain.value = params.outputGain ?? 0.55;
+    synth.outputNode.connect(gain);
     if (connectTo) {
       gain.connect(connectTo);
     } else {
-      gain.toDestination();
+      gain.connect(ctx.destination);
     }
     this.fmSynths.set(trackId, { synth, params, gain, connectTo });
     return synth;
   }
 
-  /** Retrieve an existing FM synth for a track, or null. */
-  getFmSynth(trackId: string): Tone.FMSynth | null {
+  getFmSynth(trackId: string): NativeFmSynth | null {
     return this.fmSynths.get(trackId)?.synth ?? null;
   }
 
-  /** Remove and dispose an FM synth for a track. */
   removeFmSynth(trackId: string) {
     const instance = this.fmSynths.get(trackId);
     if (!instance) return;
     instance.synth.dispose();
-    instance.gain.dispose();
+    try { instance.gain.disconnect(); } catch { /* noop */ }
     this.fmSynths.delete(trackId);
   }
 
-  /** Get the extra unison voices for a track (does not include the main synth). */
   getUnisonVoices(trackId: string): UnisonVoice[] {
     return this.unisonVoices.get(trackId) ?? [];
   }
 
-  /** Apply unison voice stacking. Creates/removes extra detuned synth voices. */
   applyUnison(trackId: string, settings: UnisonSettings): void {
     const instance = this.synths.get(trackId);
     if (!instance) return;
-
-    // Dispose existing unison voices
     this.disposeUnisonVoices(trackId);
 
     const extraCount = Math.max(0, settings.voices - 1);
     if (extraCount === 0) return;
 
+    const ctx = getAudioEngine().ctx;
     const offsets = computeUnisonOffsets(extraCount, settings.detune, settings.spread);
     const voices: UnisonVoice[] = [];
-
-    // Reduce main voice gain to compensate for added voices
     const perVoiceGain = 0.55 / (extraCount + 1);
     instance.gain.gain.value = perVoiceGain;
 
     for (const offset of offsets) {
-      const synth = createSynthForPreset(instance.preset);
-      synth.set({ detune: offset.detune });
-      const panner = new Tone.Panner(offset.pan);
-      const gain = new Tone.Gain(perVoiceGain);
-      synth.connect(gain);
+      const voiceSynth = createSynthForPreset(instance.preset);
+      voiceSynth.set({ detune: offset.detune });
+      const panner = ctx.createStereoPanner();
+      panner.pan.value = offset.pan;
+      const gain = ctx.createGain();
+      gain.gain.value = perVoiceGain;
+      voiceSynth.outputNode.connect(gain);
       gain.connect(panner);
-      panner.toDestination();
-      voices.push({ synth, panner, gain });
+      panner.connect(ctx.destination);
+      voices.push({ synth: voiceSynth, panner, gain });
     }
-
     this.unisonVoices.set(trackId, voices);
   }
 
@@ -353,35 +721,36 @@ class SynthEngine {
     for (const voice of voices) {
       voice.synth.releaseAll();
       voice.synth.dispose();
-      voice.panner.dispose();
-      voice.gain.dispose();
+      try { voice.panner.disconnect(); } catch { /* noop */ }
+      try { voice.gain.disconnect(); } catch { /* noop */ }
     }
     this.unisonVoices.delete(trackId);
   }
 
   async previewNote(pitch: number, velocity = 100, duration = 0.3, preset: SynthPreset = 'piano') {
     await this.ensureStarted();
+    const ctx = getAudioEngine().ctx;
     if (!this.previewSynth || !this.previewGain) {
       this.previewSynth = createSynthForPreset(preset);
-      this.previewGain = new Tone.Gain(0.3).toDestination();
-      this.previewSynth.connect(this.previewGain);
+      this.previewGain = ctx.createGain();
+      this.previewGain.gain.value = 0.3;
+      this.previewSynth.outputNode.connect(this.previewGain);
+      this.previewGain.connect(ctx.destination);
     }
-    const freq = Tone.Frequency(pitch, 'midi').toFrequency();
+    const freq = midiToFrequency(pitch);
     this.previewSynth.triggerAttackRelease(freq, duration, undefined, velocity / 127);
   }
 
   async playNote(trackId: string, pitch: number, velocity: number, duration: number, preset: SynthPreset) {
     await this.ensureStarted();
     const synth = this.ensureTrackSynth(trackId, preset);
-    const freq = Tone.Frequency(pitch, 'midi').toFrequency();
-    // Trigger filter envelope if present
+    const freq = midiToFrequency(pitch);
     const filterEnv = this.synths.get(trackId)?.filterEnvelope;
     if (filterEnv) {
       filterEnv.triggerAttackRelease(duration);
     }
     synth.triggerAttackRelease(freq, duration, undefined, velocity / 127);
 
-    // Trigger unison voices too
     const voices = this.unisonVoices.get(trackId);
     if (voices) {
       for (const voice of voices) {
@@ -399,36 +768,31 @@ class SynthEngine {
     preset: SynthPreset,
   ) {
     await this.ensureStarted();
-    const synth = this.ensureTrackSynth(trackId, preset) as unknown as {
-      set: (options: Record<string, unknown>) => void;
-      triggerAttack: (note: number, time?: string | number, velocity?: number) => void;
-      triggerRelease: (note: number, time?: string | number) => void;
-      triggerAttackRelease: (note: number, duration: number, time?: string | number, velocity?: number) => void;
-    };
+    const synth = this.ensureTrackSynth(trackId, preset);
     const glideTime = Math.max(0.03, Math.min(0.12, duration * 0.35));
-    const fromFreq = Tone.Frequency(fromPitch, 'midi').toFrequency();
-    const toFreq = Tone.Frequency(toPitch, 'midi').toFrequency();
+    const fromFreq = midiToFrequency(fromPitch);
+    const toFreq = midiToFrequency(toPitch);
+    const ctx = getAudioEngine().ctx;
+    const now = ctx.currentTime;
+
     synth.set({ portamento: glideTime });
-    synth.triggerAttack(fromFreq, undefined, velocity / 127);
-    synth.triggerRelease(fromFreq, `+${glideTime}`);
-    // Trigger filter envelope for slide note
+    synth.triggerAttack(fromFreq, now, velocity / 127);
+    synth.triggerRelease(fromFreq, now + glideTime);
+
     const filterEnv = this.synths.get(trackId)?.filterEnvelope;
     if (filterEnv) {
-      filterEnv.triggerAttackRelease(Math.max(0.04, duration) + glideTime);
+      filterEnv.triggerAttackRelease(Math.max(0.04, duration) + glideTime, now);
     }
-    synth.triggerAttackRelease(toFreq, Math.max(0.04, duration), `+${glideTime}`, velocity / 127);
+    synth.triggerAttackRelease(toFreq, Math.max(0.04, duration), now + glideTime, velocity / 127);
   }
 
-  /** Trigger note on for a track synth (for live playing / recording). */
   noteOn(trackId: string, pitch: number, velocity = 100) {
     const instance = this.synths.get(trackId);
     if (!instance) return;
-    const freq = Tone.Frequency(pitch, 'midi').toFrequency();
-    // Trigger filter envelope attack
+    const freq = midiToFrequency(pitch);
     instance.filterEnvelope?.triggerAttack();
     instance.synth.triggerAttack(freq, undefined, velocity / 127);
 
-    // Trigger unison voices too
     const voices = this.unisonVoices.get(trackId);
     if (voices) {
       for (const voice of voices) {
@@ -437,16 +801,13 @@ class SynthEngine {
     }
   }
 
-  /** Trigger note off for a track synth. */
   noteOff(trackId: string, pitch: number) {
     const instance = this.synths.get(trackId);
     if (!instance) return;
-    const freq = Tone.Frequency(pitch, 'midi').toFrequency();
-    // Trigger filter envelope release
+    const freq = midiToFrequency(pitch);
     instance.filterEnvelope?.triggerRelease();
     instance.synth.triggerRelease(freq);
 
-    // Release unison voices too
     const voices = this.unisonVoices.get(trackId);
     if (voices) {
       for (const voice of voices) {
@@ -455,7 +816,6 @@ class SynthEngine {
     }
   }
 
-  /** Release all currently sounding notes on all track synths (subtractive + FM). */
   releaseAll() {
     for (const instance of this.synths.values()) {
       instance.filterEnvelope?.triggerRelease();
@@ -471,12 +831,10 @@ class SynthEngine {
     }
   }
 
-  /** Update the oscillator waveform on a live synth instance and any unison voices. */
   setOscillatorType(trackId: string, type: 'sine' | 'triangle' | 'sawtooth' | 'square'): void {
     const instance = this.synths.get(trackId);
     if (!instance) return;
     instance.synth.set({ oscillator: { type } });
-    // Also update unison voices
     const voices = this.unisonVoices.get(trackId);
     if (voices) {
       for (const voice of voices) {
@@ -485,7 +843,6 @@ class SynthEngine {
     }
   }
 
-  /** Update the amplitude envelope on a live synth instance. */
   setEnvelope(trackId: string, envelope: { attack?: number; decay?: number; sustain?: number; release?: number }): void {
     const instance = this.synths.get(trackId);
     if (!instance) return;
@@ -498,18 +855,20 @@ class SynthEngine {
     }
   }
 
-  /** Ensure a filter node exists in the signal chain for a track synth. */
-  private ensureTrackFilter(instance: SynthInstance): Tone.Filter {
+  private ensureTrackFilter(instance: SynthInstance): BiquadFilterNode {
     if (instance.filter) return instance.filter;
-    const filter = new Tone.Filter({ type: 'lowpass', frequency: 20000, Q: 0 });
-    instance.synth.disconnect();
-    instance.synth.connect(filter);
+    const ctx = getAudioEngine().ctx;
+    const filter = ctx.createBiquadFilter();
+    filter.type = 'lowpass';
+    filter.frequency.value = 20000;
+    filter.Q.value = 0;
+    try { instance.synth.outputNode.disconnect(); } catch { /* noop */ }
+    instance.synth.outputNode.connect(filter);
     filter.connect(instance.gain);
     instance.filter = filter;
     return filter;
   }
 
-  /** Update the filter settings (type, frequency, Q) on a live synth's filter node. */
   setFilter(trackId: string, filter: { type?: string; frequency?: number; Q?: number }): void {
     const instance = this.synths.get(trackId);
     if (!instance) return;
@@ -525,8 +884,10 @@ class SynthEngine {
     if (!instance) return;
     instance.synth.releaseAll();
     instance.synth.dispose();
-    instance.gain.dispose();
-    instance.filter?.dispose();
+    try { instance.gain.disconnect(); } catch { /* noop */ }
+    if (instance.filter) {
+      try { instance.filter.disconnect(); } catch { /* noop */ }
+    }
     instance.filterEnvelope?.dispose();
     this.synths.delete(trackId);
   }
@@ -539,7 +900,9 @@ class SynthEngine {
       this.removeFmSynth(trackId);
     }
     this.previewSynth?.dispose();
-    this.previewGain?.dispose();
+    if (this.previewGain) {
+      try { this.previewGain.disconnect(); } catch { /* noop */ }
+    }
     this.previewSynth = null;
     this.previewGain = null;
   }

--- a/src/engine/__tests__/SynthEngineFm.test.ts
+++ b/src/engine/__tests__/SynthEngineFm.test.ts
@@ -1,52 +1,80 @@
+/**
+ * SynthEngine FM — unit tests
+ *
+ * Phase 5L migration: FM path uses a local `NativeFmSynth` wired
+ * against `getAudioEngine().ctx`. Algorithm-specific parameter
+ * mapping is exercised via the exported `buildFmSynthOptions`
+ * helper (pure function) instead of spying on Tone.FMSynth.set.
+ */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Mock Tone.js
-const mockFMSynthSet = vi.fn();
-const mockFMSynthConnect = vi.fn();
-const mockFMSynthDispose = vi.fn();
-const mockFMSynthTriggerAttackRelease = vi.fn();
-const mockFMSynthTriggerAttack = vi.fn();
-const mockFMSynthTriggerRelease = vi.fn();
-const mockFMSynthReleaseAll = vi.fn();
-
-const mockGainConnect = vi.fn();
-const mockGainToDestination = vi.fn();
-const mockGainDispose = vi.fn();
-
-vi.mock('tone', () => {
-  return {
-    FMSynth: class MockFMSynth {
-      set = mockFMSynthSet;
-      connect = mockFMSynthConnect;
-      dispose = mockFMSynthDispose;
-      triggerAttackRelease = mockFMSynthTriggerAttackRelease;
-      triggerAttack = mockFMSynthTriggerAttack;
-      triggerRelease = mockFMSynthTriggerRelease;
-      releaseAll = mockFMSynthReleaseAll;
-    },
-    PolySynth: class MockPolySynth {
-      set = vi.fn();
-      connect = vi.fn();
-      dispose = vi.fn();
-      triggerAttackRelease = vi.fn();
-      triggerAttack = vi.fn();
-      triggerRelease = vi.fn();
-      releaseAll = vi.fn();
-    },
-    Synth: class MockSynth {},
-    Gain: class MockGain {
-      connect = mockGainConnect;
-      toDestination = mockGainToDestination;
-      dispose = mockGainDispose;
-    },
-    Frequency: vi.fn().mockReturnValue({ toFrequency: () => 440 }),
-    getContext: vi.fn().mockReturnValue({ state: 'running' }),
+const { mockCtx } = vi.hoisted(() => {
+  const makeParam = () => ({
+    value: 0,
+    setValueAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+    cancelScheduledValues: vi.fn(),
+    cancelAndHoldAtTime: vi.fn(),
+  });
+  const makeGain = () => ({
+    gain: makeParam(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  });
+  const makeOsc = () => ({
+    type: 'sine' as OscillatorType,
+    frequency: makeParam(),
+    detune: makeParam(),
     start: vi.fn(),
+    stop: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    onended: null as (() => void) | null,
+  });
+  return {
+    mockCtx: {
+      state: 'running' as AudioContextState,
+      currentTime: 0,
+      destination: {} as AudioNode,
+      createGain: vi.fn(makeGain),
+      createOscillator: vi.fn(makeOsc),
+      createBiquadFilter: vi.fn(),
+      createStereoPanner: vi.fn(() => ({
+        pan: makeParam(),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      })),
+      createConstantSource: vi.fn(() => ({
+        offset: makeParam(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      })),
+    },
   };
 });
 
-import { synthEngine } from '../SynthEngine';
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(() => ({
+    ctx: mockCtx,
+    resume: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { synthEngine, buildFmSynthOptions } from '../SynthEngine';
 import type { FmInstrumentSettings, FmAlgorithm } from '../../types/project';
+
+const baseParams: FmInstrumentSettings = {
+  carrier: { waveform: 'sine', ratio: 1, level: 1 },
+  modulator: { waveform: 'sine', ratio: 2, level: 0.75 },
+  modulationIndex: 3,
+  harmonicity: 2,
+  feedback: 0,
+  algorithm: 'serial',
+  ampEnvelope: { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 },
+  outputGain: 0,
+};
 
 describe('SynthEngine FM integration', () => {
   beforeEach(() => {
@@ -58,146 +86,68 @@ describe('SynthEngine FM integration', () => {
   });
 
   describe('ensureFmSynth', () => {
-    it('creates a Tone.FMSynth for an FM instrument', () => {
-      const params: FmInstrumentSettings = {
-        carrier: { waveform: 'sine', ratio: 1, level: 1 },
-        modulator: { waveform: 'sine', ratio: 2, level: 0.75 },
-        modulationIndex: 3,
-        harmonicity: 2,
-        feedback: 0,
-        algorithm: 'serial',
-        ampEnvelope: { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 },
-        outputGain: 0,
-      };
-      const synth = synthEngine.ensureFmSynth('test-track', params);
+    it('creates an FM synth instance', () => {
+      const synth = synthEngine.ensureFmSynth('test-track', baseParams);
       expect(synth).not.toBeUndefined();
-      expect(mockFMSynthSet).toHaveBeenCalled();
-    });
-
-    it('applies carrier waveform and modulation index via set()', () => {
-      const params: FmInstrumentSettings = {
-        carrier: { waveform: 'triangle', ratio: 1, level: 1 },
-        modulator: { waveform: 'sawtooth', ratio: 3, level: 0.8 },
-        modulationIndex: 5,
-        harmonicity: 3,
-        feedback: 0.2,
-        algorithm: 'serial',
-        ampEnvelope: { attack: 0.05, decay: 0.2, sustain: 0.6, release: 0.5 },
-        outputGain: 0,
-      };
-      synthEngine.ensureFmSynth('test-track', params);
-
-      expect(mockFMSynthSet).toHaveBeenCalledWith(
-        expect.objectContaining({
-          modulationIndex: 5,
-          harmonicity: 3,
-        }),
-      );
     });
 
     it('returns existing synth when params match', () => {
-      const params: FmInstrumentSettings = {
-        carrier: { waveform: 'sine', ratio: 1, level: 1 },
-        modulator: { waveform: 'sine', ratio: 2, level: 0.75 },
-        modulationIndex: 2,
-        harmonicity: 2,
-        feedback: 0,
-        algorithm: 'serial',
-        ampEnvelope: { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 },
-        outputGain: 0,
-      };
-      const synth1 = synthEngine.ensureFmSynth('test-track', params);
-      const synth2 = synthEngine.ensureFmSynth('test-track', params);
-      // Should return same instance without recreating
+      const synth1 = synthEngine.ensureFmSynth('test-track', baseParams);
+      const synth2 = synthEngine.ensureFmSynth('test-track', baseParams);
       expect(synth1).toBe(synth2);
     });
 
     it('recreates synth when params change', () => {
-      const params1: FmInstrumentSettings = {
-        carrier: { waveform: 'sine', ratio: 1, level: 1 },
-        modulator: { waveform: 'sine', ratio: 2, level: 0.75 },
-        modulationIndex: 2,
-        harmonicity: 2,
-        feedback: 0,
-        algorithm: 'serial',
-        ampEnvelope: { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 },
-        outputGain: 0,
-      };
-      const synth1 = synthEngine.ensureFmSynth('test-track', params1);
-
-      const params2: FmInstrumentSettings = {
-        ...params1,
-        modulationIndex: 8,
-        algorithm: 'parallel',
-      };
+      const synth1 = synthEngine.ensureFmSynth('test-track', baseParams);
+      const params2 = { ...baseParams, modulationIndex: 8, algorithm: 'parallel' as FmAlgorithm };
       const synth2 = synthEngine.ensureFmSynth('test-track', params2);
       expect(synth2).not.toBe(synth1);
-      expect(mockFMSynthDispose).toHaveBeenCalled();
     });
   });
 
-  describe('FM algorithms', () => {
-    const baseParams: FmInstrumentSettings = {
-      carrier: { waveform: 'sine', ratio: 1, level: 1 },
-      modulator: { waveform: 'sine', ratio: 2, level: 0.75 },
-      modulationIndex: 2,
-      harmonicity: 2,
-      feedback: 0,
-      algorithm: 'serial',
-      ampEnvelope: { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 },
-      outputGain: 0,
-    };
-
-    it.each<FmAlgorithm>(['serial', 'parallel', 'stack', 'feedback'])(
-      'accepts algorithm "%s"',
-      (algorithm) => {
-        const params = { ...baseParams, algorithm };
-        const synth = synthEngine.ensureFmSynth(`test-${algorithm}`, params);
-        expect(synth).not.toBeUndefined();
-        synthEngine.removeFmSynth(`test-${algorithm}`);
-      },
-    );
-
-    it('configures harmonicity for serial algorithm', () => {
-      const params = { ...baseParams, algorithm: 'serial' as const, harmonicity: 4 };
-      synthEngine.ensureFmSynth('test-track', params);
-      expect(mockFMSynthSet).toHaveBeenCalledWith(
-        expect.objectContaining({ harmonicity: 4 }),
-      );
+  describe('buildFmSynthOptions algorithm mapping', () => {
+    it('serial: pass-through', () => {
+      const opts = buildFmSynthOptions({ ...baseParams, algorithm: 'serial', modulationIndex: 5, harmonicity: 4 });
+      expect(opts.modulationIndex).toBe(5);
+      expect(opts.harmonicity).toBe(4);
     });
 
-    it('configures feedback amount for feedback algorithm', () => {
-      const params = { ...baseParams, algorithm: 'feedback' as const, feedback: 0.5, modulationIndex: 3 };
-      synthEngine.ensureFmSynth('test-track', params);
-      // feedback algorithm: modulationIndex * (1 + feedback) = 3 * 1.5 = 4.5
-      expect(mockFMSynthSet).toHaveBeenCalledWith(
-        expect.objectContaining({ modulationIndex: 4.5 }),
-      );
+    it('parallel: scales modulationIndex by 0.3', () => {
+      const opts = buildFmSynthOptions({ ...baseParams, algorithm: 'parallel', modulationIndex: 10 });
+      expect(opts.modulationIndex).toBeCloseTo(3, 2);
+    });
+
+    it('stack: scales modulationIndex by 1.5 and harmonicity by 0.5', () => {
+      const opts = buildFmSynthOptions({ ...baseParams, algorithm: 'stack', modulationIndex: 4, harmonicity: 6 });
+      expect(opts.modulationIndex).toBeCloseTo(6, 2);
+      expect(opts.harmonicity).toBeCloseTo(3, 2);
+    });
+
+    it('feedback: scales modulationIndex by (1 + feedback)', () => {
+      const opts = buildFmSynthOptions({ ...baseParams, algorithm: 'feedback', modulationIndex: 3, feedback: 0.5 });
+      expect(opts.modulationIndex).toBeCloseTo(4.5, 2);
+    });
+
+    it('carries carrier / modulator waveforms through to the oscillator options', () => {
+      const opts = buildFmSynthOptions({
+        ...baseParams,
+        carrier: { waveform: 'square', ratio: 1, level: 1 },
+        modulator: { waveform: 'sawtooth', ratio: 3, level: 0.5 },
+      });
+      expect(opts.oscillator?.type).toBe('square');
+      expect(opts.modulation?.type).toBe('sawtooth');
     });
   });
 
   describe('removeFmSynth', () => {
-    it('disposes and removes an FM synth', () => {
-      const params: FmInstrumentSettings = {
-        carrier: { waveform: 'sine', ratio: 1, level: 1 },
-        modulator: { waveform: 'sine', ratio: 2, level: 0.75 },
-        modulationIndex: 2,
-        harmonicity: 2,
-        feedback: 0,
-        algorithm: 'serial',
-        ampEnvelope: { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 },
-        outputGain: 0,
-      };
-      synthEngine.ensureFmSynth('test-track', params);
+    it('removes an FM synth', () => {
+      synthEngine.ensureFmSynth('test-track', baseParams);
       synthEngine.removeFmSynth('test-track');
-
-      expect(mockFMSynthDispose).toHaveBeenCalled();
-      expect(mockGainDispose).toHaveBeenCalled();
+      expect(synthEngine.getFmSynth('test-track')).toBeNull();
     });
 
     it('is a no-op for unknown trackId', () => {
-      synthEngine.removeFmSynth('nonexistent');
-      // Should not throw
+      expect(() => synthEngine.removeFmSynth('nonexistent')).not.toThrow();
     });
   });
 
@@ -207,17 +157,7 @@ describe('SynthEngine FM integration', () => {
     });
 
     it('returns the FM synth instance for a registered track', () => {
-      const params: FmInstrumentSettings = {
-        carrier: { waveform: 'sine', ratio: 1, level: 1 },
-        modulator: { waveform: 'sine', ratio: 2, level: 0.75 },
-        modulationIndex: 2,
-        harmonicity: 2,
-        feedback: 0,
-        algorithm: 'serial',
-        ampEnvelope: { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 },
-        outputGain: 0,
-      };
-      const created = synthEngine.ensureFmSynth('test-track', params);
+      const created = synthEngine.ensureFmSynth('test-track', baseParams);
       expect(synthEngine.getFmSynth('test-track')).toBe(created);
     });
   });

--- a/src/engine/__tests__/SynthEngineUnison.test.ts
+++ b/src/engine/__tests__/SynthEngineUnison.test.ts
@@ -1,49 +1,61 @@
+/**
+ * SynthEngine unison voice stacking — unit tests
+ *
+ * Phase 5L migration: voices and main synth are NativeBasicPolySynth
+ * instances over `getAudioEngine().ctx`. We mock the context with a
+ * minimal node factory so the engine code runs unmodified; tests
+ * observe the voice-allocation bookkeeping via `getUnisonVoices`.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock Tone.js before importing SynthEngine
-const mockConnect = vi.fn().mockReturnThis();
-const mockToDestination = vi.fn().mockReturnThis();
-const mockDispose = vi.fn();
-const mockReleaseAll = vi.fn();
-const mockTriggerAttackRelease = vi.fn();
-const mockSet = vi.fn();
-
-vi.mock('tone', () => {
-  class MockPolySynth {
-    connect = mockConnect;
-    toDestination = mockToDestination;
-    dispose = mockDispose;
-    releaseAll = mockReleaseAll;
-    triggerAttackRelease = mockTriggerAttackRelease;
-    set = mockSet;
-  }
-  class MockGain {
-    connect = mockConnect;
-    toDestination = mockToDestination;
-    dispose = mockDispose;
-    gain = { value: 1 };
-  }
-  class MockPanner {
-    connect = mockConnect;
-    toDestination = mockToDestination;
-    dispose = mockDispose;
-    pan = { value: 0 };
-  }
-  return {
-    PolySynth: MockPolySynth,
-    Synth: class {},
-    Gain: MockGain,
-    Panner: MockPanner,
-    Frequency: (val: number, type: string) => ({
-      toFrequency: () => val * 10,
-    }),
-    getContext: () => ({ state: 'running' }),
+const { mockCtx } = vi.hoisted(() => {
+  const makeParam = () => ({
+    value: 0,
+    setValueAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+    cancelScheduledValues: vi.fn(),
+    cancelAndHoldAtTime: vi.fn(),
+  });
+  const makeGain = () => ({ gain: makeParam(), connect: vi.fn(), disconnect: vi.fn() });
+  const makeOsc = () => ({
+    type: 'sine' as OscillatorType,
+    frequency: makeParam(),
+    detune: makeParam(),
     start: vi.fn(),
+    stop: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    onended: null as (() => void) | null,
+  });
+  const makePanner = () => ({ pan: makeParam(), connect: vi.fn(), disconnect: vi.fn() });
+  return {
+    mockCtx: {
+      state: 'running' as AudioContextState,
+      currentTime: 0,
+      destination: {} as AudioNode,
+      createGain: vi.fn(makeGain),
+      createOscillator: vi.fn(makeOsc),
+      createBiquadFilter: vi.fn(),
+      createStereoPanner: vi.fn(makePanner),
+      createConstantSource: vi.fn(() => ({
+        offset: makeParam(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      })),
+    },
   };
 });
 
+vi.mock('../../hooks/useAudioEngine', () => ({
+  getAudioEngine: vi.fn(() => ({
+    ctx: mockCtx,
+    resume: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 import { synthEngine } from '../SynthEngine';
-import type { UnisonSettings } from '../../types/project';
 
 describe('SynthEngine unison voice stacking', () => {
   beforeEach(() => {
@@ -51,32 +63,27 @@ describe('SynthEngine unison voice stacking', () => {
     synthEngine.dispose();
   });
 
-  it('creates a single synth voice when unison voices is 1', () => {
+  it('creates no extra voices when unison voices = 1', () => {
     synthEngine.ensureTrackSynth('track1', 'lead');
     synthEngine.applyUnison('track1', { voices: 1, detune: 0, spread: 0 });
-    // With 1 voice, no extra unison voices should be created
     const voices = synthEngine.getUnisonVoices('track1');
-    expect(voices).toHaveLength(0); // 0 extra voices, main synth is the only one
+    expect(voices).toHaveLength(0);
   });
 
-  it('creates additional synth voices when unison > 1', () => {
+  it('creates N-1 extra voices when unison voices > 1', () => {
     synthEngine.ensureTrackSynth('track1', 'lead');
     synthEngine.applyUnison('track1', { voices: 4, detune: 25, spread: 0.8 });
     const voices = synthEngine.getUnisonVoices('track1');
-    // 4 voices total means 3 extra unison voices (main + 3)
     expect(voices).toHaveLength(3);
   });
 
   it('disposes old unison voices when reapplying', () => {
     synthEngine.ensureTrackSynth('track1', 'pad');
     synthEngine.applyUnison('track1', { voices: 4, detune: 25, spread: 0.5 });
-    const firstVoices = synthEngine.getUnisonVoices('track1');
-    expect(firstVoices).toHaveLength(3);
+    expect(synthEngine.getUnisonVoices('track1')).toHaveLength(3);
 
-    // Reapply with fewer voices
     synthEngine.applyUnison('track1', { voices: 2, detune: 10, spread: 0.3 });
-    const secondVoices = synthEngine.getUnisonVoices('track1');
-    expect(secondVoices).toHaveLength(1);
+    expect(synthEngine.getUnisonVoices('track1')).toHaveLength(1);
   });
 
   it('cleans up unison voices when track synth is removed', () => {

--- a/src/engine/offlineRender.ts
+++ b/src/engine/offlineRender.ts
@@ -2,6 +2,7 @@ import * as Tone from 'tone';
 import type { ToneAudioBuffer } from 'tone';
 import { createDrumVoicesForKit } from './DrumEngine';
 import { createSynthForPreset } from './SynthEngine';
+import { midiToFrequency } from '../utils/pitch';
 import type { DrumKitName, MidiNote, SamplerConfig, SequencerPattern, SynthPreset } from '../types/project';
 
 const DRUM_PAD_INDEX_BY_SAMPLE_KEY: Record<string, number> = {
@@ -44,31 +45,33 @@ export async function renderMidiTrackOffline(
   totalDuration: number,
   sampleRate: number = 48000,
 ): Promise<AudioBuffer> {
-  const buffer = await Tone.Offline(({ transport }) => {
-    const synth = createSynthForPreset(synthPreset);
-    const gain = new Tone.Gain(0.55).toDestination();
-    synth.connect(gain);
+  // Phase 5L: drop Tone.Offline in favour of the native
+  // OfflineAudioContext — NativeBasicPolySynth is created against
+  // this offline context, and notes are scheduled directly at
+  // their start times (AudioParam automation is sample-accurate
+  // under offline rendering).
+  const length = Math.max(1, Math.ceil(totalDuration * sampleRate));
+  const offlineCtx = new OfflineAudioContext(2, length, sampleRate);
+  const secondsPerBeat = 60 / bpm;
 
-    transport.bpm.value = bpm;
-    const secondsPerBeat = 60 / bpm;
+  const synth = createSynthForPreset(synthPreset, offlineCtx);
+  const gain = offlineCtx.createGain();
+  gain.gain.value = 0.55;
+  synth.connect(gain);
+  gain.connect(offlineCtx.destination);
 
-    for (const note of notes) {
-      const noteDuration = Math.max(0, note.durationBeats * secondsPerBeat);
-      const noteStart = clipStartTime + note.startBeat * secondsPerBeat;
-      const noteEnd = noteStart + noteDuration;
-      if (noteDuration <= 0 || noteEnd <= 0 || noteStart >= totalDuration) continue;
+  for (const note of notes) {
+    const noteDuration = Math.max(0, note.durationBeats * secondsPerBeat);
+    const noteStart = clipStartTime + note.startBeat * secondsPerBeat;
+    const noteEnd = noteStart + noteDuration;
+    if (noteDuration <= 0 || noteEnd <= 0 || noteStart >= totalDuration) continue;
 
-      const velocity = Math.max(0, Math.min(1, note.velocity));
-      const frequency = Tone.Frequency(note.pitch, 'midi').toFrequency();
-      transport.schedule((time) => {
-        synth.triggerAttackRelease(frequency, noteDuration, time, velocity);
-      }, noteStart);
-    }
+    const velocity = Math.max(0, Math.min(1, note.velocity));
+    const frequency = midiToFrequency(note.pitch);
+    synth.triggerAttackRelease(frequency, noteDuration, noteStart, velocity);
+  }
 
-    transport.start(0);
-  }, totalDuration, 2, sampleRate);
-
-  return toAudioBuffer(buffer);
+  return offlineCtx.startRendering();
 }
 
 export async function renderSamplerTrackOffline(


### PR DESCRIPTION
## Summary

Drops Tone from SynthEngine (the deprecated legacy engine) and from \`renderMidiTrackOffline\`.

Mapping:
- \`Tone.PolySynth(Tone.Synth)\` → local \`NativeBasicPolySynth\`
- \`Tone.FMSynth\` → local \`NativeFmSynth\` (single-op FM: carrier + modulator + modIndex × carrierFreq routed to carrier.frequency)
- \`Tone.Filter\` → \`BiquadFilterNode\`
- \`Tone.FrequencyEnvelope\` → local \`NativeFrequencyEnvelope\` that schedules ramps on \`BiquadFilterNode.frequency\` (baseFreq → baseFreq·2^octaves peak → sustain fraction → release back)
- \`Tone.Offline\` → native \`OfflineAudioContext\` in \`renderMidiTrackOffline\` (\`createSynthForPreset\` now takes an optional ctx so the offline renderer can opt out of the live engine ctx)

Unison + playSlideNote portamento preserved via per-voice detune and frequency glide ramps. \`renderSequencerTrackOffline\` stays on Tone until 5N/5O lands (it depends on DrumEngine voices).

Test rewrite: FM algorithm mapping assertions now exercise the exported pure helper \`buildFmSynthOptions\`; unison tests continue to observe via \`getUnisonVoices()\`.

Closes #1744
Part of #1525

## Test plan

- [x] \`npm test\` — 7311 pass, same 2 pre-existing \`clipResizeModifiers\` failures as prior phase PRs
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — succeeds
- [ ] Copilot + Codex review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)