### PR TITLE
feat: Phase 4C-2 — Plugin Delay Compensation (PDC) reporting + restart notifications

### DIFF
--- a/crates/ace-plugin-host/src/host.rs
+++ b/crates/ace-plugin-host/src/host.rs
@@ -16,7 +16,7 @@ use crate::error::PluginHostError;
 use crate::host_impl::{
     ComponentRestartCollector, HostComponentRestart, HostParamChange, ParamChangeCollector,
 };
-use crate::loader::{load_plugin, Vst3PluginInstance};
+use crate::loader::{load_plugin_with_collectors, Vst3PluginInstance};
 use crate::midi::MidiEvent;
 use crate::types::InstanceInfo;
 
@@ -81,7 +81,12 @@ impl PluginHost {
         bundle_path: &Path,
     ) -> Result<InstanceInfo, PluginHostError> {
         let instance_id = Uuid::new_v4().to_string();
-        let (instance, info) = load_plugin(bundle_path, &instance_id)?;
+        let (instance, info) = load_plugin_with_collectors(
+            bundle_path,
+            &instance_id,
+            Some(&self.collector),
+            Some(&self.restart_collector),
+        )?;
 
         let mut inner = self
             .inner

--- a/crates/ace-plugin-host/src/host.rs
+++ b/crates/ace-plugin-host/src/host.rs
@@ -13,7 +13,9 @@ use uuid::Uuid;
 
 use crate::audio::AudioConfig;
 use crate::error::PluginHostError;
-use crate::host_impl::{HostParamChange, ParamChangeCollector};
+use crate::host_impl::{
+    ComponentRestartCollector, HostComponentRestart, HostParamChange, ParamChangeCollector,
+};
 use crate::loader::{load_plugin, Vst3PluginInstance};
 use crate::midi::MidiEvent;
 use crate::types::InstanceInfo;
@@ -23,6 +25,7 @@ use crate::types::InstanceInfo;
 pub struct PluginHost {
     inner: Mutex<Inner>,
     collector: ParamChangeCollector,
+    restart_collector: ComponentRestartCollector,
 }
 
 struct Inner {
@@ -48,6 +51,7 @@ impl PluginHost {
                 instances: HashMap::new(),
             }),
             collector: ParamChangeCollector::new(),
+            restart_collector: ComponentRestartCollector::new(),
         }
     }
 
@@ -56,6 +60,14 @@ impl PluginHost {
     /// timer and emit events to the UI.
     pub fn param_change_collector(&self) -> ParamChangeCollector {
         self.collector.clone()
+    }
+
+    /// Shared collector for `IComponentHandler::restartComponent`
+    /// notifications — lets the Tauri layer react to plugin-side
+    /// topology changes (latency, routing) by re-querying the
+    /// instance and pushing a refresh to the UI.
+    pub fn component_restart_collector(&self) -> ComponentRestartCollector {
+        self.restart_collector.clone()
     }
 
     /// Load a `.vst3` bundle and register the resulting instance.
@@ -219,6 +231,20 @@ impl PluginHost {
     pub fn take_pending_param_changes(&self) -> Vec<HostParamChange> {
         self.collector.drain()
     }
+
+    /// Drain queued restart notifications. Consumers inspect the
+    /// flags and re-query affected instances — for `kLatencyChanged`,
+    /// via `instance_latency`.
+    pub fn take_pending_restart_notifications(&self) -> Vec<HostComponentRestart> {
+        self.restart_collector.drain()
+    }
+
+    /// Current processing latency for an instance, re-queried live
+    /// from the plugin. Use this after draining restart notifications
+    /// to refresh the DAW's cached latency alignment.
+    pub fn instance_latency(&self, instance_id: &str) -> Result<u32, PluginHostError> {
+        Ok(self.lookup(instance_id)?.current_latency_samples())
+    }
 }
 
 impl Default for PluginHost {
@@ -306,6 +332,26 @@ mod tests {
         let host = PluginHost::new();
         let err = host.load_instance_state("ghost", &[]).unwrap_err();
         assert!(matches!(err, PluginHostError::UnknownInstance(_)));
+    }
+
+    #[test]
+    fn instance_latency_unknown_errors_out() {
+        let host = PluginHost::new();
+        let err = host.instance_latency("ghost").unwrap_err();
+        assert!(matches!(err, PluginHostError::UnknownInstance(_)));
+    }
+
+    #[test]
+    fn restart_collector_is_shared_and_drainable() {
+        let host = PluginHost::new();
+        let c = host.component_restart_collector();
+        c.push(HostComponentRestart {
+            instance_id: "i".into(),
+            flags: crate::host_impl::RESTART_LATENCY_CHANGED,
+        });
+        let drained = host.take_pending_restart_notifications();
+        assert_eq!(drained.len(), 1);
+        assert!(host.take_pending_restart_notifications().is_empty());
     }
 
     #[test]

--- a/crates/ace-plugin-host/src/host_impl.rs
+++ b/crates/ace-plugin-host/src/host_impl.rs
@@ -31,6 +31,20 @@ pub struct HostParamChange {
     pub value: f64,
 }
 
+/// A restart notification from the plugin's `IComponentHandler::restartComponent`
+/// call. The `flags` bitfield is Steinberg's `RestartFlags`; callers
+/// inspect `kLatencyChanged` (`1 << 2`) to know when to re-query
+/// `processor.getLatencySamples()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostComponentRestart {
+    pub instance_id: String,
+    pub flags: i32,
+}
+
+/// `RestartFlags::kLatencyChanged` per VST3 SDK
+/// `pluginterfaces/vst/ivsteditcontroller.h`.
+pub const RESTART_LATENCY_CHANGED: i32 = 1 << 2;
+
 /// Shared lock-free queue that aggregates parameter changes from every
 /// loaded plugin. Cloning is cheap (internal `Arc`). The Tauri layer
 /// drains this queue periodically and forwards the changes as events.
@@ -63,26 +77,66 @@ impl ParamChangeCollector {
     }
 }
 
