### PR TITLE
fix: apply max plugin delay compensation

### DIFF
--- a/src/engine/PluginEngine.ts
+++ b/src/engine/PluginEngine.ts
@@ -230,7 +230,7 @@ export class PluginEngine {
 
   /**
    * Get total latency of plugin chain for a track (in samples).
-   * Sums latencySamples from all plugins in the chain.
+   * Sums latencySamples from all active plugins in the chain.
    * WAP plugins without latencySamples are assumed to have 0 latency.
    */
   getChainLatency(trackId: string): number {
@@ -238,9 +238,44 @@ export class PluginEngine {
     if (!chain) return 0;
     let total = 0;
     for (const node of chain) {
-      total += node.plugin.latencySamples ?? 0;
+      if (node.bypassed) continue;
+      const latencySamples = node.plugin.latencySamples ?? 0;
+      total += Number.isFinite(latencySamples) ? Math.max(0, Math.floor(latencySamples)) : 0;
     }
     return total;
+  }
+
+  /**
+   * Update a live plugin's reported latency.
+   * VST3 plugins can report latency after instantiation or after parameter changes.
+   */
+  setPluginLatency(trackId: string, instanceId: string, latencySamples: number): void {
+    const chain = this.chains.get(trackId);
+    if (!chain) return;
+    const node = chain.find((candidate) => candidate.instanceId === instanceId);
+    if (!node) return;
+
+    const sanitizedLatency = Number.isFinite(latencySamples)
+      ? Math.max(0, Math.floor(latencySamples))
+      : 0;
+    const plugin = node.plugin as WAPPlugin & {
+      setLatencySamples?: (samples: number) => void;
+      latencySamples?: number;
+    };
+    if (typeof plugin.setLatencySamples === 'function') {
+      plugin.setLatencySamples(sanitizedLatency);
+      return;
+    }
+
+    try {
+      Object.defineProperty(plugin, 'latencySamples', {
+        value: sanitizedLatency,
+        configurable: true,
+        enumerable: true,
+      });
+    } catch {
+      // Some third-party plugin wrappers may expose latency as a non-configurable readonly field.
+    }
   }
 
   /**

--- a/src/hooks/__tests__/useEffectsSync.vst3.test.ts
+++ b/src/hooks/__tests__/useEffectsSync.vst3.test.ts
@@ -9,6 +9,8 @@ import { pluginEngine } from '../../engine/PluginEngine';
 import { effectsEngine } from '../../engine/EffectsEngine';
 import {
   buildCombinedEffectsChain,
+  calculatePluginDelayCompensation,
+  calculatePluginDelayCompensationForTracks,
 } from '../useEffectsSync';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -83,5 +85,58 @@ describe('buildCombinedEffectsChain', () => {
     expect(result.output).toBe(effectsOutput);
     // VST3 output connected to built-in input
     expect(pluginOutput.connect).toHaveBeenCalledWith(effectsInput);
+  });
+});
+
+describe('calculatePluginDelayCompensation', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('delays lower-latency tracks to match the maximum active plugin chain latency', () => {
+    vi.spyOn(pluginEngine, 'getChainLatency').mockImplementation((trackId) => {
+      if (trackId === 'track-late') return 512;
+      if (trackId === 'track-mid') return 128;
+      return 0;
+    });
+
+    const result = calculatePluginDelayCompensation(
+      ['track-late', 'track-mid', 'track-dry'],
+      48000,
+    );
+
+    expect(result.get('track-late')).toBe(0);
+    expect(result.get('track-mid')).toBe(384);
+    expect(result.get('track-dry')).toBe(512);
+  });
+
+  it('clears compensation when active plugin latencies are all zero', () => {
+    vi.spyOn(pluginEngine, 'getChainLatency').mockReturnValue(0);
+
+    const result = calculatePluginDelayCompensation(['track-a', 'track-b'], 48000);
+
+    expect(result.get('track-a')).toBe(0);
+    expect(result.get('track-b')).toBe(0);
+  });
+
+  it('accounts for group-bus latency without applying extra compensation to the bus', () => {
+    vi.spyOn(pluginEngine, 'getChainLatency').mockImplementation((trackId) => {
+      if (trackId === 'group-bus') return 512;
+      if (trackId === 'track-child') return 128;
+      return 0;
+    });
+
+    const result = calculatePluginDelayCompensationForTracks(
+      [
+        { id: 'group-bus', isGroup: true },
+        { id: 'track-child', parentTrackId: 'group-bus' },
+        { id: 'track-dry' },
+      ],
+      48000,
+    );
+
+    expect(result.get('group-bus')).toBe(0);
+    expect(result.get('track-child')).toBe(0);
+    expect(result.get('track-dry')).toBe(640);
   });
 });

--- a/src/hooks/useEffectsSync.ts
+++ b/src/hooks/useEffectsSync.ts
@@ -13,6 +13,7 @@ import { useWAMStore } from '../store/wamStore';
 import { effectsEngine, initWasmDsp } from '../engine/EffectsEngine';
 import { pluginEngine } from '../engine/PluginEngine';
 import { getAudioEngine } from './useAudioEngine';
+import { VST3LatencyCompensation } from '../services/vst3bridge/VST3LatencyCompensation';
 import { createDebugLogger } from '../utils/debugLogger';
 import type { CompressorParams } from '../types/project';
 import type { WAMActiveInstance } from '../types/wam';
@@ -51,12 +52,12 @@ export function buildCombinedEffectsChain(trackId: string): { input: AudioNode |
 
 /**
  * Derive a stable fingerprint of VST3 instances for effect chain syncing.
- * Only includes fields that affect audio routing (instanceId, trackId, enabled).
+ * Only includes fields that affect audio routing or timing.
  */
 function selectVst3EffectChainKey(s: { instances: Record<string, VST3ActiveInstance> }): string {
   const parts: string[] = [];
   for (const [id, inst] of Object.entries(s.instances)) {
-    parts.push(`${id}:${inst.trackId ?? ''}:${inst.enabled ? '1' : '0'}`);
+    parts.push(`${id}:${inst.trackId ?? ''}:${inst.enabled ? '1' : '0'}:${inst.latencySamples ?? 0}`);
   }
   return parts.sort().join('|');
 }
@@ -67,6 +68,56 @@ function selectWamEffectChainKey(s: { instances: Record<string, WAMActiveInstanc
     parts.push(`${id}:${inst.trackId ?? ''}:${inst.enabled ? '1' : '0'}`);
   }
   return parts.sort().join('|');
+}
+
+export function calculatePluginDelayCompensation(trackIds: string[], sampleRate: number): Map<string, number> {
+  return VST3LatencyCompensation.calculateCompensation(
+    trackIds.map((id) => ({
+      id,
+      pluginLatencies: [pluginEngine.getChainLatency(id)],
+    })),
+    sampleRate,
+  );
+}
+
+interface PluginDelayCompensationTrack {
+  id: string;
+  isGroup?: boolean;
+  parentTrackId?: string;
+}
+
+function getSignalPathTrackIds(
+  track: PluginDelayCompensationTrack,
+  trackById: Map<string, PluginDelayCompensationTrack>,
+): string[] {
+  const path = [track.id];
+  const visited = new Set(path);
+  let parentTrackId = track.parentTrackId;
+  while (parentTrackId && !visited.has(parentTrackId)) {
+    visited.add(parentTrackId);
+    path.push(parentTrackId);
+    parentTrackId = trackById.get(parentTrackId)?.parentTrackId;
+  }
+  return path;
+}
+
+export function calculatePluginDelayCompensationForTracks(
+  tracks: PluginDelayCompensationTrack[],
+  sampleRate: number,
+): Map<string, number> {
+  const trackById = new Map(tracks.map((track) => [track.id, track]));
+  const sourceTracks = tracks.filter((track) => !track.isGroup);
+  const compensationByTrack = VST3LatencyCompensation.calculateCompensation(
+    sourceTracks.map((track) => ({
+      id: track.id,
+      pluginLatencies: getSignalPathTrackIds(track, trackById).map((id) => pluginEngine.getChainLatency(id)),
+    })),
+    sampleRate,
+  );
+  for (const track of tracks) {
+    if (track.isGroup) compensationByTrack.set(track.id, 0);
+  }
+  return compensationByTrack;
 }
 
 export function useEffectsSync() {
@@ -116,6 +167,8 @@ export function useEffectsSync() {
       instancesByTrack.set(inst.trackId, list);
     }
 
+    const trackNodes = new Map<string, ReturnType<typeof engine.getOrCreateTrackNode>>();
+
     // First pass: rebuild built-in effect chains + sync VST3 bypass, then splice combined chain
     for (const track of tracks) {
       const effects = track.effects ?? [];
@@ -133,12 +186,17 @@ export function useEffectsSync() {
       if (trackNode) {
         const { input, output } = buildCombinedEffectsChain(track.id);
         trackNode.spliceEffects(input, output);
-
-        // Always apply latency compensation (including clearing to 0 when plugins removed/bypassed)
-        const pluginLatency = pluginEngine.getChainLatency(track.id);
-        const sampleRate = engine.ctx?.sampleRate ?? 44100;
-        trackNode.setLatencyCompensation(pluginLatency, sampleRate);
+        trackNodes.set(track.id, trackNode);
       }
+    }
+
+    const sampleRate = engine.ctx?.sampleRate ?? 44100;
+    const compensationByTrack = calculatePluginDelayCompensationForTracks(
+      tracks.filter((track) => trackNodes.has(track.id)),
+      sampleRate,
+    );
+    for (const [trackId, trackNode] of trackNodes) {
+      trackNode.setLatencyCompensation(compensationByTrack.get(trackId) ?? 0, sampleRate);
     }
 
     // Second pass: wire sidechain connections (all chains must exist first)

--- a/src/hooks/useVST3Connection.ts
+++ b/src/hooks/useVST3Connection.ts
@@ -92,11 +92,18 @@ export function useVST3Connection() {
       });
     };
 
+    const onLatencyInfo = (msg: Record<string, unknown>) => {
+      const instanceId = msg.instanceId as string | undefined;
+      if (!instanceId) return;
+      store._updateLatency(instanceId, Number(msg.samples ?? 0));
+    };
+
     const unsubs = [
       client.on('statusChange', onStatusChange),
       client.on('error', onError),
       client.on('scanComplete', onScanComplete),
       client.on('scanProgress', onScanProgress),
+      client.on('latencyInfo', onLatencyInfo),
     ];
 
     // Sync current state immediately (handles HMR / singleton already connected)

--- a/src/services/vst3bridge/VST3PluginAdapter.ts
+++ b/src/services/vst3bridge/VST3PluginAdapter.ts
@@ -37,6 +37,10 @@ const AUDIO_PUMP_INTERVAL_MS = 5;
 /** Audio block size sent per pump iteration (in sample frames). */
 const BLOCK_SIZE = 128;
 
+function sanitizeLatencySamples(samples: number): number {
+  return Number.isFinite(samples) ? Math.max(0, Math.floor(samples)) : 0;
+}
+
 // ─── Adapter ────────────────────────────────────────────────────────────────
 
 export class VST3PluginAdapter implements WAPPlugin {
@@ -45,8 +49,8 @@ export class VST3PluginAdapter implements WAPPlugin {
   readonly version: string;
   readonly author: string;
   readonly description: string;
-  readonly latencySamples: number;
 
+  private _latencySamples: number;
   private instanceId: string;
   private bridgeClient: VST3BridgeClient;
   private paramDescriptors: PluginParamDescriptor[] = [];
@@ -74,7 +78,7 @@ export class VST3PluginAdapter implements WAPPlugin {
     this.author = pluginInfo.vendor;
     this.description = `VST3: ${pluginInfo.name} by ${pluginInfo.vendor}`;
     this.bridgeClient = bridgeClient;
-    this.latencySamples = instantiateResponse.latencySamples;
+    this._latencySamples = sanitizeLatencySamples(instantiateResponse.latencySamples);
     this.instanceIdHash = fnv1aHash(instanceId);
 
     // Map VST3 params to WAP param descriptors
@@ -235,8 +239,18 @@ export class VST3PluginAdapter implements WAPPlugin {
   }
 
   /** Latency in samples introduced by this plugin. */
+  get latencySamples(): number {
+    return this._latencySamples;
+  }
+
+  /** Update latency reported by the companion. */
+  setLatencySamples(samples: number): void {
+    this._latencySamples = sanitizeLatencySamples(samples);
+  }
+
+  /** Latency in samples introduced by this plugin. */
   get pluginLatency(): number {
-    return this.latencySamples;
+    return this._latencySamples;
   }
 
   /** Ask the companion to open the native VST3 editor window. */

--- a/src/services/vst3bridge/__tests__/PluginEngineLatency.test.ts
+++ b/src/services/vst3bridge/__tests__/PluginEngineLatency.test.ts
@@ -59,4 +59,33 @@ describe('PluginEngine.getChainLatency', () => {
     engine.addPlugin('track-1', 'inst-3', p3, ctx);
     expect(engine.getChainLatency('track-1')).toBe(384);
   });
+
+  it('excludes bypassed plugins from chain latency', () => {
+    const p1 = createMockPlugin(128);
+    const p2 = createMockPlugin(256);
+    engine.addPlugin('track-1', 'inst-1', p1, ctx);
+    engine.addPlugin('track-1', 'inst-2', p2, ctx);
+
+    engine.setPluginBypassed('track-1', 'inst-2', true);
+
+    expect(engine.getChainLatency('track-1')).toBe(128);
+  });
+
+  it('updates a live plugin latency report', () => {
+    const plugin = createMockPlugin(128);
+    engine.addPlugin('track-1', 'inst-1', plugin, ctx);
+
+    engine.setPluginLatency('track-1', 'inst-1', 512);
+
+    expect(engine.getChainLatency('track-1')).toBe(512);
+  });
+
+  it('normalizes invalid and fractional latency samples', () => {
+    const p1 = createMockPlugin(128.8);
+    const p2 = createMockPlugin(Number.NaN);
+    engine.addPlugin('track-1', 'inst-1', p1, ctx);
+    engine.addPlugin('track-1', 'inst-2', p2, ctx);
+
+    expect(engine.getChainLatency('track-1')).toBe(128);
+  });
 });

--- a/src/store/__tests__/vst3Store.test.ts
+++ b/src/store/__tests__/vst3Store.test.ts
@@ -25,6 +25,7 @@ const mockInstance = (overrides: Partial<VST3ActiveInstance> = {}): VST3ActiveIn
   parameters: [],
   presets: [],
   activePreset: null,
+  latencySamples: 0,
   ...overrides,
 });
 
@@ -249,29 +250,21 @@ describe('vst3Store', () => {
       const { _getBridgeClient } = await import('../../hooks/useVST3Connection');
       const client = _getBridgeClient();
 
-      // Intercept on/off to capture event listeners registered by loadPlugin
-      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
-      client.on = vi.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
-        if (!listeners[event]) listeners[event] = [];
-        listeners[event].push(handler);
-      });
-      client.off = vi.fn();
-
-      // Mock createInstance to simulate the companion responding with instanceCreated
-      const mockCreateInstance = vi.fn().mockImplementation((_pluginUid: string, instanceId: string) => {
-        queueMicrotask(() => {
-          for (const fn of listeners['instanceCreated'] ?? []) {
-            fn({ type: 'instanceCreated', instanceId, parameters: [] });
-          }
-        });
-        return Promise.resolve();
-      });
-      client.createInstance = mockCreateInstance;
+      const mockInstantiate = vi.fn().mockImplementation((_pluginUid: string, instanceId: string) => Promise.resolve({
+        type: 'instantiated',
+        reqId: 'req-1',
+        instanceId,
+        parameters: [],
+        latencySamples: 384,
+        tailSamples: 0,
+        presets: [],
+      }));
+      client.instantiate = mockInstantiate;
 
       await useVST3Store.getState().loadPlugin('com.xfer.serum', 'track-1');
 
-      // Should have called createInstance with the pluginId and a generated instanceId
-      expect(mockCreateInstance).toHaveBeenCalledWith('com.xfer.serum', expect.any(String));
+      // Should have called instantiate with the pluginId and a generated instanceId
+      expect(mockInstantiate).toHaveBeenCalledWith('com.xfer.serum', expect.any(String));
 
       // Should have created an instance in the store
       const { instances } = useVST3Store.getState();
@@ -285,28 +278,26 @@ describe('vst3Store', () => {
       expect(instance.trackId).toBe('track-1');
       expect(instance.enabled).toBe(true);
       expect(instance.online).toBe(true);
+      expect(instance.latencySamples).toBe(384);
+    });
+
+    it('updates store and PluginEngine when the companion reports latency changes', () => {
+      const setPluginLatencySpy = vi.spyOn(pluginEngine, 'setPluginLatency').mockImplementation(() => undefined);
+      useVST3Store.getState()._upsertInstance(mockInstance({ instanceId: 'inst-1', trackId: 'track-1', latencySamples: 128 }));
+
+      useVST3Store.getState()._updateLatency('inst-1', 512.8);
+
+      expect(setPluginLatencySpy).toHaveBeenCalledWith('track-1', 'inst-1', 512);
+      expect(useVST3Store.getState().instances['inst-1'].latencySamples).toBe(512);
+
+      setPluginLatencySpy.mockRestore();
     });
 
     it('does not create an instance when bridge call fails', async () => {
       const { _getBridgeClient } = await import('../../hooks/useVST3Connection');
       const client = _getBridgeClient();
 
-      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
-      client.on = vi.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
-        if (!listeners[event]) listeners[event] = [];
-        listeners[event].push(handler);
-      });
-      client.off = vi.fn();
-
-      client.createInstance = vi.fn().mockImplementation(() => {
-        // Trigger the error listener
-        queueMicrotask(() => {
-          for (const fn of listeners['error'] ?? []) {
-            fn('Connection lost');
-          }
-        });
-        return Promise.resolve();
-      });
+      client.instantiate = vi.fn().mockRejectedValue(new Error('Connection lost'));
 
       await useVST3Store.getState().loadPlugin('com.xfer.serum', 'track-1');
 

--- a/src/store/vst3Store.ts
+++ b/src/store/vst3Store.ts
@@ -13,6 +13,7 @@ import { toastSuccess, toastError } from '../hooks/useToast';
 import { _getBridgeClient } from '../hooks/useVST3Connection';
 import { VST3PluginAdapter } from '../services/vst3bridge/VST3PluginAdapter';
 import { pluginEngine } from '../engine/PluginEngine';
+import type { VST3ParamInfo } from '../services/vst3bridge/VST3BridgeProtocol';
 
 export interface VST3Store {
   /* ── Connection ──────────────────────────────────────── */
@@ -77,6 +78,7 @@ export interface VST3Store {
   _upsertInstance: (instance: VST3ActiveInstance) => void;
   _removeInstance: (instanceId: string) => void;
   _updateParameter: (instanceId: string, paramId: number, value: number) => void;
+  _updateLatency: (instanceId: string, latencySamples: number) => void;
 }
 
 /** Load favorites from localStorage */
@@ -95,6 +97,25 @@ function saveFavorites(ids: Set<string>): void {
   } catch {
     /* ignore persistence failures so UI state updates still succeed */
   }
+}
+
+function sanitizeLatencySamples(samples: unknown): number {
+  const value = Number(samples);
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function normalizeParameter(param: VST3ParamInfo): VST3Parameter {
+  const defaultValue = param.defaultValue ?? param.default ?? param.min;
+  return {
+    id: param.id,
+    name: param.name ?? param.title ?? `Parameter ${param.id}`,
+    value: defaultValue,
+    minValue: param.min,
+    maxValue: param.max,
+    defaultValue,
+    enumValues: [],
+    unit: param.units ?? param.unitName ?? '',
+  };
 }
 
 /** Compare semver strings: returns true if version >= minimum */
@@ -151,38 +172,10 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
     try {
       const client = _getBridgeClient();
 
-      // Listen for the instanceCreated event from the bridge
-      const instancePromise = new Promise<VST3Parameter[]>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          client.off('instanceCreated', onCreated);
-          client.off('error', onError);
-          reject(new Error('Plugin instantiation timed out'));
-        }, 10_000);
-
-        const onCreated = (msg: Record<string, unknown>) => {
-          const createdId = msg.instanceId as string;
-          if (createdId === instanceId) {
-            clearTimeout(timeout);
-            client.off('instanceCreated', onCreated);
-            client.off('error', onError);
-            const params = (msg.parameters as VST3Parameter[]) ?? [];
-            resolve(params);
-          }
-        };
-
-        const onError = (msg: Record<string, unknown>) => {
-          clearTimeout(timeout);
-          client.off('instanceCreated', onCreated);
-          client.off('error', onError);
-          reject(new Error((msg.message as string) ?? 'Unknown error'));
-        };
-
-        client.on('instanceCreated', onCreated);
-        client.on('error', onError);
-      });
-
-      await client.createInstance(pluginId, instanceId);
-      const parameters = await instancePromise;
+      const instantiateResponse = await client.instantiate(pluginId, instanceId);
+      const pluginParameters = instantiateResponse.parameters ?? [];
+      const parameters = pluginParameters.map(normalizeParameter);
+      const latencySamples = sanitizeLatencySamples(instantiateResponse.latencySamples);
 
       get()._upsertInstance({
         instanceId,
@@ -195,6 +188,7 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
         parameters,
         presets: [],
         activePreset: null,
+        latencySamples,
       });
 
       // Create the audio adapter and register with the plugin engine
