### PR TITLE
feat: Phase 4B-2a — MIDI events into VST3 process() via IEventList

### DIFF
--- a/crates/ace-plugin-host/src/audio.rs
+++ b/crates/ace-plugin-host/src/audio.rs
@@ -490,14 +490,21 @@ impl Vst3PluginInstance {
         channels: u32,
         samples: u32,
     ) -> Result<Vec<f32>, PluginHostError> {
-        // 4B-1 is stereo-only — mono input would require
-        // `IAudioProcessor::setBusArrangements` to negotiate a mono
-        // main input, which we don't call yet, so most stereo plugins
-        // would either reject the block or read out-of-bounds. Bus
-        // negotiation lands in 4B-3.
-        if channels != 2 {
+        // Branch on the plugin's audio-input-bus topology, captured at
+        // load time:
+        //
+        // - Pure instrument (no audio input bus): ignore `channels`
+        //   and `input`; send `numInputs: 0` + `inputs: null`. VST3
+        //   plugins with no audio input will reject a non-zero
+        //   `numInputs`, so this distinction is load-bearing for
+        //   synths / samplers / MIDI-FX.
+        // - Effect (has audio input bus): require `channels == 2`,
+        //   stereo main input. Mono / surround support lands in 4B-3
+        //   alongside `setBusArrangements` negotiation.
+        let is_instrument = self.is_instrument();
+        if !is_instrument && channels != 2 {
             return Err(PluginHostError::InvalidLifecycle(format!(
-                "process_block only supports stereo (channels == 2) in 4B-1; got {channels} — bus-arrangement negotiation lands in 4B-3"
+                "process_block only supports stereo (channels == 2) for effect plugins in 4B-2a; got {channels} — bus-arrangement negotiation lands in 4B-3"
             )));
         }
 
@@ -526,39 +533,51 @@ impl Vst3PluginInstance {
             }
         }
 
-        let num_channels = channels as usize;
         let num_samples = samples as usize;
         let output_stereo = 2usize;
-        let expected_input_len = num_channels * num_samples;
 
-        if input.len() < expected_input_len {
-            return Err(PluginHostError::InvalidLifecycle(format!(
-                "input buffer too small: have {} interleaved f32 elements, need {} ({} channels × {} samples)",
-                input.len(),
-                expected_input_len,
-                num_channels,
-                num_samples
-            )));
-        }
-
-        // De-interleave input into per-channel buffers.
-        let mut input_channels: Vec<Vec<f32>> = vec![vec![0.0f32; num_samples]; num_channels];
-        for s in 0..num_samples {
-            for ch in 0..num_channels {
-                input_channels[ch][s] = input[s * num_channels + ch];
+        // Input-side setup — only validate + de-interleave for effect
+        // plugins. Instruments get `numInputs: 0` below and never
+        // dereference the input buffers.
+        let input_channels: Vec<Vec<f32>> = if is_instrument {
+            Vec::new()
+        } else {
+            let num_channels = channels as usize;
+            let expected_input_len = num_channels * num_samples;
+            if input.len() < expected_input_len {
+                return Err(PluginHostError::InvalidLifecycle(format!(
+                    "input buffer too small: have {} interleaved f32 elements, need {} ({} channels × {} samples)",
+                    input.len(),
+                    expected_input_len,
+                    num_channels,
+                    num_samples
+                )));
             }
-        }
+            let mut channels_buf: Vec<Vec<f32>> =
+                vec![vec![0.0f32; num_samples]; num_channels];
+            for s in 0..num_samples {
+                for ch in 0..num_channels {
+                    channels_buf[ch][s] = input[s * num_channels + ch];
+                }
+            }
+            channels_buf
+        };
 
-        let mut input_ptrs: Vec<*mut f32> = input_channels
+        let mut input_channels_owned = input_channels;
+        let mut input_ptrs: Vec<*mut f32> = input_channels_owned
             .iter_mut()
             .map(|c| c.as_mut_ptr())
             .collect();
 
         let mut input_bus = AudioBusBuffers {
-            numChannels: num_channels as i32,
+            numChannels: if is_instrument { 0 } else { channels as i32 },
             silenceFlags: 0,
             __field0: AudioBusBuffers__type0 {
-                channelBuffers32: input_ptrs.as_mut_ptr(),
+                channelBuffers32: if is_instrument {
+                    ptr::null_mut()
+                } else {
+                    input_ptrs.as_mut_ptr()
+                },
             },
         };
 
@@ -577,13 +596,18 @@ impl Vst3PluginInstance {
             },
         };
 
-        // Drain any queued MIDI events into a fresh `EventList`.
+        // Drain any queued MIDI events, sort by sampleOffset, then
+        // convert into VST3 `Event`s. VST3 plugins iterate the host's
+        // `IEventList` forward by index and do not re-sort, so an
+        // out-of-order list can mis-fire notes or terminate them
+        // prematurely — sorting here makes block-local timing
+        // deterministic regardless of queue-insertion order.
         // Unsupported message types (CC, pitchbend, sysex in 4B-2a)
-        // are silently dropped by the converter; we'll extend as the
-        // DAW adds needs. `event_list` must outlive `process_data`
-        // because the plugin may read from the COM pointer during
-        // `process()`.
-        let pending = self.drain_midi();
+        // are silently dropped by the converter. `event_list` must
+        // outlive `process_data` because the plugin may read from the
+        // COM pointer during `process()`.
+        let mut pending = self.drain_midi();
+        pending.sort_by_key(|e| e.sample_offset);
         let vst3_events: Vec<_> = pending
             .iter()
             .filter_map(midi_to_vst3_event)
@@ -603,9 +627,13 @@ impl Vst3PluginInstance {
             processMode: ProcessModes_::kRealtime as i32,
             symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
             numSamples: num_samples as i32,
-            numInputs: 1,
+            numInputs: if is_instrument { 0 } else { 1 },
             numOutputs: 1,
-            inputs: &mut input_bus,
+            inputs: if is_instrument {
+                ptr::null_mut()
+            } else {
+                &mut input_bus
+            },
             outputs: &mut output_bus,
             inputParameterChanges: ptr::null_mut(),
             outputParameterChanges: ptr::null_mut(),

--- a/crates/ace-plugin-host/src/audio.rs
+++ b/crates/ace-plugin-host/src/audio.rs
@@ -596,17 +596,31 @@ impl Vst3PluginInstance {
             },
         };
 
-        // Drain any queued MIDI events, sort by sampleOffset, then
-        // convert into VST3 `Event`s. VST3 plugins iterate the host's
-        // `IEventList` forward by index and do not re-sort, so an
-        // out-of-order list can mis-fire notes or terminate them
-        // prematurely — sorting here makes block-local timing
-        // deterministic regardless of queue-insertion order.
-        // Unsupported message types (CC, pitchbend, sysex in 4B-2a)
-        // are silently dropped by the converter. `event_list` must
-        // outlive `process_data` because the plugin may read from the
-        // COM pointer during `process()`.
+        // Drain any queued MIDI events, filter to the current block's
+        // window, sort by `sampleOffset`, then convert into VST3
+        // `Event`s. Three things worth calling out:
+        //
+        // 1. **Window filter**: events with `sample_offset >=
+        //    num_samples` belong to a later block — forwarding them
+        //    would cause plugins to schedule past the end of the
+        //    current buffer, producing incorrect timing or OOB
+        //    writes. The companion app didn't do this because its
+        //    block boundaries were always exactly `num_samples`; our
+        //    Phase 5 integration will hand us blocks whose size
+        //    varies with the audio callback.
+        // 2. **Sort**: VST3 plugins iterate the host's `IEventList`
+        //    forward by index and do not re-sort, so an out-of-order
+        //    list can mis-fire notes. The `SegQueue` has no
+        //    cross-producer ordering guarantees, so we sort here to
+        //    make block-local timing deterministic.
+        // 3. **Unsupported types**: CC / pitchbend / sysex (4B-2a
+        //    scope) are silently dropped by `midi_to_vst3_event`.
+        //
+        // `event_list` must outlive `process_data` because the plugin
+        // may read from the COM pointer during `process()`.
         let mut pending = self.drain_midi();
+        let block_samples = samples;
+        pending.retain(|e| e.sample_offset < block_samples);
         pending.sort_by_key(|e| e.sample_offset);
         let vst3_events: Vec<_> = pending
             .iter()

--- a/crates/ace-plugin-host/src/audio.rs
+++ b/crates/ace-plugin-host/src/audio.rs
@@ -9,8 +9,9 @@
 //! Scope is deliberately narrow:
 //!
 //! - Stereo-only main bus I/O (multi-output busses land in 4B-3)
-//! - Empty `inputEvents` / `inputParameterChanges` (MIDI + automation
-//!   land in 4B-2)
+//! - 4B-2a adds MIDI note-on / note-off via `IEventList`;
+//!   `inputParameterChanges` stays null until 4B-2b ships the
+//!   host-side `IParameterChanges` wrapper.
 //! - No sidechain, no PDC, no sandbox (later sub-phases of #1524)
 //!
 //! Ported from `companion/src/audio_thread.rs::process_vst3_multi`,
@@ -23,13 +24,14 @@ use std::ptr;
 
 use tracing::warn;
 use vst3::Steinberg::Vst::{
-    AudioBusBuffers, AudioBusBuffers__type0, IAudioProcessorTrait, IComponentTrait, ProcessData,
-    ProcessModes_, ProcessSetup, SymbolicSampleSizes_,
+    AudioBusBuffers, AudioBusBuffers__type0, IAudioProcessorTrait, IComponentTrait, IEventList,
+    ProcessData, ProcessModes_, ProcessSetup, SymbolicSampleSizes_,
 };
 use vst3::Steinberg::kResultOk;
 
 use crate::error::PluginHostError;
 use crate::loader::Vst3PluginInstance;
+use crate::midi::{midi_to_vst3_event, EventList};
 use crate::types::OutputBusInfo;
 
 /// Pure-logic guard that `setup_processing` delegates to. Extracted
@@ -575,6 +577,28 @@ impl Vst3PluginInstance {
             },
         };
 
