### PR TITLE
fix: reject absolute paths in extractServerPath to fix LEGO task 400 error (#1702)

### DIFF
--- a/src/services/__tests__/extractServerPath.test.ts
+++ b/src/services/__tests__/extractServerPath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractServerPath } from '../../utils/serverPath';
+import { extractServerPath, sanitizeServerPath } from '../../utils/serverPath';
 
 /**
  * Regression tests for #1702: multi-stem LEGO generation fails when
@@ -48,5 +48,15 @@ describe('extractServerPath', () => {
   it('returns null for UNC paths in query param', () => {
     expect(extractServerPath('/v1/audio?path=\\\\server\\share\\output.wav')).toBeNull();
     expect(extractServerPath('/v1/audio?path=//server/share/output.wav')).toBeNull();
+  });
+
+  it('rejects persisted absolute server paths before reuse', () => {
+    expect(sanitizeServerPath('/tmp/ace-step/output.wav')).toBeNull();
+    expect(sanitizeServerPath('C:\\tmp\\output.wav')).toBeNull();
+    expect(sanitizeServerPath('\\\\server\\share\\output.wav')).toBeNull();
+  });
+
+  it('keeps persisted relative server paths before reuse', () => {
+    expect(sanitizeServerPath('outputs/stem.wav')).toBe('outputs/stem.wav');
   });
 });

--- a/src/services/__tests__/extractServerPath.test.ts
+++ b/src/services/__tests__/extractServerPath.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { extractServerPath } from '../../utils/serverPath';
+
+/**
+ * Regression tests for #1702: multi-stem LEGO generation fails when
+ * extractServerPath returns absolute paths that the release_task
+ * endpoint rejects with "absolute audio file paths are not allowed".
+ */
+describe('extractServerPath', () => {
+  it('returns null for backend audio URLs with absolute query path', () => {
+    // Backend returns URLs like /v1/audio?path=/tmp/.../output.wav
+    // The extracted path (/tmp/.../output.wav) is absolute → reject
+    expect(extractServerPath('/v1/audio?path=/tmp/ace-step/output.wav')).toBeNull();
+  });
+
+  it('returns null for raw absolute paths', () => {
+    expect(extractServerPath('/tmp/ace-step/output.wav')).toBeNull();
+    expect(extractServerPath('/home/user/audio/stem.wav')).toBeNull();
+  });
+
+  it('returns relative path from query parameter', () => {
+    // If the backend ever returns a relative path, accept it
+    expect(extractServerPath('/v1/audio?path=outputs/stem.wav')).toBe('outputs/stem.wav');
+  });
+
+  it('returns null for URLs without path query param', () => {
+    expect(extractServerPath('/v1/audio')).toBeNull();
+    expect(extractServerPath('/v1/audio?format=wav')).toBeNull();
+  });
+
+  it('returns null for full HTTP URLs with absolute path param', () => {
+    expect(extractServerPath('http://localhost:8000/v1/audio?path=/tmp/output.wav')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractServerPath('')).toBeNull();
+  });
+
+  it('returns null for blob URLs', () => {
+    expect(extractServerPath('blob:http://localhost/abc-123')).toBeNull();
+  });
+});

--- a/src/services/__tests__/extractServerPath.test.ts
+++ b/src/services/__tests__/extractServerPath.test.ts
@@ -39,4 +39,14 @@ describe('extractServerPath', () => {
   it('returns null for blob URLs', () => {
     expect(extractServerPath('blob:http://localhost/abc-123')).toBeNull();
   });
+
+  it('returns null for Windows absolute paths in query param', () => {
+    expect(extractServerPath('/v1/audio?path=C:\\tmp\\output.wav')).toBeNull();
+    expect(extractServerPath('/v1/audio?path=D:/users/audio/stem.wav')).toBeNull();
+  });
+
+  it('returns null for UNC paths in query param', () => {
+    expect(extractServerPath('/v1/audio?path=\\\\server\\share\\output.wav')).toBeNull();
+    expect(extractServerPath('/v1/audio?path=//server/share/output.wav')).toBeNull();
+  });
 });

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -22,7 +22,7 @@ import { POLL_INTERVAL_MS, MAX_POLL_DURATION_MS } from '../constants/defaults';
 import { extractContextAudioLazy } from './lazyContextAudioExtractor';
 import { computeEta } from '../utils/generationProgress';
 import { createDebugLogger } from '../utils/debugLogger';
-import { extractServerPath } from '../utils/serverPath';
+import { extractServerPath, sanitizeServerPath } from '../utils/serverPath';
 
 const logger = createDebugLogger('ace-step:generation');
 
@@ -1338,8 +1338,9 @@ export async function generateBatch(options: GenerateBatchOptions): Promise<void
           opts.srcAudioPath = contextAudioPath;
         } else if (!firstCall && prevClipId) {
           const prevClip = useProjectStore.getState().getClipById(prevClipId);
-          if (prevClip?.serverCumulativePath) {
-            opts.srcAudioPath = prevClip.serverCumulativePath;
+          const serverCumulativePath = sanitizeServerPath(prevClip?.serverCumulativePath);
+          if (serverCumulativePath) {
+            opts.srcAudioPath = serverCumulativePath;
           }
         }
         firstCall = false;
@@ -1742,8 +1743,9 @@ export async function generateFromMultiTrack(opts: MultiTrackGenerateOptions): P
         };
         if (prevClipId) {
           const prevClip = useProjectStore.getState().getClipById(prevClipId);
-          if (prevClip?.serverCumulativePath) {
-            clipOpts.srcAudioPath = prevClip.serverCumulativePath;
+          const serverCumulativePath = sanitizeServerPath(prevClip?.serverCumulativePath);
+          if (serverCumulativePath) {
+            clipOpts.srcAudioPath = serverCumulativePath;
           }
         }
         prevClipId = clipId;

--- a/src/services/generationPipeline.ts
+++ b/src/services/generationPipeline.ts
@@ -22,6 +22,7 @@ import { POLL_INTERVAL_MS, MAX_POLL_DURATION_MS } from '../constants/defaults';
 import { extractContextAudioLazy } from './lazyContextAudioExtractor';
 import { computeEta } from '../utils/generationProgress';
 import { createDebugLogger } from '../utils/debugLogger';
+import { extractServerPath } from '../utils/serverPath';
 
 const logger = createDebugLogger('ace-step:generation');
 
@@ -2702,21 +2703,6 @@ export async function generateVocalReplacement(opts: VocalReplacementOptions): P
   });
 }
 