@@ -207,18 +201,19 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
           { ...pluginInfo, uid: pluginInfo.id },
           {
             instanceId,
-            parameters: parameters.map((p) => ({
+            parameters: pluginParameters.map((p) => ({
               id: p.id,
-              name: p.name,
-              title: p.name,
-              default: p.defaultValue,
-              defaultValue: p.defaultValue,
-              min: p.minValue,
-              max: p.maxValue,
-              stepCount: 0,
-              unit: '',
+              name: p.name ?? p.title ?? `Parameter ${p.id}`,
+              title: p.title ?? p.name ?? `Parameter ${p.id}`,
+              default: p.default ?? p.defaultValue ?? p.min,
+              defaultValue: p.defaultValue ?? p.default ?? p.min,
+              min: p.min,
+              max: p.max,
+              stepCount: p.stepCount,
+              unitName: p.unitName,
+              units: p.units,
             })),
-            latencySamples: 0,
+            latencySamples,
           },
           client,
         );
@@ -430,6 +425,29 @@ export const useVST3Store = create<VST3Store>()((set, get) => ({
           parameters: inst.parameters.map((p: VST3Parameter) =>
             p.id === paramId ? { ...p, value } : p,
           ),
+        },
+      },
+    });
+  },
+
+  _updateLatency: (instanceId, latencySamples) => {
+    const { instances } = get();
+    const inst = instances[instanceId];
+    if (!inst) return;
+
+    const sanitizedLatency = sanitizeLatencySamples(latencySamples);
+    try {
+      pluginEngine.setPluginLatency(inst.trackId, instanceId, sanitizedLatency);
+    } catch {
+      // Store state should still reflect the companion's latest latency report.
+    }
+
+    set({
+      instances: {
+        ...instances,
+        [instanceId]: {
+          ...inst,
+          latencySamples: sanitizedLatency,
         },
       },
     });

--- a/src/types/vst3.ts
+++ b/src/types/vst3.ts
@@ -41,6 +41,8 @@ export interface VST3ActiveInstance {
   hasSidechainInput?: boolean;
   /** Track ID feeding the sidechain input, or null if none. */
   sidechainSourceTrackId?: string | null;
+  /** Processing latency currently reported by the VST3 companion. */
+  latencySamples?: number;
 }
 
 /** A single parameter exposed by a VST3 plugin */


### PR DESCRIPTION
## Summary
- apply plugin delay compensation using the maximum active chain latency across tracks
- exclude bypassed plugins from latency totals and sanitize live latency reports
- preserve VST3 companion latency from instance creation and later latencyInfo updates

## Verification
- npx tsc --noEmit --pretty false
- npx vitest run src/services/vst3bridge/__tests__/PluginEngineLatency.test.ts src/services/vst3bridge/__tests__/VST3LatencyCompensation.test.ts src/services/vst3bridge/__tests__/VST3PluginAdapter.test.ts src/hooks/__tests__/useEffectsSync.vst3.test.ts src/store/__tests__/vst3Store.test.ts
- git diff --check

Closes #1783