### PR TITLE
feat: Phase 4A-1 — ace-plugin-host crate scaffold + VST3 bundle scanner

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -21,6 +21,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ace-plugin-host"
+version = "0.1.0"
+dependencies = [
+ "plist",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
 name = "ace-timestretch"
 version = "0.1.0"
 dependencies = [
@@ -56,6 +69,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +99,18 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -110,10 +141,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -140,6 +208,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,10 +278,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -196,6 +340,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -235,6 +385,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primal-check"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +448,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rustfft"
@@ -276,6 +470,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +496,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -363,6 +576,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "transpose"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +667,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +691,24 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -483,6 +806,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10091e48e3231b0f567b098ddb9a107310eb2629ae0eaa7c98dd746d5e80ee78"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +861,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "ace-dsp-core",
     "ace-dsp-wasm",
+    "ace-plugin-host",
     "ace-timestretch",
     "ace-timestretch-wasm",
     "ace-waveform",

--- a/crates/ace-plugin-host/Cargo.toml
+++ b/crates/ace-plugin-host/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ace-plugin-host"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "VST3 plugin host for ACE-Step DAW — pure Rust, no C++ bridge"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+walkdir = "2"
+plist = "1"
+uuid = { version = "1", features = ["v4"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/ace-plugin-host/src/lib.rs
+++ b/crates/ace-plugin-host/src/lib.rs
@@ -1,0 +1,15 @@
+//! VST3 plugin host for ACE-Step DAW.
+//!
+//! Phase 4A-1 scope: filesystem scanning only. Plugin *loading*
+//! (`libloading` + the `vst3` crate) arrives in a later subphase so the
+//! unsafe surface stays strictly additive as each capability lands.
+//!
+//! This crate is deliberately Tauri-free — Tauri command wiring lives
+//! in `src-tauri/` and depends on this crate through plain function
+//! calls, keeping the host logic unit-testable without a Tauri runtime.
+
+pub mod scanner;
+pub mod types;
+
+pub use scanner::{PluginScanner, ScanProgressCallback};
+pub use types::{PluginInfo, ScanProgress};

--- a/crates/ace-plugin-host/src/scanner.rs
+++ b/crates/ace-plugin-host/src/scanner.rs
@@ -1,0 +1,687 @@
+//! Scans the filesystem for VST3 plugin bundles.
+//!
+//! A `.vst3` bundle is a directory whose name ends in `.vst3`. The
+//! standard macOS search locations are:
+//!
+//! - `/Library/Audio/Plug-Ins/VST3/`
+//! - `~/Library/Audio/Plug-Ins/VST3/`
+//!
+//! Metadata is extracted from the bundle's `Info.plist` and optional
+//! `moduleinfo.json` files. Falls back to the bundle filename when
+//! metadata is unavailable.
+//!
+//! # Progress reporting
+//!
+//! `scan_with_progress` does a two-pass walk: first counts the bundles
+//! so the UI can show an accurate total, then parses metadata and
+//! emits one progress tick per bundle. `scan` (no callback) is the
+//! single-pass fast path.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tracing::info;
+use uuid::Uuid;
+use walkdir::WalkDir;
+
+use crate::types::{PluginInfo, ScanProgress};
+
+/// Callback fired once per plugin while a scan is in progress.
+pub type ScanProgressCallback<'a> = &'a (dyn Fn(ScanProgress) + Send + Sync);
+
+/// In-memory cache of scan results. Cheap to construct; stateless from
+/// the caller's perspective — the cache is private.
+pub struct PluginScanner {
+    cache: Mutex<Option<Vec<PluginInfo>>>,
+}
+
+impl PluginScanner {
+    pub fn new() -> Self {
+        Self {
+            cache: Mutex::new(None),
+        }
+    }
+
+    /// Default VST3 search directories for macOS. Adjust the list for
+    /// other platforms in a later subphase — keeping macOS-only here
+    /// matches the current companion behaviour.
+    pub fn default_search_dirs() -> Vec<PathBuf> {
+        let mut dirs = vec![PathBuf::from("/Library/Audio/Plug-Ins/VST3")];
+        if let Some(home) = home_dir() {
+            dirs.push(home.join("Library/Audio/Plug-Ins/VST3"));
+        }
+        dirs
+    }
+
+    /// Scan the given directories for `.vst3` bundles. Results are
+    /// cached; subsequent calls return the cached list until
+    /// [`clear_cache`] is called.
+    pub fn scan(&self, search_dirs: &[PathBuf]) -> Vec<PluginInfo> {
+        self.scan_with_progress(search_dirs, None)
+    }
+
+    /// Scan with optional progress reporting. When `callback` is
+    /// `Some`, a first pass walks the directories to count bundles so
+    /// the callback receives an accurate `total` on every tick.
+    pub fn scan_with_progress(
+        &self,
+        search_dirs: &[PathBuf],
+        callback: Option<ScanProgressCallback<'_>>,
+    ) -> Vec<PluginInfo> {
+        {
+            let guard = self.cache.lock().unwrap();
+            if let Some(ref cached) = *guard {
+                return cached.clone();
+            }
+        }
+
+        let plugins = scan_directories(search_dirs, callback);
+        let mut guard = self.cache.lock().unwrap();
+        *guard = Some(plugins.clone());
+        plugins
+    }
+
+    /// Drop the cached scan results so the next [`scan`] re-reads the
+    /// filesystem.
+    pub fn clear_cache(&self) {
+        let mut guard = self.cache.lock().unwrap();
+        *guard = None;
+    }
+}
+
+impl Default for PluginScanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Walk `search_dirs` and collect every `.vst3` bundle found at
+/// depth 1. With a callback, pre-count bundles so each tick carries an
+/// accurate total.
+fn scan_directories(
+    search_dirs: &[PathBuf],
+    callback: Option<ScanProgressCallback<'_>>,
+) -> Vec<PluginInfo> {
+    let total: u32 = if callback.is_some() {
+        count_bundles(search_dirs) as u32
+    } else {
+        0
+    };
+
+    let mut plugins = Vec::new();
+    let mut scanned: u32 = 0;
+
+    for dir in search_dirs {
+        if !dir.exists() {
+            info!("Skipping non-existent directory: {}", dir.display());
+            continue;
+        }
+
+        for entry in WalkDir::new(dir).min_depth(1).max_depth(1) {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            if is_vst3_bundle(entry.path()) {
+                if let Some(info) = plugin_info_from_path(entry.path()) {
+                    info!("Found VST3 plugin: {} at {}", info.name, info.path);
+                    scanned += 1;
+                    if let Some(cb) = callback {
+                        cb(ScanProgress {
+                            scanned,
+                            total,
+                            current_plugin: info.name.clone(),
+                        });
+                    }
+                    plugins.push(info);
+                }
+            }
+        }
+    }
+
+    plugins
+}
+
+fn count_bundles(search_dirs: &[PathBuf]) -> usize {
+    let mut count = 0usize;
+    for dir in search_dirs {
+        if !dir.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(dir).min_depth(1).max_depth(1).into_iter().flatten() {
+            if is_vst3_bundle(entry.path()) {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+/// True if `path` looks like a `.vst3` bundle (a directory whose name
+/// ends in `.vst3`, case-insensitive).
+fn is_vst3_bundle(path: &Path) -> bool {
+    path.is_dir()
+        && path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("vst3"))
+}
+
+#[derive(Debug, Default)]
+struct PlistMetadata {
+    version: Option<String>,
+    vendor: Option<String>,
+}
+
+/// Read and parse `Info.plist` from a VST3 bundle, preferring
+/// `Contents/Info.plist` but falling back to the bundle root.
+fn read_plist_metadata(bundle_path: &Path) -> PlistMetadata {
+    let candidates = [
+        bundle_path.join("Contents/Info.plist"),
+        bundle_path.join("Info.plist"),
+    ];
+
+    let plist_path = match candidates.iter().find(|p| p.is_file()) {
+        Some(p) => p,
+        None => return PlistMetadata::default(),
+    };
+
+    let dict = match plist::Value::from_file(plist_path) {
+        Ok(plist::Value::Dictionary(d)) => d,
+        _ => return PlistMetadata::default(),
+    };
+
+    let version = dict
+        .get("CFBundleShortVersionString")
+        .or_else(|| dict.get("CFBundleVersion"))
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_string());
+
+    let vendor = extract_vendor_from_dict(&dict);
+
+    PlistMetadata { version, vendor }
+}
+
+fn extract_vendor_from_dict(dict: &plist::Dictionary) -> Option<String> {
+    if let Some(id) = dict.get("CFBundleIdentifier").and_then(|v| v.as_string()) {
+        if let Some(vendor) = vendor_from_bundle_id(id) {
+            return Some(vendor);
+        }
+    }
+
+    if let Some(copyright) = dict
+        .get("NSHumanReadableCopyright")
+        .and_then(|v| v.as_string())
+    {
+        if let Some(vendor) = vendor_from_copyright(copyright) {
+            return Some(vendor);
+        }
+    }
+
+    None
+}
+
+/// Extract vendor from a reverse-DNS bundle identifier, e.g.
+/// `com.fabfilter.Pro-Q3` → `fabfilter`. Apple-signed shim bundles are
+/// filtered out because they never identify the third-party vendor.
+fn vendor_from_bundle_id(bundle_id: &str) -> Option<String> {
+    let parts: Vec<&str> = bundle_id.split('.').collect();
+    if parts.len() >= 3 {
+        let vendor = parts[1].to_string();
+        if !vendor.is_empty() && vendor.to_lowercase() != "apple" {
+            return Some(vendor);
+        }
+    }
+    None
+}
+
+/// Extract vendor from a copyright string like
+/// `Copyright © 2020-2024 Native Instruments. All rights reserved.`
+fn vendor_from_copyright(copyright: &str) -> Option<String> {
+    let stripped = copyright
+        .trim()
+        .trim_start_matches("Copyright")
+        .trim()
+        .trim_start_matches('©')
+        .trim_start_matches("(c)")
+        .trim_start_matches("(C)")
+        .trim();
+
+    let after_year = skip_year_prefix(stripped);
+
+    let vendor = after_year.trim();
+    if vendor.is_empty() {
+        return None;
+    }
+
+    let vendor = match vendor.to_lowercase().find(". all rights") {
+        Some(pos) => &vendor[..pos],
+        None => vendor,
+    }
+    .trim()
+    .trim_end_matches('.');
+
+    if vendor.is_empty() {
+        None
+    } else {
+        Some(vendor.to_string())
+    }
+}
+
+fn skip_year_prefix(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 4 && bytes[..4].iter().all(|b| b.is_ascii_digit()) {
+        let rest = &s[4..];
+        let rest = if let Some(after_dash) = rest.strip_prefix('-') {
+            if after_dash.len() >= 4
+                && after_dash.as_bytes()[..4].iter().all(|b| b.is_ascii_digit())
+            {
+                &after_dash[4..]
+            } else {
+                rest
+            }
+        } else {
+            rest
+        };
+        rest.trim_start()
+    } else {
+        s
+    }
+}
+
+/// Read an optional `Contents/Resources/moduleinfo.json` and extract
+/// the first non-empty sub-category from the first class. Format
+/// reference: <https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Plug-in+Format/ModuleInfo.html>
+fn read_category_from_moduleinfo(bundle_path: &Path) -> Option<String> {
+    let moduleinfo_path = bundle_path.join("Contents/Resources/moduleinfo.json");
+    let data = std::fs::read_to_string(&moduleinfo_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&data).ok()?;
+
+    let classes = json.get("Classes")?.as_array()?;
+    for class in classes {
+        if let Some(subcats) = class.get("Sub Categories").and_then(|v| v.as_array()) {
+            for subcat in subcats {
+                if let Some(s) = subcat.as_str() {
+                    let s = s.trim();
+                    if !s.is_empty() {
+                        return Some(s.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Build [`PluginInfo`] from a `.vst3` bundle path. Missing metadata
+/// falls back to the bundle filename and `"Unknown"`.
+fn plugin_info_from_path(path: &Path) -> Option<PluginInfo> {
+    let stem = path.file_stem()?.to_string_lossy().to_string();
+
+    let plist_meta = read_plist_metadata(path);
+    let category = read_category_from_moduleinfo(path);
+
+    let raw_category = category.unwrap_or_default();
+    let (main_cat, sub_cat) = if raw_category.contains('|') {
+        let parts: Vec<&str> = raw_category.splitn(2, '|').collect();
+        (parts[0].to_string(), parts.get(1).unwrap_or(&"").to_string())
+    } else {
+        (raw_category.clone(), String::new())
+    };
+
+    Some(PluginInfo {
+        uid: Uuid::new_v4().to_string(),
+        name: stem,
+        vendor: plist_meta.vendor.unwrap_or_else(|| "Unknown".into()),
+        version: plist_meta.version.unwrap_or_else(|| "0.0.0".into()),
+        category: if main_cat.is_empty() { "Unknown".into() } else { main_cat },
+        subcategory: sub_cat,
+        path: path.to_string_lossy().to_string(),
+    })
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::{Arc, Mutex as StdMutex};
+    use tempfile::TempDir;
+
+    fn make_vst3_bundle(parent: &Path, name: &str) {
+        let bundle = parent.join(format!("{name}.vst3"));
+        fs::create_dir_all(&bundle).unwrap();
+    }
+
+    fn make_vst3_bundle_with_plist(
+        parent: &Path,
+        name: &str,
+        plist_entries: &[(&str, &str)],
+    ) -> PathBuf {
+        let bundle = parent.join(format!("{name}.vst3"));
+        let contents = bundle.join("Contents");
+        fs::create_dir_all(&contents).unwrap();
+
+        let mut dict = plist::Dictionary::new();
+        for (key, value) in plist_entries {
+            dict.insert(key.to_string(), plist::Value::String(value.to_string()));
+        }
+        let plist_path = contents.join("Info.plist");
+        plist::Value::Dictionary(dict)
+            .to_file_xml(&plist_path)
+            .unwrap();
+
+        bundle
+    }
+
+    fn add_moduleinfo(bundle: &Path, subcategories: &[&str]) {
+        let resources = bundle.join("Contents/Resources");
+        fs::create_dir_all(&resources).unwrap();
+
+        let subcats: Vec<serde_json::Value> = subcategories
+            .iter()
+            .map(|s| serde_json::Value::String(s.to_string()))
+            .collect();
+
+        let json = serde_json::json!({
+            "Classes": [
+                { "Sub Categories": subcats }
+            ]
+        });
+
+        fs::write(
+            resources.join("moduleinfo.json"),
+            serde_json::to_string_pretty(&json).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn scan_finds_vst3_bundles() {
+        let tmp = TempDir::new().unwrap();
+        make_vst3_bundle(tmp.path(), "Synth1");
+        make_vst3_bundle(tmp.path(), "Compressor");
+
+        // Non-vst3 directory and a regular file — must be ignored.
+        fs::create_dir_all(tmp.path().join("NotAPlugin")).unwrap();
+        fs::write(tmp.path().join("readme.txt"), "hello").unwrap();
+
+        let scanner = PluginScanner::new();
+        let plugins = scanner.scan(&[tmp.path().to_path_buf()]);
+
+        assert_eq!(plugins.len(), 2);
+        let names: Vec<&str> = plugins.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"Synth1"));
+        assert!(names.contains(&"Compressor"));
+    }
+
+    #[test]
+    fn scan_caches_results_until_cleared() {
+        let tmp = TempDir::new().unwrap();
+        make_vst3_bundle(tmp.path(), "CachedPlugin");
+
+        let scanner = PluginScanner::new();
+        let first = scanner.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(first.len(), 1);
+
+        make_vst3_bundle(tmp.path(), "NewPlugin");
+        let second = scanner.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(second.len(), 1, "cache must hide newly added bundle");
+
+        scanner.clear_cache();
+        let third = scanner.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(third.len(), 2);
+    }
+
+    #[test]
+    fn scan_skips_nonexistent_dirs_without_panicking() {
+        let scanner = PluginScanner::new();
+        let plugins = scanner.scan(&[PathBuf::from("/tmp/definitely_does_not_exist_12345")]);
+        assert!(plugins.is_empty());
+    }
+
+    #[test]
+    fn is_vst3_bundle_accepts_only_vst3_directories() {
+        let tmp = TempDir::new().unwrap();
+
+        let bundle = tmp.path().join("Test.vst3");
+        fs::create_dir_all(&bundle).unwrap();
+        assert!(is_vst3_bundle(&bundle));
+
+        let not_bundle = tmp.path().join("Test.txt");
+        fs::write(&not_bundle, "hi").unwrap();
+        assert!(!is_vst3_bundle(&not_bundle));
+
+        let not_ext = tmp.path().join("Test.dll");
+        fs::create_dir_all(&not_ext).unwrap();
+        assert!(!is_vst3_bundle(&not_ext));
+    }
+
+    #[test]
+    fn plugin_info_falls_back_when_no_plist() {
+        let tmp = TempDir::new().unwrap();
+        let bundle = tmp.path().join("MySynth.vst3");
+        fs::create_dir_all(&bundle).unwrap();
+
+        let info = plugin_info_from_path(&bundle).unwrap();
+        assert_eq!(info.name, "MySynth");
+        assert_eq!(info.vendor, "Unknown");
+        assert_eq!(info.version, "0.0.0");
+        assert_eq!(info.category, "Unknown");
+        assert!(!info.uid.is_empty());
+        assert!(info.path.contains("MySynth.vst3"));
+    }
+
+    #[test]
+    fn plugin_info_reads_plist_version_and_vendor() {
+        let tmp = TempDir::new().unwrap();
+        let bundle = make_vst3_bundle_with_plist(
+            tmp.path(),
+            "TestPlugin",
+            &[
+                ("CFBundleShortVersionString", "3.2.1"),
+                ("CFBundleIdentifier", "com.testvendor.TestPlugin"),
+            ],
+        );
+
+        let info = plugin_info_from_path(&bundle).unwrap();
+        assert_eq!(info.name, "TestPlugin");
+        assert_eq!(info.version, "3.2.1");
+        assert_eq!(info.vendor, "testvendor");
+    }
+
+    #[test]
+    fn plugin_info_prefers_short_version_then_falls_back_to_bundle_version() {
+        let tmp = TempDir::new().unwrap();
+        let bundle = make_vst3_bundle_with_plist(
+            tmp.path(),
+            "FallbackPlugin",
+            &[("CFBundleVersion", "1.0.5")],
+        );
+
+        let info = plugin_info_from_path(&bundle).unwrap();
+        assert_eq!(info.version, "1.0.5");
+        assert_eq!(info.vendor, "Unknown");
+    }
+
+    #[test]
+    fn vendor_from_bundle_id_extracts_reverse_dns_middle_segment() {
+        assert_eq!(
+            vendor_from_bundle_id("com.fabfilter.Pro-Q3"),
+            Some("fabfilter".into())
+        );
+        assert_eq!(
+            vendor_from_bundle_id("com.native-instruments.Kontakt"),
+            Some("native-instruments".into())
+        );
+        assert_eq!(
+            vendor_from_bundle_id("org.surge-synth-team.surge-xt"),
+            Some("surge-synth-team".into())
+        );
+        assert_eq!(vendor_from_bundle_id("com.single"), None);
+        assert_eq!(vendor_from_bundle_id("com.apple.AUPlugin"), None);
+    }
+
+    #[test]
+    fn vendor_from_copyright_parses_common_formats() {
+        assert_eq!(
+            vendor_from_copyright("Copyright © 2023 FabFilter"),
+            Some("FabFilter".into())
+        );
+        assert_eq!(
+            vendor_from_copyright("© 2024 Steinberg Media Technologies"),
+            Some("Steinberg Media Technologies".into())
+        );
+        assert_eq!(
+            vendor_from_copyright("Copyright 2020-2024 Native Instruments. All rights reserved."),
+            Some("Native Instruments".into())
+        );
+        assert_eq!(
+            vendor_from_copyright("(c) 2023 Arturia"),
+            Some("Arturia".into())
+        );
+        assert_eq!(vendor_from_copyright(""), None);
+        assert_eq!(vendor_from_copyright("©"), None);
+    }
+
+    #[test]
+    fn vendor_from_copyright_is_used_when_bundle_id_lacks_vendor() {
+        let tmp = TempDir::new().unwrap();
+        let bundle = make_vst3_bundle_with_plist(
+            tmp.path(),
+            "CopyrightPlugin",
+            &[
+                ("CFBundleIdentifier", "com"),
+                ("NSHumanReadableCopyright", "© 2024 Cool Audio Inc"),
+            ],
+        );
+
+        let info = plugin_info_from_path(&bundle).unwrap();
+        assert_eq!(info.vendor, "Cool Audio Inc");
+    }
+
+    #[test]
+    fn category_from_moduleinfo_is_split_on_pipe() {
+        let tmp = TempDir::new().unwrap();
+        let bundle = make_vst3_bundle_with_plist(
+            tmp.path(),
+            "CatPlugin",
+            &[("CFBundleIdentifier", "com.test.CatPlugin")],
+        );
+        add_moduleinfo(&bundle, &["Fx|EQ"]);
+
+        let info = plugin_info_from_path(&bundle).unwrap();
+        assert_eq!(info.category, "Fx");
+        assert_eq!(info.subcategory, "EQ");
+    }
+
+    #[test]
+    fn category_is_unknown_without_moduleinfo() {
+        let tmp = TempDir::new().unwrap();
+        let bundle = make_vst3_bundle_with_plist(
+            tmp.path(),
+            "NoCatPlugin",
+            &[("CFBundleIdentifier", "com.test.NoCatPlugin")],
+        );
+
+        let info = plugin_info_from_path(&bundle).unwrap();
+        assert_eq!(info.category, "Unknown");
+    }
+
+    #[test]
+    fn plist_at_bundle_root_is_also_honoured() {
+        // Some third-party bundles ship Info.plist at the root rather
+        // than under Contents/ — we accept both.
+        let tmp = TempDir::new().unwrap();
+        let bundle = tmp.path().join("RootPlist.vst3");
+        fs::create_dir_all(&bundle).unwrap();
+
+        let mut dict = plist::Dictionary::new();
+        dict.insert(
+            "CFBundleVersion".to_string(),
+            plist::Value::String("2.0.0".to_string()),
+        );
+        dict.insert(
+            "CFBundleIdentifier".to_string(),
+            plist::Value::String("com.rootvendor.RootPlist".to_string()),
+        );
+        plist::Value::Dictionary(dict)
+            .to_file_xml(bundle.join("Info.plist"))
+            .unwrap();
+
+        let info = plugin_info_from_path(&bundle).unwrap();
+        assert_eq!(info.version, "2.0.0");
+        assert_eq!(info.vendor, "rootvendor");
+    }
+
+    #[test]
+    fn skip_year_prefix_handles_single_year_and_range() {
+        assert_eq!(skip_year_prefix("2023 FabFilter"), "FabFilter");
+        assert_eq!(skip_year_prefix("2020-2024 NI"), "NI");
+        assert_eq!(skip_year_prefix("FabFilter"), "FabFilter");
+        assert_eq!(skip_year_prefix(""), "");
+    }
+
+    #[test]
+    fn scan_reads_full_metadata_from_well_formed_bundle() {
+        let tmp = TempDir::new().unwrap();
+        let bundle = make_vst3_bundle_with_plist(
+            tmp.path(),
+            "FullPlugin",
+            &[
+                ("CFBundleShortVersionString", "1.2.3"),
+                ("CFBundleIdentifier", "com.acme.FullPlugin"),
+            ],
+        );
+        add_moduleinfo(&bundle, &["Instrument|Synth"]);
+
+        let scanner = PluginScanner::new();
+        let plugins = scanner.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(plugins.len(), 1);
+
+        let p = &plugins[0];
+        assert_eq!(p.name, "FullPlugin");
+        assert_eq!(p.vendor, "acme");
+        assert_eq!(p.version, "1.2.3");
+        assert_eq!(p.category, "Instrument");
+        assert_eq!(p.subcategory, "Synth");
+    }
+
+    #[test]
+    fn scan_with_progress_reports_accurate_total_and_current() {
+        let tmp = TempDir::new().unwrap();
+        make_vst3_bundle(tmp.path(), "One");
+        make_vst3_bundle(tmp.path(), "Two");
+        make_vst3_bundle(tmp.path(), "Three");
+
+        let ticks: Arc<StdMutex<Vec<ScanProgress>>> = Arc::new(StdMutex::new(Vec::new()));
+        let ticks_inner = Arc::clone(&ticks);
+
+        let scanner = PluginScanner::new();
+        let cb = move |p: ScanProgress| {
+            ticks_inner.lock().unwrap().push(p);
+        };
+        let plugins = scanner.scan_with_progress(&[tmp.path().to_path_buf()], Some(&cb));
+
+        assert_eq!(plugins.len(), 3);
+        let ticks = ticks.lock().unwrap();
+        assert_eq!(ticks.len(), 3, "one tick per discovered plugin");
+        for (i, tick) in ticks.iter().enumerate() {
+            assert_eq!(tick.total, 3, "total must be the full count on every tick");
+            assert_eq!(
+                tick.scanned,
+                (i + 1) as u32,
+                "scanned must advance 1..=total"
+            );
+            assert!(!tick.current_plugin.is_empty());
+        }
+    }
+}

--- a/crates/ace-plugin-host/src/types.rs
+++ b/crates/ace-plugin-host/src/types.rs
@@ -1,0 +1,38 @@
+//! Shared data types for the plugin host. Kept deliberately small —
+//! these are the shapes that cross the Tauri IPC boundary and show up
+//! in the UI layer, so every field is serde-friendly and camelCased on
+//! the wire.
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata about a discovered VST3 plugin bundle. Produced by the
+/// scanner, surfaced to the UI via a Tauri command. Identical shape to
+/// the legacy `companion` app's `PluginInfo` so the existing
+/// `src/types/vst3.ts` bindings continue to work.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginInfo {
+    /// Opaque unique identifier assigned at scan time. Stable within a
+    /// single process run but not persisted across scans — callers that
+    /// need persistent identity key on `path`.
+    pub uid: String,
+    pub name: String,
+    pub vendor: String,
+    pub version: String,
+    pub category: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub subcategory: String,
+    /// Absolute path to the `.vst3` bundle directory.
+    pub path: String,
+}
+
+/// Progress emitted while a scan is running. Shaped to drive a simple
+/// "N of M — Plugin X" status UI without the caller needing to buffer
+/// intermediate state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanProgress {
+    pub scanned: u32,
+    pub total: u32,
+    pub current_plugin: String,
+}

--- a/crates/ace-plugin-host/tests/scanner_smoke.rs
+++ b/crates/ace-plugin-host/tests/scanner_smoke.rs
@@ -1,0 +1,47 @@
+//! Crate-boundary smoke test — exercises the public API the way a
+//! Tauri command handler will in 4A-2.
+
+use std::fs;
+use tempfile::TempDir;
+
+use ace_plugin_host::{PluginScanner, ScanProgress};
+
+#[test]
+fn public_api_scans_tempdir_and_exposes_plugin_info_fields() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("Alpha.vst3/Contents")).unwrap();
+    fs::create_dir_all(tmp.path().join("Beta.vst3/Contents")).unwrap();
+
+    let scanner = PluginScanner::new();
+    let plugins = scanner.scan(&[tmp.path().to_path_buf()]);
+
+    assert_eq!(plugins.len(), 2);
+    for p in &plugins {
+        assert!(!p.uid.is_empty());
+        assert!(!p.name.is_empty());
+        assert!(p.path.ends_with(".vst3"));
+    }
+}
+
+#[test]
+fn public_api_scan_with_progress_emits_ticks_through_callback() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("Solo.vst3")).unwrap();
+
+    let received: std::sync::Arc<std::sync::Mutex<Vec<ScanProgress>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let received_inner = std::sync::Arc::clone(&received);
+
+    let scanner = PluginScanner::new();
+    let cb = move |p: ScanProgress| {
+        received_inner.lock().unwrap().push(p);
+    };
+    let plugins = scanner.scan_with_progress(&[tmp.path().to_path_buf()], Some(&cb));
+
+    assert_eq!(plugins.len(), 1);
+    let ticks = received.lock().unwrap();
+    assert_eq!(ticks.len(), 1);
+    assert_eq!(ticks[0].scanned, 1);
+    assert_eq!(ticks[0].total, 1);
+    assert_eq!(ticks[0].current_plugin, "Solo");
+}


### PR DESCRIPTION
Closes #1754 · Part of #1524 · Epic #1519

First Phase 4 deliverable. Phase 5 (Tone.js removal) merged in #1753 — VST3 work is now unblocked.

## Summary

- New workspace crate `crates/ace-plugin-host/` carved out to hold all VST3-hosting logic, independent of Tauri
- Port `companion/src/plugin_scanner.rs` (636 LOC) → `src/scanner.rs`
- Clean public API: `PluginScanner::new()`, `scan(dirs)`, `scan_with_progress(dirs, callback)`, `clear_cache()`, `default_search_dirs()`
- `PluginInfo` shape matches `src/types/vst3.ts` — existing UI bindings will keep working once 4A-2 wires up Tauri commands
- Two-pass scan with callback emits accurate `scanned / total / current_plugin` ticks
- No `libloading`, no `vst3` crate, no `tokio` yet — loading lands in 4A-3 so the unsafe surface stays strictly additive

## Why a separate crate (not `src-tauri/src/engine/`)

- Reusable — same code hosts plugins in Tauri, in standalone tests, and (eventually) in an isolated audio-worker binary for crash sandboxing
- Testable — `cargo test -p ace-plugin-host` runs without a Tauri runtime
- Firewall — VST3 host code uses `libloading` + COM interop in later subphases; keeping it separate stops unsafe-block contagion from leaking into higher-level engine code
- Matches existing layout — `ace-dsp-core`, `ace-timestretch`, `ace-waveform` are all separate crates under `crates/`

## What's in this PR

| File | Purpose |
|---|---|
| `crates/ace-plugin-host/Cargo.toml` | Crate manifest |
| `crates/ace-plugin-host/src/lib.rs` | Public API re-exports |
| `crates/ace-plugin-host/src/types.rs` | `PluginInfo`, `ScanProgress` (serde camelCase) |
| `crates/ace-plugin-host/src/scanner.rs` | Ported + refactored scanner with progress callback |
| `crates/ace-plugin-host/tests/scanner_smoke.rs` | Crate-boundary smoke tests |
| `crates/Cargo.toml` | Workspace member registration |

## Test Results

- 16 unit tests + 2 integration tests — all passing
- `cargo clippy -p ace-plugin-host --all-targets -- -D warnings` — clean
- `cargo build -p ace-plugin-host` — green
- `npx tsc --noEmit` — green (no frontend changes)

## Test coverage

- Bundle detection: `.vst3` dir, case-insensitive extension, rejects files + wrong-extension dirs
- Plist parsing: `CFBundleShortVersionString`, `CFBundleVersion` fallback, `Contents/Info.plist` + root fallback
- Vendor extraction: reverse-DNS bundle ID (filters `com.apple.*`), copyright string (handles ©, (c), year ranges, "All rights reserved")
- Category: `moduleinfo.json` → split `Fx|Reverb` into category + subcategory, falls back to `"Unknown"`
- Cache semantics: `scan()` caches, `clear_cache()` forces re-scan
- Progress callback: accurate `total` on first tick, `scanned` advances 1..=total
- Tolerance: non-existent dirs are silent no-ops

## Not in scope (later subphases, see #1524 comment)

- **4A-2**: Tauri `plugin_scan` / `plugin_rescan` commands + IPC progress events
- **4A-3**: `libloading` + `vst3` crate plugin instantiation (port from `companion/src/vst3_loader.rs`)
- **4B-\*** and beyond: audio-graph integration, parameter automation, editor GUI, presets, sidechain, PDC, sandbox

## Test plan

- [x] `cd crates && cargo test -p ace-plugin-host` passes
- [x] `cd crates && cargo clippy -p ace-plugin-host --all-targets -- -D warnings` clean
- [x] `cd crates && cargo build -p ace-plugin-host` green
- [x] `npx tsc --noEmit` green (frontend untouched)
- [ ] Copilot review
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)