+/// Shared lock-free queue for `IComponentHandler::restartComponent`
+/// notifications. Separate from the parameter-change collector
+/// because the payloads and consumers are different — the Tauri
+/// layer reacts to restart by re-querying latency and pushing a
+/// fresh `InstanceInfo` to the UI.
+#[derive(Clone, Default)]
+pub struct ComponentRestartCollector {
+    queue: Arc<SegQueue<HostComponentRestart>>,
+}
+
+impl ComponentRestartCollector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&self, notification: HostComponentRestart) {
+        self.queue.push(notification);
+    }
+
+    pub fn drain(&self) -> Vec<HostComponentRestart> {
+        let mut out = Vec::new();
+        while let Some(n) = self.queue.pop() {
+            out.push(n);
+        }
+        out
+    }
+
+    pub(crate) fn queue_arc(&self) -> &Arc<SegQueue<HostComponentRestart>> {
+        &self.queue
+    }
+}
+
 /// Implements `IComponentHandler`. VST3 plugins call into this when
 /// the user turns a knob on the plugin's own GUI — the edit shows up
-/// here and we funnel it into the shared collector.
+/// here and we funnel it into the shared collector. The plugin also
+/// calls `restartComponent` when its internal topology changes
+/// (latency, routing, parameter values); those go into the separate
+/// restart collector.
 pub struct AceComponentHandler {
     instance_id: String,
     collector: Arc<SegQueue<HostParamChange>>,
+    restart_collector: Arc<SegQueue<HostComponentRestart>>,
     /// Local queue used when no collector is wired up (helpful in
     /// tests — lets us assert on changes without instantiating a
     /// `ParamChangeCollector`).
     pub changes: SegQueue<HostParamChange>,
+    /// Local queue for restart notifications, same test convenience.
+    pub restarts: SegQueue<HostComponentRestart>,
 }
 
 impl AceComponentHandler {
     /// Construct a handler whose edits are pushed only to its own
-    /// local `changes` queue — used by tests.
+    /// local queues — used by tests.
     pub fn new() -> ComWrapper<Self> {
         ComWrapper::new(Self {
             instance_id: String::new(),
             collector: Arc::new(SegQueue::new()),
+            restart_collector: Arc::new(SegQueue::new()),
             changes: SegQueue::new(),
+            restarts: SegQueue::new(),
         })
     }
 
@@ -95,7 +149,26 @@ impl AceComponentHandler {
         ComWrapper::new(Self {
             instance_id,
             collector: Arc::clone(collector.queue_arc()),
+            restart_collector: Arc::new(SegQueue::new()),
             changes: SegQueue::new(),
+            restarts: SegQueue::new(),
+        })
+    }
+
+    /// Full-featured constructor wiring both the param-change and
+    /// restart collectors. Used by the real host registry; tests
+    /// stick with the simpler `new` / `with_collector` variants.
+    pub fn with_collectors(
+        instance_id: String,
+        params: &ParamChangeCollector,
+        restarts: &ComponentRestartCollector,
+    ) -> ComWrapper<Self> {
+        ComWrapper::new(Self {
+            instance_id,
+            collector: Arc::clone(params.queue_arc()),
+            restart_collector: Arc::clone(restarts.queue_arc()),
+            changes: SegQueue::new(),
+            restarts: SegQueue::new(),
         })
     }
 }
