### PR TITLE
test: assert transport playback state

### DIFF
--- a/tests/e2e/qa-full-workflow.spec.ts
+++ b/tests/e2e/qa-full-workflow.spec.ts
@@ -28,6 +28,7 @@ import {
 import {
   getProjectBpm,
   getProjectName,
+  getTransportState,
   getTrackCount,
   type E2EBrowserWindow,
 } from '../support/browserStores';
@@ -418,15 +419,11 @@ test.describe('QA Test Suite: Full Workflow', () => {
       await page.screenshot({ path: path.join(SCREENSHOT_DIR, '04a-space-play.png'), fullPage: true });
 
       // Check transport state
-      const isPlaying = await page.evaluate(() => {
-        const ts = (window as E2EBrowserWindow).__transportStore;
-        if (ts) return ts.getState().isPlaying;
-        return null;
-      });
+      await expect.poll(async () => (await getTransportState(page)).isPlaying).toBe(true);
 
       // Press space again
       await page.keyboard.press('Space');
-      await page.waitForTimeout(200);
+      await expect.poll(async () => (await getTransportState(page)).isPlaying).toBe(false);
       await page.screenshot({ path: path.join(SCREENSHOT_DIR, '04a-space-pause.png'), fullPage: true });
     });
 
@@ -472,21 +469,18 @@ test.describe('QA Test Suite: Full Workflow', () => {
     });
 
     test('4f. L toggles loop mode', async ({ page }) => {
-      await page.keyboard.press('l');
-      await page.waitForTimeout(200);
-      await page.screenshot({ path: path.join(SCREENSHOT_DIR, '04f-loop-toggle.png'), fullPage: true });
+      const before = (await getTransportState(page)).loopEnabled;
 
-      const loopEnabled = await page.evaluate(() => {
-        const ts = (window as E2EBrowserWindow).__transportStore;
-        if (ts) return ts.getState().loopEnabled;
-        return null;
-      });
-      // Just verify no crash
+      await page.keyboard.press('l');
+      await expect.poll(async () => (await getTransportState(page)).loopEnabled).toBe(!before);
+      await page.screenshot({ path: path.join(SCREENSHOT_DIR, '04f-loop-toggle.png'), fullPage: true });
     });
 
     test('4g. K toggles metronome', async ({ page }) => {
+      const before = (await getTransportState(page)).metronomeEnabled;
+
       await page.keyboard.press('k');
-      await page.waitForTimeout(200);
+      await expect.poll(async () => (await getTransportState(page)).metronomeEnabled).toBe(!before);
       await page.screenshot({ path: path.join(SCREENSHOT_DIR, '04g-metronome.png'), fullPage: true });
     });
 

--- a/tests/e2e/transport.spec.ts
+++ b/tests/e2e/transport.spec.ts
@@ -8,20 +8,55 @@
  * Why this test exists: protects the transport surface separately from larger bundles.
  * Left to other layers: detailed focus routing and human audible timing checks.
  */
-import { test, expect } from '@playwright/test';
-import { dismissWelcomeOverlay } from '../support/e2eStartup';
+import { test, expect, type Page } from '@playwright/test';
+import {
+  focusApplicationShell,
+  loadFreshApp,
+} from '../support/e2eStartup';
+import {
+  getProjectBpm,
+  getTransportState,
+  type E2EBrowserWindow,
+} from '../support/browserStores';
+
+async function readTransportLineX(page: Page) {
+  return page.evaluate(() => {
+    const line = document.querySelector<HTMLElement>('.playhead-glow');
+    const transform = line?.style.transform ?? '';
+    const match = /translateX\((-?\d+(?:\.\d+)?)px\)/.exec(transform);
+    return match ? Number(match[1]) : null;
+  });
+}
+
+async function focusTransportTestSurface(page: Page) {
+  await page.evaluate(() => {
+    const dawWindow = window as E2EBrowserWindow;
+    const active = document.activeElement as HTMLElement | null;
+    active?.blur?.();
+    dawWindow.__uiStore.getState().setKeyboardContext('timeline');
+    dawWindow.__uiStore.getState().setHistoryFocusScope('arrangement');
+  });
+  await page.mouse.click(10, 10);
+  await focusApplicationShell(page);
+}
 
 test.describe('Transport Controls @critical', () => {
   test.beforeEach(async ({ page }) => {
-    await dismissWelcomeOverlay(page);
-    await page.goto('/');
-    await page.waitForLoadState('domcontentloaded');
-    await page.waitForFunction(() => typeof (window as any).__store !== 'undefined', null, { timeout: 10000 });
-    // Create a project so the DAW UI is visible
+    await loadFreshApp(page);
+    await page.waitForFunction(
+      () => typeof (window as E2EBrowserWindow).__transportStore !== 'undefined',
+      null,
+      { timeout: 10000 },
+    );
     await page.evaluate(() => {
-      const store = (window as any).__store;
-      store.getState().createProject({ name: 'Transport Test' });
+      const dawWindow = window as E2EBrowserWindow;
+      dawWindow.__uiStore.getState().setShowNewProjectDialog(false);
+      dawWindow.__store.getState().createProject({ name: 'Transport Test' });
+      dawWindow.__store.getState().addTrack('drums');
+      dawWindow.__transportStore.getState().seek(0);
     });
+    await expect(page.getByTestId('transport-bar')).toBeVisible({ timeout: 10000 });
+    await focusTransportTestSurface(page);
   });
 
   test('transport bar is visible', async ({ page }) => {
@@ -29,25 +64,61 @@ test.describe('Transport Controls @critical', () => {
     await expect(page.getByTestId('transport-bar')).toBeVisible({ timeout: 10000 });
   });
 
-  test('play button exists and is clickable', async ({ page }) => {
-    // Look for play button by aria-label or role
-    const playButton = page.getByRole('button', { name: /play/i });
-    // If no button found by role, try finding by keyboard shortcut hint
-    if (await playButton.count() === 0) {
-      // Verify play can be triggered via space key
-      await page.keyboard.press('Space');
-      // Just verify no error thrown
-    } else {
-      await expect(playButton.first()).toBeVisible();
-    }
+  test('play button starts and pauses transport state', async ({ page }) => {
+    await page.getByRole('button', { name: 'Play' }).click();
+    await expect.poll(async () => (await getTransportState(page)).isPlaying).toBe(true);
+    await expect(page.getByRole('button', { name: 'Pause' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Pause' }).click();
+    await expect.poll(async () => (await getTransportState(page)).isPlaying).toBe(false);
+  });
+
+  test('spacebar advances transport time and visible playhead position', async ({ page }) => {
+    const before = await getTransportState(page);
+
+    await page.keyboard.press('Space');
+
+    await expect.poll(async () => (await getTransportState(page)).isPlaying).toBe(true);
+    await expect.poll(async () => (await getTransportState(page)).currentTime, {
+      timeout: 5000,
+    }).toBeGreaterThan(before.currentTime + 0.05);
+
+    await expect.poll(async () => await readTransportLineX(page) ?? -1, {
+      timeout: 5000,
+    }).toBeGreaterThan(0);
+    const firstX = await readTransportLineX(page);
+    expect(firstX).not.toBeNull();
+
+    await expect.poll(async () => await readTransportLineX(page) ?? -1, {
+      timeout: 5000,
+    }).toBeGreaterThan((firstX ?? 0) + 2);
+
+    await page.keyboard.press('Space');
+    await expect.poll(async () => (await getTransportState(page)).isPlaying).toBe(false);
+
+    const pausedTime = (await getTransportState(page)).currentTime;
+    await page.waitForTimeout(250);
+    const laterTime = (await getTransportState(page)).currentTime;
+    expect(Math.abs(laterTime - pausedTime)).toBeLessThan(0.05);
+  });
+
+  test('loop and metronome shortcuts toggle their transport flags', async ({ page }) => {
+    const initial = await getTransportState(page);
+
+    await page.keyboard.press('l');
+    await expect.poll(async () => (await getTransportState(page)).loopEnabled).toBe(!initial.loopEnabled);
+
+    await page.keyboard.press('l');
+    await expect.poll(async () => (await getTransportState(page)).loopEnabled).toBe(initial.loopEnabled);
+
+    await page.keyboard.press('k');
+    await expect.poll(async () => (await getTransportState(page)).metronomeEnabled).toBe(!initial.metronomeEnabled);
+
+    await page.keyboard.press('k');
+    await expect.poll(async () => (await getTransportState(page)).metronomeEnabled).toBe(initial.metronomeEnabled);
   });
 
   test('BPM display shows current BPM', async ({ page }) => {
-    // Check that BPM value is displayed somewhere in the UI
-    const bpmText = await page.evaluate(() => {
-      const store = (window as any).__store;
-      return store.getState().project?.bpm;
-    });
-    expect(bpmText).toBe(120);
+    expect(await getProjectBpm(page)).toBe(120);
   });
 });

--- a/tests/support/e2eStartup.ts
+++ b/tests/support/e2eStartup.ts
@@ -39,16 +39,20 @@ export async function createProjectViaDialog(
   bpm?: number,
 ) {
   await ensureNewProjectDialog(page);
+  const dialog = page.locator('.fixed.inset-0').filter({
+    has: page.getByRole('heading', { name: 'New Project' }),
+  }).first();
+  await expect(dialog).toBeVisible();
 
-  const nameInput = page.locator('input[type="text"]').first();
+  const nameInput = dialog.locator('input[type="text"]').first();
   await nameInput.fill(name);
 
   if (typeof bpm === 'number') {
-    const bpmInput = page.locator('input[type="number"]').first();
+    const bpmInput = dialog.locator('input[type="number"]').first();
     await bpmInput.fill(String(bpm));
   }
 
-  await page.locator('button:has-text("Create")').first().click();
+  await dialog.locator('button:has-text("Create")').first().click();
   await page.waitForFunction(
     (expectedName) => {
       const dawWindow = window as E2EBrowserWindow;


### PR DESCRIPTION
## Summary
- Strengthen the critical transport E2E spec so it asserts real playback state transitions, `currentTime` advancement, visible playhead movement, and pause stability.
- Add loop and metronome shortcut state assertions to the transport and full workflow E2E coverage.
- Scope the New Project E2E helper to the dialog before filling inputs so it cannot accidentally target the toolbar BPM input.

## Verification
- `npx tsc --noEmit --pretty false`
- `npx playwright test tests/e2e/transport.spec.ts --project=chromium`
- `npx playwright test tests/e2e/qa-full-workflow.spec.ts --project=chromium -g "4a|4f|4g"`
- `git diff --check`

Closes #1784