-/**
- * Extract a server-local file path from the audio URL returned by the backend.
- * The backend URL is typically `/v1/audio?path=/tmp/.../output.wav`.
- */
-function extractServerPath(audioPath: string): string | null {
-  try {
-    const url = new URL(audioPath, 'http://localhost');
-    const p = url.searchParams.get('path');
-    if (p) return p;
-  } catch {
-    // not a valid URL — fall through
-  }
-  if (audioPath.startsWith('/') && !audioPath.includes('?')) return audioPath;
-  return null;
-}
 
 // ---------------------------------------------------------------------------
 // Text2Music — Full-song generation

--- a/src/utils/serverPath.ts
+++ b/src/utils/serverPath.ts
@@ -18,11 +18,16 @@ function isAbsoluteServerPath(p: string): boolean {
   );
 }
 
+export function sanitizeServerPath(serverPath: string | null | undefined): string | null {
+  if (!serverPath || isAbsoluteServerPath(serverPath)) return null;
+  return serverPath;
+}
+
 export function extractServerPath(audioPath: string): string | null {
   try {
     const url = new URL(audioPath, 'http://localhost');
     const p = url.searchParams.get('path');
-    if (p && !isAbsoluteServerPath(p)) return p;
+    return sanitizeServerPath(p);
   } catch {
     // not a valid URL — fall through
   }

--- a/src/utils/serverPath.ts
+++ b/src/utils/serverPath.ts
@@ -1,0 +1,20 @@
+/**
+ * Extract a server-relative file path from the audio URL returned by the backend.
+ * The backend URL is typically `/v1/audio?path=/tmp/.../output.wav`.
+ *
+ * The release_task endpoint rejects absolute paths ("absolute audio file paths
+ * are not allowed"), so we only return paths that are relative. Since the
+ * backend currently always returns absolute paths in the `path` query param,
+ * this effectively disables the server-path optimisation and forces blob upload
+ * — which is correct and avoids the 400 error in multi-stem generation (#1702).
+ */
+export function extractServerPath(audioPath: string): string | null {
+  try {
+    const url = new URL(audioPath, 'http://localhost');
+    const p = url.searchParams.get('path');
+    if (p && !p.startsWith('/')) return p;
+  } catch {
+    // not a valid URL — fall through
+  }
+  return null;
+}

--- a/src/utils/serverPath.ts
+++ b/src/utils/serverPath.ts
@@ -8,11 +8,21 @@
  * this effectively disables the server-path optimisation and forces blob upload
  * — which is correct and avoids the 400 error in multi-stem generation (#1702).
  */
+
+function isAbsoluteServerPath(p: string): boolean {
+  return (
+    p.startsWith('/') ||
+    p.startsWith('\\\\') ||
+    p.startsWith('//') ||
+    /^[A-Za-z]:[/\\]/.test(p)
+  );
+}
+
 export function extractServerPath(audioPath: string): string | null {
   try {
     const url = new URL(audioPath, 'http://localhost');
     const p = url.searchParams.get('path');
-    if (p && !p.startsWith('/')) return p;
+    if (p && !isAbsoluteServerPath(p)) return p;
   } catch {
     // not a valid URL — fall through
   }


### PR DESCRIPTION
## Summary

Closes #1702

Fixes the bug where multi-stem LEGO generation fails with `releaseLegoTask failed: 400 - "absolute audio file paths are not allowed"`.

### Root Cause

`extractServerPath()` extracted absolute paths (e.g. `/tmp/ace-step/output.wav`) from backend audio URLs like `/v1/audio?path=/tmp/.../output.wav`. These absolute paths were stored in `clip.serverCumulativePath` and reused as `src_audio_path` for subsequent stems in multi-track generation. The `release_task` endpoint rejects absolute paths, causing all chained stems to fail.

### Fix

- Extract `extractServerPath` to `src/utils/serverPath.ts` (pure utility, testable in isolation)
- Reject absolute paths: only accept relative paths from the `path` query parameter
- Since the backend currently always returns absolute paths, this forces blob upload for all stems — correct behavior that avoids the 400 error
- Added 7 regression tests covering absolute paths, relative paths, full URLs, blob URLs, and edge cases

### Files Changed

- `src/utils/serverPath.ts` — new utility with safe path extraction
- `src/services/generationPipeline.ts` — import from utility instead of inline function
- `src/services/__tests__/extractServerPath.test.ts` — 7 regression tests

## Test plan

- [x] 7 new regression tests pass
- [x] All pre-existing tests still pass (44 failures are pre-existing: missing rubberband-wasm and @tauri-apps/api packages, unrelated to this fix)
- [x] TypeScript pre-existing errors only (Tauri deps)

https://claude.ai/code/session_01Q6ZMsrMoPCrnTH8auYHZdd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6ZMsrMoPCrnTH8auYHZdd)_