### PR TITLE
fix: clean up VST3 plugin engine removal

### DIFF
--- a/src/store/__tests__/vst3Store.test.ts
+++ b/src/store/__tests__/vst3Store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { useVST3Store } from '../vst3Store';
+import { pluginEngine } from '../../engine/PluginEngine';
 import type { VST3ActiveInstance, VST3PluginInfo } from '../../types/vst3';
 
 const mockPlugin = (overrides: Partial<VST3PluginInfo> = {}): VST3PluginInfo => ({
@@ -38,6 +39,7 @@ describe('vst3Store', () => {
       scanning: false,
       scanProgress: null,
       instances: {},
+      pluginOrder: {},
     });
   });
 
@@ -158,10 +160,27 @@ describe('vst3Store', () => {
       expect(useVST3Store.getState().instances['inst-1']).toBeUndefined();
     });
 
+    it('removeInstance removes the live plugin from PluginEngine and track order', () => {
+      const removePluginSpy = vi.spyOn(pluginEngine, 'removePlugin').mockImplementation(() => undefined);
+      useVST3Store.getState()._upsertInstance(mockInstance());
+      useVST3Store.setState({ pluginOrder: { 'track-1': ['inst-1', 'inst-2'] } });
+
+      useVST3Store.getState().removeInstance('inst-1');
+
+      expect(removePluginSpy).toHaveBeenCalledWith('track-1', 'inst-1');
+      expect(useVST3Store.getState().instances['inst-1']).toBeUndefined();
+      expect(useVST3Store.getState().pluginOrder['track-1']).toEqual(['inst-2']);
+
+      removePluginSpy.mockRestore();
+    });
+
     it('removing non-existent instance is a no-op', () => {
+      const removePluginSpy = vi.spyOn(pluginEngine, 'removePlugin').mockImplementation(() => undefined);
       useVST3Store.getState()._upsertInstance(mockInstance());
       useVST3Store.getState().removeInstance('non-existent');
       expect(Object.keys(useVST3Store.getState().instances)).toHaveLength(1);
+      expect(removePluginSpy).not.toHaveBeenCalled();
+      removePluginSpy.mockRestore();
     });
 
     it('toggleInstance toggles enabled state', () => {

--- a/src/store/__tests__/vst3Store.test.ts
+++ b/src/store/__tests__/vst3Store.test.ts
@@ -174,6 +174,18 @@ describe('vst3Store', () => {
       removePluginSpy.mockRestore();
     });
 
+    it('_removeInstance also removes the live plugin for bridge callback paths', () => {
+      const removePluginSpy = vi.spyOn(pluginEngine, 'removePlugin').mockImplementation(() => undefined);
+      useVST3Store.getState()._upsertInstance(mockInstance());
+
+      useVST3Store.getState()._removeInstance('inst-1');
+
+      expect(removePluginSpy).toHaveBeenCalledWith('track-1', 'inst-1');
+      expect(useVST3Store.getState().instances['inst-1']).toBeUndefined();
+
+      removePluginSpy.mockRestore();
+    });
+
     it('removing non-existent instance is a no-op', () => {
       const removePluginSpy = vi.spyOn(pluginEngine, 'removePlugin').mockImplementation(() => undefined);
       useVST3Store.getState()._upsertInstance(mockInstance());

--- a/src/store/vst3Store.ts
+++ b/src/store/vst3Store.ts
@@ -234,15 +234,6 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
   },
 
   removeInstance: (instanceId: string) => {
-    const inst = get().instances[instanceId];
-    if (!inst) return;
-
-    try {
-      pluginEngine.removePlugin(inst.trackId, instanceId);
-    } catch {
-      // Store removal should still succeed if the live audio chain is already gone.
-    }
-
     get()._removeInstance(instanceId);
   },
 
@@ -409,6 +400,12 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
     if (!inst) {
       set({ instances: next });
       return;
+    }
+
+    try {
+      pluginEngine.removePlugin(inst.trackId, instanceId);
+    } catch {
+      // Store removal should still succeed if the live audio chain is already gone.
     }
 
     const order = (pluginOrder[inst.trackId] ?? []).filter((id) => id !== instanceId);

--- a/src/store/vst3Store.ts
+++ b/src/store/vst3Store.ts
@@ -234,6 +234,15 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
   },
 
   removeInstance: (instanceId: string) => {
+    const inst = get().instances[instanceId];
+    if (!inst) return;
+
+    try {
+      pluginEngine.removePlugin(inst.trackId, instanceId);
+    } catch {
+      // Store removal should still succeed if the live audio chain is already gone.
+    }
+
     get()._removeInstance(instanceId);
   },
 
@@ -392,10 +401,24 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
   },
 
   _removeInstance: (instanceId) => {
-    const { instances } = get();
+    const { instances, pluginOrder } = get();
+    const inst = instances[instanceId];
     const next = { ...instances };
     delete next[instanceId];
-    set({ instances: next });
+
+    if (!inst) {
+      set({ instances: next });
+      return;
+    }
+
+    const order = (pluginOrder[inst.trackId] ?? []).filter((id) => id !== instanceId);
+    set({
+      instances: next,
+      pluginOrder: {
+        ...pluginOrder,
+        [inst.trackId]: order,
+      },
+    });
   },
 
   _updateParameter: (instanceId, paramId, value) => {


### PR DESCRIPTION
## Summary
- remove live VST3 plugin nodes from `PluginEngine` when instances are removed from the store
- clear removed VST3 instances from per-track plugin order
- add regression coverage that mirrors the existing WAM cleanup behavior

## Root Cause
`vst3Store.removeInstance()` only removed Zustand state. WAM removal already cleans up `PluginEngine`, but the VST3 path left the live plugin chain untouched.

## Verification
- `npx vitest run src/store/__tests__/vst3Store.test.ts src/store/__tests__/wamStore.test.ts src/engine/__tests__/PluginEngine.test.ts src/hooks/__tests__/useVST3Sync.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`

Closes #1782