@@ -124,7 +197,21 @@ impl IComponentHandlerTrait for AceComponentHandler {
         kResultOk
     }
 
-    unsafe fn restartComponent(&self, _flags: int32) -> tresult {
+    unsafe fn restartComponent(&self, flags: int32) -> tresult {
+        // Non-zero flags means "something topologically changed —
+        // re-query me". We preserve the full bitfield rather than
+        // peeling out individual flags here; the consumer (Tauri
+        // layer in Phase 5) decides what to re-query based on which
+        // bits are set. A zero `flags` is technically ambiguous per
+        // spec — some plugins call this without flags as a generic
+        // "poke me to refresh"; we pass it through so consumers can
+        // treat it as a full refresh if they choose.
+        let notification = HostComponentRestart {
+            instance_id: self.instance_id.clone(),
+            flags,
+        };
+        self.restart_collector.push(notification.clone());
+        self.restarts.push(notification);
         kResultOk
     }
 }
@@ -201,6 +288,53 @@ mod tests {
         let c2 = handler.changes.pop().unwrap();
         assert_eq!(c2.param_id, 7);
         assert!((c2.value - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn restart_component_with_zero_flags_still_produces_notification() {
+        // Some plugins call restartComponent() with flags=0 as a
+        // generic "please refresh me" poke. Consumers can choose to
+        // treat it as a full refresh; we shouldn't drop the signal.
+        let handler = AceComponentHandler::new();
+        unsafe {
+            handler.restartComponent(0);
+        }
+        let n = handler.restarts.pop().unwrap();
+        assert_eq!(n.flags, 0);
+    }
+
+    #[test]
+    fn restart_component_preserves_flags_bitfield() {
+        // Don't peel out individual flags — pass the raw bitfield
+        // through so consumers can inspect whichever bits they care
+        // about.
+        let handler = AceComponentHandler::new();
+        let combined = RESTART_LATENCY_CHANGED | (1 << 1) | (1 << 8);
+        unsafe {
+            handler.restartComponent(combined);
+        }
+        let n = handler.restarts.pop().unwrap();
+        assert_eq!(n.flags, combined);
+        assert!(n.flags & RESTART_LATENCY_CHANGED != 0);
+    }
+
+    #[test]
+    fn restart_component_pushes_into_shared_collector() {
+        let params = ParamChangeCollector::new();
+        let restarts = ComponentRestartCollector::new();
+        let h = AceComponentHandler::with_collectors(
+            "inst-9".into(),
+            &params,
+            &restarts,
+        );
+        unsafe {
+            h.restartComponent(RESTART_LATENCY_CHANGED);
+        }
+        let drained = restarts.drain();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].instance_id, "inst-9");
+        assert_eq!(drained[0].flags, RESTART_LATENCY_CHANGED);
+        assert!(restarts.drain().is_empty(), "drain is destructive");
     }
 
     #[test]

--- a/crates/ace-plugin-host/src/lib.rs
+++ b/crates/ace-plugin-host/src/lib.rs
@@ -34,7 +34,10 @@ pub mod types;
 pub use audio::{AudioConfig, OutputBusConfig, ProcessingState};
 pub use error::PluginHostError;
 pub use host::PluginHost;
-pub use host_impl::{AceComponentHandler, AceHostApplication, HostParamChange, ParamChangeCollector};
+pub use host_impl::{
+    AceComponentHandler, AceHostApplication, ComponentRestartCollector, HostComponentRestart,
+    HostParamChange, ParamChangeCollector, RESTART_LATENCY_CHANGED,
+};
 pub use loader::{load_plugin, Vst3PluginInstance};
 pub use midi::{midi_to_vst3_event, EventList, MidiEvent};
 pub use params::{ParamPoint, ParamValueQueue, ParameterChanges};

--- a/crates/ace-plugin-host/src/loader.rs
+++ b/crates/ace-plugin-host/src/loader.rs
@@ -30,9 +30,13 @@ use vst3::Steinberg::{
     PFactoryInfo,
 };
 
+use vst3::ComWrapper;
+
 use crate::audio::ProcessingState;
 use crate::error::PluginHostError;
-use crate::host_impl::AceHostApplication;
+use crate::host_impl::{
+    AceComponentHandler, AceHostApplication, ComponentRestartCollector, ParamChangeCollector,
+};
 use crate::midi::MidiEvent;
 use crate::params::ParamPoint;
 use crate::stream::MemoryStream;
@@ -46,6 +50,13 @@ pub struct Vst3PluginInstance {
     pub component: ComPtr<IComponent>,
     pub processor: ComPtr<IAudioProcessor>,
     pub controller: Option<ComPtr<IEditController>>,
+    /// Live `AceComponentHandler` wired into the plugin's controller
+    /// via `IEditController::setComponentHandler`. The `ComWrapper`
+    /// holds the handler's refcount — dropping the instance releases
+    /// the handler reference, which is what VST3 expects on teardown.
+    /// `None` when the plugin has no controller or setting the
+    /// handler was declined.
+    _component_handler: Option<ComWrapper<AceComponentHandler>>,
     pub instance_id: String,
     pub plugin_uid: String,
     pub bundle_path: PathBuf,
@@ -524,6 +535,26 @@ pub unsafe fn load_plugin(
     bundle_path: &Path,
     instance_id: &str,
 ) -> Result<(Vst3PluginInstance, InstanceInfo), PluginHostError> {
+    load_plugin_with_collectors(bundle_path, instance_id, None, None)
+}
+
+/// Full-featured loader: same contract as `load_plugin` but wires
+/// the plugin's `IEditController::setComponentHandler` to an
+/// `AceComponentHandler` backed by the supplied collectors. The
+/// handler forwards plugin-side edits (performEdit) to
+/// `params`, and topology-change notifications (restartComponent) to
+/// `restarts`. Pass `None` for either collector to skip that wiring
+/// — the returned instance still works, just without the
+/// corresponding events surfacing.
+///
+/// # Safety
+/// Same as `load_plugin`.
+pub unsafe fn load_plugin_with_collectors(
+    bundle_path: &Path,
+    instance_id: &str,
+    params: Option<&ParamChangeCollector>,
+    restarts: Option<&ComponentRestartCollector>,
+) -> Result<(Vst3PluginInstance, InstanceInfo), PluginHostError> {
     // 1. Resolve + dlopen the dylib.
     let dylib_path = bundle_dylib_path(bundle_path).ok_or_else(|| {
         PluginHostError::InvalidBundle(format!(
@@ -628,6 +659,39 @@ pub unsafe fn load_plugin(
         debug!("IEditController not exposed via IComponent");
     }
 
+    // 8b. Wire our component handler into the controller so
+    //     plugin-side parameter edits and topology changes (e.g.
+    //     latency) surface through the shared collectors. Handler
+    //     lives in the instance for as long as the plugin does.
+    let component_handler = controller.as_ref().and_then(|ctrl| {
+        // Use collectors if provided; otherwise fall back to empty
+        // ones so the handler still implements the trait correctly
+        // — plugins never see a null handler pointer that way.
+        let params_ref = params.cloned().unwrap_or_default();
+        let restarts_ref = restarts.cloned().unwrap_or_default();
+        let handler = AceComponentHandler::with_collectors(
+            instance_id.to_string(),
+            &params_ref,
+            &restarts_ref,
+        );
+        let handler_ptr = handler
+            .to_com_ptr::<vst3::Steinberg::Vst::IComponentHandler>()
+            .map(|p| p.as_ptr());
+        if let Some(ptr) = handler_ptr {
+            // SAFETY: `ctrl` is a live ComPtr; `ptr` refers to the
+            // ComWrapper we hold and outlives this call.
+            let r = ctrl.setComponentHandler(ptr);
+            if r != kResultOk {
+                warn!(result = r, "setComponentHandler declined — plugin-side edits + restarts will not surface");
+                return None;
+            }
+            Some(handler)
+        } else {
+            warn!("AceComponentHandler could not expose IComponentHandler — plugin-side edits will not surface");
+            None
+        }
+    });
+
     // 9. Snapshot parameter + bus + latency data for the UI.
     let parameters = extract_parameters(&controller);
     let output_busses = extract_output_busses(&component);
@@ -659,6 +723,7 @@ pub unsafe fn load_plugin(
         component,
         processor,
         controller,
+        _component_handler: component_handler,
         instance_id: instance_id.to_string(),
         plugin_uid: uid_str,
         bundle_path: bundle_path.to_path_buf(),

--- a/crates/ace-plugin-host/src/loader.rs
+++ b/crates/ace-plugin-host/src/loader.rs
@@ -230,6 +230,20 @@ impl Vst3PluginInstance {
         self.param_queue.len()
     }
 
+    /// Re-query the plugin's current processing latency (in samples).
+    /// Plugins can change this in response to parameter edits —
+    /// oversampling toggles, lookahead window changes — and notify
+    /// the host via `IComponentHandler::restartComponent(kLatencyChanged)`.
+    /// Consumers drain the restart collector and call this to refresh
+    /// their cached latency.
+    pub fn current_latency_samples(&self) -> u32 {
+        // SAFETY: `self.processor` is a live COM pointer; the
+        // `getLatencySamples` call is const on the plugin's side
+        // (doesn't mutate state) so it's safe to call without
+        // holding the lifecycle mutex.
+        unsafe { self.processor.getLatencySamples() }
+    }
+
     /// Serialise the plugin's state to an opaque byte blob. Matches
     /// the `IComponent::getState` side of VST3's preset contract —
     /// the blob is what a DAW writes into a project file so the


### PR DESCRIPTION
Closes #1770 · Part of #1524 · Epic #1519 · Follows #1769

VST3 plugins introduce processing latency (lookahead compressors, FFT reverbs, oversampling). For accurate timing the DAW needs the exact sample delay so it can align a plugin's output with other tracks — **PDC**. This PR covers the host-side reporting; Phase 5's audio-engine DSP graph will consume the value to align track outputs.

Plugins change their latency in response to parameter edits and notify the host via `IComponentHandler::restartComponent(kLatencyChanged)`. The previous no-op restartComponent impl silently discarded these signals — the host had no way to know when to re-query latency.

## Summary

- New `HostComponentRestart { instance_id, flags }` + `ComponentRestartCollector` parallel to `ParamChangeCollector`
- `AceComponentHandler::restartComponent` captures the flags bitfield verbatim and pushes into both the local test queue and the shared collector. Zero-flags calls are preserved (some plugins use them as a generic "refresh me" poke) — consumers choose how to interpret
- `RESTART_LATENCY_CHANGED = 1 << 2` exported for filtering
- `Vst3PluginInstance::current_latency_samples()` re-queries `getLatencySamples()` live
- `PluginHost::component_restart_collector()` / `take_pending_restart_notifications()` / `instance_latency(id)` wrappers
- `AceComponentHandler::with_collectors` wires both collectors; older constructors kept for tests

## Why preserve flags instead of peeling into named fields

VST3 plugins OR together multiple `RestartFlags` in a single call — `kLatencyChanged | kParamValuesChanged` is common after a preset load. If the host peeled bits here, downstream filtering would need either separate events per bit (torn ordering) or a reconstituted flags field. Passing the raw bitfield keeps ordering correct and lets consumers pick any future bits without this layer changing.

## Test Results

- \`cargo test -p ace-plugin-host\`: **128 passed / 0 failed** (5 new: flag-preservation edge cases, shared-collector aggregation, host-wrapper guards)
- \`cargo clippy -p ace-plugin-host --all-targets -- -D warnings\`: clean

## Non-goals (explicit)

- ❌ Applying the delay in the audio graph — Phase 5
- ❌ Per-flag convenience methods — callers filter bits themselves
- ❌ UI for latency display — frontend concern

## Test plan

- [x] cargo test -p ace-plugin-host
- [x] cargo clippy -p ace-plugin-host --all-targets -- -D warnings
- [ ] Copilot review
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)