### PR TITLE
ci: run src-tauri Rust tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,24 @@ jobs:
       - name: Run Rust tests
         run: cd crates && cargo test --all
 
+  # Run Tauri app-shell Rust unit tests
+  tauri-rust-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2-dev \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+      - name: Run Tauri Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
   type-check:
     runs-on: ubuntu-latest
     needs: [build-wasm]
@@ -85,7 +103,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [type-check, unit-test, rust-test]
+    needs: [type-check, unit-test, rust-test, tauri-rust-test]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,8 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
+      - name: Create placeholder frontend dist
+        run: mkdir -p dist
       - name: Run Tauri Rust tests
         run: cargo test --manifest-path src-tauri/Cargo.toml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
 
   # Run Tauri app-shell Rust unit tests
   tauri-rust-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Add a dedicated `tauri-rust-test` CI job for `src-tauri` Rust tests.
- Install Linux system dependencies required by Tauri/CPAL on Ubuntu runners.
- Gate the final build job on the new Tauri Rust test job.

Closes #1691.

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- `codex review --base origin/main`