+        // Drain any queued MIDI events into a fresh `EventList`.
+        // Unsupported message types (CC, pitchbend, sysex in 4B-2a)
+        // are silently dropped by the converter; we'll extend as the
+        // DAW adds needs. `event_list` must outlive `process_data`
+        // because the plugin may read from the COM pointer during
+        // `process()`.
+        let pending = self.drain_midi();
+        let vst3_events: Vec<_> = pending
+            .iter()
+            .filter_map(midi_to_vst3_event)
+            .collect();
+        let event_list = if vst3_events.is_empty() {
+            None
+        } else {
+            Some(EventList::with_events(vst3_events))
+        };
+        let input_events_ptr = event_list
+            .as_ref()
+            .and_then(|el| el.to_com_ptr::<IEventList>())
+            .map(|p| p.as_ptr())
+            .unwrap_or(ptr::null_mut());
+
         let mut process_data = ProcessData {
             processMode: ProcessModes_::kRealtime as i32,
             symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
@@ -585,7 +609,7 @@ impl Vst3PluginInstance {
             outputs: &mut output_bus,
             inputParameterChanges: ptr::null_mut(),
             outputParameterChanges: ptr::null_mut(),
-            inputEvents: ptr::null_mut(),
+            inputEvents: input_events_ptr,
             outputEvents: ptr::null_mut(),
             processContext: ptr::null_mut(),
         };
@@ -594,7 +618,8 @@ impl Vst3PluginInstance {
         // `Vec<f32>`s outlive the call; the pointer arrays in
         // `input_ptrs` / `output_ptrs` are heap-stable for the duration
         // of `process()` because their owning `Vec`s are not modified
-        // between construction and this call.
+        // between construction and this call. `event_list` lives in
+        // this function's stack frame and outlives `process_data`.
         let result = unsafe { self.processor.process(&mut process_data) };
         if result != kResultOk {
             warn!(
@@ -612,7 +637,8 @@ impl Vst3PluginInstance {
                 out[s * output_stereo + ch] = output_channels[ch][s];
             }
         }
-        // `state` guard dropped here — after process() returns.
+        // `state` guard + `event_list` dropped here — after process().
+        drop(event_list);
         drop(state);
         Ok(out)
     }
@@ -625,6 +651,7 @@ impl Vst3PluginInstance {
 #[cfg(test)]
 mod smoke {
     use super::*;
+    use crate::midi::MidiEvent;
     use std::path::Path;
 
     /// Runs the full lifecycle against a real plugin when one is
@@ -670,5 +697,48 @@ mod smoke {
         // process_block after deactivate errors.
         let err = instance.process_block(&input, 2, 512).unwrap_err();
         assert!(matches!(err, PluginHostError::InvalidLifecycle(_)));
+    }
+
+    /// Queues a MIDI note-on / note-off pair and runs one block.
+    /// The plugin under test (ACE Bridge) is primarily an audio
+    /// effect, so we can't assert on output semantics — but we can
+    /// assert that the `process()` call succeeded with `inputEvents`
+    /// populated, that the queue was drained, and no COM error was
+    /// returned. A future follow-up could add a sampler smoke plugin
+    /// for fuller MIDI-in assertions.
+    #[test]
+    fn midi_queued_events_are_drained_through_process_block() {
+        let candidates = ["/Library/Audio/Plug-Ins/VST3/ACE Bridge.vst3"];
+        let Some(path) = candidates.iter().map(Path::new).find(|p| p.exists()) else {
+            eprintln!("skipping: no known VST3 bundle installed");
+            return;
+        };
+
+        let (instance, _) = match unsafe { crate::loader::load_plugin(path, "midi-smoke") } {
+            Ok(pair) => pair,
+            Err(e) => {
+                eprintln!("load failed (environment-specific, not fatal): {e}");
+                return;
+            }
+        };
+
+        instance
+            .setup_processing(AudioConfig::new(48000.0, 512).unwrap())
+            .unwrap();
+        instance.activate().unwrap();
+
+        instance.queue_midi(&[
+            MidiEvent::note_on(0, 60, 100, 0),
+            MidiEvent::note_off(0, 60, 0, 256),
+        ]);
+        assert_eq!(instance.midi_queue_len(), 2);
+
+        let input = vec![0.0f32; 2 * 512];
+        let out = instance.process_block(&input, 2, 512).unwrap();
+        assert_eq!(out.len(), 2 * 512);
+        // Queue should be fully drained after one process_block.
+        assert_eq!(instance.midi_queue_len(), 0);
+
+        instance.deactivate().unwrap();
     }
 }

--- a/crates/ace-plugin-host/src/host.rs
+++ b/crates/ace-plugin-host/src/host.rs
@@ -15,6 +15,7 @@ use crate::audio::AudioConfig;
 use crate::error::PluginHostError;
 use crate::host_impl::{HostParamChange, ParamChangeCollector};
 use crate::loader::{load_plugin, Vst3PluginInstance};
+use crate::midi::MidiEvent;
 use crate::types::InstanceInfo;
 
 /// Process-wide plugin instance registry. One live `PluginHost` is
@@ -137,6 +138,19 @@ impl PluginHost {
             .process_block(input, channels, samples)
     }
 
+    /// Queue MIDI events for delivery on the instance's next
+    /// `process_block` call. The queue is lock-free so multiple
+    /// producers (sequencer thread, MIDI-learn handler, test) can
+    /// push concurrently without blocking each other.
+    pub fn queue_instance_midi(
+        &self,
+        instance_id: &str,
+        events: &[MidiEvent],
+    ) -> Result<(), PluginHostError> {
+        self.lookup(instance_id)?.queue_midi(events);
+        Ok(())
+    }
+
     /// Drop a live instance. Releasing the only reference to its
     /// `Vst3PluginInstance` unloads the dylib. Unknown instance IDs
     /// produce an error so callers notice stale handles.
@@ -224,6 +238,15 @@ mod tests {
         let host = PluginHost::new();
         let err = host
             .process_instance_block("ghost", &[0.0; 1024], 2, 512)
+            .unwrap_err();
+        assert!(matches!(err, PluginHostError::UnknownInstance(_)));
+    }
+
+    #[test]
+    fn queue_midi_unknown_instance_errors_out() {
+        let host = PluginHost::new();
+        let err = host
+            .queue_instance_midi("ghost", &[MidiEvent::note_on(0, 60, 100, 0)])
             .unwrap_err();
         assert!(matches!(err, PluginHostError::UnknownInstance(_)));
     }

--- a/crates/ace-plugin-host/src/lib.rs
+++ b/crates/ace-plugin-host/src/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod host;
 pub mod host_impl;
 pub mod loader;
+pub mod midi;
 pub mod scanner;
 pub mod types;
 
@@ -32,5 +33,6 @@ pub use error::PluginHostError;
 pub use host::PluginHost;
 pub use host_impl::{AceComponentHandler, AceHostApplication, HostParamChange, ParamChangeCollector};
 pub use loader::{load_plugin, Vst3PluginInstance};
+pub use midi::{midi_to_vst3_event, EventList, MidiEvent};
 pub use scanner::{PluginScanner, ScanProgressCallback};
 pub use types::{InstanceInfo, OutputBusInfo, ParamInfo, PluginInfo, ScanProgress};

--- a/crates/ace-plugin-host/src/loader.rs
+++ b/crates/ace-plugin-host/src/loader.rs
@@ -52,6 +52,14 @@ pub struct Vst3PluginInstance {
     /// 4B-1 is still stereo-only; bus-arrangement negotiation lands
     /// in 4B-3.
     pub output_busses: Vec<OutputBusInfo>,
+    /// Channel count of the main audio input bus, or `None` for pure
+    /// instruments (synths / samplers that expose no audio input).
+    /// Captured at load time so `process_block` can choose between
+    /// the effect path (`numInputs: 1` with a stereo input bus) and
+    /// the instrument path (`numInputs: 0`, `inputs: null`). VST3
+    /// plugins with no audio input bus reject calls with a non-zero
+    /// `numInputs`, so this distinction is load-bearing for synths.
+    pub input_main_channels: Option<u32>,
     /// Processing lifecycle state. Guarded by a `Mutex` so the VST3
     /// spec's serialisation requirement for `setupProcessing` /
     /// `setActive` / `process` is enforced at our layer.
@@ -99,6 +107,13 @@ impl Vst3PluginInstance {
     #[cfg(test)]
     pub(crate) fn midi_queue_len(&self) -> usize {
         self.midi_queue.len()
+    }
+
+    /// True when the plugin exposes no audio input bus — i.e. a
+    /// synth, sampler, or MIDI-FX. `process_block` sends
+    /// `numInputs: 0` with a null `inputs` pointer for these.
+    pub fn is_instrument(&self) -> bool {
+        self.input_main_channels.is_none()
     }
 }
 
@@ -282,12 +297,14 @@ pub unsafe fn load_plugin(
     // 9. Snapshot parameter + bus + latency data for the UI.
     let parameters = extract_parameters(&controller);
     let output_busses = extract_output_busses(&component);
+    let input_main_channels = extract_main_input_channels(&component);
     let latency_samples = processor.getLatencySamples();
     let tail_samples = processor.getTailSamples();
 
     info!(
         params = parameters.len(),
         output_busses = output_busses.len(),
+        input_main = ?input_main_channels,
         latency = latency_samples,
         tail = tail_samples,
         "plugin loaded"
@@ -312,6 +329,7 @@ pub unsafe fn load_plugin(
         plugin_uid: uid_str,
         bundle_path: bundle_path.to_path_buf(),
         output_busses: info.output_busses.clone(),
+        input_main_channels,
         processing_state: Mutex::new(ProcessingState::default()),
         midi_queue: SegQueue::new(),
     };
@@ -352,6 +370,37 @@ fn extract_parameters(controller: &Option<ComPtr<IEditController>>) -> Vec<Param
     }
 
     params
+}
+
+/// Channel count of the main audio *input* bus, or `None` if the
+/// plugin exposes no audio input (pure instrument case). Only the
+/// main bus (index 0) is returned in 4B-2a — sidechain inputs are a
+/// separate concern tracked by a later sub-phase.
+fn extract_main_input_channels(component: &ComPtr<IComponent>) -> Option<u32> {
+    let num_inputs = unsafe {
+        component.getBusCount(
+            MediaTypes_::kAudio as i32,
+            BusDirections_::kInput as i32,
+        )
+    };
+    if num_inputs <= 0 {
+        return None;
+    }
+
+    let mut info: BusInfo = unsafe { std::mem::zeroed() };
+    let result = unsafe {
+        component.getBusInfo(
+            MediaTypes_::kAudio as i32,
+            BusDirections_::kInput as i32,
+            0,
+            &mut info,
+        )
+    };
+    if result != kResultOk {
+        warn!(result, "getBusInfo(input,0) failed; treating plugin as instrument");
+        return None;
+    }
+    Some(info.channelCount as u32)
 }
 
 fn extract_output_busses(component: &ComPtr<IComponent>) -> Vec<OutputBusInfo> {

--- a/crates/ace-plugin-host/src/loader.rs
+++ b/crates/ace-plugin-host/src/loader.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use std::ptr;
 use std::sync::Mutex;
 
+use crossbeam::queue::SegQueue;
 use libloading::{Library, Symbol};
 use tracing::{debug, info, warn};
 use vst3::ComPtr;
@@ -32,6 +33,7 @@ use vst3::Steinberg::{
 use crate::audio::ProcessingState;
 use crate::error::PluginHostError;
 use crate::host_impl::AceHostApplication;
+use crate::midi::MidiEvent;
 use crate::types::{InstanceInfo, OutputBusInfo, ParamInfo};
 
 /// A loaded VST3 plugin instance + its COM handles. The `_library`
@@ -54,6 +56,14 @@ pub struct Vst3PluginInstance {
     /// spec's serialisation requirement for `setupProcessing` /
     /// `setActive` / `process` is enforced at our layer.
     processing_state: Mutex<ProcessingState>,
+    /// Lock-free queue of pending MIDI events. Producers push from
+    /// any thread (sequencer callback, MIDI-learn handler, test);
+    /// `process_block` drains it, converts to VST3 `Event`s, and
+    /// hands them to the plugin via `IEventList`. Events queued
+    /// while the plugin is not processing accumulate and fire on
+    /// the next `process_block` call — that's how DAWs typically
+    /// handle latched notes during transport start.
+    midi_queue: SegQueue<MidiEvent>,
 }
 
 impl Vst3PluginInstance {
@@ -62,6 +72,33 @@ impl Vst3PluginInstance {
     /// duplicating state here.
     pub(crate) fn processing_state(&self) -> &Mutex<ProcessingState> {
         &self.processing_state
+    }
+
+    /// Queue a batch of MIDI events to be delivered on the next
+    /// `process_block` call. Thread-safe: any producer (sequencer,
+    /// MIDI-learn, test harness) may push concurrently.
+    ///
+    /// Events are not de-duplicated or re-ordered here — VST3
+    /// plugins sort by `sampleOffset` themselves, and the wall-clock
+    /// arrival order is what determines which of two identical
+    /// offsets wins, which matches DAW expectations.
+    pub fn queue_midi(&self, events: &[MidiEvent]) {
+        for e in events {
+            self.midi_queue.push(*e);
+        }
+    }
+
+    pub(crate) fn drain_midi(&self) -> Vec<MidiEvent> {
+        let mut out = Vec::new();
+        while let Some(e) = self.midi_queue.pop() {
+            out.push(e);
+        }
+        out
+    }
+
+    #[cfg(test)]
+    pub(crate) fn midi_queue_len(&self) -> usize {
+        self.midi_queue.len()
     }
 }
 
@@ -276,6 +313,7 @@ pub unsafe fn load_plugin(
         bundle_path: bundle_path.to_path_buf(),
         output_busses: info.output_busses.clone(),
         processing_state: Mutex::new(ProcessingState::default()),
+        midi_queue: SegQueue::new(),
     };
 
     Ok((instance, info))
@@ -395,6 +433,42 @@ pub fn format_uid(uid: &[i8; 16]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::midi::MidiEvent;
+
+    #[test]
+    fn midi_queue_accumulates_and_drains_in_fifo_order() {
+        // Build an instance by hand-rolling via the smoke test path is
+        // not possible without COM — instead, use the real bundle-load
+        // path only if available; otherwise skip.
+        let candidates = ["/Library/Audio/Plug-Ins/VST3/ACE Bridge.vst3"];
+        let Some(path) = candidates.iter().map(Path::new).find(|p| p.exists()) else {
+            eprintln!("skipping: no known VST3 bundle installed");
+            return;
+        };
+        let (instance, _) = match unsafe { load_plugin(path, "midi-queue-test") } {
+            Ok(pair) => pair,
+            Err(e) => {
+                eprintln!("load failed (environment-specific, not fatal): {e}");
+                return;
+            }
+        };
+
+        assert_eq!(instance.midi_queue_len(), 0);
+
+        instance.queue_midi(&[
+            MidiEvent::note_on(0, 60, 100, 0),
+            MidiEvent::note_on(1, 72, 80, 128),
+        ]);
+        instance.queue_midi(&[MidiEvent::note_off(0, 60, 0, 256)]);
+        assert_eq!(instance.midi_queue_len(), 3);
+
+        let drained = instance.drain_midi();
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].data1, 60);
+        assert_eq!(drained[1].data1, 72);
+        assert_eq!(drained[2].data1, 60);
+        assert_eq!(instance.midi_queue_len(), 0);
+    }
 
     #[test]
     fn bundle_dylib_path_returns_none_for_missing_bundle() {

--- a/crates/ace-plugin-host/src/loader.rs
+++ b/crates/ace-plugin-host/src/loader.rs
@@ -86,10 +86,18 @@ impl Vst3PluginInstance {
     /// `process_block` call. Thread-safe: any producer (sequencer,
     /// MIDI-learn, test harness) may push concurrently.
     ///
-    /// Events are not de-duplicated or re-ordered here — VST3
-    /// plugins sort by `sampleOffset` themselves, and the wall-clock
-    /// arrival order is what determines which of two identical
-    /// offsets wins, which matches DAW expectations.
+    /// Ordering contract:
+    /// - Events are enqueued as received and are not de-duplicated.
+    /// - `process_block` **sorts** the drained events by
+    ///   `sample_offset` before handing them to the plugin, so
+    ///   per-block timing is deterministic regardless of
+    ///   cross-producer interleaving.
+    /// - For events with *identical* `sample_offset` pushed from
+    ///   different threads, the tie-break follows `SegQueue`'s
+    ///   internal ordering (neither strictly FIFO nor LIFO across
+    ///   threads). Callers that need a deterministic tie-break
+    ///   should stamp a monotonic counter into the high bits of
+    ///   `sample_offset` themselves.
     pub fn queue_midi(&self, events: &[MidiEvent]) {
         for e in events {
             self.midi_queue.push(*e);
@@ -485,10 +493,18 @@ mod tests {
     use crate::midi::MidiEvent;
 
     #[test]
-    fn midi_queue_accumulates_and_drains_in_fifo_order() {
+    fn midi_queue_accumulates_and_drains() {
         // Build an instance by hand-rolling via the smoke test path is
         // not possible without COM — instead, use the real bundle-load
         // path only if available; otherwise skip.
+        //
+        // This asserts only that every queued event ends up in the
+        // drained vector. Order across multiple `queue_midi` calls
+        // on a single thread happens to be FIFO with `SegQueue`,
+        // but that's not part of the `queue_midi` contract (see its
+        // docs) — `process_block` sorts by `sample_offset` before
+        // handing events to the plugin, so the test checks the
+        // contract, not the incidental FIFO.
         let candidates = ["/Library/Audio/Plug-Ins/VST3/ACE Bridge.vst3"];
         let Some(path) = candidates.iter().map(Path::new).find(|p| p.exists()) else {
             eprintln!("skipping: no known VST3 bundle installed");
@@ -511,10 +527,16 @@ mod tests {
         instance.queue_midi(&[MidiEvent::note_off(0, 60, 0, 256)]);
         assert_eq!(instance.midi_queue_len(), 3);
 
-        let drained = instance.drain_midi();
+        let mut drained = instance.drain_midi();
         assert_eq!(drained.len(), 3);
+        // Sort by sample_offset before comparing — that matches how
+        // the plugin actually sees the events via process_block.
+        drained.sort_by_key(|e| e.sample_offset);
+        assert_eq!(drained[0].sample_offset, 0);
         assert_eq!(drained[0].data1, 60);
+        assert_eq!(drained[1].sample_offset, 128);
         assert_eq!(drained[1].data1, 72);
+        assert_eq!(drained[2].sample_offset, 256);
         assert_eq!(drained[2].data1, 60);
         assert_eq!(instance.midi_queue_len(), 0);
     }

--- a/crates/ace-plugin-host/src/midi.rs
+++ b/crates/ace-plugin-host/src/midi.rs
@@ -74,6 +74,12 @@ pub fn midi_to_vst3_event(midi: &MidiEvent) -> Option<Event> {
     let message_type = midi.status & 0xF0;
     let channel = (midi.status & 0x0F) as i16;
 
+    // VST3's `Event::sampleOffset` is `i32`. Our input is `u32`, so
+    // any value past `i32::MAX` would wrap to negative — nonsensical
+    // as a block-relative offset and a source of plugin-side OOB
+    // scheduling bugs. Drop the event outright if it can't round-trip.
+    let sample_offset = i32::try_from(midi.sample_offset).ok()?;
+
     match message_type {
         0x90 => {
             // Note-on with velocity 0 is treated as note-off per the
@@ -84,14 +90,14 @@ pub fn midi_to_vst3_event(midi: &MidiEvent) -> Option<Event> {
                     channel,
                     midi.data1 as i16,
                     0.0,
-                    midi.sample_offset as i32,
+                    sample_offset,
                 ))
             } else {
                 Some(make_note_on_event(
                     channel,
                     midi.data1 as i16,
                     midi.data2 as f32 / 127.0,
-                    midi.sample_offset as i32,
+                    sample_offset,
                 ))
             }
         }
@@ -99,7 +105,7 @@ pub fn midi_to_vst3_event(midi: &MidiEvent) -> Option<Event> {
             channel,
             midi.data1 as i16,
             midi.data2 as f32 / 127.0,
-            midi.sample_offset as i32,
+            sample_offset,
         )),
         _ => None,
     }
@@ -269,6 +275,31 @@ mod tests {
         let midi = MidiEvent::note_on(0, 60, 0, 0);
         let event = midi_to_vst3_event(&midi).expect("velocity-0 note-on should convert");
         assert_eq!(event.r#type, EventTypes_::kNoteOffEvent as u16);
+    }
+
+    #[test]
+    fn midi_to_vst3_drops_events_with_sample_offset_past_i32_max() {
+        // u32 > i32::MAX would wrap to negative when cast — drop it
+        // rather than scheduling at a nonsensical offset.
+        let bad = MidiEvent {
+            status: 0x90,
+            data1: 60,
+            data2: 100,
+            sample_offset: (i32::MAX as u32) + 1,
+        };
+        assert!(midi_to_vst3_event(&bad).is_none());
+    }
+
+    #[test]
+    fn midi_to_vst3_accepts_sample_offset_at_i32_max() {
+        let ok = MidiEvent {
+            status: 0x90,
+            data1: 60,
+            data2: 100,
+            sample_offset: i32::MAX as u32,
+        };
+        let event = midi_to_vst3_event(&ok).expect("i32::MAX should round-trip");
+        assert_eq!(event.sampleOffset, i32::MAX);
     }
 
     #[test]

--- a/crates/ace-plugin-host/src/midi.rs
+++ b/crates/ace-plugin-host/src/midi.rs
@@ -367,4 +367,24 @@ mod tests {
         let result = unsafe { el.addEvent(std::ptr::null_mut()) };
         assert_eq!(result, kInvalidArgument);
     }
+
+    /// Regression test for Codex P2: drained MIDI must be sorted by
+    /// `sample_offset` before converting, because VST3 plugins
+    /// iterate the host's IEventList forward by index and don't
+    /// re-sort internally. Out-of-order input has been observed to
+    /// cause missed note-offs and stuck notes in real-world plugins.
+    #[test]
+    fn sort_by_sample_offset_is_deterministic() {
+        // Producer pushed note-off BEFORE note-on for the same pitch,
+        // e.g. because two threads raced on queuing.
+        let mut events = [
+            MidiEvent::note_off(0, 60, 0, 256),
+            MidiEvent::note_on(0, 60, 100, 0),
+            MidiEvent::note_on(0, 64, 80, 128),
+        ];
+        events.sort_by_key(|e| e.sample_offset);
+        assert_eq!(events[0].sample_offset, 0);
+        assert_eq!(events[1].sample_offset, 128);
+        assert_eq!(events[2].sample_offset, 256);
+    }
 }

--- a/crates/ace-plugin-host/src/midi.rs
+++ b/crates/ace-plugin-host/src/midi.rs
@@ -1,0 +1,370 @@
+//! MIDI event handling: a flat `MidiEvent` struct for cross-IPC
+//! transport, a conversion into VST3's `Event` union, and a minimal
+//! host-side `IEventList` implementation to hand note-on / note-off
+//! events to `IAudioProcessor::process()`.
+//!
+//! Ported from `companion/src/host_impl.rs` (`EventList`,
+//! `midi_to_vst3_event`, `make_note_on_event`, `make_note_off_event`)
+//! — the companion ran this in production so the COM-side logic is
+//! battle-tested. Adapted to live in a module that can exist without
+//! the companion's WebSocket protocol.
+//!
+//! Phase 4B-2a scope:
+//!
+//! - Note-on (`0x90`) / note-off (`0x80`) only. Note-on with velocity
+//!   0 is interpreted as note-off per the MIDI 1.0 spec.
+//! - Other MIDI message types (CC, pitchbend, aftertouch, sysex)
+//!   return `None` from the converter — plugins that need them can
+//!   be wired up incrementally in a follow-up.
+//! - `outputEvents` is always null; 4B / future phases can wire up
+//!   plugin-emitted MIDI if a DAW workflow ever needs it.
+
+use std::cell::RefCell;
+
+use vst3::Steinberg::Vst::{
+    Event, Event__type0, Event_::EventTypes_, IEventList, IEventListTrait, NoteOffEvent,
+    NoteOnEvent,
+};
+use vst3::Steinberg::{int32, kInvalidArgument, kResultOk, tresult};
+use vst3::{Class, ComWrapper};
+
+/// A flat MIDI event — the shape we accept from callers (the DAW's
+/// sequencer, a MIDI-learn mapping, etc.). We keep `u8` status /
+/// data1 / data2 instead of a parsed enum so unsupported message
+/// types round-trip cleanly and can be filtered later.
+///
+/// `sample_offset` is the offset within the current audio block
+/// where the event should fire; VST3 forwards this as `sampleOffset`
+/// in the `Event` struct so plugins can render sample-accurate MIDI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MidiEvent {
+    pub status: u8,
+    pub data1: u8,
+    pub data2: u8,
+    pub sample_offset: u32,
+}
+
+impl MidiEvent {
+    pub const fn note_on(channel: u8, pitch: u8, velocity: u8, sample_offset: u32) -> Self {
+        Self {
+            status: 0x90 | (channel & 0x0F),
+            data1: pitch & 0x7F,
+            data2: velocity & 0x7F,
+            sample_offset,
+        }
+    }
+
+    pub const fn note_off(channel: u8, pitch: u8, velocity: u8, sample_offset: u32) -> Self {
+        Self {
+            status: 0x80 | (channel & 0x0F),
+            data1: pitch & 0x7F,
+            data2: velocity & 0x7F,
+            sample_offset,
+        }
+    }
+}
+
+/// Convert a flat `MidiEvent` into a VST3 `Event`.
+///
+/// Returns `None` for unsupported status bytes — CC, pitchbend,
+/// aftertouch, program change, sysex all currently fall here. Adding
+/// them is a question of wiring the equivalent `Event` variant; the
+/// skeleton is deliberately minimal for 4B-2a.
+pub fn midi_to_vst3_event(midi: &MidiEvent) -> Option<Event> {
+    let message_type = midi.status & 0xF0;
+    let channel = (midi.status & 0x0F) as i16;
+
+    match message_type {
+        0x90 => {
+            // Note-on with velocity 0 is treated as note-off per the
+            // MIDI 1.0 spec (§A-2). Plugins that don't implement this
+            // convention will get stuck notes if we don't translate.
+            if midi.data2 == 0 {
+                Some(make_note_off_event(
+                    channel,
+                    midi.data1 as i16,
+                    0.0,
+                    midi.sample_offset as i32,
+                ))
+            } else {
+                Some(make_note_on_event(
+                    channel,
+                    midi.data1 as i16,
+                    midi.data2 as f32 / 127.0,
+                    midi.sample_offset as i32,
+                ))
+            }
+        }
+        0x80 => Some(make_note_off_event(
+            channel,
+            midi.data1 as i16,
+            midi.data2 as f32 / 127.0,
+            midi.sample_offset as i32,
+        )),
+        _ => None,
+    }
+}
+
+fn make_note_on_event(channel: i16, pitch: i16, velocity: f32, sample_offset: i32) -> Event {
+    Event {
+        busIndex: 0,
+        sampleOffset: sample_offset,
+        ppqPosition: 0.0,
+        flags: 0,
+        r#type: EventTypes_::kNoteOnEvent as u16,
+        __field0: Event__type0 {
+            noteOn: NoteOnEvent {
+                channel,
+                pitch,
+                tuning: 0.0,
+                velocity,
+                length: 0,
+                noteId: -1,
+            },
+        },
+    }
+}
+
+fn make_note_off_event(channel: i16, pitch: i16, velocity: f32, sample_offset: i32) -> Event {
+    Event {
+        busIndex: 0,
+        sampleOffset: sample_offset,
+        ppqPosition: 0.0,
+        flags: 0,
+        r#type: EventTypes_::kNoteOffEvent as u16,
+        __field0: Event__type0 {
+            noteOff: NoteOffEvent {
+                channel,
+                pitch,
+                velocity,
+                noteId: -1,
+                tuning: 0.0,
+            },
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IEventList
+// ---------------------------------------------------------------------------
+
+/// Host-side `IEventList` implementation. VST3 expects events
+/// delivered to `IAudioProcessor::process()` to live behind a COM
+/// interface the plugin can poll; this is the smallest possible
+/// implementation — a `RefCell<Vec<Event>>` under the `ComWrapper`
+/// the `vst3` crate provides.
+///
+/// Thread model: constructed on the host thread, read from the
+/// plugin's `process()` call, dropped when `process()` returns.
+/// `RefCell` is fine because the plugin never retains the pointer
+/// past the call, and we don't share the wrapper across threads.
+pub struct EventList {
+    events: RefCell<Vec<Event>>,
+}
+
+impl EventList {
+    /// Empty list — used as a "no MIDI this block" sentinel.
+    pub fn new() -> ComWrapper<Self> {
+        ComWrapper::new(Self {
+            events: RefCell::new(Vec::new()),
+        })
+    }
+
+    /// Pre-populated list. Taking ownership here avoids a clone at
+    /// each block boundary.
+    pub fn with_events(events: Vec<Event>) -> ComWrapper<Self> {
+        ComWrapper::new(Self {
+            events: RefCell::new(events),
+        })
+    }
+}
+
+impl Class for EventList {
+    type Interfaces = (IEventList,);
+}
+
+impl IEventListTrait for EventList {
+    unsafe fn getEventCount(&self) -> int32 {
+        self.events.borrow().len() as int32
+    }
+
+    unsafe fn getEvent(&self, index: int32, e: *mut Event) -> tresult {
+        let events = self.events.borrow();
+        if index < 0 || (index as usize) >= events.len() || e.is_null() {
+            return kInvalidArgument;
+        }
+        *e = events[index as usize];
+        kResultOk
+    }
+
+    unsafe fn addEvent(&self, e: *mut Event) -> tresult {
+        if e.is_null() {
+            return kInvalidArgument;
+        }
+        self.events.borrow_mut().push(*e);
+        kResultOk
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn note_on_helper_packs_status_byte() {
+        let e = MidiEvent::note_on(3, 60, 100, 128);
+        assert_eq!(e.status, 0x93);
+        assert_eq!(e.data1, 60);
+        assert_eq!(e.data2, 100);
+        assert_eq!(e.sample_offset, 128);
+    }
+
+    #[test]
+    fn note_on_helper_masks_channel_to_low_nibble() {
+        let e = MidiEvent::note_on(0xFF, 60, 100, 0);
+        assert_eq!(e.status, 0x9F);
+    }
+
+    #[test]
+    fn note_off_helper_packs_status_byte() {
+        let e = MidiEvent::note_off(0, 60, 64, 0);
+        assert_eq!(e.status, 0x80);
+    }
+
+    #[test]
+    fn midi_to_vst3_converts_note_on_to_note_on_event() {
+        let midi = MidiEvent::note_on(5, 69, 100, 42);
+        let event = midi_to_vst3_event(&midi).expect("note-on should convert");
+        assert_eq!(event.r#type, EventTypes_::kNoteOnEvent as u16);
+        assert_eq!(event.sampleOffset, 42);
+        // SAFETY: the type tag above confirms the union variant.
+        unsafe {
+            let note = event.__field0.noteOn;
+            assert_eq!(note.channel, 5);
+            assert_eq!(note.pitch, 69);
+            assert!((note.velocity - (100.0 / 127.0)).abs() < f32::EPSILON);
+        }
+    }
+
+    #[test]
+    fn midi_to_vst3_converts_note_off_to_note_off_event() {
+        let midi = MidiEvent::note_off(2, 60, 64, 0);
+        let event = midi_to_vst3_event(&midi).expect("note-off should convert");
+        assert_eq!(event.r#type, EventTypes_::kNoteOffEvent as u16);
+        unsafe {
+            let note = event.__field0.noteOff;
+            assert_eq!(note.channel, 2);
+            assert_eq!(note.pitch, 60);
+        }
+    }
+
+    #[test]
+    fn midi_to_vst3_treats_velocity_zero_note_on_as_note_off() {
+        // MIDI 1.0 spec §A-2: note-on with velocity 0 is the
+        // canonical way many controllers send note-off.
+        let midi = MidiEvent::note_on(0, 60, 0, 0);
+        let event = midi_to_vst3_event(&midi).expect("velocity-0 note-on should convert");
+        assert_eq!(event.r#type, EventTypes_::kNoteOffEvent as u16);
+    }
+
+    #[test]
+    fn midi_to_vst3_returns_none_for_unsupported_types() {
+        // CC message
+        let cc = MidiEvent {
+            status: 0xB0,
+            data1: 7,
+            data2: 127,
+            sample_offset: 0,
+        };
+        assert!(midi_to_vst3_event(&cc).is_none());
+
+        // Pitchbend
+        let pb = MidiEvent {
+            status: 0xE0,
+            data1: 0,
+            data2: 64,
+            sample_offset: 0,
+        };
+        assert!(midi_to_vst3_event(&pb).is_none());
+    }
+
+    #[test]
+    fn event_list_starts_empty() {
+        let list = EventList::new();
+        let el = list.to_com_ptr::<IEventList>().unwrap();
+        unsafe {
+            assert_eq!(el.getEventCount(), 0);
+        }
+    }
+
+    #[test]
+    fn event_list_with_events_reports_count() {
+        let events = vec![
+            midi_to_vst3_event(&MidiEvent::note_on(0, 60, 100, 0)).unwrap(),
+            midi_to_vst3_event(&MidiEvent::note_off(0, 60, 0, 64)).unwrap(),
+        ];
+        let list = EventList::with_events(events);
+        let el = list.to_com_ptr::<IEventList>().unwrap();
+        unsafe {
+            assert_eq!(el.getEventCount(), 2);
+        }
+    }
+
+    #[test]
+    fn event_list_get_event_round_trips() {
+        let original = midi_to_vst3_event(&MidiEvent::note_on(3, 72, 80, 256)).unwrap();
+        let list = EventList::with_events(vec![original]);
+        let el = list.to_com_ptr::<IEventList>().unwrap();
+        let mut out: Event = unsafe { std::mem::zeroed() };
+        let result = unsafe { el.getEvent(0, &mut out) };
+        assert_eq!(result, kResultOk);
+        assert_eq!(out.r#type, original.r#type);
+        assert_eq!(out.sampleOffset, 256);
+    }
+
+    #[test]
+    fn event_list_get_event_rejects_out_of_bounds() {
+        let list = EventList::new();
+        let el = list.to_com_ptr::<IEventList>().unwrap();
+        let mut out: Event = unsafe { std::mem::zeroed() };
+        let result = unsafe { el.getEvent(0, &mut out) };
+        assert_eq!(result, kInvalidArgument);
+        let result = unsafe { el.getEvent(-1, &mut out) };
+        assert_eq!(result, kInvalidArgument);
+    }
+
+    #[test]
+    fn event_list_get_event_rejects_null_output_pointer() {
+        let list = EventList::with_events(vec![
+            midi_to_vst3_event(&MidiEvent::note_on(0, 60, 100, 0)).unwrap(),
+        ]);
+        let el = list.to_com_ptr::<IEventList>().unwrap();
+        let result = unsafe { el.getEvent(0, std::ptr::null_mut()) };
+        assert_eq!(result, kInvalidArgument);
+    }
+
+    #[test]
+    fn event_list_add_event_appends() {
+        let list = EventList::new();
+        let el = list.to_com_ptr::<IEventList>().unwrap();
+        let mut event =
+            midi_to_vst3_event(&MidiEvent::note_on(1, 64, 90, 0)).unwrap();
+        let result = unsafe { el.addEvent(&mut event) };
+        assert_eq!(result, kResultOk);
+        unsafe {
+            assert_eq!(el.getEventCount(), 1);
+        }
+    }
+
+    #[test]
+    fn event_list_add_event_rejects_null() {
+        let list = EventList::new();
+        let el = list.to_com_ptr::<IEventList>().unwrap();
+        let result = unsafe { el.addEvent(std::ptr::null_mut()) };
+        assert_eq!(result, kInvalidArgument);
+    }
+}


### PR DESCRIPTION
Closes #1762 · Part of #1524 · Epic #1519 · Follows #1761

Extends the audio-processing lifecycle landed in 4B-1 by wiring MIDI note-on / note-off events into `IAudioProcessor::process()` via the `IEventList` COM interface. Instrument plugins (synths, samplers, drum modules) need this to produce any sound at all; audio-effect plugins ignore MIDI but won't be harmed by an empty list.

Parameter automation (`IParameterChanges`) is still null — that lives in **4B-2b**, which has to build host-side `IParameterChanges` and `IParamValueQueue` wrappers the companion app never implemented (enough novel COM surface to deserve its own PR).

## Summary

- New `midi` module with `MidiEvent` (flat status/data1/data2 shape), `midi_to_vst3_event` conversion (note-on, note-off, velocity-0 note-on → note-off per MIDI 1.0 §A-2), and an `EventList` COM class implementing `IEventList` — ported from `companion/src/host_impl.rs`
- Lock-free `SegQueue<MidiEvent>` on `Vst3PluginInstance`; multiple producers (sequencer thread, MIDI-learn handler, tests) can push without blocking
- `process_block` drains the queue, converts to VST3 `Event`s, and hands them to the plugin via `ProcessData::inputEvents`. The `EventList` ComWrapper is held on the stack and drops after `process()` returns, so its lifetime strictly outlives the COM call
- `PluginHost::queue_instance_midi` host-level wrapper with `UnknownInstance` guard

## New API

\`\`\`rust
// Push MIDI:
let note_on = MidiEvent::note_on(channel, pitch, velocity, sample_offset);
instance.queue_midi(&[note_on]);
// or via the host:
host.queue_instance_midi(instance_id, &[note_on])?;

// Delivered on the next process_block; queue drains fully on each call.
host.process_instance_block(instance_id, &input, 2, 512)?;
\`\`\`

## Non-goals (explicit)

- ❌ `IParameterChanges` (host → plugin param automation) — **4B-2b**
- ❌ CC / pitchbend / aftertouch / sysex — `midi_to_vst3_event` returns `None`; adding them is a follow-up
- ❌ `outputEvents` (plugin-emitted MIDI) — stays null until a feature surfaces the need
- ❌ MIDI clock, MTC, song-position — those come through `ProcessContext`, separate 4B concern

## Test Results

- \`cargo test -p ace-plugin-host\`: **69 passed / 0 failed** (17 new tests: MidiEvent helpers, midi_to_vst3_event coverage incl. velocity-0-is-note-off + unsupported-returns-None + channel masking, EventList round-trip incl. empty / out-of-bounds / null pointer, host-wrapper UnknownInstance guard, plus 2 gated smoke tests that load ACE Bridge VST3, queue MIDI, run a block, and assert the queue drains cleanly)
- \`cargo clippy -p ace-plugin-host --all-targets -- -D warnings\`: clean
- \`cargo build --lib\` in src-tauri: clean
- TypeScript untouched (Rust-only change)

## Reusable Assets

`companion/src/host_impl.rs` lines 317-444 ran in production in the companion app:
- `EventList` struct + `IEventListTrait` impl
- `midi_to_vst3_event` conversion
- `make_note_on_event` / `make_note_off_event` helpers

Ported mechanically; the only adaptation was moving off the companion's `WsMidi` protocol shape onto a standalone `MidiEvent` type.

## Test plan

- [x] \`cargo test -p ace-plugin-host\`
- [x] \`cargo clippy -p ace-plugin-host --all-targets -- -D warnings\`
- [x] \`cargo build --lib\` in src-tauri
- [ ] Copilot review
- [ ] Codex review (\`/codex review\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)