### PR TITLE
feat: Phase 4A-2 — Tauri plugin_scan / list_cached / rescan commands

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,10 +10,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ace-plugin-host"
+version = "0.1.0"
+dependencies = [
+ "plist",
+ "serde",
+ "serde_json",
+ "tracing",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
 name = "ace-step-daw"
 version = "0.1.0"
 dependencies = [
  "ace-dsp-core",
+ "ace-plugin-host",
  "arc-swap",
  "cpal",
  "crossbeam-channel",
@@ -22,6 +35,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
  "thiserror 1.0.69",
 ]
 
@@ -861,6 +875,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1905,6 +1929,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3024,6 +3054,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,6 +3860,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4102,7 +4158,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ace-dsp-core = { path = "../crates/ace-dsp-core" }
+ace-plugin-host = { path = "../crates/ace-plugin-host" }
 cpal = "0.15"
 crossbeam-channel = "0.5"
 ringbuf = "0.4"
@@ -27,6 +28,9 @@ thiserror = "1"
 # Arc<T>. Used to publish TempoMap / TimeSignatureMap from the main
 # thread to the audio thread without locking the audio callback.
 arc-swap = "1.7"
+
+[dev-dependencies]
+tempfile = "3"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,3 +2,4 @@
 //! `lib.rs` stays a thin registration table.
 
 pub mod audio;
+pub mod plugin;

--- a/src-tauri/src/commands/plugin.rs
+++ b/src-tauri/src/commands/plugin.rs
@@ -1,0 +1,192 @@
+//! Tauri IPC commands exposing the `ace-plugin-host` scanner to the
+//! webview. The scanner itself is stateful (owns an in-memory cache),
+//! so a single `Arc<PluginScanner>` is shared via managed state.
+//!
+//! Phase 4A-2 scope — scanning only. Plugin instantiation lives in a
+//! later subphase.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+
+use ace_plugin_host::{PluginInfo, PluginScanner, ScanProgress};
+
+/// Event name emitted once per discovered bundle during `plugin_rescan`.
+/// Matches the camelCase convention of every other cross-process event.
+pub const PLUGIN_SCAN_PROGRESS_EVENT: &str = "plugin-scan-progress";
+
+/// Managed-state wrapper around the process-wide scanner.
+///
+/// `PluginScanner` owns its own `Mutex` around the cache, so we only
+/// need `Arc` here — no outer mutex. Cloning `Arc` is cheap and the
+/// scanner's public API is internally synchronised.
+pub struct PluginScannerState(pub Arc<PluginScanner>);
+
+impl PluginScannerState {
+    pub fn new() -> Self {
+        Self(Arc::new(PluginScanner::new()))
+    }
+}
+
+impl Default for PluginScannerState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Thin error shape — scanner operations are infallible from the
+/// caller's perspective today, but keeping a result type in the wire
+/// signature means 4A-3 can extend it without breaking clients.
+#[derive(Debug, Serialize)]
+pub struct PluginCommandError {
+    pub message: String,
+}
+
+impl std::fmt::Display for PluginCommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for PluginCommandError {}
+
+/// Resolve the list of directories to scan. Empty / None → platform
+/// defaults (currently macOS-only, extended in a later subphase).
+fn resolve_search_dirs(paths: Option<Vec<String>>) -> Vec<PathBuf> {
+    match paths {
+        Some(p) if !p.is_empty() => p.into_iter().map(PathBuf::from).collect(),
+        _ => PluginScanner::default_search_dirs(),
+    }
+}
+
+/// Return the current scan result, triggering a fresh scan only if the
+/// cache is cold. Callers that want to force a re-scan should use
+/// [`plugin_rescan`] instead.
+#[tauri::command]
+pub fn plugin_scan(
+    paths: Option<Vec<String>>,
+    state: State<'_, PluginScannerState>,
+) -> Result<Vec<PluginInfo>, PluginCommandError> {
+    let dirs = resolve_search_dirs(paths);
+    Ok(state.0.scan(&dirs))
+}
+
+/// Return the cached scan result without touching the filesystem.
+/// Returns an empty vec when the cache is cold — callers can use that
+/// as a signal to invoke `plugin_scan` or `plugin_rescan`.
+#[tauri::command]
+pub fn plugin_list_cached(
+    state: State<'_, PluginScannerState>,
+) -> Result<Vec<PluginInfo>, PluginCommandError> {
+    // `PluginScanner` has no public `cached()` accessor — calling
+    // `scan()` with the default dirs would re-scan if the cache is
+    // empty, which we explicitly do not want here. Instead we scan a
+    // zero-dir list so any cached result comes back unchanged, and a
+    // cold cache simply yields an empty vec without touching the fs.
+    Ok(state.0.scan(&[]))
+}
+
+/// Force a re-scan, clearing the cache first. Each discovered bundle
+/// triggers a `plugin-scan-progress` event so the UI can render
+/// `N of M — Plugin X` progress without buffering intermediate state.
+#[tauri::command]
+pub fn plugin_rescan(
+    paths: Option<Vec<String>>,
+    state: State<'_, PluginScannerState>,
+    app: AppHandle,
+) -> Result<Vec<PluginInfo>, PluginCommandError> {
+    let dirs = resolve_search_dirs(paths);
+    state.0.clear_cache();
+
+    let scanner = Arc::clone(&state.0);
+    let callback_app = app.clone();
+    let callback = move |progress: ScanProgress| {
+        // Best-effort emit — webview may be unresponsive during a
+        // rescan in edge cases; a dropped tick is preferable to
+        // panicking the scanner thread.
+        let _ = callback_app.emit(PLUGIN_SCAN_PROGRESS_EVENT, progress);
+    };
+
+    Ok(scanner.scan_with_progress(&dirs, Some(&callback)))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Scanner-state tests that exercise behaviour visible through the
+    //! `PluginScannerState` wrapper without instantiating Tauri. The
+    //! commands themselves are thin enough that the underlying scanner
+    //! tests (in `ace-plugin-host`) already cover the real logic — what
+    //! we validate here is the cache-wiring contract.
+
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_bundle(parent: &std::path::Path, name: &str) {
+        fs::create_dir_all(parent.join(format!("{name}.vst3"))).unwrap();
+    }
+
+    #[test]
+    fn state_is_process_wide_cache_across_calls() {
+        let tmp = TempDir::new().unwrap();
+        make_bundle(tmp.path(), "Alpha");
+
+        let state = PluginScannerState::new();
+        let first = state.0.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(first.len(), 1);
+
+        // Second call on the same Arc returns cached data — proving
+        // that the managed-state Arc is the cache owner.
+        make_bundle(tmp.path(), "Beta");
+        let second = state.0.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(second.len(), 1, "cache masks the new bundle");
+
+        state.0.clear_cache();
+        let third = state.0.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(third.len(), 2, "rescan picks up the new bundle");
+    }
+
+    #[test]
+    fn resolve_search_dirs_uses_default_when_none_or_empty() {
+        // Snapshot the default list so we can verify the helper returns
+        // the same value regardless of whether the caller passes None
+        // or an empty vec.
+        let defaults = PluginScanner::default_search_dirs();
+        assert_eq!(resolve_search_dirs(None), defaults);
+        assert_eq!(resolve_search_dirs(Some(vec![])), defaults);
+    }
+
+    #[test]
+    fn resolve_search_dirs_honours_caller_supplied_paths() {
+        let dirs = resolve_search_dirs(Some(vec!["/custom/one".into(), "/custom/two".into()]));
+        assert_eq!(dirs.len(), 2);
+        assert_eq!(dirs[0], PathBuf::from("/custom/one"));
+        assert_eq!(dirs[1], PathBuf::from("/custom/two"));
+    }
+
+    #[test]
+    fn list_cached_returns_empty_vec_when_cache_is_cold() {
+        // Scanning a zero-dir slice must not panic and must not
+        // re-scan the default dirs; it should simply yield what the
+        // cache already contains.
+        let state = PluginScannerState::new();
+        let cached = state.0.scan(&[]);
+        assert!(cached.is_empty(), "cold cache must not implicitly re-scan");
+    }
+
+    #[test]
+    fn list_cached_returns_last_scan_result_after_warm_up() {
+        let tmp = TempDir::new().unwrap();
+        make_bundle(tmp.path(), "Warm");
+
+        let state = PluginScannerState::new();
+        let fresh = state.0.scan(&[tmp.path().to_path_buf()]);
+        assert_eq!(fresh.len(), 1);
+
+        // list_cached's zero-dir scan should surface the warmed cache.
+        let cached = state.0.scan(&[]);
+        assert_eq!(cached, fresh);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,9 @@ use crate::commands::audio::{
     audio_transport_set_tempo_map, audio_transport_set_time_signature_map,
     audio_transport_stop, EngineState, TransportEmitterState,
 };
+use crate::commands::plugin::{
+    plugin_list_cached, plugin_rescan, plugin_scan, PluginScannerState,
+};
 
 /// Greet command — placeholder to verify IPC works.
 #[tauri::command]
@@ -37,6 +40,7 @@ pub fn run() {
     tauri::Builder::default()
         .manage(EngineState::new())
         .manage(TransportEmitterState::new())
+        .manage(PluginScannerState::new())
         .invoke_handler(tauri::generate_handler![
             greet,
             is_desktop,
@@ -75,6 +79,9 @@ pub fn run() {
             audio_transport_set_punch_enabled,
             audio_transport_set_count_in,
             audio_transport_get_count_in,
+            plugin_scan,
+            plugin_list_cached,
+            plugin_rescan,
         ])
         .setup(|app| {
             // Focus main window on startup


### PR DESCRIPTION
Closes #1756 · Part of #1524 · Epic #1519 · Follows #1755

Exposes the `ace-plugin-host` scanner to the frontend via in-process Tauri IPC. UI layer is untouched — `src/store/vst3Store.ts` will switch transports in Phase 4F once `plugin_instantiate` / `plugin_release` exist (arriving in 4A-3).

## Summary

- `src-tauri` now depends on `ace-plugin-host` via workspace path
- New `src-tauri/src/commands/plugin.rs` with three commands + managed state
- `plugin_rescan` emits `plugin-scan-progress` events so the UI can render `N of M — Plugin X` progress without buffering intermediate state
- 5 new unit tests; 324 lib tests pass, 0 fail

## Commands

| Command | Signature | Semantics |
|---|---|---|
| `plugin_scan` | `(paths?: string[]) -> PluginInfo[]` | Returns cached list if warm; scans defaults or caller-supplied dirs if cold |
| `plugin_list_cached` | `() -> PluginInfo[]` | Returns cache only; `[]` when cold (no implicit re-scan) |
| `plugin_rescan` | `(paths?: string[], app) -> PluginInfo[]` | Clears cache, re-scans, emits progress events |

## Wire format

- \`PluginInfo\` comes from `ace_plugin_host::types` — serde camelCase, matches the existing `src/types/vst3.ts` \`VST3PluginInfo\` shape exactly
- \`plugin-scan-progress\` event payload: \`{ scanned: number, total: number, currentPlugin: string }\`

## Test Results

- \`cd src-tauri && cargo test --lib\`: **324 passed / 0 failed** (5 new + 319 existing)
- \`cd src-tauri && cargo build\`: green
- \`npx tsc --noEmit\`: green (frontend untouched)
- No new clippy warnings in \`commands/plugin.rs\` (the 10 pre-existing clippy errors elsewhere in \`engine/\` are unchanged and out of scope)

## Files changed

| File | Purpose |
|---|---|
| \`src-tauri/Cargo.toml\` | Add \`ace-plugin-host\` dep + \`tempfile\` dev-dep |
| \`src-tauri/src/commands/mod.rs\` | Register \`plugin\` submodule |
| \`src-tauri/src/commands/plugin.rs\` | Commands + \`PluginScannerState\` + tests |
| \`src-tauri/src/lib.rs\` | \`.manage()\` + \`invoke_handler!\` registration |

## Not in scope (follows in later subphases — see #1524 breakdown)

- **4A-3**: \`plugin_instantiate\` / \`plugin_release\` / param enumeration — requires \`libloading\` + \`vst3\` crate
- **4F**: UI transport swap — \`vst3Store\` keeps WebSocket bridge until the full read/write command surface exists

## Test plan

- [x] \`cd src-tauri && cargo test --lib\` green (324/324)
- [x] \`cd src-tauri && cargo build\` green
- [x] \`npx tsc --noEmit\` green
- [ ] Copilot review
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)