### PR TITLE
fix: align playhead pointer animation

### DIFF
--- a/src/components/timeline/Playhead.tsx
+++ b/src/components/timeline/Playhead.tsx
@@ -22,10 +22,11 @@ export function Playhead() {
   const showTransportLine = Math.abs(currentTime - playStartTime) > 0.001;
 
   // Anchor cursor on selected track rows — always at playStartTime
+  const anchorBlinking = !isPlaying && timelineFocused;
   const showAnchorCursor = selectedTrackIds.size > 0 && (isPlaying || timelineFocused);
   const anchorCursors = showAnchorCursor
     ? Array.from(selectedTrackIds).map((trackId) => (
-        <SelectedTrackCursor key={trackId} trackId={trackId} x={anchorX} blink />
+        <SelectedTrackCursor key={trackId} trackId={trackId} x={anchorX} blink={anchorBlinking} />
       ))
     : null;
 
@@ -56,7 +57,7 @@ function SelectedTrackCursor({ trackId, x, blink }: { trackId: string; x: number
 
   return (
     <div
-      className="absolute w-px z-20 pointer-events-none playhead-glow"
+      className="absolute w-px z-20 pointer-events-none"
       style={{
         left: x,
         top: laneRect.top,

--- a/src/components/timeline/TimeRuler.tsx
+++ b/src/components/timeline/TimeRuler.tsx
@@ -423,7 +423,7 @@ const PlayheadRulerIndicator = memo(function PlayheadRulerIndicator({ pixelsPerS
   const svgH = 12;
   return (
     <div
-      className="absolute bottom-[-1px] z-30 h-full w-5"
+      className="absolute bottom-[-2px] z-30 flex h-full w-5 items-end justify-center"
       style={{ left: x, transform: 'translateX(-50%)', cursor: CURSOR_BRACKET_RIGHT }}
       onPointerDown={handlePointerDown}
       data-testid="timeline-playhead-loop-handle"
@@ -433,7 +433,7 @@ const PlayheadRulerIndicator = memo(function PlayheadRulerIndicator({ pixelsPerS
         height={svgH}
         viewBox={`0 0 ${svgW} ${svgH}`}
         className={blinking ? 'playhead-triangle-blink' : undefined}
-        style={{ display: 'block', margin: 'auto', pointerEvents: 'none' }}
+        style={{ display: 'block', pointerEvents: 'none' }}
       >
         <polygon
           points={`0.5,0.5 ${svgW - 0.5},0.5 ${svgW / 2},${svgH - 0.5}`}

--- a/src/components/timeline/__tests__/PlayheadBlink.test.tsx
+++ b/src/components/timeline/__tests__/PlayheadBlink.test.tsx
@@ -64,6 +64,27 @@ describe('Playhead blink animation', () => {
     expect(cursor!.style.left).toBe('200px'); // playStartTime=2 * pps=100
   });
 
+  it('keeps the selected-track anchor cursor static during playback', () => {
+    const rects = new Map([['track-a', { top: 50, height: 80 }]]);
+    useTransportStore.setState({ isPlaying: true, currentTime: 4, playStartTime: 2 });
+    useUIStore.setState({
+      pixelsPerSecond: 100,
+      timelineFocused: true,
+      selectedTrackIds: new Set(['track-a']),
+      trackLaneRects: rects,
+    });
+
+    const { container } = render(<Playhead />);
+    const cursor = Array.from(container.children).find(
+      (el) => (el as HTMLElement).style.top === '50px' && (el as HTMLElement).style.height === '80px',
+    ) as HTMLElement | undefined;
+
+    expect(cursor).not.toBeNull();
+    expect(cursor!.style.animation).toBe('');
+    expect(cursor!.style.backgroundColor).toBe('rgb(255, 255, 255)');
+    expect(cursor!.className).not.toContain('playhead-glow');
+  });
+
   it('does not render anchor cursor when trackLaneRects has no entry for the track', () => {
     useTransportStore.setState({ isPlaying: false, currentTime: 0, playStartTime: 2 });
     useUIStore.setState({

--- a/src/components/timeline/__tests__/TimeRulerLoopBraces.test.tsx
+++ b/src/components/timeline/__tests__/TimeRulerLoopBraces.test.tsx
@@ -140,6 +140,14 @@ describe('TimeRuler loop region braces', () => {
     expect(state.loopEnd).toBeGreaterThan(state.loopStart);
   });
 
+  it('positions the playhead triangle tip on the ruler divider', () => {
+    render(<TimeRuler />);
+    const handle = screen.getByTestId('timeline-playhead-loop-handle');
+
+    expect(handle.className).toContain('bottom-[-2px]');
+    expect(handle.className).toContain('items-end');
+  });
+
   describe('store-level loop region interactions', () => {
     it('setLoopRegion updates loopStart and loopEnd', () => {
       const store = useTransportStore.getState();

--- a/src/components/timeline/__tests__/TimeRulerLoopBraces.test.tsx
+++ b/src/components/timeline/__tests__/TimeRulerLoopBraces.test.tsx
@@ -40,6 +40,8 @@ describe('TimeRuler loop region braces', () => {
       loopStart: 0,
       loopEnd: 0,
       currentTime: 0,
+      playStartTime: 0,
+      isPlaying: false,
       isScrubbing: false,
     });
     useUIStore.setState({ pixelsPerSecond: 50 });

--- a/src/index.css
+++ b/src/index.css
@@ -369,7 +369,7 @@ select:focus-visible,
 
 /* Playhead glow — bright halo for visibility during playback */
 .playhead-glow {
-  box-shadow: 0 0 4px rgba(255, 255, 255, 0.5), 0 0 8px rgba(147, 197, 253, 0.3), 0 0 3px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 0 2px rgba(255, 255, 255, 0.28);
 }
 
 /* Clip mount fade-in animation */
@@ -526,12 +526,6 @@ select:focus-visible,
   width: 8px;
   height: 12px;
 }
-/* Playhead: thin white line, no blink, Ableton uses a simple static line */
-[data-theme="ableton"] .playhead-triangle-blink polygon {
-  animation: none !important;
-  fill: #e6e6e6 !important;
-  stroke: #e6e6e6 !important;
-}
 /* Toolbar separators: even thinner and more subtle */
 [data-theme="ableton"] .bg-white\/8 {
   opacity: 0.04;
@@ -610,12 +604,6 @@ select:focus-visible,
   border-radius: 50%;
   border: 2px solid rgba(255, 255, 255, 0.2);
 }
-/* Playhead: purple (Apple purple), smooth */
-[data-theme="logic-pro"] .playhead-triangle-blink polygon {
-  animation: none !important;
-  fill: #bf5af2 !important;
-  stroke: #bf5af2 !important;
-}
 /* Scrollbar: round, Apple style */
 [data-theme="logic-pro"] ::-webkit-scrollbar-thumb {
   border-radius: 10px;
@@ -666,12 +654,6 @@ select:focus-visible,
   width: 8px;
   height: 14px;
   border-radius: 2px;
-}
-/* Playhead: orange line (FL signature), no blink */
-[data-theme="fl-studio"] .playhead-triangle-blink polygon {
-  animation: none !important;
-  fill: #ff6e00 !important;
-  stroke: #ff6e00 !important;
 }
 /* Borders: slightly thicker, higher contrast */
 [data-theme="fl-studio"] .border-b,
@@ -733,12 +715,6 @@ select:focus-visible,
   height: 12px;
   border-radius: 50%;
   border: 1px solid rgba(255, 255, 255, 0.1);
-}
-/* Playhead: blue (broadcast standard), no blink */
-[data-theme="pro-tools"] .playhead-triangle-blink polygon {
-  animation: none !important;
-  fill: #4a7fbf !important;
-  stroke: #4a7fbf !important;
 }
 /* Track color strip: small radius */
 [data-theme="pro-tools"] .rounded-r-sm {

--- a/src/index.css
+++ b/src/index.css
@@ -367,7 +367,7 @@ select:focus-visible,
   opacity: 0.5;
 }
 
-/* Playhead glow — bright halo for visibility during playback */
+/* Playhead glow — subtle glow for visibility during playback */
 .playhead-glow {
   box-shadow: 0 0 2px rgba(255, 255, 255, 0.28);
 }


### PR DESCRIPTION
## Summary
- Align the selected-track playhead cursor blink state with the ruler triangle.
- Position the inverted playhead triangle so its tip meets the ruler divider.
- Reduce playhead line glow and keep theme CSS from disabling triangle blink animation.

## Root Cause
The selected-track anchor cursor always blinked while the ruler triangle only blinked when playback was stopped and the timeline was focused. Theme-specific overrides also disabled the triangle blink animation, and the anchor cursor inherited the bright transport-line glow.

## Verification
- `npx vitest run src/components/timeline/__tests__/PlayheadBlink.test.tsx src/components/timeline/__tests__/TimeRulerLoopBraces.test.tsx tests/unit/timelineVisualPolish.test.tsx`
- `npx tsc --noEmit --pretty false`
- `git diff --check`

Closes #1778