### PR TITLE
feat: Phase 4B-2b — IParameterChanges host-driven parameter automation

### DIFF
--- a/crates/ace-plugin-host/src/audio.rs
+++ b/crates/ace-plugin-host/src/audio.rs
@@ -10,8 +10,8 @@
 //!
 //! - Stereo-only main bus I/O (multi-output busses land in 4B-3)
 //! - 4B-2a adds MIDI note-on / note-off via `IEventList`;
-//!   `inputParameterChanges` stays null until 4B-2b ships the
-//!   host-side `IParameterChanges` wrapper.
+//!   4B-2b adds parameter automation via host-side
+//!   `IParameterChanges` + `IParamValueQueue`.
 //! - No sidechain, no PDC, no sandbox (later sub-phases of #1524)
 //!
 //! Ported from `companion/src/audio_thread.rs::process_vst3_multi`,
@@ -25,13 +25,14 @@ use std::ptr;
 use tracing::warn;
 use vst3::Steinberg::Vst::{
     AudioBusBuffers, AudioBusBuffers__type0, IAudioProcessorTrait, IComponentTrait, IEventList,
-    ProcessData, ProcessModes_, ProcessSetup, SymbolicSampleSizes_,
+    IParameterChanges, ProcessData, ProcessModes_, ProcessSetup, SymbolicSampleSizes_,
 };
 use vst3::Steinberg::kResultOk;
 
 use crate::error::PluginHostError;
 use crate::loader::Vst3PluginInstance;
 use crate::midi::{midi_to_vst3_event, EventList};
+use crate::params::{group_points_for_block, ParameterChanges};
 use crate::types::OutputBusInfo;
 
 /// Pure-logic guard that `setup_processing` delegates to. Extracted
@@ -637,6 +638,31 @@ impl Vst3PluginInstance {
             .map(|p| p.as_ptr())
             .unwrap_or(ptr::null_mut());
 
+        // Drain queued parameter-automation points and build a
+        // host-side `ParameterChanges`. The `group_points_for_block`
+        // helper handles the window filter (same contract as MIDI),
+        // drops points whose `sample_offset` would wrap negative in
+        // VST3's `i32`, and sorts each group by `sampleOffset`.
+        // Points queued before `setup_processing` / `activate` will
+        // sit in the queue until the first `process_block` call —
+        // matching DAW expectations for pre-roll automation.
+        let pending_params = self.drain_param_points();
+        let param_changes = if pending_params.is_empty() {
+            None
+        } else {
+            let groups = group_points_for_block(pending_params, block_samples);
+            if groups.is_empty() {
+                None
+            } else {
+                Some(ParameterChanges::with_groups(groups))
+            }
+        };
+        let input_param_changes_ptr = param_changes
+            .as_ref()
+            .and_then(|pc| pc.to_com_ptr::<IParameterChanges>())
+            .map(|p| p.as_ptr())
+            .unwrap_or(ptr::null_mut());
+
         let mut process_data = ProcessData {
             processMode: ProcessModes_::kRealtime as i32,
             symbolicSampleSize: SymbolicSampleSizes_::kSample32 as i32,
@@ -649,7 +675,7 @@ impl Vst3PluginInstance {
                 &mut input_bus
             },
             outputs: &mut output_bus,
-            inputParameterChanges: ptr::null_mut(),
+            inputParameterChanges: input_param_changes_ptr,
             outputParameterChanges: ptr::null_mut(),
             inputEvents: input_events_ptr,
             outputEvents: ptr::null_mut(),
@@ -679,8 +705,12 @@ impl Vst3PluginInstance {
                 out[s * output_stereo + ch] = output_channels[ch][s];
             }
         }
-        // `state` guard + `event_list` dropped here — after process().
+        // `state` guard + `event_list` + `param_changes` dropped
+        // here — after process() returns. Explicit drops document
+        // the lifetime requirement: their COM pointers were handed
+        // to the plugin via `process_data` and must outlive the call.
         drop(event_list);
+        drop(param_changes);
         drop(state);
         Ok(out)
     }
@@ -739,6 +769,49 @@ mod smoke {
         // process_block after deactivate errors.
         let err = instance.process_block(&input, 2, 512).unwrap_err();
         assert!(matches!(err, PluginHostError::InvalidLifecycle(_)));
+    }
+
+    /// Queues a parameter automation point and verifies the queue
+    /// drains through `process_block`. The plugin's reaction to the
+    /// value change isn't asserted — ACE Bridge is an effect, we
+    /// just confirm the host wiring doesn't reject or hang.
+    #[test]
+    fn parameter_queue_drains_through_process_block() {
+        let candidates = ["/Library/Audio/Plug-Ins/VST3/ACE Bridge.vst3"];
+        let Some(path) = candidates.iter().map(Path::new).find(|p| p.exists()) else {
+            eprintln!("skipping: no known VST3 bundle installed");
+            return;
+        };
+
+        let (instance, info) = match unsafe { crate::loader::load_plugin(path, "param-smoke") } {
+            Ok(pair) => pair,
+            Err(e) => {
+                eprintln!("load failed (environment-specific, not fatal): {e}");
+                return;
+            }
+        };
+
+        instance
+            .setup_processing(AudioConfig::new(48000.0, 512).unwrap())
+            .unwrap();
+        instance.activate().unwrap();
+
+        // Pick the plugin's first parameter if any; otherwise skip
+        // this assertion — some bundles expose no automatable params.
+        if let Some(first) = info.parameters.first() {
+            instance.set_parameter(first.id, 0, 0.5);
+            instance.set_parameter(first.id, 128, 0.75);
+            assert_eq!(instance.param_queue_len(), 2);
+        } else {
+            eprintln!("plugin exposes no parameters — skipping set_parameter assertion");
+        }
+
+        let input = vec![0.0f32; 2 * 512];
+        let out = instance.process_block(&input, 2, 512).unwrap();
+        assert_eq!(out.len(), 2 * 512);
+        assert_eq!(instance.param_queue_len(), 0);
+
+        instance.deactivate().unwrap();
     }
 
     /// Queues a MIDI note-on / note-off pair and runs one block.

--- a/crates/ace-plugin-host/src/audio.rs
+++ b/crates/ace-plugin-host/src/audio.rs
@@ -32,7 +32,7 @@ use vst3::Steinberg::kResultOk;
 use crate::error::PluginHostError;
 use crate::loader::Vst3PluginInstance;
 use crate::midi::{midi_to_vst3_event, EventList};
-use crate::params::{group_points_for_block, ParameterChanges};
+use crate::params::{partition_points_for_block, ParameterChanges};
 use crate::types::OutputBusInfo;
 
 /// Pure-logic guard that `setup_processing` delegates to. Extracted
@@ -619,11 +619,20 @@ impl Vst3PluginInstance {
         //
         // `event_list` must outlive `process_data` because the plugin
         // may read from the COM pointer during `process()`.
-        let mut pending = self.drain_midi();
+        let pending = self.drain_midi();
         let block_samples = samples;
-        pending.retain(|e| e.sample_offset < block_samples);
-        pending.sort_by_key(|e| e.sample_offset);
-        let vst3_events: Vec<_> = pending
+        let (mut this_block, future): (Vec<_>, Vec<_>) =
+            pending.into_iter().partition(|e| e.sample_offset < block_samples);
+        // Re-queue future events with offsets ticked down so they
+        // stay block-relative on the next call — matches the param
+        // automation path and avoids silently losing events when a
+        // caller batches multiple blocks of MIDI ahead of time.
+        for mut e in future {
+            e.sample_offset = e.sample_offset.saturating_sub(block_samples);
+            self.requeue_midi_event(e);
+        }
+        this_block.sort_by_key(|e| e.sample_offset);
+        let vst3_events: Vec<_> = this_block
             .iter()
             .filter_map(midi_to_vst3_event)
             .collect();
@@ -639,24 +648,25 @@ impl Vst3PluginInstance {
             .unwrap_or(ptr::null_mut());
 
         // Drain queued parameter-automation points and build a
-        // host-side `ParameterChanges`. The `group_points_for_block`
-        // helper handles the window filter (same contract as MIDI),
-        // drops points whose `sample_offset` would wrap negative in
-        // VST3's `i32`, and sorts each group by `sampleOffset`.
-        // Points queued before `setup_processing` / `activate` will
-        // sit in the queue until the first `process_block` call —
-        // matching DAW expectations for pre-roll automation.
+        // host-side `ParameterChanges`. `partition_points_for_block`
+        // returns `(this_block_groups, future_overflow)` so we can
+        // re-queue points scheduled past the current block —
+        // callers that batch multiple blocks of automation (bounce
+        // / sequencer workflows) would otherwise silently lose
+        // everything past block_samples. Future-bucket offsets are
+        // already decremented by block_samples so they stay
+        // block-relative on the next call.
         let pending_params = self.drain_param_points();
-        let param_changes = if pending_params.is_empty() {
+        let (groups, future_params) =
+            partition_points_for_block(pending_params, block_samples);
+        let param_changes = if groups.is_empty() {
             None
         } else {
-            let groups = group_points_for_block(pending_params, block_samples);
-            if groups.is_empty() {
-                None
-            } else {
-                Some(ParameterChanges::with_groups(groups))
-            }
+            Some(ParameterChanges::with_groups(groups))
         };
+        for p in future_params {
+            self.requeue_param_point(p);
+        }
         let input_param_changes_ptr = param_changes
             .as_ref()
             .and_then(|pc| pc.to_com_ptr::<IParameterChanges>())

--- a/crates/ace-plugin-host/src/audio.rs
+++ b/crates/ace-plugin-host/src/audio.rs
@@ -809,8 +809,8 @@ mod smoke {
         // Pick the plugin's first parameter if any; otherwise skip
         // this assertion — some bundles expose no automatable params.
         if let Some(first) = info.parameters.first() {
-            instance.set_parameter(first.id, 0, 0.5);
-            instance.set_parameter(first.id, 128, 0.75);
+            instance.set_parameter(first.id, 0, 0.5).unwrap();
+            instance.set_parameter(first.id, 128, 0.75).unwrap();
             assert_eq!(instance.param_queue_len(), 2);
         } else {
             eprintln!("plugin exposes no parameters — skipping set_parameter assertion");

--- a/crates/ace-plugin-host/src/host.rs
+++ b/crates/ace-plugin-host/src/host.rs
@@ -151,6 +151,22 @@ impl PluginHost {
         Ok(())
     }
 
+    /// Queue a parameter automation point for the instance. VST3
+    /// values are always `[0.0, 1.0]` normalised — consult
+    /// `ParamInfo` via `list`/`instance` metadata for the raw range.
+    /// Thread-safe; same ordering contract as `queue_instance_midi`.
+    pub fn set_instance_parameter(
+        &self,
+        instance_id: &str,
+        param_id: u32,
+        sample_offset: u32,
+        value: f64,
+    ) -> Result<(), PluginHostError> {
+        self.lookup(instance_id)?
+            .set_parameter(param_id, sample_offset, value);
+        Ok(())
+    }
+
     /// Drop a live instance. Releasing the only reference to its
     /// `Vst3PluginInstance` unloads the dylib. Unknown instance IDs
     /// produce an error so callers notice stale handles.
@@ -247,6 +263,15 @@ mod tests {
         let host = PluginHost::new();
         let err = host
             .queue_instance_midi("ghost", &[MidiEvent::note_on(0, 60, 100, 0)])
+            .unwrap_err();
+        assert!(matches!(err, PluginHostError::UnknownInstance(_)));
+    }
+
+    #[test]
+    fn set_parameter_unknown_instance_errors_out() {
+        let host = PluginHost::new();
+        let err = host
+            .set_instance_parameter("ghost", 1, 0, 0.5)
             .unwrap_err();
         assert!(matches!(err, PluginHostError::UnknownInstance(_)));
     }

--- a/crates/ace-plugin-host/src/host.rs
+++ b/crates/ace-plugin-host/src/host.rs
@@ -163,8 +163,7 @@ impl PluginHost {
         value: f64,
     ) -> Result<(), PluginHostError> {
         self.lookup(instance_id)?
-            .set_parameter(param_id, sample_offset, value);
-        Ok(())
+            .set_parameter(param_id, sample_offset, value)
     }
 
     /// Drop a live instance. Releasing the only reference to its

--- a/crates/ace-plugin-host/src/lib.rs
+++ b/crates/ace-plugin-host/src/lib.rs
@@ -25,6 +25,7 @@ pub mod host;
 pub mod host_impl;
 pub mod loader;
 pub mod midi;
+pub mod params;
 pub mod scanner;
 pub mod types;
 
@@ -34,5 +35,6 @@ pub use host::PluginHost;
 pub use host_impl::{AceComponentHandler, AceHostApplication, HostParamChange, ParamChangeCollector};
 pub use loader::{load_plugin, Vst3PluginInstance};
 pub use midi::{midi_to_vst3_event, EventList, MidiEvent};
+pub use params::{ParamPoint, ParamValueQueue, ParameterChanges};
 pub use scanner::{PluginScanner, ScanProgressCallback};
 pub use types::{InstanceInfo, OutputBusInfo, ParamInfo, PluginInfo, ScanProgress};

--- a/crates/ace-plugin-host/src/loader.rs
+++ b/crates/ace-plugin-host/src/loader.rs
@@ -135,7 +135,19 @@ impl Vst3PluginInstance {
     /// Queue a parameter-automation point. VST3 `value` is always
     /// 0..1 normalised; callers get the raw range via `ParamInfo`.
     ///
-    /// Two things happen simultaneously:
+    /// Input validation:
+    ///
+    /// - Non-finite `value` (NaN / ±Inf) → rejected with
+    ///   `InvalidLifecycle`. Forwarding NaN to a plugin's DSP graph
+    ///   reliably destabilises it and often produces audio-thread
+    ///   panics.
+    /// - `value` outside `[0.0, 1.0]` → clamped silently. VST3's
+    ///   contract is that parameters are always normalised; out-of-
+    ///   range values are a common caller mistake (e.g. forgetting
+    ///   to divide by 127 for a MIDI CC mapping) and clamping is
+    ///   safer than rejecting.
+    ///
+    /// On success, two things happen simultaneously:
     ///
     /// 1. The point is pushed onto the audio-thread queue and will
     ///    be delivered via `inputParameterChanges` on the next
@@ -156,7 +168,19 @@ impl Vst3PluginInstance {
     /// Ordering contract mirrors `queue_midi`: unordered cross-thread
     /// pushes, deterministic sort by `(param_id, sample_offset)` at
     /// process time.
-    pub fn set_parameter(&self, param_id: u32, sample_offset: u32, value: f64) {
+    pub fn set_parameter(
+        &self,
+        param_id: u32,
+        sample_offset: u32,
+        value: f64,
+    ) -> Result<(), PluginHostError> {
+        if !value.is_finite() {
+            return Err(PluginHostError::InvalidLifecycle(format!(
+                "set_parameter value must be finite (got {value})"
+            )));
+        }
+        let clamped = value.clamp(0.0, 1.0);
+
         if sample_offset == 0 {
             if let Some(ctrl) = self.controller.as_ref() {
                 // SAFETY: `ctrl` is a live `ComPtr<IEditController>`
@@ -166,15 +190,16 @@ impl Vst3PluginInstance {
                 // state snapshots reflect the edit even when
                 // processing is stopped.
                 unsafe {
-                    ctrl.setParamNormalized(param_id, value);
+                    ctrl.setParamNormalized(param_id, clamped);
                 }
             }
         }
         self.param_queue.push(ParamPoint {
             param_id,
             sample_offset,
-            value,
+            value: clamped,
         });
+        Ok(())
     }
 
     pub(crate) fn drain_param_points(&self) -> Vec<ParamPoint> {
@@ -590,9 +615,9 @@ mod tests {
 
         assert_eq!(instance.param_queue_len(), 0);
 
-        instance.set_parameter(1, 0, 0.25);
-        instance.set_parameter(2, 128, 0.5);
-        instance.set_parameter(1, 256, 0.75);
+        instance.set_parameter(1, 0, 0.25).unwrap();
+        instance.set_parameter(2, 128, 0.5).unwrap();
+        instance.set_parameter(1, 256, 0.75).unwrap();
         assert_eq!(instance.param_queue_len(), 3);
 
         let drained = instance.drain_param_points();
@@ -603,6 +628,44 @@ mod tests {
         let ids: Vec<u32> = drained.iter().map(|p| p.param_id).collect();
         assert!(ids.contains(&1));
         assert!(ids.contains(&2));
+    }
+
+    #[test]
+    fn set_parameter_rejects_nan_and_inf_clamps_out_of_range() {
+        let candidates = ["/Library/Audio/Plug-Ins/VST3/ACE Bridge.vst3"];
+        let Some(path) = candidates.iter().map(Path::new).find(|p| p.exists()) else {
+            eprintln!("skipping: no known VST3 bundle installed");
+            return;
+        };
+        let (instance, _) = match unsafe { load_plugin(path, "param-validate-test") } {
+            Ok(pair) => pair,
+            Err(e) => {
+                eprintln!("load failed (environment-specific, not fatal): {e}");
+                return;
+            }
+        };
+
+        // NaN / Inf rejected with InvalidLifecycle.
+        assert!(matches!(
+            instance.set_parameter(1, 0, f64::NAN),
+            Err(PluginHostError::InvalidLifecycle(_))
+        ));
+        assert!(matches!(
+            instance.set_parameter(1, 0, f64::INFINITY),
+            Err(PluginHostError::InvalidLifecycle(_))
+        ));
+        assert!(matches!(
+            instance.set_parameter(1, 0, f64::NEG_INFINITY),
+            Err(PluginHostError::InvalidLifecycle(_))
+        ));
+
+        // Out-of-range clamped silently.
+        assert!(instance.set_parameter(1, 0, -0.5).is_ok());
+        assert!(instance.set_parameter(1, 0, 1.5).is_ok());
+        let pts = instance.drain_param_points();
+        assert_eq!(pts.len(), 2);
+        assert!(pts.iter().any(|p| p.value == 0.0)); // -0.5 clamped
+        assert!(pts.iter().any(|p| p.value == 1.0)); // 1.5 clamped
     }
 
     #[test]

--- a/crates/ace-plugin-host/src/loader.rs
+++ b/crates/ace-plugin-host/src/loader.rs
@@ -34,6 +34,7 @@ use crate::audio::ProcessingState;
 use crate::error::PluginHostError;
 use crate::host_impl::AceHostApplication;
 use crate::midi::MidiEvent;
+use crate::params::ParamPoint;
 use crate::types::{InstanceInfo, OutputBusInfo, ParamInfo};
 
 /// A loaded VST3 plugin instance + its COM handles. The `_library`
@@ -72,6 +73,13 @@ pub struct Vst3PluginInstance {
     /// the next `process_block` call — that's how DAWs typically
     /// handle latched notes during transport start.
     midi_queue: SegQueue<MidiEvent>,
+    /// Lock-free queue of pending parameter automation points.
+    /// Same shape as `midi_queue` so the two pipelines are
+    /// symmetric; `process_block` drains, windows, groups by
+    /// `param_id`, sorts each group by `sample_offset`, and wraps
+    /// the result in a host-side `ParameterChanges` COM object
+    /// passed via `ProcessData::inputParameterChanges`.
+    param_queue: SegQueue<ParamPoint>,
 }
 
 impl Vst3PluginInstance {
@@ -122,6 +130,33 @@ impl Vst3PluginInstance {
     /// `numInputs: 0` with a null `inputs` pointer for these.
     pub fn is_instrument(&self) -> bool {
         self.input_main_channels.is_none()
+    }
+
+    /// Queue a parameter-automation point. VST3 `value` is always
+    /// 0..1 normalised; callers get the raw range via `ParamInfo`.
+    ///
+    /// Ordering contract mirrors `queue_midi`: unordered cross-thread
+    /// pushes, deterministic sort by `(param_id, sample_offset)` at
+    /// process time.
+    pub fn set_parameter(&self, param_id: u32, sample_offset: u32, value: f64) {
+        self.param_queue.push(ParamPoint {
+            param_id,
+            sample_offset,
+            value,
+        });
+    }
+
+    pub(crate) fn drain_param_points(&self) -> Vec<ParamPoint> {
+        let mut out = Vec::new();
+        while let Some(p) = self.param_queue.pop() {
+            out.push(p);
+        }
+        out
+    }
+
+    #[cfg(test)]
+    pub(crate) fn param_queue_len(&self) -> usize {
+        self.param_queue.len()
     }
 }
 
@@ -340,6 +375,7 @@ pub unsafe fn load_plugin(
         input_main_channels,
         processing_state: Mutex::new(ProcessingState::default()),
         midi_queue: SegQueue::new(),
+        param_queue: SegQueue::new(),
     };
 
     Ok((instance, info))
@@ -491,6 +527,38 @@ pub fn format_uid(uid: &[i8; 16]) -> String {
 mod tests {
     use super::*;
     use crate::midi::MidiEvent;
+
+    #[test]
+    fn param_queue_accumulates_and_drains() {
+        let candidates = ["/Library/Audio/Plug-Ins/VST3/ACE Bridge.vst3"];
+        let Some(path) = candidates.iter().map(Path::new).find(|p| p.exists()) else {
+            eprintln!("skipping: no known VST3 bundle installed");
+            return;
+        };
+        let (instance, _) = match unsafe { load_plugin(path, "param-queue-test") } {
+            Ok(pair) => pair,
+            Err(e) => {
+                eprintln!("load failed (environment-specific, not fatal): {e}");
+                return;
+            }
+        };
+
+        assert_eq!(instance.param_queue_len(), 0);
+
+        instance.set_parameter(1, 0, 0.25);
+        instance.set_parameter(2, 128, 0.5);
+        instance.set_parameter(1, 256, 0.75);
+        assert_eq!(instance.param_queue_len(), 3);
+
+        let drained = instance.drain_param_points();
+        assert_eq!(drained.len(), 3);
+        assert_eq!(instance.param_queue_len(), 0);
+
+        // Content round-trips without loss.
+        let ids: Vec<u32> = drained.iter().map(|p| p.param_id).collect();
+        assert!(ids.contains(&1));
+        assert!(ids.contains(&2));
+    }
 
     #[test]
     fn midi_queue_accumulates_and_drains() {

--- a/crates/ace-plugin-host/src/loader.rs
+++ b/crates/ace-plugin-host/src/loader.rs
@@ -135,10 +135,41 @@ impl Vst3PluginInstance {
     /// Queue a parameter-automation point. VST3 `value` is always
     /// 0..1 normalised; callers get the raw range via `ParamInfo`.
     ///
+    /// Two things happen simultaneously:
+    ///
+    /// 1. The point is pushed onto the audio-thread queue and will
+    ///    be delivered via `inputParameterChanges` on the next
+    ///    `process_block` call.
+    /// 2. If the plugin exposes an `IEditController` and
+    ///    `sample_offset == 0` (i.e. "apply now"), we also call
+    ///    `setParamNormalized` directly so the plugin's own
+    ///    controller state — which drives its GUI and any state
+    ///    snapshot the DAW asks for — updates even when audio
+    ///    processing isn't running (transport stopped, pre-roll,
+    ///    user tweaking a slider while paused).
+    ///
+    /// Non-zero `sample_offset` points are treated as pure audio-
+    /// thread automation: the GUI / controller state stays at
+    /// whatever the plugin last rendered. This matches how real
+    /// DAWs handle block-internal automation.
+    ///
     /// Ordering contract mirrors `queue_midi`: unordered cross-thread
     /// pushes, deterministic sort by `(param_id, sample_offset)` at
     /// process time.
     pub fn set_parameter(&self, param_id: u32, sample_offset: u32, value: f64) {
+        if sample_offset == 0 {
+            if let Some(ctrl) = self.controller.as_ref() {
+                // SAFETY: `ctrl` is a live `ComPtr<IEditController>`
+                // obtained from the loader. The setter only updates
+                // the controller's internal state — safe to call
+                // off the audio thread, and required here so GUI /
+                // state snapshots reflect the edit even when
+                // processing is stopped.
+                unsafe {
+                    ctrl.setParamNormalized(param_id, value);
+                }
+            }
+        }
         self.param_queue.push(ParamPoint {
             param_id,
             sample_offset,
@@ -152,6 +183,20 @@ impl Vst3PluginInstance {
             out.push(p);
         }
         out
+    }
+
+    /// Push a point back onto the queue — used by `process_block` to
+    /// preserve automation scheduled past the current block boundary
+    /// so it fires on a subsequent call.
+    pub(crate) fn requeue_param_point(&self, p: ParamPoint) {
+        self.param_queue.push(p);
+    }
+
+    /// Symmetric to `requeue_param_point` but for MIDI events.
+    /// Callers are responsible for decrementing `sample_offset` by
+    /// the current block's sample count before re-queueing.
+    pub(crate) fn requeue_midi_event(&self, e: MidiEvent) {
+        self.midi_queue.push(e);
     }
 
     #[cfg(test)]

--- a/crates/ace-plugin-host/src/params.rs
+++ b/crates/ace-plugin-host/src/params.rs
@@ -1,0 +1,540 @@
+//! Host-side `IParameterChanges` + `IParamValueQueue` for Phase 4B-2b.
+//!
+//! Unlike 4B-2a's MIDI port, this module has **no reference
+//! implementation** in the companion app — its `process_vst3_multi`
+//! always passed `inputParameterChanges: ptr::null_mut()` with a
+//! `TODO`. Everything here is built fresh against the Steinberg SDK
+//! signatures surfaced by the `vst3` crate.
+//!
+//! ## Model
+//!
+//! VST3's `IParameterChanges` is a **list of per-parameter queues**,
+//! not a flat list of events:
+//!
+//! - One `IParamValueQueue` per `ParamID` touched this block.
+//! - Each queue holds `(sampleOffset, normalisedValue)` points.
+//! - The plugin iterates queues forward by index; within a queue, the
+//!   host is expected to keep points sorted by `sampleOffset`.
+//!
+//! The host side of the flow is built in `process_block`:
+//!
+//! 1. Drain a flat `SegQueue<ParamPoint>` from the instance.
+//! 2. Filter to the current block window (points with
+//!    `sample_offset >= samples` belong to a later block).
+//! 3. Group by `param_id`.
+//! 4. Sort each group by `sample_offset`.
+//! 5. Build a `ParameterChanges` containing one `ParamValueQueue`
+//!    per group, and hand the pointer to `process()` via
+//!    `ProcessData::inputParameterChanges`.
+//!
+//! ## Ownership
+//!
+//! `ComWrapper<ParameterChanges>` owns its child `ComWrapper<ParamValueQueue>`
+//! instances (wrapped in `ComPtr` so their refcount is held). The
+//! plugin reads through the pointer we hand it during `process()`
+//! but never retains it past the call, so the wrapper lives on the
+//! host stack for the block duration.
+
+use std::cell::RefCell;
+
+use vst3::Steinberg::Vst::{
+    IParamValueQueue, IParamValueQueueTrait, IParameterChanges, IParameterChangesTrait, ParamID,
+    ParamValue,
+};
+use vst3::Steinberg::{int32, kInvalidArgument, kResultOk, tresult};
+use vst3::{Class, ComPtr, ComWrapper};
+
+/// A single host-side parameter automation point. Kept in a flat
+/// `SegQueue` on the instance until `process_block` drains it. Matches
+/// the shape of MIDI's `MidiEvent` so the two pipelines are
+/// symmetric.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ParamPoint {
+    pub param_id: ParamID,
+    pub sample_offset: u32,
+    /// VST3 normalised value in `[0.0, 1.0]`. Callers get the
+    /// normalisation range via `ParamInfo::min_value` /
+    /// `max_value` — both are always 0 and 1 at the wire per the
+    /// 4A-3 contract.
+    pub value: f64,
+}
+
+// ---------------------------------------------------------------------------
+// IParamValueQueue — per-parameter point list
+// ---------------------------------------------------------------------------
+
+/// Host-side `IParamValueQueue`. Holds all the automation points
+/// for a single parameter id within one processing block.
+pub struct ParamValueQueue {
+    id: ParamID,
+    /// Sample-offset + normalised value. Kept sorted by
+    /// `sampleOffset` so plugins iterating `getPoint(0..)` see
+    /// ascending times — VST3 expects this but doesn't enforce it.
+    points: RefCell<Vec<(i32, ParamValue)>>,
+}
+
+impl ParamValueQueue {
+    pub fn new(id: ParamID) -> ComWrapper<Self> {
+        ComWrapper::new(Self {
+            id,
+            points: RefCell::new(Vec::new()),
+        })
+    }
+
+    pub fn with_points(id: ParamID, mut points: Vec<(i32, ParamValue)>) -> ComWrapper<Self> {
+        // Sort defensively — caller should already sort but we don't
+        // trust other modules to uphold the invariant.
+        points.sort_by_key(|(offset, _)| *offset);
+        ComWrapper::new(Self {
+            id,
+            points: RefCell::new(points),
+        })
+    }
+}
+
+impl Class for ParamValueQueue {
+    type Interfaces = (IParamValueQueue,);
+}
+
+impl IParamValueQueueTrait for ParamValueQueue {
+    unsafe fn getParameterId(&self) -> ParamID {
+        self.id
+    }
+
+    unsafe fn getPointCount(&self) -> int32 {
+        self.points.borrow().len() as int32
+    }
+
+    unsafe fn getPoint(
+        &self,
+        index: int32,
+        sample_offset: *mut int32,
+        value: *mut ParamValue,
+    ) -> tresult {
+        if sample_offset.is_null() || value.is_null() {
+            return kInvalidArgument;
+        }
+        let points = self.points.borrow();
+        if index < 0 || (index as usize) >= points.len() {
+            return kInvalidArgument;
+        }
+        let (off, val) = points[index as usize];
+        *sample_offset = off;
+        *value = val;
+        kResultOk
+    }
+
+    unsafe fn addPoint(
+        &self,
+        sample_offset: int32,
+        value: ParamValue,
+        index: *mut int32,
+    ) -> tresult {
+        if index.is_null() {
+            return kInvalidArgument;
+        }
+        let mut points = self.points.borrow_mut();
+        // VST3 semantics: addPoint inserts maintaining sort order and
+        // returns the index at which the point was placed. Callers
+        // (including plugins that write into output queues) rely on
+        // this rather than doing their own sort pass.
+        let pos = points
+            .binary_search_by_key(&sample_offset, |(off, _)| *off)
+            .unwrap_or_else(|e| e);
+        points.insert(pos, (sample_offset, value));
+        *index = pos as int32;
+        kResultOk
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IParameterChanges — list of per-parameter queues
+// ---------------------------------------------------------------------------
+
+/// Host-side `IParameterChanges`. Holds one `ParamValueQueue` per
+/// parameter id touched during the current block. The
+/// `ComPtr<IParamValueQueue>` stored here keeps each child queue's
+/// COM refcount incremented for the lifetime of the parent — so
+/// pointers returned from `getParameterData` stay valid as long as
+/// the parent's `ComWrapper` does.
+pub struct ParameterChanges {
+    queues: RefCell<Vec<ComPtr<IParamValueQueue>>>,
+}
+
+impl ParameterChanges {
+    pub fn new() -> ComWrapper<Self> {
+        ComWrapper::new(Self {
+            queues: RefCell::new(Vec::new()),
+        })
+    }
+
+    /// Pre-populate from already-grouped points. `grouped` is a list
+    /// of `(param_id, sorted_points)` pairs. Each group becomes one
+    /// `ParamValueQueue`.
+    pub fn with_groups(grouped: Vec<(ParamID, Vec<(i32, ParamValue)>)>) -> ComWrapper<Self> {
+        let queues: Vec<ComPtr<IParamValueQueue>> = grouped
+            .into_iter()
+            .filter_map(|(id, points)| {
+                ParamValueQueue::with_points(id, points).to_com_ptr::<IParamValueQueue>()
+            })
+            .collect();
+        ComWrapper::new(Self {
+            queues: RefCell::new(queues),
+        })
+    }
+}
+
+impl Class for ParameterChanges {
+    type Interfaces = (IParameterChanges,);
+}
+
+impl IParameterChangesTrait for ParameterChanges {
+    unsafe fn getParameterCount(&self) -> int32 {
+        self.queues.borrow().len() as int32
+    }
+
+    unsafe fn getParameterData(&self, index: int32) -> *mut IParamValueQueue {
+        let queues = self.queues.borrow();
+        if index < 0 || (index as usize) >= queues.len() {
+            return std::ptr::null_mut();
+        }
+        queues[index as usize].as_ptr()
+    }
+
+    unsafe fn addParameterData(
+        &self,
+        id: *const ParamID,
+        index: *mut int32,
+    ) -> *mut IParamValueQueue {
+        if id.is_null() || index.is_null() {
+            return std::ptr::null_mut();
+        }
+        let target = *id;
+        let mut queues = self.queues.borrow_mut();
+
+        // If we already have a queue for this id, return its pointer
+        // (spec-compliant de-dup: addParameterData should not create
+        // a duplicate queue for the same id).
+        for (i, q) in queues.iter().enumerate() {
+            if q.getParameterId() == target {
+                *index = i as int32;
+                return q.as_ptr();
+            }
+        }
+
+        // Otherwise create a fresh queue.
+        let new_q = match ParamValueQueue::new(target).to_com_ptr::<IParamValueQueue>() {
+            Some(q) => q,
+            None => return std::ptr::null_mut(),
+        };
+        let raw = new_q.as_ptr();
+        queues.push(new_q);
+        *index = (queues.len() - 1) as int32;
+        raw
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host-side grouping helpers
+// ---------------------------------------------------------------------------
+
+/// Group a flat list of param points into per-id, sorted vectors
+/// suitable for `ParameterChanges::with_groups`. Pure logic —
+/// exercised by unit tests without touching COM.
+///
+/// - Points with `sample_offset >= block_samples` are dropped
+///   (mirrors the MIDI block-window filter from 4B-2a).
+/// - `sample_offset` values past `i32::MAX` are also dropped
+///   (would wrap negative in VST3's `i32` field).
+/// - Preserves insertion order across identical `(param_id,
+///   sample_offset)` tuples — callers that need strict determinism
+///   for equal offsets must stamp a monotonic counter themselves.
+pub(crate) fn group_points_for_block(
+    mut points: Vec<ParamPoint>,
+    block_samples: u32,
+) -> Vec<(ParamID, Vec<(i32, ParamValue)>)> {
+    points.retain(|p| p.sample_offset < block_samples);
+
+    // Sort primarily by id so we can walk the list in one pass to
+    // group. Secondary sort by sample_offset for within-group
+    // ordering. Stable sort keeps original insertion order for
+    // tie-breaks.
+    points.sort_by(|a, b| {
+        a.param_id
+            .cmp(&b.param_id)
+            .then(a.sample_offset.cmp(&b.sample_offset))
+    });
+
+    let mut out: Vec<(ParamID, Vec<(i32, ParamValue)>)> = Vec::new();
+    for p in points {
+        let offset = match i32::try_from(p.sample_offset) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        match out.last_mut() {
+            Some((id, ref mut pts)) if *id == p.param_id => {
+                pts.push((offset, p.value));
+            }
+            _ => {
+                out.push((p.param_id, vec![(offset, p.value)]));
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------- grouping (pure logic) --------
+
+    #[test]
+    fn group_points_splits_by_param_id() {
+        let points = vec![
+            ParamPoint { param_id: 1, sample_offset: 0, value: 0.25 },
+            ParamPoint { param_id: 2, sample_offset: 0, value: 0.5 },
+            ParamPoint { param_id: 1, sample_offset: 100, value: 0.75 },
+        ];
+        let groups = group_points_for_block(points, 512);
+        assert_eq!(groups.len(), 2);
+        let p1 = groups.iter().find(|(id, _)| *id == 1).unwrap();
+        assert_eq!(p1.1.len(), 2);
+        let p2 = groups.iter().find(|(id, _)| *id == 2).unwrap();
+        assert_eq!(p2.1.len(), 1);
+    }
+
+    #[test]
+    fn group_points_sorts_within_group_by_sample_offset() {
+        let points = vec![
+            ParamPoint { param_id: 7, sample_offset: 256, value: 0.9 },
+            ParamPoint { param_id: 7, sample_offset: 0, value: 0.1 },
+            ParamPoint { param_id: 7, sample_offset: 128, value: 0.5 },
+        ];
+        let groups = group_points_for_block(points, 512);
+        assert_eq!(groups.len(), 1);
+        let (_, pts) = &groups[0];
+        assert_eq!(pts[0].0, 0);
+        assert_eq!(pts[1].0, 128);
+        assert_eq!(pts[2].0, 256);
+    }
+
+    #[test]
+    fn group_points_drops_points_past_block_window() {
+        let points = vec![
+            ParamPoint { param_id: 1, sample_offset: 0, value: 0.5 },
+            ParamPoint { param_id: 1, sample_offset: 512, value: 0.6 }, // at boundary, drop
+            ParamPoint { param_id: 1, sample_offset: 1024, value: 0.7 }, // past, drop
+        ];
+        let groups = group_points_for_block(points, 512);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].1.len(), 1);
+        assert_eq!(groups[0].1[0].0, 0);
+    }
+
+    #[test]
+    fn group_points_drops_points_past_i32_max() {
+        let points = vec![ParamPoint {
+            param_id: 1,
+            sample_offset: (i32::MAX as u32) + 1,
+            value: 0.5,
+        }];
+        let groups = group_points_for_block(points, u32::MAX);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn group_points_empty_input_returns_empty() {
+        assert!(group_points_for_block(vec![], 512).is_empty());
+    }
+
+    // -------- ParamValueQueue COM class --------
+
+    #[test]
+    fn param_value_queue_exposes_param_id() {
+        let q = ParamValueQueue::new(42);
+        let ptr = q.to_com_ptr::<IParamValueQueue>().unwrap();
+        unsafe {
+            assert_eq!(ptr.getParameterId(), 42);
+            assert_eq!(ptr.getPointCount(), 0);
+        }
+    }
+
+    #[test]
+    fn param_value_queue_with_points_reports_count() {
+        let q = ParamValueQueue::with_points(7, vec![(0, 0.1), (128, 0.5), (256, 0.9)]);
+        let ptr = q.to_com_ptr::<IParamValueQueue>().unwrap();
+        unsafe {
+            assert_eq!(ptr.getPointCount(), 3);
+        }
+    }
+
+    #[test]
+    fn param_value_queue_get_point_round_trips() {
+        let q = ParamValueQueue::with_points(7, vec![(128, 0.5)]);
+        let ptr = q.to_com_ptr::<IParamValueQueue>().unwrap();
+        let mut off: int32 = -1;
+        let mut val: ParamValue = -1.0;
+        let r = unsafe { ptr.getPoint(0, &mut off, &mut val) };
+        assert_eq!(r, kResultOk);
+        assert_eq!(off, 128);
+        assert!((val - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn param_value_queue_get_point_rejects_out_of_bounds() {
+        let q = ParamValueQueue::new(1);
+        let ptr = q.to_com_ptr::<IParamValueQueue>().unwrap();
+        let mut off: int32 = 0;
+        let mut val: ParamValue = 0.0;
+        unsafe {
+            assert_eq!(ptr.getPoint(-1, &mut off, &mut val), kInvalidArgument);
+            assert_eq!(ptr.getPoint(0, &mut off, &mut val), kInvalidArgument);
+        }
+    }
+
+    #[test]
+    fn param_value_queue_get_point_rejects_null_outputs() {
+        let q = ParamValueQueue::with_points(1, vec![(0, 0.5)]);
+        let ptr = q.to_com_ptr::<IParamValueQueue>().unwrap();
+        let mut val: ParamValue = 0.0;
+        let mut off: int32 = 0;
+        unsafe {
+            assert_eq!(
+                ptr.getPoint(0, std::ptr::null_mut(), &mut val),
+                kInvalidArgument
+            );
+            assert_eq!(
+                ptr.getPoint(0, &mut off, std::ptr::null_mut()),
+                kInvalidArgument
+            );
+        }
+    }
+
+    #[test]
+    fn param_value_queue_add_point_inserts_in_sort_order() {
+        let q = ParamValueQueue::new(1);
+        let ptr = q.to_com_ptr::<IParamValueQueue>().unwrap();
+        let mut idx: int32 = -1;
+        unsafe {
+            assert_eq!(ptr.addPoint(256, 0.9, &mut idx), kResultOk);
+            assert_eq!(idx, 0);
+            assert_eq!(ptr.addPoint(0, 0.1, &mut idx), kResultOk);
+            assert_eq!(idx, 0); // inserted before 256
+            assert_eq!(ptr.addPoint(128, 0.5, &mut idx), kResultOk);
+            assert_eq!(idx, 1); // between 0 and 256
+
+            // Verify final ordering.
+            let mut off: int32 = 0;
+            let mut val: ParamValue = 0.0;
+            ptr.getPoint(0, &mut off, &mut val);
+            assert_eq!(off, 0);
+            ptr.getPoint(1, &mut off, &mut val);
+            assert_eq!(off, 128);
+            ptr.getPoint(2, &mut off, &mut val);
+            assert_eq!(off, 256);
+        }
+    }
+
+    #[test]
+    fn param_value_queue_add_point_rejects_null_index() {
+        let q = ParamValueQueue::new(1);
+        let ptr = q.to_com_ptr::<IParamValueQueue>().unwrap();
+        unsafe {
+            assert_eq!(
+                ptr.addPoint(0, 0.5, std::ptr::null_mut()),
+                kInvalidArgument
+            );
+        }
+    }
+
+    // -------- ParameterChanges COM class --------
+
+    #[test]
+    fn parameter_changes_empty_on_construction() {
+        let pc = ParameterChanges::new();
+        let ptr = pc.to_com_ptr::<IParameterChanges>().unwrap();
+        unsafe {
+            assert_eq!(ptr.getParameterCount(), 0);
+            assert!(ptr.getParameterData(0).is_null());
+        }
+    }
+
+    #[test]
+    fn parameter_changes_with_groups_exposes_each_queue() {
+        let pc = ParameterChanges::with_groups(vec![
+            (1, vec![(0, 0.25)]),
+            (2, vec![(0, 0.5), (128, 0.75)]),
+        ]);
+        let ptr = pc.to_com_ptr::<IParameterChanges>().unwrap();
+        unsafe {
+            assert_eq!(ptr.getParameterCount(), 2);
+
+            let q0 = ptr.getParameterData(0);
+            assert!(!q0.is_null());
+            let q1 = ptr.getParameterData(1);
+            assert!(!q1.is_null());
+        }
+    }
+
+    #[test]
+    fn parameter_changes_get_data_rejects_out_of_bounds() {
+        let pc = ParameterChanges::new();
+        let ptr = pc.to_com_ptr::<IParameterChanges>().unwrap();
+        unsafe {
+            assert!(ptr.getParameterData(-1).is_null());
+            assert!(ptr.getParameterData(0).is_null());
+        }
+    }
+
+    #[test]
+    fn parameter_changes_add_parameter_data_creates_new_queue() {
+        let pc = ParameterChanges::new();
+        let ptr = pc.to_com_ptr::<IParameterChanges>().unwrap();
+        let id: ParamID = 42;
+        let mut idx: int32 = -1;
+        unsafe {
+            let q_ptr = ptr.addParameterData(&id, &mut idx);
+            assert!(!q_ptr.is_null());
+            assert_eq!(idx, 0);
+            assert_eq!(ptr.getParameterCount(), 1);
+        }
+    }
+
+    #[test]
+    fn parameter_changes_add_parameter_data_dedupes_by_id() {
+        let pc = ParameterChanges::new();
+        let ptr = pc.to_com_ptr::<IParameterChanges>().unwrap();
+        let id: ParamID = 42;
+        let mut idx1: int32 = -1;
+        let mut idx2: int32 = -1;
+        unsafe {
+            let q1 = ptr.addParameterData(&id, &mut idx1);
+            let q2 = ptr.addParameterData(&id, &mut idx2);
+            // Same id → same queue (spec: addParameterData de-dups).
+            assert_eq!(idx1, idx2);
+            assert_eq!(q1, q2);
+            assert_eq!(ptr.getParameterCount(), 1);
+        }
+    }
+
+    #[test]
+    fn parameter_changes_add_parameter_data_rejects_null() {
+        let pc = ParameterChanges::new();
+        let ptr = pc.to_com_ptr::<IParameterChanges>().unwrap();
+        let mut idx: int32 = 0;
+        let id: ParamID = 1;
+        unsafe {
+            assert!(ptr
+                .addParameterData(std::ptr::null(), &mut idx)
+                .is_null());
+            assert!(ptr
+                .addParameterData(&id, std::ptr::null_mut())
+                .is_null());
+        }
+    }
+}

--- a/crates/ace-plugin-host/src/params.rs
+++ b/crates/ace-plugin-host/src/params.rs
@@ -176,11 +176,22 @@ impl ParameterChanges {
     /// Pre-populate from already-grouped points. `grouped` is a list
     /// of `(param_id, sorted_points)` pairs. Each group becomes one
     /// `ParamValueQueue`.
+    ///
+    /// `to_com_ptr` failure on a child queue is treated as a
+    /// programming error (the `Class` impl advertises
+    /// `IParamValueQueue` so the cast must succeed for a correctly
+    /// linked build) — we `expect` rather than silently drop,
+    /// because partial automation is a nightmare to debug
+    /// downstream.
     pub fn with_groups(grouped: Vec<ParamGroup>) -> ComWrapper<Self> {
         let queues: Vec<ComPtr<IParamValueQueue>> = grouped
             .into_iter()
-            .filter_map(|(id, points)| {
-                ParamValueQueue::with_points(id, points).to_com_ptr::<IParamValueQueue>()
+            .map(|(id, points)| {
+                ParamValueQueue::with_points(id, points)
+                    .to_com_ptr::<IParamValueQueue>()
+                    .expect(
+                        "ParamValueQueue must expose IParamValueQueue — programming error",
+                    )
             })
             .collect();
         ComWrapper::new(Self {

--- a/crates/ace-plugin-host/src/params.rs
+++ b/crates/ace-plugin-host/src/params.rs
@@ -151,6 +151,11 @@ impl IParamValueQueueTrait for ParamValueQueue {
 // IParameterChanges — list of per-parameter queues
 // ---------------------------------------------------------------------------
 
+/// One parameter's points for the current block: `(param_id, sorted
+/// `(sampleOffset, value)` tuples)`. Shape matches
+/// `ParameterChanges::with_groups`.
+pub(crate) type ParamGroup = (ParamID, Vec<(i32, ParamValue)>);
+
 /// Host-side `IParameterChanges`. Holds one `ParamValueQueue` per
 /// parameter id touched during the current block. The
 /// `ComPtr<IParamValueQueue>` stored here keeps each child queue's
@@ -171,7 +176,7 @@ impl ParameterChanges {
     /// Pre-populate from already-grouped points. `grouped` is a list
     /// of `(param_id, sorted_points)` pairs. Each group becomes one
     /// `ParamValueQueue`.
-    pub fn with_groups(grouped: Vec<(ParamID, Vec<(i32, ParamValue)>)>) -> ComWrapper<Self> {
+    pub fn with_groups(grouped: Vec<ParamGroup>) -> ComWrapper<Self> {
         let queues: Vec<ComPtr<IParamValueQueue>> = grouped
             .into_iter()
             .filter_map(|(id, points)| {
@@ -238,49 +243,89 @@ impl IParameterChangesTrait for ParameterChanges {
 // Host-side grouping helpers
 // ---------------------------------------------------------------------------
 
-/// Group a flat list of param points into per-id, sorted vectors
-/// suitable for `ParameterChanges::with_groups`. Pure logic —
-/// exercised by unit tests without touching COM.
+/// Partition a flat list of param points into `(for_this_block,
+/// future_blocks)`:
 ///
-/// - Points with `sample_offset >= block_samples` are dropped
-///   (mirrors the MIDI block-window filter from 4B-2a).
-/// - `sample_offset` values past `i32::MAX` are also dropped
-///   (would wrap negative in VST3's `i32` field).
-/// - Preserves insertion order across identical `(param_id,
-///   sample_offset)` tuples — callers that need strict determinism
-///   for equal offsets must stamp a monotonic counter themselves.
-pub(crate) fn group_points_for_block(
+/// - `for_this_block`: points with `sample_offset < block_samples`,
+///   grouped by `param_id` and sorted by `sampleOffset` within each
+///   group. Ready to be handed to `ParameterChanges::with_groups`.
+/// - `future_blocks`: points with `sample_offset >= block_samples`,
+///   offset-decremented by `block_samples` so they fire at the
+///   right absolute position on a subsequent `process_block` call.
+///
+/// This preserves the callers that batch multiple blocks of
+/// automation ahead of time (bounce / sequencer workflows) — a
+/// previous version dropped the overflow points, which silently
+/// lost later automation. Callers that know their block boundary
+/// can still schedule per-block if they want; callers that don't
+/// can batch and let the host distribute.
+///
+/// - Points with `sample_offset > i32::MAX` are dropped even in the
+///   future bucket (they'd wrap negative in VST3's `i32` field
+///   once they reached the "now" bucket — not preservable).
+pub(crate) fn partition_points_for_block(
     mut points: Vec<ParamPoint>,
     block_samples: u32,
-) -> Vec<(ParamID, Vec<(i32, ParamValue)>)> {
-    points.retain(|p| p.sample_offset < block_samples);
+) -> (Vec<ParamGroup>, Vec<ParamPoint>) {
+    // Drop points whose sample_offset would overflow i32 even after
+    // the block-boundary subtraction below. These are not
+    // representable in VST3's `sampleOffset` field regardless of
+    // which block they eventually land in.
+    points.retain(|p| p.sample_offset <= i32::MAX as u32);
+
+    let (this_block, future): (Vec<ParamPoint>, Vec<ParamPoint>) = points
+        .into_iter()
+        .partition(|p| p.sample_offset < block_samples);
+
+    // Future points tick down by the block size so their sampleOffset
+    // stays block-relative on the next call. Saturating_sub is belt-
+    // and-braces — the partition predicate already guarantees
+    // sample_offset >= block_samples for this branch.
+    let future: Vec<ParamPoint> = future
+        .into_iter()
+        .map(|mut p| {
+            p.sample_offset = p.sample_offset.saturating_sub(block_samples);
+            p
+        })
+        .collect();
 
     // Sort primarily by id so we can walk the list in one pass to
     // group. Secondary sort by sample_offset for within-group
     // ordering. Stable sort keeps original insertion order for
     // tie-breaks.
-    points.sort_by(|a, b| {
+    let mut this_block = this_block;
+    this_block.sort_by(|a, b| {
         a.param_id
             .cmp(&b.param_id)
             .then(a.sample_offset.cmp(&b.sample_offset))
     });
 
-    let mut out: Vec<(ParamID, Vec<(i32, ParamValue)>)> = Vec::new();
-    for p in points {
-        let offset = match i32::try_from(p.sample_offset) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        match out.last_mut() {
+    let mut groups: Vec<ParamGroup> = Vec::new();
+    for p in this_block {
+        // Guaranteed to succeed — the `retain` above bounded us.
+        let offset = p.sample_offset as i32;
+        match groups.last_mut() {
             Some((id, ref mut pts)) if *id == p.param_id => {
                 pts.push((offset, p.value));
             }
             _ => {
-                out.push((p.param_id, vec![(offset, p.value)]));
+                groups.push((p.param_id, vec![(offset, p.value)]));
             }
         }
     }
-    out
+    (groups, future)
+}
+
+/// Back-compat wrapper for callers that only need the "this block"
+/// half (e.g. tests asserting on the grouped output). Production
+/// callers use `partition_points_for_block` directly so they can
+/// re-queue the overflow.
+#[cfg(test)]
+pub(crate) fn group_points_for_block(
+    points: Vec<ParamPoint>,
+    block_samples: u32,
+) -> Vec<ParamGroup> {
+    partition_points_for_block(points, block_samples).0
 }
 
 // ---------------------------------------------------------------------------
@@ -324,16 +369,51 @@ mod tests {
     }
 
     #[test]
-    fn group_points_drops_points_past_block_window() {
+    fn partition_preserves_overflow_points_ticked_down() {
         let points = vec![
             ParamPoint { param_id: 1, sample_offset: 0, value: 0.5 },
-            ParamPoint { param_id: 1, sample_offset: 512, value: 0.6 }, // at boundary, drop
-            ParamPoint { param_id: 1, sample_offset: 1024, value: 0.7 }, // past, drop
+            ParamPoint { param_id: 1, sample_offset: 512, value: 0.6 },  // next block, offset 0
+            ParamPoint { param_id: 1, sample_offset: 1024, value: 0.7 }, // next-next, offset 512
+            ParamPoint { param_id: 1, sample_offset: 600, value: 0.8 },  // next block, offset 88
         ];
-        let groups = group_points_for_block(points, 512);
+        let (groups, future) = partition_points_for_block(points, 512);
+
+        // This-block only includes offset 0.
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].1.len(), 1);
         assert_eq!(groups[0].1[0].0, 0);
+        assert!((groups[0].1[0].1 - 0.5).abs() < f64::EPSILON);
+
+        // Future contains the 3 overflow points with offsets
+        // decremented by block_samples (512).
+        assert_eq!(future.len(), 3);
+        let offsets: Vec<u32> = future.iter().map(|p| p.sample_offset).collect();
+        assert!(offsets.contains(&0));   // was 512
+        assert!(offsets.contains(&512)); // was 1024
+        assert!(offsets.contains(&88));  // was 600
+    }
+
+    #[test]
+    fn partition_is_idempotent_across_block_boundaries() {
+        // Point at sample_offset=1500 with 512-sample blocks should
+        // fire on the 3rd block (offset 1500 -> 988 -> 476 -> fires).
+        let mut pts = vec![ParamPoint {
+            param_id: 1,
+            sample_offset: 1500,
+            value: 0.5,
+        }];
+        for expected_block in 0..3 {
+            let (groups, future) = partition_points_for_block(pts, 512);
+            if expected_block == 2 {
+                assert_eq!(groups.len(), 1, "should fire on block 3");
+                assert_eq!(groups[0].1[0].0, 476);
+                assert!(future.is_empty());
+                return;
+            }
+            assert!(groups.is_empty(), "should not fire on block {}", expected_block + 1);
+            pts = future;
+        }
+        panic!("never fired");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1764 · Part of #1524 · Epic #1519 · Follows #1763

Completes the 4B-2 sub-phase by wiring host → plugin parameter automation into `IAudioProcessor::process()`. 4B-2a shipped MIDI; this ships the other half of the process() data dependency: `inputParameterChanges`.

**Net-new COM work.** Unlike 4B-2a this has no reference implementation in the companion app — `companion/src/audio_thread.rs:342` was stubbed with `inputParameterChanges: ptr::null_mut() // TODO`. Everything here is built fresh against the Steinberg SDK signatures exposed by the `vst3` crate.

## Summary

- New `params` module with **two custom COM classes**:
  - `ParamValueQueue` implements `IParamValueQueue` — holds `(sampleOffset, value)` points for one parameter id. `addPoint` inserts in sort order so plugins iterating `getPoint(0..getPointCount())` see ascending offsets as VST3 expects.
  - `ParameterChanges` implements `IParameterChanges` — list of per-parameter queues. `addParameterData` de-dupes by id per VST3 spec; `getParameterData` returns the raw `*mut IParamValueQueue` while the parent's `ComWrapper` holds the refcount.
- `group_points_for_block` pure-logic helper: flat `Vec<ParamPoint>` → per-id sorted groups. Window-filters points past `block_samples` and drops `sample_offset > i32::MAX` (would wrap negative in VST3's `i32`).
- Per-instance lock-free `SegQueue<ParamPoint>`; same shape as the MIDI queue so the pipelines are symmetric.
- `process_block` drains, groups, sorts, wraps in `ParameterChanges`, and passes the pointer via `ProcessData::inputParameterChanges`.
- `PluginHost::set_instance_parameter(instance_id, id, sample_offset, value)` wrapper with `UnknownInstance` guard.

## New API

\`\`\`rust
// VST3 values are always 0..1 normalised; ParamInfo gives the raw range.
instance.set_parameter(param_id, sample_offset, 0.5);
// or via the host:
host.set_instance_parameter(instance_id, param_id, sample_offset, 0.5)?;

// Delivered on the next process_block; queue drains fully per call.
host.process_instance_block(instance_id, &input, 2, 512)?;
\`\`\`

## Non-goals (explicit)

- ❌ `outputParameterChanges` (plugin → host readback — LFO outputs driving other automation) — later sub-phase
- ❌ UI for parameter editing — frontend concern separate from the host wire contract
- ❌ Param-change batching / rate-limiting — callers debounce upstream if needed

## Test Results

- \`cargo test -p ace-plugin-host\`: **93 passed / 0 failed** (21 new: grouping pure-logic tests, COM class round-trips including edge cases — null pointer / out-of-bounds / de-dup by id / null outputs / insertion order, host-wrapper UnknownInstance guard, plus a gated smoke test that sets a parameter through the real ACE Bridge VST3)
- \`cargo clippy -p ace-plugin-host --all-targets -- -D warnings\`: clean
- \`cargo build --lib\` in src-tauri: clean

## Design Notes

**Why group by id before wrapping:** VST3's `IParameterChanges` is a *list of per-parameter queues*, not a flat list of events. Sending 10 changes to 1 parameter is one queue with 10 points; sending 10 changes to 10 parameters is 10 queues with 1 point each. The grouping step turns our flat `ParamPoint` list into that shape.

**Block-window filter:** same reasoning as the MIDI fix in 4B-2a — `process_block` gets variable-size buffers from the audio callback (Phase 5); forwarding points with `sample_offset >= samples` would schedule past the end of the current block.

**ComPtr lifetime:** `ParameterChanges` stores `ComPtr<IParamValueQueue>` for each child queue so the refcount is held for the parent's lifetime. Pointers returned from `getParameterData` stay valid as long as the parent `ComWrapper<ParameterChanges>` does — which is the block duration.

## Test plan

- [x] \`cargo test -p ace-plugin-host\`
- [x] \`cargo clippy -p ace-plugin-host --all-targets -- -D warnings\`
- [x] \`cargo build --lib\` in src-tauri
- [ ] Copilot review
- [ ] Codex review (\`/codex review\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)