### PR TITLE
fix: gate native Tauri audio backend

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -102,6 +102,14 @@ pub fn audio_start_engine(
         .lock()
         .map_err(|_| EngineError::Open("emitter mutex poisoned".into()))?;
 
+    let current_status = engine.status();
+    if current_status.is_running() {
+        // `Engine::start` returns AlreadyRunning, but the emitter is
+        // already valid in the normal running case. Return the current
+        // status without tearing it down.
+        return Ok(current_status);
+    }
+
     // Stop any leftover emitter BEFORE starting the new engine — so
     // we never have two emitters pushing to the same event name, and
     // we don't leak a thread if `start` fails.

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -247,6 +247,27 @@ pub fn audio_get_master_meter(state: State<'_, EngineState>) -> Result<MeterRead
     Ok(engine.get_master_meter())
 }
 
+#[tauri::command]
+pub fn audio_reset_track_clip(
+    handle: SlotHandle,
+    state: State<'_, EngineState>,
+) -> Result<(), CommandError> {
+    let mut engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.reset_track_clip(handle)
+}
+
+#[tauri::command]
+pub fn audio_reset_master_clip(state: State<'_, EngineState>) -> Result<(), CommandError> {
+    let mut engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    engine.reset_master_clip()
+}
+
 // ── Transport (3A) ──────────────────────────────────────────────────
 
 #[tauri::command]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -10,9 +10,9 @@ use tauri::{Emitter, State};
 
 use crate::engine::{
     audio_io, AudioDeviceInfo, ClipSchedule, ClipSource, CommandError, CountIn, Engine,
-    EngineConfig, EngineError, EngineStatus, LoopRegion, MetronomeConfig, PositionEmitter,
-    PunchRegion, TempoEvent, TempoMap, TimeSignatureEvent, TimeSignatureMap, TrackParams,
-    POSITION_EVENT_DEFAULT_INTERVAL,
+    EngineConfig, EngineError, EngineStatus, LoopRegion, MeterReading, MetronomeConfig,
+    PositionEmitter, PunchRegion, TempoEvent, TempoMap, TimeSignatureEvent, TimeSignatureMap,
+    TrackParams, POSITION_EVENT_DEFAULT_INTERVAL,
 };
 use crate::engine::slot::SlotHandle;
 
@@ -216,6 +216,27 @@ pub fn audio_set_master_volume(
         .lock()
         .map_err(|_| CommandError::Disconnected)?;
     engine.set_master_volume(volume)
+}
+
+#[tauri::command]
+pub fn audio_get_track_meter(
+    handle: SlotHandle,
+    state: State<'_, EngineState>,
+) -> Result<MeterReading, CommandError> {
+    let mut engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    Ok(engine.get_track_meter(handle))
+}
+
+#[tauri::command]
+pub fn audio_get_master_meter(state: State<'_, EngineState>) -> Result<MeterReading, CommandError> {
+    let mut engine = state
+        .0
+        .lock()
+        .map_err(|_| CommandError::Disconnected)?;
+    Ok(engine.get_master_meter())
 }
 
 // ── Transport (3A) ──────────────────────────────────────────────────

--- a/src-tauri/src/engine/audio_io.rs
+++ b/src-tauri/src/engine/audio_io.rs
@@ -354,6 +354,14 @@ fn make_audio_callback(
                             bus.enabled = enabled;
                         }
                     }
+                    EngineCommand::ResetTrackClip { handle } => {
+                        if graph.handle_matches(handle) {
+                            meters.track_meters[handle.index()].reset_clip();
+                        }
+                    }
+                    EngineCommand::ResetMasterClip => {
+                        meters.master_meter.reset_clip();
+                    }
                     // Transport commands (3A) — route to the audio-thread
                     // `Transport` instance. Position advance happens at
                     // the tail of the callback, AFTER the drain, so that

--- a/src-tauri/src/engine/command.rs
+++ b/src-tauri/src/engine/command.rs
@@ -142,6 +142,13 @@ pub enum EngineCommand {
     /// Enable or disable an aux return bus.
     SetAuxBusEnabled { bus_index: u8, enabled: bool },
 
+    /// Clear the latched clip flag on a track meter.
+    /// Generation-checked like other track-targeted commands.
+    ResetTrackClip { handle: SlotHandle },
+
+    /// Clear the latched clip flag on the master meter.
+    ResetMasterClip,
+
     // ── Transport (3A) ────────────────────────────────────────────────
 
     /// Begin playback from the current position.

--- a/src-tauri/src/engine/graph.rs
+++ b/src-tauri/src/engine/graph.rs
@@ -252,6 +252,8 @@ impl AudioGraph {
             | EngineCommand::SetTrackSendLevel { .. }
             | EngineCommand::SetAuxBusVolume { .. }
             | EngineCommand::SetAuxBusEnabled { .. }
+            | EngineCommand::ResetTrackClip { .. }
+            | EngineCommand::ResetMasterClip
             | EngineCommand::TransportPlay
             | EngineCommand::TransportStop
             | EngineCommand::TransportPause

--- a/src-tauri/src/engine/meter_bank.rs
+++ b/src-tauri/src/engine/meter_bank.rs
@@ -68,6 +68,22 @@ impl MeterConsumers {
         drain_into(&mut self.master_consumer, &mut self.master_cache);
         self.master_cache
     }
+
+    /// Clear the latched clip flag from the main-thread cache for a
+    /// track slot. The audio-thread meter is reset by command queue;
+    /// this avoids one stale UI poll before that command drains.
+    pub fn reset_track_clip(&mut self, slot: usize) {
+        if let Some(cons) = self.track_consumers.get_mut(slot) {
+            drain_into(cons, &mut self.track_cache[slot]);
+            self.track_cache[slot].clipped = false;
+        }
+    }
+
+    /// Clear the latched clip flag from the main-thread master cache.
+    pub fn reset_master_clip(&mut self) {
+        drain_into(&mut self.master_consumer, &mut self.master_cache);
+        self.master_cache.clipped = false;
+    }
 }
 
 /// Drain the ring buffer into a cached value. If new entries exist,

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -497,6 +497,20 @@ impl Engine {
         self.send_command(EngineCommand::SetMasterVolume { volume })
     }
 
+    /// Clear a track meter's latched clip flag.
+    pub fn reset_track_clip(&mut self, handle: SlotHandle) -> Result<(), CommandError> {
+        let running = self.running.as_mut().ok_or(CommandError::NotRunning)?;
+        running.meter_consumers.reset_track_clip(handle.index());
+        self.send_command(EngineCommand::ResetTrackClip { handle })
+    }
+
+    /// Clear the master meter's latched clip flag.
+    pub fn reset_master_clip(&mut self) -> Result<(), CommandError> {
+        let running = self.running.as_mut().ok_or(CommandError::NotRunning)?;
+        running.meter_consumers.reset_master_clip();
+        self.send_command(EngineCommand::ResetMasterClip)
+    }
+
     // ── Transport (3A) ───────────────────────────────────────────────
 
     /// Begin playback from the current position.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,8 @@ use tauri::Manager;
 
 use crate::commands::audio::{
     audio_add_track, audio_clip_get_schedule, audio_clip_set_schedule,
-    audio_get_default_device, audio_get_engine_status, audio_list_devices,
+    audio_get_default_device, audio_get_engine_status, audio_get_master_meter,
+    audio_get_track_meter, audio_list_devices,
     audio_metronome_get_config, audio_metronome_set_config, audio_metronome_set_enabled,
     audio_remove_track, audio_set_master_volume, audio_set_track_params,
     audio_start_engine, audio_stop_engine, audio_transport_get_count_in,
@@ -55,6 +56,8 @@ pub fn run() {
             audio_remove_track,
             audio_set_track_params,
             audio_set_master_volume,
+            audio_get_track_meter,
+            audio_get_master_meter,
             audio_transport_play,
             audio_transport_stop,
             audio_transport_pause,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ use tauri::Manager;
 use crate::commands::audio::{
     audio_add_track, audio_clip_get_schedule, audio_clip_set_schedule,
     audio_get_default_device, audio_get_engine_status, audio_get_master_meter,
-    audio_get_track_meter, audio_list_devices,
+    audio_get_track_meter, audio_list_devices, audio_reset_master_clip, audio_reset_track_clip,
     audio_metronome_get_config, audio_metronome_set_config, audio_metronome_set_enabled,
     audio_remove_track, audio_set_master_volume, audio_set_track_params,
     audio_start_engine, audio_stop_engine, audio_transport_get_count_in,
@@ -58,6 +58,8 @@ pub fn run() {
             audio_set_master_volume,
             audio_get_track_meter,
             audio_get_master_meter,
+            audio_reset_track_clip,
+            audio_reset_master_clip,
             audio_transport_play,
             audio_transport_stop,
             audio_transport_pause,

--- a/src/components/mixer/LevelMeter.tsx
+++ b/src/components/mixer/LevelMeter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getAudioBridge } from '../../engine/bridge';
 import { METER_CANVAS_STOPS, METER_DB_TICKS, METER_DB_TICKS_MINOR, METER_PADDING_PCT, dbToFill, levelToFill } from '../meter-colors';
 
 const BAR_WIDTH = 4;
@@ -77,6 +78,7 @@ export function LevelMeter({ trackId, masterStage, returnTrackId, stereo, showSc
     };
 
     const engine = getAudioEngine();
+    const bridge = getAudioBridge(engine);
 
     const tick = () => {
       const dpr = window.devicePixelRatio || 1;
@@ -93,7 +95,7 @@ export function LevelMeter({ trackId, masterStage, returnTrackId, stereo, showSc
       let clipped = false;
 
       if (masterStage) {
-        const meter = engine.getMasterMeter(masterStage);
+        const meter = bridge.getMasterMeter(masterStage);
         leftLevel = meter.level;
         rightLevel = meter.level;
         clipped = meter.clipped;
@@ -103,7 +105,7 @@ export function LevelMeter({ trackId, masterStage, returnTrackId, stereo, showSc
         rightLevel = meter.level;
         clipped = meter.clipped;
       } else if (trackId) {
-        const meter = engine.getTrackMeter(trackId);
+        const meter = bridge.getTrackMeter(trackId);
         leftLevel = isStereo ? meter.leftLevel : meter.level;
         rightLevel = isStereo ? meter.rightLevel : meter.level;
         clipped = meter.clipped;
@@ -183,12 +185,13 @@ export function LevelMeter({ trackId, masterStage, returnTrackId, stereo, showSc
 
   const resetClip = () => {
     const engine = getAudioEngine();
+    const bridge = getAudioBridge(engine);
     if (masterStage) {
-      engine.resetMasterClip(masterStage);
+      bridge.resetMasterClip(masterStage);
     } else if (returnTrackId) {
       engine.resetReturnTrackClip(returnTrackId);
     } else if (trackId) {
-      engine.resetTrackClip(trackId);
+      bridge.resetTrackClip(trackId);
     }
     clippedRef.current = false;
     clippedStateRef.current = false;

--- a/src/components/mixer/LevelMeter.tsx
+++ b/src/components/mixer/LevelMeter.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react';
-import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getAudioEngine, getTauriPlaybackClockOwner } from '../../hooks/useAudioEngine';
 import { getAudioBridge } from '../../engine/bridge';
 import { METER_CANVAS_STOPS, METER_DB_TICKS, METER_DB_TICKS_MINOR, METER_PADDING_PCT, dbToFill, levelToFill } from '../meter-colors';
 
@@ -94,8 +94,12 @@ export function LevelMeter({ trackId, masterStage, returnTrackId, stereo, showSc
       let rightLevel = 0;
       let clipped = false;
 
+      const meterSource = bridge.backend === 'tauri' && getTauriPlaybackClockOwner() === 'native'
+        ? bridge
+        : engine;
+
       if (masterStage) {
-        const meter = bridge.getMasterMeter(masterStage);
+        const meter = meterSource.getMasterMeter(masterStage);
         leftLevel = meter.level;
         rightLevel = meter.level;
         clipped = meter.clipped;
@@ -105,7 +109,7 @@ export function LevelMeter({ trackId, masterStage, returnTrackId, stereo, showSc
         rightLevel = meter.level;
         clipped = meter.clipped;
       } else if (trackId) {
-        const meter = bridge.getTrackMeter(trackId);
+        const meter = meterSource.getTrackMeter(trackId);
         leftLevel = isStereo ? meter.leftLevel : meter.level;
         rightLevel = isStereo ? meter.rightLevel : meter.level;
         clipped = meter.clipped;
@@ -186,12 +190,15 @@ export function LevelMeter({ trackId, masterStage, returnTrackId, stereo, showSc
   const resetClip = () => {
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
+    const meterSource = bridge.backend === 'tauri' && getTauriPlaybackClockOwner() === 'native'
+      ? bridge
+      : engine;
     if (masterStage) {
-      bridge.resetMasterClip(masterStage);
+      meterSource.resetMasterClip(masterStage);
     } else if (returnTrackId) {
       engine.resetReturnTrackClip(returnTrackId);
     } else if (trackId) {
-      bridge.resetTrackClip(trackId);
+      meterSource.resetTrackClip(trackId);
     }
     clippedRef.current = false;
     clippedStateRef.current = false;

--- a/src/components/mixer/__tests__/LevelMeter.test.tsx
+++ b/src/components/mixer/__tests__/LevelMeter.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { LevelMeter } from '../LevelMeter';
 
 vi.mock('../../../hooks/useAudioEngine', () => ({
+  getTauriPlaybackClockOwner: () => 'web-audio',
   getAudioEngine: () => ({
     getTrackMeter: () => ({ level: 0.5, leftLevel: 0.4, rightLevel: 0.6, clipped: false }),
     getMasterMeter: () => ({ level: 0.3, clipped: false }),

--- a/src/components/session/SessionMixerStrip.tsx
+++ b/src/components/session/SessionMixerStrip.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getAudioBridge } from '../../engine/bridge';
 import { Knob } from '../ui/Knob';
 
 /** Convert linear level (0..1+) to a 0..1 fill fraction mapping -60dB..0dB */
@@ -45,8 +46,9 @@ export function SessionMixerStrip({
   // Animate meter levels
   useEffect(() => {
     const engine = getAudioEngine();
+    const bridge = getAudioBridge(engine);
     const tick = () => {
-      const meter = engine.getTrackMeter(trackId);
+      const meter = bridge.getTrackMeter(trackId);
       setLeftFill(levelToFill(meter.leftLevel));
       setRightFill(levelToFill(meter.rightLevel));
       rafRef.current = requestAnimationFrame(tick);

--- a/src/components/session/SessionMixerStrip.tsx
+++ b/src/components/session/SessionMixerStrip.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getAudioEngine, getTauriPlaybackClockOwner } from '../../hooks/useAudioEngine';
 import { getAudioBridge } from '../../engine/bridge';
 import { Knob } from '../ui/Knob';
 
@@ -48,7 +48,10 @@ export function SessionMixerStrip({
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
     const tick = () => {
-      const meter = bridge.getTrackMeter(trackId);
+      const meterSource = bridge.backend === 'tauri' && getTauriPlaybackClockOwner() === 'native'
+        ? bridge
+        : engine;
+      const meter = meterSource.getTrackMeter(trackId);
       setLeftFill(levelToFill(meter.leftLevel));
       setRightFill(levelToFill(meter.rightLevel));
       rafRef.current = requestAnimationFrame(tick);

--- a/src/components/session/__tests__/SessionMixer.test.tsx
+++ b/src/components/session/__tests__/SessionMixer.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../../../services/projectStorage', () => ({
 }));
 
 vi.mock('../../../hooks/useAudioEngine', () => ({
+  getTauriPlaybackClockOwner: () => 'web-audio',
   getAudioEngine: () => ({
     getTrackMeter: () => ({ leftLevel: 0, rightLevel: 0, clipped: false }),
     getTrackLevel: () => 0,

--- a/src/components/tracks/FaderMeter.tsx
+++ b/src/components/tracks/FaderMeter.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getAudioBridge } from '../../engine/bridge';
 import { METER_GRADIENT_HORIZONTAL, levelToMeterFill } from '../meter-colors';
 
 interface FaderMeterProps {
@@ -33,8 +34,9 @@ export function FaderMeter({ trackId, volume, onVolumeChange, trackName }: Fader
   // Animate meter levels
   useEffect(() => {
     const engine = getAudioEngine();
+    const bridge = getAudioBridge(engine);
     const tick = () => {
-      const meter = engine.getTrackMeter(trackId);
+      const meter = bridge.getTrackMeter(trackId);
       setLeftFill(levelToMeterFill(meter.leftLevel));
       setRightFill(levelToMeterFill(meter.rightLevel));
       setClipping((was) => was || meter.clipped);
@@ -46,7 +48,8 @@ export function FaderMeter({ trackId, volume, onVolumeChange, trackName }: Fader
 
   const resetClip = useCallback(() => {
     const engine = getAudioEngine();
-    engine.resetTrackClip(trackId);
+    const bridge = getAudioBridge(engine);
+    bridge.resetTrackClip(trackId);
     setClipping(false);
   }, [trackId]);
 

--- a/src/components/tracks/FaderMeter.tsx
+++ b/src/components/tracks/FaderMeter.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getAudioEngine, getTauriPlaybackClockOwner } from '../../hooks/useAudioEngine';
 import { getAudioBridge } from '../../engine/bridge';
 import { METER_GRADIENT_HORIZONTAL, levelToMeterFill } from '../meter-colors';
 
@@ -36,7 +36,10 @@ export function FaderMeter({ trackId, volume, onVolumeChange, trackName }: Fader
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
     const tick = () => {
-      const meter = bridge.getTrackMeter(trackId);
+      const meterSource = bridge.backend === 'tauri' && getTauriPlaybackClockOwner() === 'native'
+        ? bridge
+        : engine;
+      const meter = meterSource.getTrackMeter(trackId);
       setLeftFill(levelToMeterFill(meter.leftLevel));
       setRightFill(levelToMeterFill(meter.rightLevel));
       setClipping((was) => was || meter.clipped);
@@ -49,7 +52,10 @@ export function FaderMeter({ trackId, volume, onVolumeChange, trackName }: Fader
   const resetClip = useCallback(() => {
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
-    bridge.resetTrackClip(trackId);
+    const meterSource = bridge.backend === 'tauri' && getTauriPlaybackClockOwner() === 'native'
+      ? bridge
+      : engine;
+    meterSource.resetTrackClip(trackId);
     setClipping(false);
   }, [trackId]);
 

--- a/src/components/tracks/StereoMeter.tsx
+++ b/src/components/tracks/StereoMeter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getAudioBridge } from '../../engine/bridge';
 import { METER_GRADIENT_HORIZONTAL, levelToMeterFill } from '../meter-colors';
 
 interface StereoMeterProps {
@@ -14,9 +15,10 @@ export function StereoMeter({ trackId }: StereoMeterProps) {
 
   useEffect(() => {
     const engine = getAudioEngine();
+    const bridge = getAudioBridge(engine);
 
     const tick = () => {
-      const meter = engine.getTrackMeter(trackId);
+      const meter = bridge.getTrackMeter(trackId);
       setLeftFill(levelToMeterFill(meter.leftLevel));
       setRightFill(levelToMeterFill(meter.rightLevel));
       setClipping((was) => was || meter.clipped);
@@ -29,7 +31,8 @@ export function StereoMeter({ trackId }: StereoMeterProps) {
 
   const resetClip = () => {
     const engine = getAudioEngine();
-    engine.resetTrackClip(trackId);
+    const bridge = getAudioBridge(engine);
+    bridge.resetTrackClip(trackId);
     setClipping(false);
   };
 

--- a/src/components/tracks/StereoMeter.tsx
+++ b/src/components/tracks/StereoMeter.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { getAudioEngine } from '../../hooks/useAudioEngine';
+import { getAudioEngine, getTauriPlaybackClockOwner } from '../../hooks/useAudioEngine';
 import { getAudioBridge } from '../../engine/bridge';
 import { METER_GRADIENT_HORIZONTAL, levelToMeterFill } from '../meter-colors';
 
@@ -18,7 +18,10 @@ export function StereoMeter({ trackId }: StereoMeterProps) {
     const bridge = getAudioBridge(engine);
 
     const tick = () => {
-      const meter = bridge.getTrackMeter(trackId);
+      const meterSource = bridge.backend === 'tauri' && getTauriPlaybackClockOwner() === 'native'
+        ? bridge
+        : engine;
+      const meter = meterSource.getTrackMeter(trackId);
       setLeftFill(levelToMeterFill(meter.leftLevel));
       setRightFill(levelToMeterFill(meter.rightLevel));
       setClipping((was) => was || meter.clipped);
@@ -32,7 +35,10 @@ export function StereoMeter({ trackId }: StereoMeterProps) {
   const resetClip = () => {
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
-    bridge.resetTrackClip(trackId);
+    const meterSource = bridge.backend === 'tauri' && getTauriPlaybackClockOwner() === 'native'
+      ? bridge
+      : engine;
+    meterSource.resetTrackClip(trackId);
     setClipping(false);
   };
 

--- a/src/components/tracks/__tests__/StereoMeter.test.tsx
+++ b/src/components/tracks/__tests__/StereoMeter.test.tsx
@@ -10,6 +10,7 @@ const engine = {
 
 vi.mock('../../../hooks/useAudioEngine', () => ({
   getAudioEngine: () => engine,
+  getTauriPlaybackClockOwner: () => 'web-audio',
 }));
 
 describe('StereoMeter', () => {

--- a/src/components/tracks/__tests__/TrackHeader.test.tsx
+++ b/src/components/tracks/__tests__/TrackHeader.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../../../services/freezeTrack', () => ({
 }));
 
 vi.mock('../../../hooks/useAudioEngine', () => ({
+  getTauriPlaybackClockOwner: () => 'web-audio',
   getAudioEngine: () => ({
     getTrackLevel: () => 0,
     getTrackMeter: () => ({ level: 0, clipped: false }),

--- a/src/components/tracks/__tests__/TrackHeaderAnimation.test.tsx
+++ b/src/components/tracks/__tests__/TrackHeaderAnimation.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../../../services/freezeTrack', () => ({
   flattenTrackToAudio: vi.fn(),
 }));
 vi.mock('../../../hooks/useAudioEngine', () => ({
+  getTauriPlaybackClockOwner: () => 'web-audio',
   getAudioEngine: () => ({
     getTrackLevel: () => 0,
   }),

--- a/src/components/tracks/__tests__/TrackHeaderLayout.test.tsx
+++ b/src/components/tracks/__tests__/TrackHeaderLayout.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../../../services/freezeTrack', () => ({
   flattenTrackToAudio: vi.fn(),
 }));
 vi.mock('../../../hooks/useAudioEngine', () => ({
+  getTauriPlaybackClockOwner: () => 'web-audio',
   getAudioEngine: () => ({
     getTrackLevel: () => 0,
     getTrackMeter: () => ({ level: 0, clipped: false }),

--- a/src/components/tracks/__tests__/TrackHeaderMeter.test.tsx
+++ b/src/components/tracks/__tests__/TrackHeaderMeter.test.tsx
@@ -10,6 +10,7 @@ const engine = {
 
 vi.mock('../../../hooks/useAudioEngine', () => ({
   getAudioEngine: () => engine,
+  getTauriPlaybackClockOwner: () => 'web-audio',
 }));
 
 describe('TrackHeaderMeter', () => {

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -130,6 +130,7 @@ export class TauriBackend implements AudioBridge {
   private _lastMasterMeterRefreshMs = -Infinity;
   private _masterMeterRefreshInFlight = false;
   private _transportCommandToken = 0;
+  private _transportEndArmedToken: number | null = null;
   private _transportCommandQueue: Promise<void> = Promise.resolve();
   private _lastScheduledClips: BridgeClipInfo[] = [];
 
@@ -362,6 +363,7 @@ export class TauriBackend implements AudioBridge {
     totalDuration: number,
   ): void {
     const token = ++this._transportCommandToken;
+    this._transportEndArmedToken = null;
     this._lastScheduledClips = clips;
     const nativeClips = this.buildNativeClips(clips);
     const seekSamplePosition = Math.max(0, Math.round(fromTime * this.sampleRate));
@@ -375,11 +377,15 @@ export class TauriBackend implements AudioBridge {
       await invoke('audio_transport_seek', { samplePosition: seekSamplePosition });
       if (token !== this._transportCommandToken) return;
       await invoke('audio_transport_play');
+      if (token === this._transportCommandToken) {
+        this._transportEndArmedToken = token;
+      }
     });
   }
 
   stopAllSources(): void {
     const token = ++this._transportCommandToken;
+    this._transportEndArmedToken = null;
     this._scheduledEndSample = null;
     this._currentSamplePosition = 0;
     this._lastScheduledClips = [];
@@ -393,6 +399,7 @@ export class TauriBackend implements AudioBridge {
 
   pauseAllSources(): void {
     const token = ++this._transportCommandToken;
+    this._transportEndArmedToken = null;
     this.enqueueTransportCommand(async () => {
       if (token !== this._transportCommandToken) return;
       await invoke('audio_transport_pause');
@@ -533,8 +540,10 @@ export class TauriBackend implements AudioBridge {
       this._timeUpdateCb?.(currentTime);
       if (
         this._scheduledEndSample !== null
+        && this._transportEndArmedToken === this._transportCommandToken
         && this._currentSamplePosition >= this._scheduledEndSample
       ) {
+        this._transportEndArmedToken = null;
         this._scheduledEndSample = null;
         this.stopAllSources();
         this._onEndedCb?.();

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -27,9 +27,10 @@ import type {
 } from './types';
 import type { MasteringState } from '../../types/project';
 
-const ZERO_METER: MeterData = { level: -Infinity, leftLevel: -Infinity, rightLevel: -Infinity, clipped: false };
-const ZERO_MASTER: MasterMeterData = { level: -Infinity, clipped: false };
+const ZERO_METER: MeterData = { level: 0, leftLevel: 0, rightLevel: 0, clipped: false };
+const ZERO_MASTER: MasterMeterData = { level: 0, clipped: false };
 const TRANSPORT_POSITION_EVENT = 'transport-position';
+const METER_REFRESH_INTERVAL_MS = 50;
 
 function toMeterData(reading: NativeMeterReading): MeterData {
   const level = Number.isFinite(reading.peak) && reading.peak > 0 ? reading.peak : 0;
@@ -58,9 +59,11 @@ function isAlreadyRunningError(error: unknown): boolean {
 
 function getPanGains(pan: number): { left: number; right: number } {
   const clamped = Math.max(-1, Math.min(1, Number.isFinite(pan) ? pan : 0));
-  if (clamped < 0) return { left: 1, right: 1 + clamped };
-  if (clamped > 0) return { left: 1 - clamped, right: 1 };
-  return { left: 1, right: 1 };
+  const angle = ((clamped + 1) * Math.PI) / 4;
+  return {
+    left: Math.cos(angle),
+    right: Math.sin(angle),
+  };
 }
 
 function clipToNative(
@@ -122,6 +125,10 @@ export class TauriBackend implements AudioBridge {
   private _decodeContext: AudioContext | null = null;
   private _trackMeters = new Map<string, MeterData>();
   private _masterMeter: MasterMeterData = ZERO_MASTER;
+  private _lastTrackMeterRefreshMs = new Map<string, number>();
+  private _trackMeterRefreshInFlight = new Set<string>();
+  private _lastMasterMeterRefreshMs = -Infinity;
+  private _masterMeterRefreshInFlight = false;
   private _transportCommandToken = 0;
   private _lastScheduledClips: BridgeClipInfo[] = [];
 
@@ -276,12 +283,15 @@ export class TauriBackend implements AudioBridge {
 
   getTrackMeter(_trackId: string): MeterData {
     const entry = this._trackEntries.get(_trackId);
-    if (entry?.handle) {
+    if (entry?.handle && this.shouldRefreshTrackMeter(_trackId)) {
       invoke<NativeMeterReading>('audio_get_track_meter', { handle: entry.handle })
         .then((reading) => {
           this._trackMeters.set(_trackId, toMeterData(reading));
         })
-        .catch(() => {});
+        .catch(() => {})
+        .finally(() => {
+          this._trackMeterRefreshInFlight.delete(_trackId);
+        });
     }
     return this._trackMeters.get(_trackId) ?? ZERO_METER;
   }
@@ -299,11 +309,16 @@ export class TauriBackend implements AudioBridge {
   }
 
   getMasterMeter(_stage: 'input' | 'output'): MasterMeterData {
-    invoke<NativeMeterReading>('audio_get_master_meter')
-      .then((reading) => {
-        this._masterMeter = toMasterMeterData(reading);
-      })
-      .catch(() => {});
+    if (this.shouldRefreshMasterMeter()) {
+      invoke<NativeMeterReading>('audio_get_master_meter')
+        .then((reading) => {
+          this._masterMeter = toMasterMeterData(reading);
+        })
+        .catch(() => {})
+        .finally(() => {
+          this._masterMeterRefreshInFlight = false;
+        });
+    }
     return this._masterMeter;
   }
 
@@ -343,13 +358,14 @@ export class TauriBackend implements AudioBridge {
     const token = ++this._transportCommandToken;
     this._lastScheduledClips = clips;
     const nativeClips = this.buildNativeClips(clips);
+    const seekSamplePosition = Math.max(0, Math.round(fromTime * this.sampleRate));
     this._scheduledEndSample = Math.max(0, Math.round(totalDuration * this.sampleRate));
-    this._currentSamplePosition = Math.max(0, Math.round(fromTime * this.sampleRate));
+    this._currentSamplePosition = seekSamplePosition;
 
     void (async () => {
       await invoke('audio_clip_set_schedule', { clips: nativeClips });
       if (token !== this._transportCommandToken) return;
-      await invoke('audio_transport_seek', { samplePosition: this._currentSamplePosition });
+      await invoke('audio_transport_seek', { samplePosition: seekSamplePosition });
       if (token !== this._transportCommandToken) return;
       await invoke('audio_transport_play');
     })().catch(() => {});
@@ -389,6 +405,29 @@ export class TauriBackend implements AudioBridge {
         return clipToNative(clip, this.sampleRate, params, anySoloed);
       })
       .filter((clip): clip is NativeClipSource => clip !== null);
+  }
+
+  private meterNowMs(): number {
+    return typeof performance !== 'undefined' ? performance.now() : Date.now();
+  }
+
+  private shouldRefreshTrackMeter(trackId: string): boolean {
+    if (this._trackMeterRefreshInFlight.has(trackId)) return false;
+    const now = this.meterNowMs();
+    const last = this._lastTrackMeterRefreshMs.get(trackId) ?? -Infinity;
+    if (now - last < METER_REFRESH_INTERVAL_MS) return false;
+    this._lastTrackMeterRefreshMs.set(trackId, now);
+    this._trackMeterRefreshInFlight.add(trackId);
+    return true;
+  }
+
+  private shouldRefreshMasterMeter(): boolean {
+    if (this._masterMeterRefreshInFlight) return false;
+    const now = this.meterNowMs();
+    if (now - this._lastMasterMeterRefreshMs < METER_REFRESH_INTERVAL_MS) return false;
+    this._lastMasterMeterRefreshMs = now;
+    this._masterMeterRefreshInFlight = true;
+    return true;
   }
 
   private republishActiveSchedule(): void {

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -133,6 +133,7 @@ export class TauriBackend implements AudioBridge {
   private _transportEndArmedToken: number | null = null;
   private _transportCommandQueue: Promise<void> = Promise.resolve();
   private _lastScheduledClips: BridgeClipInfo[] = [];
+  private _republishQueued = false;
 
   /**
    * Maps the AudioBridge's string `trackId` to the native engine's
@@ -264,7 +265,7 @@ export class TauriBackend implements AudioBridge {
       handle: entry.handle,
       params: entry.params,
     }).catch(() => {});
-    this.republishActiveSchedule();
+    this.requestRepublishActiveSchedule();
   }
 
   setTrackGroupRouting(trackId: string, groupId: string | null): void {
@@ -278,7 +279,7 @@ export class TauriBackend implements AudioBridge {
     // via `AudioGraph::any_solo()`. No explicit command needed — the
     // individual `setTrackParams` calls with `solo: true/false`
     // already propagate through the command queue.
-    this.republishActiveSchedule();
+    this.requestRepublishActiveSchedule();
   }
 
   // ── Metering ──────────────────────────────────────────────────────
@@ -492,6 +493,16 @@ export class TauriBackend implements AudioBridge {
     this._transportCommandQueue = run.catch(() => {});
     void run.catch(() => {});
     return run;
+  }
+
+  private requestRepublishActiveSchedule(): void {
+    if (this._scheduledEndSample === null || this._lastScheduledClips.length === 0) return;
+    if (this._republishQueued) return;
+    this._republishQueued = true;
+    queueMicrotask(() => {
+      this._republishQueued = false;
+      this.republishActiveSchedule();
+    });
   }
 
   private republishActiveSchedule(): void {

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -308,8 +308,14 @@ export class TauriBackend implements AudioBridge {
     return this.getTrackMeter(trackId).level;
   }
 
-  resetTrackClip(_trackId: string): void {
-    // Will be wired in Phase 2B-2 (metering)
+  resetTrackClip(trackId: string): void {
+    this._trackMeters.set(trackId, {
+      ...(this._trackMeters.get(trackId) ?? ZERO_METER),
+      clipped: false,
+    });
+    const entry = this._trackEntries.get(trackId);
+    if (!entry?.handle) return;
+    invoke('audio_reset_track_clip', { handle: entry.handle }).catch(() => {});
   }
 
   getTrackSpectrum(_trackId: string): Float32Array | null {
@@ -335,7 +341,8 @@ export class TauriBackend implements AudioBridge {
   }
 
   resetMasterClip(_stage: 'input' | 'output'): void {
-    // Will be wired in Phase 2B-2 (metering)
+    this._masterMeter = { ...this._masterMeter, clipped: false };
+    invoke('audio_reset_master_clip').catch(() => {});
   }
 
   getMasterSpectrum(): Float32Array {
@@ -384,13 +391,13 @@ export class TauriBackend implements AudioBridge {
     });
   }
 
-  stopAllSources(): void {
+  stopAllSources(): Promise<void> {
     const token = ++this._transportCommandToken;
     this._transportEndArmedToken = null;
     this._scheduledEndSample = null;
     this._currentSamplePosition = 0;
     this._lastScheduledClips = [];
-    this.enqueueTransportCommand(async () => {
+    return this.enqueueTransportCommand(async () => {
       if (token !== this._transportCommandToken) return;
       await invoke('audio_clip_set_schedule', { clips: [] });
       if (token !== this._transportCommandToken) return;
@@ -398,10 +405,10 @@ export class TauriBackend implements AudioBridge {
     });
   }
 
-  pauseAllSources(): void {
+  pauseAllSources(): Promise<void> {
     const token = ++this._transportCommandToken;
     this._transportEndArmedToken = null;
-    this.enqueueTransportCommand(async () => {
+    return this.enqueueTransportCommand(async () => {
       if (token !== this._transportCommandToken) return;
       await invoke('audio_transport_pause');
     });
@@ -548,7 +555,7 @@ export class TauriBackend implements AudioBridge {
       const position = Number(event.payload);
       if (!Number.isFinite(position)) return;
       this._currentSamplePosition = Math.max(0, Math.floor(position));
-      const currentTime = this.getCurrentTime();
+      const currentTime = this.getCompensatedTime();
       this._timeUpdateCb?.(currentTime);
       if (
         this._scheduledEndSample !== null
@@ -557,7 +564,7 @@ export class TauriBackend implements AudioBridge {
       ) {
         this._transportEndArmedToken = null;
         this._scheduledEndSample = null;
-        this.stopAllSources();
+        void this.stopAllSources();
         this._onEndedCb?.();
       }
     })

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -123,6 +123,7 @@ export class TauriBackend implements AudioBridge {
   private _trackMeters = new Map<string, MeterData>();
   private _masterMeter: MasterMeterData = ZERO_MASTER;
   private _transportCommandToken = 0;
+  private _lastScheduledClips: BridgeClipInfo[] = [];
 
   /**
    * Maps the AudioBridge's string `trackId` to the native engine's
@@ -254,6 +255,7 @@ export class TauriBackend implements AudioBridge {
       handle: entry.handle,
       params: entry.params,
     }).catch(() => {});
+    this.republishActiveSchedule();
   }
 
   setTrackGroupRouting(trackId: string, groupId: string | null): void {
@@ -267,6 +269,7 @@ export class TauriBackend implements AudioBridge {
     // via `AudioGraph::any_solo()`. No explicit command needed — the
     // individual `setTrackParams` calls with `solo: true/false`
     // already propagate through the command queue.
+    this.republishActiveSchedule();
   }
 
   // ── Metering ──────────────────────────────────────────────────────
@@ -338,18 +341,8 @@ export class TauriBackend implements AudioBridge {
     totalDuration: number,
   ): void {
     const token = ++this._transportCommandToken;
-    const anySoloed = Array.from(this._trackEntries.values()).some((entry) => entry.params.solo);
-    const nativeClips = clips
-      .map((clip) => {
-        const params = this._trackEntries.get(clip.trackId)?.params ?? {
-          volume: 1,
-          pan: 0,
-          mute: false,
-          solo: false,
-        };
-        return clipToNative(clip, this.sampleRate, params, anySoloed);
-      })
-      .filter((clip): clip is NativeClipSource => clip !== null);
+    this._lastScheduledClips = clips;
+    const nativeClips = this.buildNativeClips(clips);
     this._scheduledEndSample = Math.max(0, Math.round(totalDuration * this.sampleRate));
     this._currentSamplePosition = Math.max(0, Math.round(fromTime * this.sampleRate));
 
@@ -363,18 +356,49 @@ export class TauriBackend implements AudioBridge {
   }
 
   stopAllSources(): void {
-    this._transportCommandToken += 1;
+    const token = ++this._transportCommandToken;
     this._scheduledEndSample = null;
     this._currentSamplePosition = 0;
+    this._lastScheduledClips = [];
     void (async () => {
+      if (token !== this._transportCommandToken) return;
       await invoke('audio_clip_set_schedule', { clips: [] });
+      if (token !== this._transportCommandToken) return;
       await invoke('audio_transport_stop');
     })().catch(() => {});
   }
 
   pauseAllSources(): void {
-    this._transportCommandToken += 1;
-    invoke('audio_transport_pause').catch(() => {});
+    const token = ++this._transportCommandToken;
+    void (async () => {
+      if (token !== this._transportCommandToken) return;
+      await invoke('audio_transport_pause');
+    })().catch(() => {});
+  }
+
+  private buildNativeClips(clips: BridgeClipInfo[]): NativeClipSource[] {
+    const anySoloed = Array.from(this._trackEntries.values()).some((entry) => entry.params.solo);
+    return clips
+      .map((clip) => {
+        const params = this._trackEntries.get(clip.trackId)?.params ?? {
+          volume: 1,
+          pan: 0,
+          mute: false,
+          solo: false,
+        };
+        return clipToNative(clip, this.sampleRate, params, anySoloed);
+      })
+      .filter((clip): clip is NativeClipSource => clip !== null);
+  }
+
+  private republishActiveSchedule(): void {
+    if (this._scheduledEndSample === null || this._lastScheduledClips.length === 0) return;
+    const token = this._transportCommandToken;
+    const nativeClips = this.buildNativeClips(this._lastScheduledClips);
+    void (async () => {
+      if (token !== this._transportCommandToken) return;
+      await invoke('audio_clip_set_schedule', { clips: nativeClips });
+    })().catch(() => {});
   }
 
   // ── Audio Data ────────────────────────────────────────────────────

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -282,6 +282,11 @@ export class TauriBackend implements AudioBridge {
   // ── Metering ──────────────────────────────────────────────────────
 
   getTrackMeter(_trackId: string): MeterData {
+    const scheduledClipMeter = this.getScheduledClipTrackMeter(_trackId);
+    if (scheduledClipMeter) {
+      this._trackMeters.set(_trackId, scheduledClipMeter);
+      return scheduledClipMeter;
+    }
     const entry = this._trackEntries.get(_trackId);
     if (entry?.handle && this.shouldRefreshTrackMeter(_trackId)) {
       invoke<NativeMeterReading>('audio_get_track_meter', { handle: entry.handle })
@@ -405,6 +410,49 @@ export class TauriBackend implements AudioBridge {
         return clipToNative(clip, this.sampleRate, params, anySoloed);
       })
       .filter((clip): clip is NativeClipSource => clip !== null);
+  }
+
+  private getScheduledClipTrackMeter(trackId: string): MeterData | null {
+    const trackClips = this._lastScheduledClips.filter((clip) => clip.trackId === trackId);
+    if (trackClips.length === 0) return null;
+
+    const params = this._trackEntries.get(trackId)?.params ?? {
+      volume: 1,
+      pan: 0,
+      mute: false,
+      solo: false,
+    };
+    const anySoloed = Array.from(this._trackEntries.values()).some((entry) => entry.params.solo);
+    if (params.mute || (anySoloed && !params.solo)) return ZERO_METER;
+
+    const currentTime = this.getCurrentTime();
+    const pan = getPanGains(params.pan);
+    const volume = Math.max(0, Math.min(1, Number.isFinite(params.volume) ? params.volume : 1));
+    let leftLevel = 0;
+    let rightLevel = 0;
+
+    for (const clip of trackClips) {
+      const clipEndTime = clip.startTime + clip.clipDuration;
+      if (currentTime < clip.startTime || currentTime >= clipEndTime) continue;
+      const sourceRate = clip.buffer.sampleRate || this.sampleRate;
+      const sourceTime = clip.audioOffset + (currentTime - clip.startTime);
+      const sampleIndex = Math.min(
+        clip.buffer.length - 1,
+        Math.max(0, Math.round(sourceTime * sourceRate)),
+      );
+      const left = clip.buffer.getChannelData(0);
+      const right = clip.buffer.numberOfChannels > 1 ? clip.buffer.getChannelData(1) : left;
+      leftLevel = Math.max(leftLevel, Math.abs(left[sampleIndex] ?? 0) * volume * pan.left);
+      rightLevel = Math.max(rightLevel, Math.abs(right[sampleIndex] ?? 0) * volume * pan.right);
+    }
+
+    const level = Math.max(leftLevel, rightLevel);
+    return {
+      level,
+      leftLevel,
+      rightLevel,
+      clipped: level >= 1,
+    };
   }
 
   private meterNowMs(): number {

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -83,7 +83,7 @@ function clipToNative(
 
   const left = clip.buffer.getChannelData(0);
   const right = clip.buffer.numberOfChannels > 1 ? clip.buffer.getChannelData(1) : left;
-  const volume = Math.max(0, Math.min(1, Number.isFinite(trackParams.volume) ? trackParams.volume : 1));
+  const volume = Math.max(0, Number.isFinite(trackParams.volume) ? trackParams.volume : 1);
   const pan = getPanGains(trackParams.pan);
   const lastSourceIndex = Math.max(sourceStart, clip.buffer.length - 1);
   const sampleAt = (channel: Float32Array, sourcePosition: number): number => {
@@ -429,7 +429,7 @@ export class TauriBackend implements AudioBridge {
 
     const currentTime = this.getCurrentTime();
     const pan = getPanGains(params.pan);
-    const volume = Math.max(0, Math.min(1, Number.isFinite(params.volume) ? params.volume : 1));
+    const volume = Math.max(0, Number.isFinite(params.volume) ? params.volume : 1);
     let leftLevel = 0;
     let rightLevel = 0;
 

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -130,6 +130,7 @@ export class TauriBackend implements AudioBridge {
   private _lastMasterMeterRefreshMs = -Infinity;
   private _masterMeterRefreshInFlight = false;
   private _transportCommandToken = 0;
+  private _transportCommandQueue: Promise<void> = Promise.resolve();
   private _lastScheduledClips: BridgeClipInfo[] = [];
 
   /**
@@ -367,13 +368,14 @@ export class TauriBackend implements AudioBridge {
     this._scheduledEndSample = Math.max(0, Math.round(totalDuration * this.sampleRate));
     this._currentSamplePosition = seekSamplePosition;
 
-    void (async () => {
+    this.enqueueTransportCommand(async () => {
+      if (token !== this._transportCommandToken) return;
       await invoke('audio_clip_set_schedule', { clips: nativeClips });
       if (token !== this._transportCommandToken) return;
       await invoke('audio_transport_seek', { samplePosition: seekSamplePosition });
       if (token !== this._transportCommandToken) return;
       await invoke('audio_transport_play');
-    })().catch(() => {});
+    });
   }
 
   stopAllSources(): void {
@@ -381,20 +383,20 @@ export class TauriBackend implements AudioBridge {
     this._scheduledEndSample = null;
     this._currentSamplePosition = 0;
     this._lastScheduledClips = [];
-    void (async () => {
+    this.enqueueTransportCommand(async () => {
       if (token !== this._transportCommandToken) return;
       await invoke('audio_clip_set_schedule', { clips: [] });
       if (token !== this._transportCommandToken) return;
       await invoke('audio_transport_stop');
-    })().catch(() => {});
+    });
   }
 
   pauseAllSources(): void {
     const token = ++this._transportCommandToken;
-    void (async () => {
+    this.enqueueTransportCommand(async () => {
       if (token !== this._transportCommandToken) return;
       await invoke('audio_transport_pause');
-    })().catch(() => {});
+    });
   }
 
   private buildNativeClips(clips: BridgeClipInfo[]): NativeClipSource[] {
@@ -478,14 +480,20 @@ export class TauriBackend implements AudioBridge {
     return true;
   }
 
+  private enqueueTransportCommand(command: () => Promise<void>): void {
+    const run = this._transportCommandQueue.then(command, command);
+    this._transportCommandQueue = run.catch(() => {});
+    void run.catch(() => {});
+  }
+
   private republishActiveSchedule(): void {
     if (this._scheduledEndSample === null || this._lastScheduledClips.length === 0) return;
     const token = this._transportCommandToken;
     const nativeClips = this.buildNativeClips(this._lastScheduledClips);
-    void (async () => {
+    this.enqueueTransportCommand(async () => {
       if (token !== this._transportCommandToken) return;
       await invoke('audio_clip_set_schedule', { clips: nativeClips });
-    })().catch(() => {});
+    });
   }
 
   // ── Audio Data ────────────────────────────────────────────────────

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -13,11 +13,14 @@
  * default in browser mode.
  */
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import type {
   AudioBridge,
   BridgeClipInfo,
   MasterMeterData,
   MeterData,
+  NativeClipSource,
+  NativeMeterReading,
   NativeSlotHandle,
   NativeTrackParams,
   TrackParams,
@@ -26,6 +29,77 @@ import type { MasteringState } from '../../types/project';
 
 const ZERO_METER: MeterData = { level: -Infinity, leftLevel: -Infinity, rightLevel: -Infinity, clipped: false };
 const ZERO_MASTER: MasterMeterData = { level: -Infinity, clipped: false };
+const TRANSPORT_POSITION_EVENT = 'transport-position';
+
+function toMeterData(reading: NativeMeterReading): MeterData {
+  const level = Number.isFinite(reading.peak) && reading.peak > 0 ? reading.peak : 0;
+  return {
+    level,
+    leftLevel: level,
+    rightLevel: level,
+    clipped: reading.clipped,
+  };
+}
+
+function toMasterMeterData(reading: NativeMeterReading): MasterMeterData {
+  const level = Number.isFinite(reading.peak) && reading.peak > 0 ? reading.peak : 0;
+  return {
+    level,
+    clipped: reading.clipped,
+  };
+}
+
+function getPanGains(pan: number): { left: number; right: number } {
+  const clamped = Math.max(-1, Math.min(1, Number.isFinite(pan) ? pan : 0));
+  if (clamped < 0) return { left: 1, right: 1 + clamped };
+  if (clamped > 0) return { left: 1 - clamped, right: 1 };
+  return { left: 1, right: 1 };
+}
+
+function clipToNative(
+  clip: BridgeClipInfo,
+  sampleRate: number,
+  trackParams: NativeTrackParams,
+  anySoloed: boolean,
+): NativeClipSource | null {
+  if (trackParams.mute || (anySoloed && !trackParams.solo)) return null;
+  const startSample = Math.max(0, Math.round(clip.startTime * sampleRate));
+  const sourceRate = clip.buffer.sampleRate || sampleRate;
+  const sourceStart = Math.max(0, Math.round(clip.audioOffset * sourceRate));
+  const availableFrames = Math.max(0, clip.buffer.length - sourceStart);
+  const sourceDuration = Math.min(Math.max(0, clip.clipDuration), availableFrames / sourceRate);
+  if (sourceDuration <= 0) return null;
+  const nativeFrames = Math.max(1, Math.round(sourceDuration * sampleRate));
+
+  const left = clip.buffer.getChannelData(0);
+  const right = clip.buffer.numberOfChannels > 1 ? clip.buffer.getChannelData(1) : left;
+  const volume = Math.max(0, Math.min(1, Number.isFinite(trackParams.volume) ? trackParams.volume : 1));
+  const pan = getPanGains(trackParams.pan);
+  const lastSourceIndex = Math.max(sourceStart, clip.buffer.length - 1);
+  const sampleAt = (channel: Float32Array, sourcePosition: number): number => {
+    const clamped = Math.min(Math.max(sourceStart, sourcePosition), lastSourceIndex);
+    const lower = Math.floor(clamped);
+    const upper = Math.min(lastSourceIndex, lower + 1);
+    const mix = clamped - lower;
+    const lowerValue = channel[lower] ?? 0;
+    const upperValue = channel[upper] ?? lowerValue;
+    return lowerValue + (upperValue - lowerValue) * mix;
+  };
+
+  const audioData: number[] = new Array(nativeFrames * 2);
+  for (let i = 0; i < nativeFrames; i++) {
+    const sourcePosition = sourceStart + (i * sourceRate) / sampleRate;
+    audioData[i * 2] = sampleAt(left, sourcePosition) * volume * pan.left;
+    audioData[i * 2 + 1] = sampleAt(right, sourcePosition) * volume * pan.right;
+  }
+
+  return {
+    startSample,
+    lengthSamples: nativeFrames,
+    gain: 1,
+    audioData,
+  };
+}
 
 export class TauriBackend implements AudioBridge {
   readonly backend = 'tauri' as const;
@@ -33,6 +107,15 @@ export class TauriBackend implements AudioBridge {
 
   private _timeUpdateCb: ((time: number) => void) | null = null;
   private _onEndedCb: (() => void) | null = null;
+  private _currentSamplePosition = 0;
+  private _playbackLatencyCompensationSeconds = 0;
+  private _scheduledEndSample: number | null = null;
+  private _transportListenerStarted = false;
+  private _transportUnlisten: (() => void) | null = null;
+  private _decodeContext: AudioContext | null = null;
+  private _trackMeters = new Map<string, MeterData>();
+  private _masterMeter: MasterMeterData = ZERO_MASTER;
+  private _transportCommandToken = 0;
 
   /**
    * Maps the AudioBridge's string `trackId` to the native engine's
@@ -53,19 +136,26 @@ export class TauriBackend implements AudioBridge {
     await invoke('audio_start_engine', {
       config: { sampleRate: 48000, bufferSize: 256, deviceName: null },
     });
+    this.startTransportListener();
+    this.refreshTransportPosition();
   }
 
   dispose(): void {
+    if (this._transportUnlisten) {
+      this._transportUnlisten();
+      this._transportUnlisten = null;
+    }
+    this._transportListenerStarted = false;
     invoke('audio_stop_engine').catch(() => {});
     this._trackEntries.clear();
+    void this._decodeContext?.close();
+    this._decodeContext = null;
   }
 
   // ── Transport ─────────────────────────────────────────────────────
 
   getCurrentTime(): number {
-    // In the Rust backend, time will be pushed via events.
-    // For now return 0 as this backend is not yet active.
-    return 0;
+    return this._currentSamplePosition / this.sampleRate;
   }
 
   getLookAhead(): number {
@@ -73,15 +163,17 @@ export class TauriBackend implements AudioBridge {
   }
 
   getCompensatedTime(): number {
-    return 0;
+    return Math.max(0, this.getCurrentTime() - this._playbackLatencyCompensationSeconds);
   }
 
-  setPlaybackLatencyCompensation(_seconds: number): void {
-    // Will invoke Rust command when implemented
+  setPlaybackLatencyCompensation(seconds: number): void {
+    this._playbackLatencyCompensationSeconds = Number.isFinite(seconds)
+      ? Math.max(0, seconds)
+      : 0;
   }
 
   getPlaybackLatencyCompensation(): number {
-    return 0;
+    return this._playbackLatencyCompensationSeconds;
   }
 
   // ── Track Management ──────────────────────────────────────────────
@@ -104,6 +196,10 @@ export class TauriBackend implements AudioBridge {
         const entry = this._trackEntries.get(trackId);
         if (entry) {
           entry.handle = handle;
+          invoke('audio_set_track_params', {
+            handle,
+            params: entry.params,
+          }).catch(() => {});
         }
         // If removeTrack was called while the IPC was in-flight, the
         // entry has already been deleted — send a compensating remove
@@ -132,7 +228,7 @@ export class TauriBackend implements AudioBridge {
 
   setTrackParams(trackId: string, params: TrackParams): void {
     const entry = this._trackEntries.get(trackId);
-    if (!entry || !entry.handle) return;
+    if (!entry) return;
     // Merge incoming partial params into the cached full state so
     // omitted fields preserve their existing values — codex found
     // that defaulting omitted fields to 1/0/false clobbers prior
@@ -142,6 +238,7 @@ export class TauriBackend implements AudioBridge {
     if (params.pan !== undefined) entry.params.pan = params.pan;
     if (params.muted !== undefined) entry.params.mute = params.muted;
     if (params.soloed !== undefined) entry.params.solo = params.soloed;
+    if (!entry.handle) return;
     invoke('audio_set_track_params', {
       handle: entry.handle,
       params: entry.params,
@@ -164,11 +261,19 @@ export class TauriBackend implements AudioBridge {
   // ── Metering ──────────────────────────────────────────────────────
 
   getTrackMeter(_trackId: string): MeterData {
-    return ZERO_METER;
+    const entry = this._trackEntries.get(_trackId);
+    if (entry?.handle) {
+      invoke<NativeMeterReading>('audio_get_track_meter', { handle: entry.handle })
+        .then((reading) => {
+          this._trackMeters.set(_trackId, toMeterData(reading));
+        })
+        .catch(() => {});
+    }
+    return this._trackMeters.get(_trackId) ?? ZERO_METER;
   }
 
-  getTrackLevel(_trackId: string): number {
-    return -Infinity;
+  getTrackLevel(trackId: string): number {
+    return this.getTrackMeter(trackId).level;
   }
 
   resetTrackClip(_trackId: string): void {
@@ -180,11 +285,16 @@ export class TauriBackend implements AudioBridge {
   }
 
   getMasterMeter(_stage: 'input' | 'output'): MasterMeterData {
-    return ZERO_MASTER;
+    invoke<NativeMeterReading>('audio_get_master_meter')
+      .then((reading) => {
+        this._masterMeter = toMasterMeterData(reading);
+      })
+      .catch(() => {});
+    return this._masterMeter;
   }
 
-  getMasterLevel(_stage: 'input' | 'output'): number {
-    return -Infinity;
+  getMasterLevel(stage: 'input' | 'output'): number {
+    return this.getMasterMeter(stage).level;
   }
 
   resetMasterClip(_stage: 'input' | 'output'): void {
@@ -212,22 +322,55 @@ export class TauriBackend implements AudioBridge {
   // ── Clip Scheduling ───────────────────────────────────────────────
 
   schedulePlayback(
-    _clips: BridgeClipInfo[],
-    _fromTime: number,
-    _totalDuration: number,
+    clips: BridgeClipInfo[],
+    fromTime: number,
+    totalDuration: number,
   ): void {
-    // Clip audio data will be sent as binary blobs in Phase 3
+    const token = ++this._transportCommandToken;
+    const anySoloed = Array.from(this._trackEntries.values()).some((entry) => entry.params.solo);
+    const nativeClips = clips
+      .map((clip) => {
+        const params = this._trackEntries.get(clip.trackId)?.params ?? {
+          volume: 1,
+          pan: 0,
+          mute: false,
+          solo: false,
+        };
+        return clipToNative(clip, this.sampleRate, params, anySoloed);
+      })
+      .filter((clip): clip is NativeClipSource => clip !== null);
+    this._scheduledEndSample = Math.max(0, Math.round(totalDuration * this.sampleRate));
+    this._currentSamplePosition = Math.max(0, Math.round(fromTime * this.sampleRate));
+
+    void (async () => {
+      await invoke('audio_clip_set_schedule', { clips: nativeClips });
+      if (token !== this._transportCommandToken) return;
+      await invoke('audio_transport_seek', { samplePosition: this._currentSamplePosition });
+      if (token !== this._transportCommandToken) return;
+      await invoke('audio_transport_play');
+    })().catch(() => {});
   }
 
   stopAllSources(): void {
-    // Will invoke Rust command in Phase 3
+    this._transportCommandToken += 1;
+    this._scheduledEndSample = null;
+    this._currentSamplePosition = 0;
+    void (async () => {
+      await invoke('audio_clip_set_schedule', { clips: [] });
+      await invoke('audio_transport_stop');
+    })().catch(() => {});
+  }
+
+  pauseAllSources(): void {
+    this._transportCommandToken += 1;
+    invoke('audio_transport_pause').catch(() => {});
   }
 
   // ── Audio Data ────────────────────────────────────────────────────
 
-  async decodeAudioData(_blob: Blob): Promise<AudioBuffer> {
-    // Rust backend will decode audio natively in Phase 2C
-    throw new Error('TauriBackend: decodeAudioData not yet implemented');
+  async decodeAudioData(blob: Blob): Promise<AudioBuffer> {
+    this._decodeContext ??= new AudioContext({ sampleRate: this.sampleRate });
+    return this._decodeContext.decodeAudioData(await blob.arrayBuffer());
   }
 
   getAudioStream(): MediaStream {
@@ -242,11 +385,46 @@ export class TauriBackend implements AudioBridge {
 
   setTimeUpdateCallback(cb: (time: number) => void): void {
     this._timeUpdateCb = cb;
-    // Will subscribe to Tauri event 'audio:time_update' in Phase 3
+    this.startTransportListener();
   }
 
   setOnEndedCallback(cb: () => void): void {
     this._onEndedCb = cb;
-    // Will subscribe to Tauri event 'audio:playback_ended' in Phase 3
+  }
+
+  private startTransportListener(): void {
+    if (this._transportListenerStarted) return;
+    this._transportListenerStarted = true;
+    void listen<number>(TRANSPORT_POSITION_EVENT, (event) => {
+      const position = Number(event.payload);
+      if (!Number.isFinite(position)) return;
+      this._currentSamplePosition = Math.max(0, Math.floor(position));
+      const currentTime = this.getCurrentTime();
+      this._timeUpdateCb?.(currentTime);
+      if (
+        this._scheduledEndSample !== null
+        && this._currentSamplePosition >= this._scheduledEndSample
+      ) {
+        this._scheduledEndSample = null;
+        this.stopAllSources();
+        this._onEndedCb?.();
+      }
+    })
+      .then((unlisten) => {
+        this._transportUnlisten = unlisten;
+      })
+      .catch(() => {
+        this._transportListenerStarted = false;
+      });
+  }
+
+  private refreshTransportPosition(): void {
+    invoke<number>('audio_transport_get_position')
+      .then((position) => {
+        if (Number.isFinite(position)) {
+          this._currentSamplePosition = Math.max(0, Math.floor(position));
+        }
+      })
+      .catch(() => {});
   }
 }

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -49,6 +49,13 @@ function toMasterMeterData(reading: NativeMeterReading): MasterMeterData {
   };
 }
 
+function isAlreadyRunningError(error: unknown): boolean {
+  if (typeof error === 'object' && error !== null && 'kind' in error) {
+    return (error as { kind?: unknown }).kind === 'alreadyRunning';
+  }
+  return String(error).includes('alreadyRunning');
+}
+
 function getPanGains(pan: number): { left: number; right: number } {
   const clamped = Math.max(-1, Math.min(1, Number.isFinite(pan) ? pan : 0));
   if (clamped < 0) return { left: 1, right: 1 + clamped };
@@ -133,9 +140,13 @@ export class TauriBackend implements AudioBridge {
   // ── Lifecycle ─────────────────────────────────────────────────────
 
   async resume(): Promise<void> {
-    await invoke('audio_start_engine', {
-      config: { sampleRate: 48000, bufferSize: 256, deviceName: null },
-    });
+    try {
+      await invoke('audio_start_engine', {
+        config: { sampleRate: 48000, bufferSize: 256, deviceName: null },
+      });
+    } catch (error) {
+      if (!isAlreadyRunningError(error)) throw error;
+    }
     this.startTransportListener();
     this.refreshTransportPosition();
   }

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -459,10 +459,12 @@ export class TauriBackend implements AudioBridge {
       );
       const left = clip.buffer.getChannelData(0);
       const right = clip.buffer.numberOfChannels > 1 ? clip.buffer.getChannelData(1) : left;
-      leftLevel = Math.max(leftLevel, Math.abs(left[sampleIndex] ?? 0) * volume * pan.left);
-      rightLevel = Math.max(rightLevel, Math.abs(right[sampleIndex] ?? 0) * volume * pan.right);
+      leftLevel += (left[sampleIndex] ?? 0) * volume * pan.left;
+      rightLevel += (right[sampleIndex] ?? 0) * volume * pan.right;
     }
 
+    leftLevel = Math.abs(leftLevel);
+    rightLevel = Math.abs(rightLevel);
     const level = Math.max(leftLevel, rightLevel);
     return {
       level,

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -361,7 +361,7 @@ export class TauriBackend implements AudioBridge {
     clips: BridgeClipInfo[],
     fromTime: number,
     totalDuration: number,
-  ): void {
+  ): Promise<void> {
     const token = ++this._transportCommandToken;
     this._transportEndArmedToken = null;
     this._lastScheduledClips = clips;
@@ -370,7 +370,7 @@ export class TauriBackend implements AudioBridge {
     this._scheduledEndSample = Math.max(0, Math.round(totalDuration * this.sampleRate));
     this._currentSamplePosition = seekSamplePosition;
 
-    this.enqueueTransportCommand(async () => {
+    return this.enqueueTransportCommand(async () => {
       if (token !== this._transportCommandToken) return;
       await invoke('audio_clip_set_schedule', { clips: nativeClips });
       if (token !== this._transportCommandToken) return;
@@ -487,10 +487,11 @@ export class TauriBackend implements AudioBridge {
     return true;
   }
 
-  private enqueueTransportCommand(command: () => Promise<void>): void {
+  private enqueueTransportCommand(command: () => Promise<void>): Promise<void> {
     const run = this._transportCommandQueue.then(command, command);
     this._transportCommandQueue = run.catch(() => {});
     void run.catch(() => {});
+    return run;
   }
 
   private republishActiveSchedule(): void {

--- a/src/engine/bridge/TauriBackend.ts
+++ b/src/engine/bridge/TauriBackend.ts
@@ -579,8 +579,10 @@ export class TauriBackend implements AudioBridge {
   }
 
   private refreshTransportPosition(): void {
+    const token = this._transportCommandToken;
     invoke<number>('audio_transport_get_position')
       .then((position) => {
+        if (token !== this._transportCommandToken) return;
         if (Number.isFinite(position)) {
           this._currentSamplePosition = Math.max(0, Math.floor(position));
         }

--- a/src/engine/bridge/WebAudioBackend.ts
+++ b/src/engine/bridge/WebAudioBackend.ts
@@ -162,9 +162,19 @@ export class WebAudioBackend implements AudioBridge {
       fadeOutDuration: c.fadeOutDuration,
       fadeInCurve: c.fadeInCurve,
       fadeOutCurve: c.fadeOutCurve,
+      fadeInCurvePoint: c.fadeInCurvePoint,
+      fadeOutCurvePoint: c.fadeOutCurvePoint,
       timeStretchRate: c.timeStretchRate,
+      pitchShift: c.pitchShift,
+      gainEnvelope: c.gainEnvelope,
+      warpMarkers: c.warpMarkers,
+      stretchMode: c.stretchMode,
     }));
     this.engine.schedulePlayback(engineClips, fromTime, totalDuration);
+  }
+
+  pauseAllSources(): void {
+    this.engine.stopAllSources();
   }
 
   stopAllSources(): void {

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -30,6 +30,23 @@ function equalPowerPan(pan: number): { left: number; right: number } {
   return { left: Math.cos(angle), right: Math.sin(angle) };
 }
 
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function flushTransportCommands(turns = 6): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('TauriBackend', () => {
   let backend: TauriBackend;
 
@@ -179,8 +196,9 @@ describe('TauriBackend', () => {
     expect(invokeMock).toHaveBeenCalledWith('audio_transport_stop');
   });
 
-  it('pauseAllSources pauses native transport without clearing the schedule', () => {
+  it('pauseAllSources pauses native transport without clearing the schedule', async () => {
     backend.pauseAllSources();
+    await flushTransportCommands();
 
     expect(invokeMock).toHaveBeenCalledWith('audio_transport_pause');
     expect(invokeMock).not.toHaveBeenCalledWith('audio_clip_set_schedule', { clips: [] });
@@ -280,10 +298,10 @@ describe('TauriBackend', () => {
         clipDuration: 1 / 48000,
       },
     ], 1, 3);
+    await Promise.resolve();
     positionHandler?.({ payload: 96000 });
     resolveSchedule();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushTransportCommands();
 
     expect(invokeMock).toHaveBeenCalledWith('audio_transport_seek', { samplePosition: 48000 });
   });
@@ -348,12 +366,11 @@ describe('TauriBackend', () => {
         clipDuration: 2 / 48000,
       },
     ], 0, 1);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushTransportCommands();
     invokeMock.mockClear();
 
     backend.setTrackParams('track-1', { volume: 0.25, pan: 0.5 });
-    await Promise.resolve();
+    await flushTransportCommands();
 
     expect(invokeMock).toHaveBeenCalledWith('audio_clip_set_schedule', {
       clips: [
@@ -391,10 +408,10 @@ describe('TauriBackend', () => {
         clipDuration: 1 / 48000,
       },
     ], 0, 1);
+    await Promise.resolve();
     backend.stopAllSources();
     resolveFirstSchedule();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushTransportCommands();
 
     expect(invokeMock).not.toHaveBeenCalledWith('audio_transport_play');
   });
@@ -496,6 +513,50 @@ describe('TauriBackend', () => {
     expect(meter.level).toBeCloseTo(0.5 * Math.max(centerPan.left, centerPan.right));
     expect(meter.leftLevel).toBeCloseTo(0.5 * centerPan.left);
     expect(meter.rightLevel).toBeCloseTo(0.5 * centerPan.right);
+  });
+
+  it('serializes stale native stop commands before a newer schedule', async () => {
+    const calls: string[] = [];
+    const clearSchedule = deferred();
+    invokeMock.mockImplementation((command, args) => {
+      calls.push(command);
+      if (
+        command === 'audio_clip_set_schedule'
+        && Array.isArray((args as { clips?: unknown[] } | undefined)?.clips)
+        && (args as { clips: unknown[] }).clips.length === 0
+      ) {
+        return clearSchedule.promise;
+      }
+      return Promise.resolve(undefined);
+    });
+
+    backend.stopAllSources();
+    await Promise.resolve();
+    expect(calls).toEqual(['audio_clip_set_schedule']);
+
+    const buffer = createMockAudioBuffer([0.5]);
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+    ], 0, 1);
+    await Promise.resolve();
+    expect(calls).toEqual(['audio_clip_set_schedule']);
+
+    clearSchedule.resolve(undefined);
+    await flushTransportCommands();
+
+    expect(calls).toEqual([
+      'audio_clip_set_schedule',
+      'audio_clip_set_schedule',
+      'audio_transport_seek',
+      'audio_transport_play',
+    ]);
   });
 
   it('throttles track meter refreshes while a native request is in flight', async () => {

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -1,10 +1,36 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TauriBackend } from '../TauriBackend';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+const invokeMock = vi.mocked(invoke);
+const listenMock = vi.mocked(listen);
+
+function createMockAudioBuffer(samples: number[], sampleRate = 48000): AudioBuffer {
+  const channel = Float32Array.from(samples);
+  return {
+    length: samples.length,
+    sampleRate,
+    numberOfChannels: 1,
+    getChannelData: vi.fn(() => channel),
+  } as unknown as AudioBuffer;
+}
 
 describe('TauriBackend', () => {
   let backend: TauriBackend;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    invokeMock.mockResolvedValue(undefined);
+    listenMock.mockResolvedValue(vi.fn());
     backend = new TauriBackend();
   });
 
@@ -18,7 +44,7 @@ describe('TauriBackend', () => {
 
   // ── Transport stubs return safe defaults ──────────────────────────
 
-  it('getCurrentTime returns 0 (stub)', () => {
+  it('getCurrentTime starts at 0', () => {
     expect(backend.getCurrentTime()).toBe(0);
   });
 
@@ -26,11 +52,17 @@ describe('TauriBackend', () => {
     expect(backend.getLookAhead()).toBe(0.1);
   });
 
-  it('getCompensatedTime returns 0 (stub)', () => {
+  it('getCompensatedTime starts at 0', () => {
     expect(backend.getCompensatedTime()).toBe(0);
   });
 
-  it('getPlaybackLatencyCompensation returns 0', () => {
+  it('stores playback latency compensation', () => {
+    backend.setPlaybackLatencyCompensation(0.25);
+
+    expect(backend.getPlaybackLatencyCompensation()).toBe(0.25);
+  });
+
+  it('getPlaybackLatencyCompensation defaults to 0', () => {
     expect(backend.getPlaybackLatencyCompensation()).toBe(0);
   });
 
@@ -74,8 +106,23 @@ describe('TauriBackend', () => {
 
   // ── Stub methods do not throw ─────────────────────────────────────
 
-  it('setMasterVolume does not throw', () => {
-    expect(() => backend.setMasterVolume(0.5)).not.toThrow();
+  it('resume starts the native engine and transport listener', async () => {
+    invokeMock.mockResolvedValueOnce({ state: 'running' });
+    invokeMock.mockResolvedValueOnce(96000);
+
+    await backend.resume();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_start_engine', {
+      config: { sampleRate: 48000, bufferSize: 256, deviceName: null },
+    });
+    expect(invokeMock).toHaveBeenCalledWith('audio_transport_get_position');
+    expect(listenMock).toHaveBeenCalledWith('transport-position', expect.any(Function));
+  });
+
+  it('setMasterVolume invokes native master gain command', () => {
+    backend.setMasterVolume(0.5);
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_set_master_volume', { volume: 0.5 });
   });
 
   it('ensureTrack does not throw', () => {
@@ -90,35 +137,49 @@ describe('TauriBackend', () => {
     expect(() => backend.setTrackParams('t1', { volume: 0.5 })).not.toThrow();
   });
 
+  it('preserves track params while native handle allocation is pending', async () => {
+    invokeMock.mockResolvedValueOnce({ slot: 2, generation: 1 });
+
+    backend.ensureTrack('track-1');
+    backend.setTrackParams('track-1', { volume: 0.25, pan: -0.5, muted: true });
+    await Promise.resolve();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_set_track_params', {
+      handle: { slot: 2, generation: 1 },
+      params: { volume: 0.25, pan: -0.5, mute: true, solo: false },
+    });
+  });
+
   it('updateSoloState does not throw', () => {
     expect(() => backend.updateSoloState()).not.toThrow();
   });
 
-  it('stopAllSources does not throw', () => {
-    expect(() => backend.stopAllSources()).not.toThrow();
+  it('stopAllSources clears the native schedule and stops transport', async () => {
+    backend.stopAllSources();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_clip_set_schedule', { clips: [] });
+    expect(invokeMock).toHaveBeenCalledWith('audio_transport_stop');
+  });
+
+  it('pauseAllSources pauses native transport without clearing the schedule', () => {
+    backend.pauseAllSources();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_transport_pause');
+    expect(invokeMock).not.toHaveBeenCalledWith('audio_clip_set_schedule', { clips: [] });
   });
 
   it('disposeAudioStream does not throw', () => {
     expect(() => backend.disposeAudioStream()).not.toThrow();
   });
 
-  it('dispose does not throw', () => {
+  it('dispose stops the native engine', () => {
     expect(() => backend.dispose()).not.toThrow();
+    expect(invokeMock).toHaveBeenCalledWith('audio_stop_engine');
   });
 
-  // ── Methods that should throw (not yet implemented) ───────────────
-
-  it('resume rejects without Tauri runtime', async () => {
-    // resume() now calls invoke('audio_start_engine', ...) which
-    // rejects in a test environment because no Tauri webview
-    // context is available. The specific error message depends on
-    // the @tauri-apps/api internals — we only assert it rejects.
-    await expect(backend.resume()).rejects.toThrow();
-  });
-
-  it('decodeAudioData throws (Rust engine not ready)', async () => {
-    await expect(backend.decodeAudioData(new Blob())).rejects.toThrow('not yet implemented');
-  });
+  // ── Methods that should throw ────────────────────────────────────
 
   it('getAudioStream throws (not available in desktop)', () => {
     expect(() => backend.getAudioStream()).toThrow('not available in desktop');
@@ -132,5 +193,178 @@ describe('TauriBackend', () => {
 
   it('setOnEndedCallback does not throw', () => {
     expect(() => backend.setOnEndedCallback(() => {})).not.toThrow();
+  });
+
+  it('schedulePlayback sends clips through native schedule and starts transport', async () => {
+    const buffer = createMockAudioBuffer([0.125, 0.25, 0.5, 1]);
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 1,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 4 / 48000,
+      },
+    ], 1, 2);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_clip_set_schedule', {
+      clips: [
+        {
+          startSample: 48000,
+          lengthSamples: 4,
+          gain: 1,
+          audioData: [0.125, 0.125, 0.25, 0.25, 0.5, 0.5, 1, 1],
+        },
+      ],
+    });
+    expect(invokeMock).toHaveBeenCalledWith('audio_transport_seek', { samplePosition: 48000 });
+    expect(invokeMock).toHaveBeenCalledWith('audio_transport_play');
+  });
+
+  it('applies cached track volume, pan, mute, and solo before native scheduling', async () => {
+    const audibleBuffer = createMockAudioBuffer([1, 1]);
+    const mutedBuffer = createMockAudioBuffer([1, 1]);
+    backend.ensureTrack('audible');
+    backend.ensureTrack('muted');
+    backend.setTrackParams('audible', { volume: 0.5, pan: -0.5, soloed: true });
+    backend.setTrackParams('muted', { volume: 1, muted: true });
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-audible',
+        trackId: 'audible',
+        startTime: 0,
+        buffer: audibleBuffer,
+        audioOffset: 0,
+        clipDuration: 2 / 48000,
+      },
+      {
+        clipId: 'clip-muted',
+        trackId: 'muted',
+        startTime: 0,
+        buffer: mutedBuffer,
+        audioOffset: 0,
+        clipDuration: 2 / 48000,
+      },
+    ], 0, 1);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_clip_set_schedule', {
+      clips: [
+        {
+          startSample: 0,
+          lengthSamples: 2,
+          gain: 1,
+          audioData: [0.5, 0.25, 0.5, 0.25],
+        },
+      ],
+    });
+  });
+
+  it('does not resume stale playback after a stop interrupts scheduling', async () => {
+    let resolveFirstSchedule!: () => void;
+    let firstSchedule = true;
+    invokeMock.mockImplementation((command) => {
+      if (command === 'audio_clip_set_schedule' && firstSchedule) {
+        firstSchedule = false;
+        return new Promise((resolve) => {
+          resolveFirstSchedule = () => resolve(undefined);
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    const buffer = createMockAudioBuffer([1]);
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+    ], 0, 1);
+    backend.stopAllSources();
+    resolveFirstSchedule();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeMock).not.toHaveBeenCalledWith('audio_transport_play');
+  });
+
+  it('fires ended callback from native transport position events', async () => {
+    let positionHandler: ((event: { payload: number }) => void) | null = null;
+    listenMock.mockImplementation(async (_event, handler) => {
+      positionHandler = handler as (event: { payload: number }) => void;
+      return vi.fn();
+    });
+    const onEnded = vi.fn();
+    const buffer = createMockAudioBuffer([1]);
+    backend.setTimeUpdateCallback(() => {});
+    backend.setOnEndedCallback(onEnded);
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+    ], 0, 1 / 48000);
+    await Promise.resolve();
+    positionHandler?.({ payload: 1 });
+
+    expect(onEnded).toHaveBeenCalledTimes(1);
+  });
+
+  it('resamples non-48kHz buffers before sending native clips', async () => {
+    const buffer = createMockAudioBuffer([0, 1], 24000);
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 2 / 24000,
+      },
+    ], 0, 1);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_clip_set_schedule', {
+      clips: [
+        {
+          startSample: 0,
+          lengthSamples: 4,
+          gain: 1,
+          audioData: [0, 0, 0.5, 0.5, 1, 1, 1, 1],
+        },
+      ],
+    });
+  });
+
+  it('refreshes track meters from native meter command', async () => {
+    invokeMock.mockResolvedValueOnce({ slot: 0, generation: 1 });
+    backend.ensureTrack('track-1');
+    await Promise.resolve();
+
+    invokeMock.mockResolvedValueOnce({ rms: 0.2, peak: 0.4, clipped: true });
+    backend.getTrackMeter('track-1');
+    await Promise.resolve();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_get_track_meter', expect.any(Object));
   });
 });

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -515,6 +515,39 @@ describe('TauriBackend', () => {
     expect(meter.rightLevel).toBeCloseTo(0.5 * centerPan.right);
   });
 
+  it('preserves boosted native track volume when baking clip audio', async () => {
+    invokeMock.mockResolvedValueOnce({ slot: 0, generation: 1 });
+    backend.ensureTrack('track-1');
+    await flushTransportCommands();
+    backend.setTrackParams('track-1', { volume: 1.25 });
+    invokeMock.mockClear();
+
+    const buffer = createMockAudioBuffer([1]);
+    const centerPan = equalPowerPan(0);
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+    ], 0, 1);
+    await flushTransportCommands();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_clip_set_schedule', {
+      clips: [
+        {
+          startSample: 0,
+          lengthSamples: 1,
+          gain: 1,
+          audioData: [1.25 * centerPan.left, 1.25 * centerPan.right],
+        },
+      ],
+    });
+  });
+
   it('serializes stale native stop commands before a newer schedule', async () => {
     const calls: string[] = [];
     const clearSchedule = deferred();

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -477,6 +477,27 @@ describe('TauriBackend', () => {
     expect(invokeMock).toHaveBeenCalledWith('audio_get_track_meter', expect.any(Object));
   });
 
+  it('reflects active native clip audio in track meters', () => {
+    const buffer = createMockAudioBuffer([0.5]);
+    const centerPan = equalPowerPan(0);
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+    ], 0, 1);
+
+    const meter = backend.getTrackMeter('track-1');
+    expect(meter.level).toBeCloseTo(0.5 * Math.max(centerPan.left, centerPan.right));
+    expect(meter.leftLevel).toBeCloseTo(0.5 * centerPan.left);
+    expect(meter.rightLevel).toBeCloseTo(0.5 * centerPan.right);
+  });
+
   it('throttles track meter refreshes while a native request is in flight', async () => {
     invokeMock.mockResolvedValueOnce({ slot: 0, generation: 1 });
     backend.ensureTrack('track-1');

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -119,6 +119,16 @@ describe('TauriBackend', () => {
     expect(listenMock).toHaveBeenCalledWith('transport-position', expect.any(Function));
   });
 
+  it('resume treats an already-running native engine as success', async () => {
+    invokeMock.mockRejectedValueOnce({ kind: 'alreadyRunning' });
+    invokeMock.mockResolvedValueOnce(0);
+
+    await expect(backend.resume()).resolves.toBeUndefined();
+
+    expect(listenMock).toHaveBeenCalledWith('transport-position', expect.any(Function));
+    expect(invokeMock).toHaveBeenCalledWith('audio_transport_get_position');
+  });
+
   it('setMasterVolume invokes native master gain command', () => {
     backend.setMasterVolume(0.5);
 

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -306,6 +306,45 @@ describe('TauriBackend', () => {
     expect(invokeMock).toHaveBeenCalledWith('audio_transport_seek', { samplePosition: 48000 });
   });
 
+  it('ignores stale end-position events until the native seek and play land', async () => {
+    let positionHandler: ((event: { payload: number }) => void) | null = null;
+    const scheduleDeferred = deferred();
+    invokeMock.mockImplementation((command) => {
+      if (command === 'audio_clip_set_schedule') return scheduleDeferred.promise;
+      return Promise.resolve(undefined);
+    });
+    listenMock.mockImplementation(async (_event, handler) => {
+      positionHandler = handler as (event: { payload: number }) => void;
+      return vi.fn();
+    });
+    const onEnded = vi.fn();
+    const buffer = createMockAudioBuffer([1]);
+    backend.setTimeUpdateCallback(() => {});
+    backend.setOnEndedCallback(onEnded);
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+    ], 0, 1 / 48000);
+    await Promise.resolve();
+    positionHandler?.({ payload: 2 });
+
+    expect(onEnded).not.toHaveBeenCalled();
+    expect(invokeMock).not.toHaveBeenCalledWith('audio_transport_stop');
+
+    scheduleDeferred.resolve(undefined);
+    await flushTransportCommands();
+    positionHandler?.({ payload: 2 });
+
+    expect(onEnded).toHaveBeenCalledTimes(1);
+  });
+
   it('applies cached track volume, pan, mute, and solo before native scheduling', async () => {
     const audibleBuffer = createMockAudioBuffer([1, 1]);
     const mutedBuffer = createMockAudioBuffer([1, 1]);
@@ -437,7 +476,7 @@ describe('TauriBackend', () => {
         clipDuration: 1 / 48000,
       },
     ], 0, 1 / 48000);
-    await Promise.resolve();
+    await flushTransportCommands();
     positionHandler?.({ payload: 1 });
 
     expect(onEnded).toHaveBeenCalledTimes(1);

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -278,6 +278,41 @@ describe('TauriBackend', () => {
     });
   });
 
+  it('republishes active native schedule when track params change', async () => {
+    const buffer = createMockAudioBuffer([1, 1]);
+    invokeMock.mockResolvedValueOnce({ slot: 0, generation: 1 });
+    backend.ensureTrack('track-1');
+    await Promise.resolve();
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 2 / 48000,
+      },
+    ], 0, 1);
+    await Promise.resolve();
+    await Promise.resolve();
+    invokeMock.mockClear();
+
+    backend.setTrackParams('track-1', { volume: 0.25, pan: 0.5 });
+    await Promise.resolve();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_clip_set_schedule', {
+      clips: [
+        {
+          startSample: 0,
+          lengthSamples: 2,
+          gain: 1,
+          audioData: [0.125, 0.25, 0.125, 0.25],
+        },
+      ],
+    });
+  });
+
   it('does not resume stale playback after a stop interrupts scheduling', async () => {
     let resolveFirstSchedule!: () => void;
     let firstSchedule = true;

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -188,17 +188,14 @@ describe('TauriBackend', () => {
   });
 
   it('stopAllSources clears the native schedule and stops transport', async () => {
-    backend.stopAllSources();
-    await Promise.resolve();
-    await Promise.resolve();
+    await backend.stopAllSources();
 
     expect(invokeMock).toHaveBeenCalledWith('audio_clip_set_schedule', { clips: [] });
     expect(invokeMock).toHaveBeenCalledWith('audio_transport_stop');
   });
 
   it('pauseAllSources pauses native transport without clearing the schedule', async () => {
-    backend.pauseAllSources();
-    await flushTransportCommands();
+    await backend.pauseAllSources();
 
     expect(invokeMock).toHaveBeenCalledWith('audio_transport_pause');
     expect(invokeMock).not.toHaveBeenCalledWith('audio_clip_set_schedule', { clips: [] });
@@ -227,6 +224,22 @@ describe('TauriBackend', () => {
 
   it('setOnEndedCallback does not throw', () => {
     expect(() => backend.setOnEndedCallback(() => {})).not.toThrow();
+  });
+
+  it('emits latency-compensated time updates from native transport events', async () => {
+    let positionHandler: ((event: { payload: number }) => void) | null = null;
+    listenMock.mockImplementation(async (_event, handler) => {
+      positionHandler = handler as (event: { payload: number }) => void;
+      return vi.fn();
+    });
+    const onTimeUpdate = vi.fn();
+
+    backend.setPlaybackLatencyCompensation(0.125);
+    backend.setTimeUpdateCallback(onTimeUpdate);
+    await Promise.resolve();
+    positionHandler?.({ payload: 48000 });
+
+    expect(onTimeUpdate).toHaveBeenCalledWith(0.875);
   });
 
   it('schedulePlayback sends clips through native schedule and starts transport', async () => {
@@ -531,6 +544,37 @@ describe('TauriBackend', () => {
     await Promise.resolve();
 
     expect(invokeMock).toHaveBeenCalledWith('audio_get_track_meter', expect.any(Object));
+  });
+
+  it('resets native track clip state through Tauri IPC', async () => {
+    invokeMock.mockResolvedValueOnce({ slot: 0, generation: 1 });
+    backend.ensureTrack('track-1');
+    await Promise.resolve();
+    invokeMock.mockResolvedValueOnce({ rms: 0.2, peak: 0.4, clipped: true });
+    backend.getTrackMeter('track-1');
+    await Promise.resolve();
+    expect(backend.getTrackMeter('track-1').clipped).toBe(true);
+    invokeMock.mockClear();
+
+    backend.resetTrackClip('track-1');
+
+    expect(backend.getTrackMeter('track-1').clipped).toBe(false);
+    expect(invokeMock).toHaveBeenCalledWith('audio_reset_track_clip', {
+      handle: { slot: 0, generation: 1 },
+    });
+  });
+
+  it('resets native master clip state through Tauri IPC', async () => {
+    invokeMock.mockResolvedValueOnce({ rms: 0.2, peak: 0.4, clipped: true });
+    backend.getMasterMeter('output');
+    await Promise.resolve();
+    expect(backend.getMasterMeter('output').clipped).toBe(true);
+    invokeMock.mockClear();
+
+    backend.resetMasterClip('output');
+
+    expect(backend.getMasterMeter('output').clipped).toBe(false);
+    expect(invokeMock).toHaveBeenCalledWith('audio_reset_master_clip');
   });
 
   it('reflects active native clip audio in track meters', () => {

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -24,6 +24,12 @@ function createMockAudioBuffer(samples: number[], sampleRate = 48000): AudioBuff
   } as unknown as AudioBuffer;
 }
 
+function equalPowerPan(pan: number): { left: number; right: number } {
+  const clamped = Math.max(-1, Math.min(1, pan));
+  const angle = ((clamped + 1) * Math.PI) / 4;
+  return { left: Math.cos(angle), right: Math.sin(angle) };
+}
+
 describe('TauriBackend', () => {
   let backend: TauriBackend;
 
@@ -70,22 +76,22 @@ describe('TauriBackend', () => {
 
   it('getTrackMeter returns silent meter', () => {
     const meter = backend.getTrackMeter('any-track');
-    expect(meter.level).toBe(-Infinity);
+    expect(meter.level).toBe(0);
     expect(meter.clipped).toBe(false);
   });
 
-  it('getTrackLevel returns -Infinity', () => {
-    expect(backend.getTrackLevel('any-track')).toBe(-Infinity);
+  it('getTrackLevel returns silence by default', () => {
+    expect(backend.getTrackLevel('any-track')).toBe(0);
   });
 
   it('getMasterMeter returns silent meter', () => {
     const meter = backend.getMasterMeter('output');
-    expect(meter.level).toBe(-Infinity);
+    expect(meter.level).toBe(0);
     expect(meter.clipped).toBe(false);
   });
 
-  it('getMasterLevel returns -Infinity', () => {
-    expect(backend.getMasterLevel('input')).toBe(-Infinity);
+  it('getMasterLevel returns silence by default', () => {
+    expect(backend.getMasterLevel('input')).toBe(0);
   });
 
   it('getTrackSpectrum returns null', () => {
@@ -207,6 +213,7 @@ describe('TauriBackend', () => {
 
   it('schedulePlayback sends clips through native schedule and starts transport', async () => {
     const buffer = createMockAudioBuffer([0.125, 0.25, 0.5, 1]);
+    const centerPan = equalPowerPan(0);
 
     backend.schedulePlayback([
       {
@@ -217,7 +224,7 @@ describe('TauriBackend', () => {
         audioOffset: 0,
         clipDuration: 4 / 48000,
       },
-    ], 1, 2);
+    ], 1, 3);
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
@@ -228,7 +235,16 @@ describe('TauriBackend', () => {
           startSample: 48000,
           lengthSamples: 4,
           gain: 1,
-          audioData: [0.125, 0.125, 0.25, 0.25, 0.5, 0.5, 1, 1],
+          audioData: [
+            0.125 * centerPan.left,
+            0.125 * centerPan.right,
+            0.25 * centerPan.left,
+            0.25 * centerPan.right,
+            0.5 * centerPan.left,
+            0.5 * centerPan.right,
+            centerPan.left,
+            centerPan.right,
+          ],
         },
       ],
     });
@@ -236,9 +252,46 @@ describe('TauriBackend', () => {
     expect(invokeMock).toHaveBeenCalledWith('audio_transport_play');
   });
 
+  it('uses the scheduled seek sample even if transport events update the cache first', async () => {
+    let positionHandler: ((event: { payload: number }) => void) | null = null;
+    let resolveSchedule!: () => void;
+    invokeMock.mockImplementation((command) => {
+      if (command === 'audio_clip_set_schedule') {
+        return new Promise((resolve) => {
+          resolveSchedule = () => resolve(undefined);
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    listenMock.mockImplementation(async (_event, handler) => {
+      positionHandler = handler as (event: { payload: number }) => void;
+      return vi.fn();
+    });
+    const buffer = createMockAudioBuffer([1]);
+    backend.setTimeUpdateCallback(() => {});
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 1,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+    ], 1, 3);
+    positionHandler?.({ payload: 96000 });
+    resolveSchedule();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeMock).toHaveBeenCalledWith('audio_transport_seek', { samplePosition: 48000 });
+  });
+
   it('applies cached track volume, pan, mute, and solo before native scheduling', async () => {
     const audibleBuffer = createMockAudioBuffer([1, 1]);
     const mutedBuffer = createMockAudioBuffer([1, 1]);
+    const pan = equalPowerPan(-0.5);
     backend.ensureTrack('audible');
     backend.ensureTrack('muted');
     backend.setTrackParams('audible', { volume: 0.5, pan: -0.5, soloed: true });
@@ -272,7 +325,7 @@ describe('TauriBackend', () => {
           startSample: 0,
           lengthSamples: 2,
           gain: 1,
-          audioData: [0.5, 0.25, 0.5, 0.25],
+          audioData: [0.5 * pan.left, 0.5 * pan.right, 0.5 * pan.left, 0.5 * pan.right],
         },
       ],
     });
@@ -280,6 +333,7 @@ describe('TauriBackend', () => {
 
   it('republishes active native schedule when track params change', async () => {
     const buffer = createMockAudioBuffer([1, 1]);
+    const pan = equalPowerPan(0.5);
     invokeMock.mockResolvedValueOnce({ slot: 0, generation: 1 });
     backend.ensureTrack('track-1');
     await Promise.resolve();
@@ -307,7 +361,7 @@ describe('TauriBackend', () => {
           startSample: 0,
           lengthSamples: 2,
           gain: 1,
-          audioData: [0.125, 0.25, 0.125, 0.25],
+          audioData: [0.25 * pan.left, 0.25 * pan.right, 0.25 * pan.left, 0.25 * pan.right],
         },
       ],
     });
@@ -374,6 +428,7 @@ describe('TauriBackend', () => {
 
   it('resamples non-48kHz buffers before sending native clips', async () => {
     const buffer = createMockAudioBuffer([0, 1], 24000);
+    const centerPan = equalPowerPan(0);
 
     backend.schedulePlayback([
       {
@@ -395,7 +450,16 @@ describe('TauriBackend', () => {
           startSample: 0,
           lengthSamples: 4,
           gain: 1,
-          audioData: [0, 0, 0.5, 0.5, 1, 1, 1, 1],
+          audioData: [
+            0,
+            0,
+            0.5 * centerPan.left,
+            0.5 * centerPan.right,
+            centerPan.left,
+            centerPan.right,
+            centerPan.left,
+            centerPan.right,
+          ],
         },
       ],
     });
@@ -411,5 +475,29 @@ describe('TauriBackend', () => {
     await Promise.resolve();
 
     expect(invokeMock).toHaveBeenCalledWith('audio_get_track_meter', expect.any(Object));
+  });
+
+  it('throttles track meter refreshes while a native request is in flight', async () => {
+    invokeMock.mockResolvedValueOnce({ slot: 0, generation: 1 });
+    backend.ensureTrack('track-1');
+    await Promise.resolve();
+    invokeMock.mockClear();
+
+    invokeMock.mockResolvedValue({ rms: 0.2, peak: 0.4, clipped: false });
+    backend.getTrackMeter('track-1');
+    backend.getTrackMeter('track-1');
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith('audio_get_track_meter', expect.any(Object));
+  });
+
+  it('throttles master meter refreshes while a native request is in flight', () => {
+    invokeMock.mockResolvedValue({ rms: 0.2, peak: 0.4, clipped: false });
+
+    backend.getMasterMeter('output');
+    backend.getMasterMeter('input');
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith('audio_get_master_meter');
   });
 });

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -319,6 +319,36 @@ describe('TauriBackend', () => {
     expect(invokeMock).toHaveBeenCalledWith('audio_transport_seek', { samplePosition: 48000 });
   });
 
+  it('does not let stale position refresh overwrite a scheduled seek', async () => {
+    const positionRefresh = deferred<number>();
+    invokeMock.mockImplementation((command) => {
+      if (command === 'audio_start_engine') return Promise.resolve({ state: 'running' });
+      if (command === 'audio_transport_get_position') return positionRefresh.promise;
+      return Promise.resolve(undefined);
+    });
+    const buffer = createMockAudioBuffer([1]);
+
+    await backend.resume();
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 1,
+        buffer,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+    ], 1, 3);
+    expect(backend.getCurrentTime()).toBe(1);
+
+    positionRefresh.resolve(0);
+    await Promise.resolve();
+    await flushTransportCommands();
+
+    expect(backend.getCurrentTime()).toBe(1);
+    expect(invokeMock).toHaveBeenCalledWith('audio_transport_seek', { samplePosition: 48000 });
+  });
+
   it('ignores stale end-position events until the native seek and play land', async () => {
     let positionHandler: ((event: { payload: number }) => void) | null = null;
     const scheduleDeferred = deferred();

--- a/src/engine/bridge/__tests__/TauriBackend.test.ts
+++ b/src/engine/bridge/__tests__/TauriBackend.test.ts
@@ -598,6 +598,36 @@ describe('TauriBackend', () => {
     expect(meter.rightLevel).toBeCloseTo(0.5 * centerPan.right);
   });
 
+  it('sums overlapping native clip audio in simulated track meters', () => {
+    const bufferA = createMockAudioBuffer([0.75]);
+    const bufferB = createMockAudioBuffer([0.75]);
+    const centerPan = equalPowerPan(0);
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-a',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer: bufferA,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+      {
+        clipId: 'clip-b',
+        trackId: 'track-1',
+        startTime: 0,
+        buffer: bufferB,
+        audioOffset: 0,
+        clipDuration: 1 / 48000,
+      },
+    ], 0, 1);
+
+    const meter = backend.getTrackMeter('track-1');
+    expect(meter.leftLevel).toBeCloseTo(1.5 * centerPan.left);
+    expect(meter.rightLevel).toBeCloseTo(1.5 * centerPan.right);
+    expect(meter.clipped).toBe(true);
+  });
+
   it('preserves boosted native track volume when baking clip audio', async () => {
     invokeMock.mockResolvedValueOnce({ slot: 0, generation: 1 });
     backend.ensureTrack('track-1');

--- a/src/engine/bridge/__tests__/WebAudioBackend.test.ts
+++ b/src/engine/bridge/__tests__/WebAudioBackend.test.ts
@@ -178,8 +178,47 @@ describe('WebAudioBackend', () => {
     expect(engine.schedulePlayback).toHaveBeenCalledWith([], 0, 10);
   });
 
+  it('preserves advanced clip playback fields', () => {
+    const buffer = {} as AudioBuffer;
+    const gainEnvelope = [{ time: 0, gain: 0.5 }];
+    const warpMarkers = [{ originalTime: 0, quantizedTime: 0 }];
+
+    backend.schedulePlayback([
+      {
+        clipId: 'clip-1',
+        trackId: 'track-1',
+        startTime: 1,
+        buffer,
+        audioOffset: 0.25,
+        clipDuration: 2,
+        fadeInCurvePoint: { x: 0.2, y: 0.8 },
+        fadeOutCurvePoint: { x: 0.7, y: 0.3 },
+        pitchShift: 3,
+        gainEnvelope,
+        warpMarkers,
+        stretchMode: 'complexPro',
+      },
+    ], 0, 4);
+
+    expect(engine.schedulePlayback).toHaveBeenCalledWith([
+      expect.objectContaining({
+        fadeInCurvePoint: { x: 0.2, y: 0.8 },
+        fadeOutCurvePoint: { x: 0.7, y: 0.3 },
+        pitchShift: 3,
+        gainEnvelope,
+        warpMarkers,
+        stretchMode: 'complexPro',
+      }),
+    ], 0, 4);
+  });
+
   it('delegates stopAllSources', () => {
     backend.stopAllSources();
+    expect(engine.stopAllSources).toHaveBeenCalled();
+  });
+
+  it('delegates pauseAllSources', () => {
+    backend.pauseAllSources();
     expect(engine.stopAllSources).toHaveBeenCalled();
   });
 

--- a/src/engine/bridge/__tests__/bridge-factory.test.ts
+++ b/src/engine/bridge/__tests__/bridge-factory.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { createBridge } from '../index';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { _resetAudioBridgeForTests, createBridge, getAudioBridge } from '../index';
 import { WebAudioBackend } from '../WebAudioBackend';
+import { TauriBackend } from '../TauriBackend';
 import type { AudioEngine } from '../../AudioEngine';
 
 const fakeEngine = {} as AudioEngine;
@@ -9,6 +10,8 @@ describe('createBridge', () => {
   afterEach(() => {
     delete (window as Record<string, unknown>).__TAURI__;
     delete (window as Record<string, unknown>).__TAURI_INTERNALS__;
+    vi.unstubAllEnvs();
+    _resetAudioBridgeForTests();
   });
 
   it('returns WebAudioBackend when not in Tauri', () => {
@@ -17,11 +20,36 @@ describe('createBridge', () => {
     expect(bridge.backend).toBe('web-audio');
   });
 
-  it('returns WebAudioBackend even inside Tauri shell (Phase 1 — Rust engine not ready)', () => {
+  it('returns WebAudioBackend inside Tauri shell when native audio gate is off', () => {
     (window as Record<string, unknown>).__TAURI_INTERNALS__ = {};
     const bridge = createBridge(fakeEngine);
-    // During Phase 1, always use WebAudioBackend until Rust engine is ready
     expect(bridge).toBeInstanceOf(WebAudioBackend);
     expect(bridge.backend).toBe('web-audio');
+  });
+
+  it('returns WebAudioBackend when native audio gate is on outside Tauri', () => {
+    vi.stubEnv('VITE_ENABLE_TAURI_AUDIO_BACKEND', 'true');
+
+    const bridge = createBridge(fakeEngine);
+
+    expect(bridge).toBeInstanceOf(WebAudioBackend);
+    expect(bridge.backend).toBe('web-audio');
+  });
+
+  it('returns TauriBackend inside Tauri shell when native audio gate is on', () => {
+    (window as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    vi.stubEnv('VITE_ENABLE_TAURI_AUDIO_BACKEND', 'true');
+
+    const bridge = createBridge(fakeEngine);
+
+    expect(bridge).toBeInstanceOf(TauriBackend);
+    expect(bridge.backend).toBe('tauri');
+  });
+
+  it('reuses the audio bridge singleton', () => {
+    const first = getAudioBridge(fakeEngine);
+    const second = getAudioBridge(fakeEngine);
+
+    expect(second).toBe(first);
   });
 });

--- a/src/engine/bridge/index.ts
+++ b/src/engine/bridge/index.ts
@@ -18,19 +18,31 @@ import type { AudioBridge } from './types';
 import type { AudioEngine } from '../AudioEngine';
 import { WebAudioBackend } from './WebAudioBackend';
 import { TauriBackend } from './TauriBackend';
-import { isTauri } from '../../utils/tauri';
+import { isTauriAudioBackendEnabled } from '../../utils/tauri';
 
 /**
  * Create the appropriate AudioBridge for the current runtime.
  *
- * During Phase 1 migration, always use the WebAudio-backed bridge,
- * including inside the Tauri shell, until the Rust/Tauri backend
- * fully implements the required AudioBridge lifecycle methods.
+ * The native Rust backend is opt-in while migration continues. Browser
+ * builds and Tauri shells without the gate keep the WebAudio backend.
  *
  * @param engine - The AudioEngine singleton used by WebAudioBackend.
  */
 export function createBridge(engine: AudioEngine): AudioBridge {
-  // TODO: Switch to TauriBackend when Rust engine is ready (Phase 3+)
-  // if (isTauri()) return new TauriBackend();
+  if (isTauriAudioBackendEnabled()) return new TauriBackend();
   return new WebAudioBackend(engine);
+}
+
+let bridgeInstance: AudioBridge | null = null;
+
+export function getAudioBridge(engine: AudioEngine): AudioBridge {
+  if (!bridgeInstance) {
+    bridgeInstance = createBridge(engine);
+  }
+  return bridgeInstance;
+}
+
+/** @internal Reset singleton for tests. */
+export function _resetAudioBridgeForTests(): void {
+  bridgeInstance = null;
 }

--- a/src/engine/bridge/types.ts
+++ b/src/engine/bridge/types.ts
@@ -110,7 +110,7 @@ export interface AudioBridge {
   applyMastering(mastering: MasteringState | null | undefined): void;
 
   // ── Clip Scheduling ─────────────────────────────────────────────
-  schedulePlayback(clips: BridgeClipInfo[], fromTime: number, totalDuration: number): void;
+  schedulePlayback(clips: BridgeClipInfo[], fromTime: number, totalDuration: number): void | Promise<void>;
   pauseAllSources(): void;
   stopAllSources(): void;
 

--- a/src/engine/bridge/types.ts
+++ b/src/engine/bridge/types.ts
@@ -6,6 +6,11 @@
  * In desktop mode it delegates to TauriBackend (IPC → Rust audio engine).
  */
 import type { MasteringState } from '../../types/project';
+import type {
+  AudioWarpMarker,
+  GainEnvelopePoint,
+  StretchMode,
+} from '../../types/project';
 
 // ── Metering ────────────────────────────────────────────────────────
 
@@ -34,7 +39,13 @@ export interface BridgeClipInfo {
   fadeOutDuration?: number;
   fadeInCurve?: 'linear' | 'exponential' | 'equal-power';
   fadeOutCurve?: 'linear' | 'exponential' | 'equal-power';
+  fadeInCurvePoint?: { x: number; y: number };
+  fadeOutCurvePoint?: { x: number; y: number };
   timeStretchRate?: number;
+  pitchShift?: number;
+  gainEnvelope?: GainEnvelopePoint[];
+  warpMarkers?: AudioWarpMarker[];
+  stretchMode?: StretchMode;
 }
 
 // ── Track Parameters ────────────────────────────────────────────────
@@ -100,6 +111,7 @@ export interface AudioBridge {
 
   // ── Clip Scheduling ─────────────────────────────────────────────
   schedulePlayback(clips: BridgeClipInfo[], fromTime: number, totalDuration: number): void;
+  pauseAllSources(): void;
   stopAllSources(): void;
 
   // ── Audio Data ──────────────────────────────────────────────────
@@ -200,3 +212,16 @@ export type NativeCommandError =
   | { kind: 'queueFull'; message: number }
   | { kind: 'disconnected' }
   | { kind: 'slotAllocatorFull'; message: number };
+
+export interface NativeMeterReading {
+  rms: number;
+  peak: number;
+  clipped: boolean;
+}
+
+export interface NativeClipSource {
+  startSample: number;
+  lengthSamples: number;
+  gain: number;
+  audioData: number[];
+}

--- a/src/engine/bridge/types.ts
+++ b/src/engine/bridge/types.ts
@@ -111,8 +111,8 @@ export interface AudioBridge {
 
   // ── Clip Scheduling ─────────────────────────────────────────────
   schedulePlayback(clips: BridgeClipInfo[], fromTime: number, totalDuration: number): void | Promise<void>;
-  pauseAllSources(): void;
-  stopAllSources(): void;
+  pauseAllSources(): void | Promise<void>;
+  stopAllSources(): void | Promise<void>;
 
   // ── Audio Data ──────────────────────────────────────────────────
   decodeAudioData(blob: Blob): Promise<AudioBuffer>;

--- a/src/hooks/__tests__/useAudioEngine.test.ts
+++ b/src/hooks/__tests__/useAudioEngine.test.ts
@@ -134,6 +134,18 @@ describe('useAudioEngine', () => {
     expect(mockResume).toHaveBeenCalledTimes(1);
   });
 
+  it('resumes WebAudio when the Tauri bridge is active', async () => {
+    mockBridge.backend = 'tauri';
+    const { result } = renderHook(() => useAudioEngine());
+
+    await act(async () => {
+      await result.current.resumeOnGesture();
+    });
+
+    expect(mockBridge.resume).toHaveBeenCalledTimes(1);
+    expect(mockResume).toHaveBeenCalledTimes(1);
+  });
+
   it('refreshes playback latency on resume', async () => {
     const { result } = renderHook(() => useAudioEngine());
 

--- a/src/hooks/__tests__/useAudioEngine.test.ts
+++ b/src/hooks/__tests__/useAudioEngine.test.ts
@@ -12,6 +12,11 @@ const mockResume = vi.fn(async () => {});
 const mockSetTimeUpdateCallback = vi.fn();
 const mockRefreshPlaybackLatencyCompensation = vi.fn(() => 5);
 const mockSetPlaybackLatencyCompensation = vi.fn();
+const mockBridge = vi.hoisted(() => ({
+  backend: 'web-audio' as 'web-audio' | 'tauri',
+  resume: vi.fn(async () => {}),
+  setTimeUpdateCallback: vi.fn(),
+}));
 
 vi.mock('../../engine/AudioEngine', () => {
   return {
@@ -25,6 +30,10 @@ vi.mock('../../engine/AudioEngine', () => {
   };
 });
 
+vi.mock('../../engine/bridge', () => ({
+  getAudioBridge: vi.fn(() => mockBridge),
+}));
+
 import { getAudioEngine, getExistingAudioEngine, _setAudioResumed, useAudioEngine } from '../useAudioEngine';
 import { useTransportStore } from '../../store/transportStore';
 import { useProjectStore } from '../../store/projectStore';
@@ -36,6 +45,9 @@ describe('useAudioEngine', () => {
     useProjectStore.setState(useProjectStore.getInitialState(), true);
     useTransportStore.setState(useTransportStore.getInitialState(), true);
     useProjectStore.getState().createProject({ name: 'Audio Test' });
+    mockBridge.backend = 'web-audio';
+    mockBridge.resume.mockReset();
+    mockBridge.setTimeUpdateCallback.mockReset();
   });
 
   afterEach(() => {
@@ -70,6 +82,20 @@ describe('useAudioEngine', () => {
     callback(5.5);
 
     expect(useTransportStore.getState().currentTime).toBe(5.5);
+  });
+
+  it('keeps the WebAudio clock active when the Tauri bridge is installed', () => {
+    mockBridge.backend = 'tauri';
+    renderHook(() => useAudioEngine());
+
+    const engineCallback = mockSetTimeUpdateCallback.mock.calls[0][0];
+    const bridgeCallback = mockBridge.setTimeUpdateCallback.mock.calls[0][0];
+
+    engineCallback(2.25);
+    expect(useTransportStore.getState().currentTime).toBe(2.25);
+
+    bridgeCallback(3.5);
+    expect(useTransportStore.getState().currentTime).toBe(3.5);
   });
 
   // ── resumeOnGesture ──

--- a/src/hooks/__tests__/useAudioEngine.test.ts
+++ b/src/hooks/__tests__/useAudioEngine.test.ts
@@ -34,7 +34,14 @@ vi.mock('../../engine/bridge', () => ({
   getAudioBridge: vi.fn(() => mockBridge),
 }));
 
-import { getAudioEngine, getExistingAudioEngine, _setAudioResumed, useAudioEngine } from '../useAudioEngine';
+import {
+  getAudioEngine,
+  getExistingAudioEngine,
+  getTauriPlaybackClockOwner,
+  setTauriPlaybackClockOwner,
+  _setAudioResumed,
+  useAudioEngine,
+} from '../useAudioEngine';
 import { useTransportStore } from '../../store/transportStore';
 import { useProjectStore } from '../../store/projectStore';
 
@@ -48,6 +55,7 @@ describe('useAudioEngine', () => {
     mockBridge.backend = 'web-audio';
     mockBridge.resume.mockReset();
     mockBridge.setTimeUpdateCallback.mockReset();
+    setTauriPlaybackClockOwner('web-audio');
   });
 
   afterEach(() => {
@@ -93,6 +101,22 @@ describe('useAudioEngine', () => {
 
     engineCallback(2.25);
     expect(useTransportStore.getState().currentTime).toBe(2.25);
+
+    bridgeCallback(3.5);
+    expect(useTransportStore.getState().currentTime).toBe(2.25);
+    expect(getTauriPlaybackClockOwner()).toBe('web-audio');
+  });
+
+  it('uses the Tauri bridge clock when native playback owns transport', () => {
+    mockBridge.backend = 'tauri';
+    setTauriPlaybackClockOwner('native');
+    renderHook(() => useAudioEngine());
+
+    const engineCallback = mockSetTimeUpdateCallback.mock.calls[0][0];
+    const bridgeCallback = mockBridge.setTimeUpdateCallback.mock.calls[0][0];
+
+    engineCallback(2.25);
+    expect(useTransportStore.getState().currentTime).toBe(0);
 
     bridgeCallback(3.5);
     expect(useTransportStore.getState().currentTime).toBe(3.5);

--- a/src/hooks/__tests__/useTransport.strudel.test.ts
+++ b/src/hooks/__tests__/useTransport.strudel.test.ts
@@ -18,6 +18,10 @@ const mocks = vi.hoisted(() => ({
     masterVolume: 1,
     playing: false,
   },
+  tauriClock: { owner: 'web-audio' as 'native' | 'web-audio' },
+  setTauriPlaybackClockOwner: vi.fn((owner: 'native' | 'web-audio') => {
+    mocks.tauriClock.owner = owner;
+  }),
   stopRecording: vi.fn(async () => {}),
   onLoopCycle: vi.fn(async () => {}),
   stopAllStrudelTracks: vi.fn(),
@@ -27,6 +31,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('tone', () => ({}));
 vi.mock('../useAudioEngine', () => ({
   getAudioEngine: () => mocks.engine,
+  getTauriPlaybackClockOwner: () => mocks.tauriClock.owner,
+  setTauriPlaybackClockOwner: (owner: 'native' | 'web-audio') => mocks.setTauriPlaybackClockOwner(owner),
 }));
 vi.mock('../useRecording', () => ({
   useRecording: () => ({
@@ -83,6 +89,7 @@ import { useUIStore } from '../../store/uiStore';
 describe('useTransport strudel controls', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.tauriClock.owner = 'web-audio';
     useProjectStore.getState().createProject('Transport Test');
     useTransportStore.setState({
       isPlaying: true,

--- a/src/hooks/__tests__/useTransport.strudel.test.ts
+++ b/src/hooks/__tests__/useTransport.strudel.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
     stop: vi.fn(),
     getCurrentTime: vi.fn(() => 3.5),
     setOnEndedCallback: vi.fn(),
+    stopAllSources: vi.fn(),
     trackNodes: new Map(),
     updateSoloState: vi.fn(),
     syncSends: vi.fn(),

--- a/src/hooks/__tests__/useTransport.test.ts
+++ b/src/hooks/__tests__/useTransport.test.ts
@@ -135,6 +135,17 @@ import { useProjectStore } from '../../store/projectStore';
 import { useTransportStore } from '../../store/transportStore';
 import { useUIStore } from '../../store/uiStore';
 
+function nativeClipEntry(trackId: string, numberOfChannels = 1) {
+  return {
+    clipId: 'clip-1',
+    trackId,
+    startTime: 0,
+    audioOffset: 0,
+    clipDuration: 1,
+    buffer: { numberOfChannels } as AudioBuffer,
+  };
+}
+
 describe('useTransport', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -237,6 +248,29 @@ describe('useTransport', () => {
     }];
 
     expect(canUseNativeClipPlayback(project, [])).toBe(false);
+  });
+
+  it('disables native clip playback when WebAudio-rendered tracks are present', () => {
+    useProjectStore.getState().addTrack('pianoRoll');
+    const project = useProjectStore.getState().project!;
+
+    expect(canUseNativeClipPlayback(project, [])).toBe(false);
+  });
+
+  it('disables native clip playback for boosted track volume', () => {
+    useProjectStore.getState().addTrack('stems');
+    const project = useProjectStore.getState().project!;
+    project.tracks[0]!.volume = 1.25;
+
+    expect(canUseNativeClipPlayback(project, [nativeClipEntry(project.tracks[0]!.id)])).toBe(false);
+  });
+
+  it('disables native clip playback for panned stereo clips', () => {
+    useProjectStore.getState().addTrack('stems');
+    const project = useProjectStore.getState().project!;
+    project.tracks[0]!.pan = 0.5;
+
+    expect(canUseNativeClipPlayback(project, [nativeClipEntry(project.tracks[0]!.id, 2)])).toBe(false);
   });
 
   // ── pause() ──

--- a/src/hooks/__tests__/useTransport.test.ts
+++ b/src/hooks/__tests__/useTransport.test.ts
@@ -273,6 +273,21 @@ describe('useTransport', () => {
     expect(canUseNativeClipPlayback(project, [nativeClipEntry(project.tracks[0]!.id, 2)])).toBe(false);
   });
 
+  it('disables native clip playback for centered stereo clips', () => {
+    useProjectStore.getState().addTrack('stems');
+    const project = useProjectStore.getState().project!;
+
+    expect(canUseNativeClipPlayback(project, [nativeClipEntry(project.tracks[0]!.id, 2)])).toBe(false);
+  });
+
+  it('disables native clip playback when the native schedule exceeds Rust capacity', () => {
+    useProjectStore.getState().addTrack('stems');
+    const project = useProjectStore.getState().project!;
+    const entries = Array.from({ length: 1025 }, () => nativeClipEntry(project.tracks[0]!.id));
+
+    expect(canUseNativeClipPlayback(project, entries)).toBe(false);
+  });
+
   // ── pause() ──
 
   it('stops all engines and strudel when pausing', async () => {

--- a/src/hooks/__tests__/useTransport.test.ts
+++ b/src/hooks/__tests__/useTransport.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
     play: vi.fn(async () => {}),
     schedulePlayback: vi.fn(),
     scheduleMetronome: vi.fn(),
+    stopAllSources: vi.fn(),
     clearBufferCache: vi.fn(),
     setMasterVolume: vi.fn(),
     ensureTrackNode: vi.fn(() => ({

--- a/src/hooks/__tests__/useTransport.test.ts
+++ b/src/hooks/__tests__/useTransport.test.ts
@@ -130,7 +130,7 @@ vi.mock('../useToast', () => ({
   toastError: vi.fn(),
 }));
 
-import { useTransport } from '../useTransport';
+import { canUseNativeClipPlayback, useTransport } from '../useTransport';
 import { useProjectStore } from '../../store/projectStore';
 import { useTransportStore } from '../../store/transportStore';
 import { useUIStore } from '../../store/uiStore';
@@ -196,6 +196,23 @@ describe('useTransport', () => {
       undefined,
       { sound: 'woodblock', volume: 0.8 },
     );
+  });
+
+  it('disables native clip playback when automation lanes are active', () => {
+    const project = useProjectStore.getState().project!;
+    expect(canUseNativeClipPlayback(project, [])).toBe(true);
+
+    project.automationLanes = [{
+      id: 'automation-1',
+      trackId: 'track-1',
+      parameter: { type: 'mixer', param: 'volume' },
+      points: [
+        { time: 0, value: 0.25 },
+        { time: 1, value: 0.75 },
+      ],
+    }];
+
+    expect(canUseNativeClipPlayback(project, [])).toBe(false);
   });
 
   // ── pause() ──

--- a/src/hooks/__tests__/useTransport.test.ts
+++ b/src/hooks/__tests__/useTransport.test.ts
@@ -135,14 +135,15 @@ import { useProjectStore } from '../../store/projectStore';
 import { useTransportStore } from '../../store/transportStore';
 import { useUIStore } from '../../store/uiStore';
 
-function nativeClipEntry(trackId: string, numberOfChannels = 1) {
+function nativeClipEntry(trackId: string, numberOfChannels = 1, clipDuration = 1) {
+  const sampleRate = 48000;
   return {
     clipId: 'clip-1',
     trackId,
     startTime: 0,
     audioOffset: 0,
-    clipDuration: 1,
-    buffer: { numberOfChannels } as AudioBuffer,
+    clipDuration,
+    buffer: { length: Math.ceil(clipDuration * sampleRate), numberOfChannels, sampleRate } as AudioBuffer,
   };
 }
 
@@ -286,6 +287,13 @@ describe('useTransport', () => {
     const entries = Array.from({ length: 1025 }, () => nativeClipEntry(project.tracks[0]!.id));
 
     expect(canUseNativeClipPlayback(project, entries)).toBe(false);
+  });
+
+  it('disables native clip playback when PCM payload would be too large', () => {
+    useProjectStore.getState().addTrack('stems');
+    const project = useProjectStore.getState().project!;
+
+    expect(canUseNativeClipPlayback(project, [nativeClipEntry(project.tracks[0]!.id, 1, 180)])).toBe(false);
   });
 
   // ── pause() ──

--- a/src/hooks/__tests__/useTransport.test.ts
+++ b/src/hooks/__tests__/useTransport.test.ts
@@ -215,6 +215,30 @@ describe('useTransport', () => {
     expect(canUseNativeClipPlayback(project, [])).toBe(false);
   });
 
+  it('disables native clip playback when enabled track plugins are active', () => {
+    useProjectStore.getState().addTrack('stems');
+    const project = useProjectStore.getState().project!;
+    expect(canUseNativeClipPlayback(project, [])).toBe(true);
+
+    project.tracks[0]!.plugins = [{
+      id: 'plugin-1',
+      pluginId: 'ace-plugin',
+      enabled: true,
+      params: {},
+      manifest: {
+        id: 'ace-plugin',
+        name: 'ACE Plugin',
+        pluginType: 'effect',
+        version: '1.0.0',
+        author: 'ACE',
+        description: 'Test plugin',
+        parameters: [],
+      },
+    }];
+
+    expect(canUseNativeClipPlayback(project, [])).toBe(false);
+  });
+
   // ── pause() ──
 
   it('stops all engines and strudel when pausing', async () => {

--- a/src/hooks/__tests__/useTransport.test.ts
+++ b/src/hooks/__tests__/useTransport.test.ts
@@ -34,6 +34,10 @@ const mocks = vi.hoisted(() => ({
     setTrackMute: vi.fn(),
     setTrackSolo: vi.fn(),
   },
+  tauriClock: { owner: 'web-audio' as 'native' | 'web-audio' },
+  setTauriPlaybackClockOwner: vi.fn((owner: 'native' | 'web-audio') => {
+    mocks.tauriClock.owner = owner;
+  }),
   stopRecording: vi.fn(async () => {}),
   onLoopCycle: vi.fn(async () => {}),
   stopAllStrudelTracks: vi.fn(),
@@ -49,6 +53,8 @@ vi.mock('tone', () => ({
 }));
 vi.mock('../useAudioEngine', () => ({
   getAudioEngine: () => mocks.engine,
+  getTauriPlaybackClockOwner: () => mocks.tauriClock.owner,
+  setTauriPlaybackClockOwner: (owner: 'native' | 'web-audio') => mocks.setTauriPlaybackClockOwner(owner),
 }));
 vi.mock('../useRecording', () => ({
   useRecording: () => ({
@@ -138,6 +144,7 @@ describe('useTransport', () => {
     useProjectStore.getState().createProject({ name: 'Transport Test' });
     useUIStore.setState({ mainView: 'arrangement' });
     mocks.engine.playing = false;
+    mocks.tauriClock.owner = 'web-audio';
   });
 
   // ── play() ──

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -29,11 +29,13 @@ export function useAudioEngine() {
   useEffect(() => {
     const engine = engineRef.current;
     const bridge = getAudioBridge(engine);
-    engine.setTimeUpdateCallback((time) => {
-      useTransportStore.getState().setCurrentTime(time);
-    });
     if (bridge.backend === 'tauri') {
+      engine.setTimeUpdateCallback(() => {});
       bridge.setTimeUpdateCallback((time) => {
+        useTransportStore.getState().setCurrentTime(time);
+      });
+    } else {
+      engine.setTimeUpdateCallback((time) => {
         useTransportStore.getState().setCurrentTime(time);
       });
     }

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback } from 'react';
 import { AudioEngine } from '../engine/AudioEngine';
 import { useTransportStore } from '../store/transportStore';
 import { useProjectStore } from '../store/projectStore';
+import { getAudioBridge } from '../engine/bridge';
 
 let _engineInstance: AudioEngine | null = null;
 let _audioResumed = false;
@@ -27,12 +28,21 @@ export function useAudioEngine() {
 
   useEffect(() => {
     const engine = engineRef.current;
+    const bridge = getAudioBridge(engine);
     engine.setTimeUpdateCallback((time) => {
       useTransportStore.getState().setCurrentTime(time);
     });
+    if (bridge.backend === 'tauri') {
+      bridge.setTimeUpdateCallback((time) => {
+        useTransportStore.getState().setCurrentTime(time);
+      });
+    }
 
     return () => {
       engine.setTimeUpdateCallback(() => {});
+      if (bridge.backend === 'tauri') {
+        bridge.setTimeUpdateCallback(() => {});
+      }
     };
   }, []);
 
@@ -44,7 +54,13 @@ export function useAudioEngine() {
     // same context. The parallel `Promise.all([engine.resume(),
     // Tone.start()])` was redundant work. Verified by codex review
     // on PR #1727.
-    await engineRef.current.resume();
+    const engine = engineRef.current;
+    const bridge = getAudioBridge(engine);
+    if (bridge.backend === 'tauri') {
+      await bridge.resume();
+    } else {
+      await engine.resume();
+    }
     const latency = engineRef.current.refreshPlaybackLatencyCompensation();
     const store = (await import('../store/projectStore')).useProjectStore.getState();
     store.detectPlaybackLatency(latency);

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -6,10 +6,19 @@ import { getAudioBridge } from '../engine/bridge';
 
 let _engineInstance: AudioEngine | null = null;
 let _audioResumed = false;
+let _tauriPlaybackClockOwner: 'native' | 'web-audio' = 'web-audio';
 
 /** @internal Set audio-resumed flag — for tests only */
 export function _setAudioResumed(value: boolean) {
   _audioResumed = value;
+}
+
+export function setTauriPlaybackClockOwner(owner: 'native' | 'web-audio') {
+  _tauriPlaybackClockOwner = owner;
+}
+
+export function getTauriPlaybackClockOwner(): 'native' | 'web-audio' {
+  return _tauriPlaybackClockOwner;
 }
 
 export function getAudioEngine(): AudioEngine {
@@ -30,10 +39,12 @@ export function useAudioEngine() {
     const engine = engineRef.current;
     const bridge = getAudioBridge(engine);
     engine.setTimeUpdateCallback((time) => {
+      if (bridge.backend === 'tauri' && _tauriPlaybackClockOwner === 'native') return;
       useTransportStore.getState().setCurrentTime(time);
     });
     if (bridge.backend === 'tauri') {
       bridge.setTimeUpdateCallback((time) => {
+        if (_tauriPlaybackClockOwner !== 'native') return;
         useTransportStore.getState().setCurrentTime(time);
       });
     }

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -69,9 +69,8 @@ export function useAudioEngine() {
     const bridge = getAudioBridge(engine);
     if (bridge.backend === 'tauri') {
       await bridge.resume();
-    } else {
-      await engine.resume();
     }
+    await engine.resume();
     const latency = engineRef.current.refreshPlaybackLatencyCompensation();
     const store = (await import('../store/projectStore')).useProjectStore.getState();
     store.detectPlaybackLatency(latency);

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -29,13 +29,11 @@ export function useAudioEngine() {
   useEffect(() => {
     const engine = engineRef.current;
     const bridge = getAudioBridge(engine);
+    engine.setTimeUpdateCallback((time) => {
+      useTransportStore.getState().setCurrentTime(time);
+    });
     if (bridge.backend === 'tauri') {
-      engine.setTimeUpdateCallback(() => {});
       bridge.setTimeUpdateCallback((time) => {
-        useTransportStore.getState().setCurrentTime(time);
-      });
-    } else {
-      engine.setTimeUpdateCallback((time) => {
         useTransportStore.getState().setCurrentTime(time);
       });
     }

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -269,7 +269,6 @@ export function useTransport() {
   const { stopRecording, onLoopCycle } = useRecording();
   const mainView = useUIStore((s) => s.mainView);
   const scrubClipsRef = useRef<TimelineScrubClip[]>([]);
-  const lastEndedAtRef = useRef(0);
 
   const play = useCallback(async (fromTime?: number) => {
     const engine = getAudioEngine();
@@ -1095,9 +1094,6 @@ export function useTransport() {
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
     const onEnded = () => {
-      const now = Date.now();
-      if (now - lastEndedAtRef.current < 250) return;
-      lastEndedAtRef.current = now;
       const {
         loopEnabled,
         isRecording,
@@ -1120,7 +1116,10 @@ export function useTransport() {
         useTransportStore.getState().stop();
       }
     };
-    engine.setOnEndedCallback(onEnded);
+    engine.setOnEndedCallback(() => {
+      if (bridge.backend === 'tauri' && getTauriPlaybackClockOwner() === 'native') return;
+      onEnded();
+    });
     if (bridge.backend === 'tauri') {
       bridge.setOnEndedCallback(onEnded);
     }

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -89,6 +89,8 @@ interface NativePlaybackEntry {
   warpMarkers?: import('../types/project').AudioWarpMarker[];
 }
 
+const NATIVE_MAX_CLIPS = 1024;
+
 function hasNonZero(value: number | undefined | null): boolean {
   return typeof value === 'number' && Number.isFinite(value) && Math.abs(value) > 0.000001;
 }
@@ -125,6 +127,7 @@ function trackNeedsWebAudio(track: Track): boolean {
 }
 
 export function canUseNativeClipPlayback(project: Project, entries: NativePlaybackEntry[]): boolean {
+  if (entries.length > NATIVE_MAX_CLIPS) return false;
   if (project.mastering?.enabled) return false;
   if ((project.returnTracks?.length ?? 0) > 0) return false;
   if (project.automationLanes?.some((lane) => lane.points.length > 0)) return false;
@@ -133,7 +136,7 @@ export function canUseNativeClipPlayback(project: Project, entries: NativePlayba
   if (entries.some((entry) => {
     if (!entry.trackId || !entry.buffer) return false;
     const track = tracksById.get(entry.trackId);
-    return entry.buffer.numberOfChannels > 1 && hasNonZero(track?.pan);
+    return entry.buffer.numberOfChannels > 1 || hasNonZero(track?.pan);
   })) return false;
   return !project.tracks.some(trackNeedsWebAudio);
 }

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -112,6 +112,7 @@ function trackNeedsWebAudio(track: Track): boolean {
     || track.compressorEnabled === true
     || hasNonZero(track.reverbMix)
     || ((track.effects?.length ?? 0) > 0 && track.effectsBypassed !== true)
+    || (track.plugins?.some((plugin) => plugin.enabled !== false) ?? false)
     || (track.sends?.some((send) => send.amount > 0.000001) ?? false);
 }
 

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -514,7 +514,7 @@ export function useTransport() {
       engine.schedulePlayback([], startFrom, effectiveEnd);
     } else if (bridge.backend === 'tauri') {
       setTauriPlaybackClockOwner('web-audio');
-      bridge.stopAllSources();
+      await bridge.stopAllSources();
       engine.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
     } else {
       setTauriPlaybackClockOwner('web-audio');
@@ -897,7 +897,7 @@ export function useTransport() {
     stopAllStrudelTracks();
     engine.stop();
     setTauriPlaybackClockOwner('web-audio');
-    bridge.pauseAllSources();
+    await bridge.pauseAllSources();
     synthEngine.releaseAll();
     subtractiveEngine.releaseAll();
     wavetableEngine.releaseAll();
@@ -921,7 +921,7 @@ export function useTransport() {
     stopStrudelEditorPlayback();
     engine.stop();
     setTauriPlaybackClockOwner('web-audio');
-    bridge.stopAllSources();
+    await bridge.stopAllSources();
     synthEngine.releaseAll();
     subtractiveEngine.releaseAll();
     wavetableEngine.releaseAll();
@@ -969,7 +969,7 @@ export function useTransport() {
     if (resumePlayback) {
       engine.stop();
       setTauriPlaybackClockOwner('web-audio');
-      bridge.stopAllSources();
+      await bridge.stopAllSources();
       synthEngine.releaseAll();
       subtractiveEngine.releaseAll();
       wavetableEngine.releaseAll();
@@ -1152,10 +1152,13 @@ export function useTransport() {
         || playbackTracks.some(trackNeedsWebAudio)
       )
     ) {
+      const restartTime = useTransportStore.getState().currentTime;
       setTauriPlaybackClockOwner('web-audio');
-      bridge.stopAllSources();
       engine.stop();
-      void play(useTransportStore.getState().currentTime);
+      void (async () => {
+        await bridge.stopAllSources();
+        await play(restartTime);
+      })();
       return;
     }
     for (const track of playbackTracks) {

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -70,6 +70,53 @@ const DRUM_PAD_INDEX_BY_SAMPLE_KEY: Record<string, number> = {
   perc: 15,
 };
 
+interface NativePlaybackEntry {
+  fadeInDuration?: number;
+  fadeOutDuration?: number;
+  fadeInCurvePoint?: { x: number; y: number };
+  fadeOutCurvePoint?: { x: number; y: number };
+  timeStretchRate?: number;
+  pitchShift?: number;
+  stretchMode?: import('../types/project').StretchMode;
+  gainEnvelope?: import('../types/project').GainEnvelopePoint[];
+  warpMarkers?: import('../types/project').AudioWarpMarker[];
+}
+
+function hasNonZero(value: number | undefined | null): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && Math.abs(value) > 0.000001;
+}
+
+function clipNeedsWebAudio(entry: NativePlaybackEntry): boolean {
+  return hasNonZero(entry.fadeInDuration)
+    || hasNonZero(entry.fadeOutDuration)
+    || entry.fadeInCurvePoint !== undefined
+    || entry.fadeOutCurvePoint !== undefined
+    || (entry.timeStretchRate !== undefined && Math.abs(entry.timeStretchRate - 1) > 0.000001)
+    || hasNonZero(entry.pitchShift)
+    || entry.stretchMode !== undefined
+    || (entry.gainEnvelope?.length ?? 0) > 0
+    || (entry.warpMarkers?.length ?? 0) > 0;
+}
+
+function trackNeedsWebAudio(track: Track): boolean {
+  return track.isGroup === true
+    || track.parentTrackId !== undefined
+    || hasNonZero(track.eqLowGain)
+    || hasNonZero(track.eqMidGain)
+    || hasNonZero(track.eqHighGain)
+    || track.compressorEnabled === true
+    || hasNonZero(track.reverbMix)
+    || ((track.effects?.length ?? 0) > 0 && track.effectsBypassed !== true)
+    || (track.sends?.some((send) => send.amount > 0.000001) ?? false);
+}
+
+function canUseNativeClipPlayback(project: Project, entries: NativePlaybackEntry[]): boolean {
+  if (project.mastering?.enabled) return false;
+  if ((project.returnTracks?.length ?? 0) > 0) return false;
+  if (entries.some(clipNeedsWebAudio)) return false;
+  return !project.tracks.some(trackNeedsWebAudio);
+}
+
 /**
  * Trim an AudioBuffer to a specific project-time region.
  * The input buffer may cover the full project duration; the output covers only
@@ -168,6 +215,7 @@ export function useTransport() {
   const { stopRecording, onLoopCycle } = useRecording();
   const mainView = useUIStore((s) => s.mainView);
   const scrubClipsRef = useRef<TimelineScrubClip[]>([]);
+  const lastEndedAtRef = useRef(0);
 
   const play = useCallback(async (fromTime?: number) => {
     const engine = getAudioEngine();
@@ -401,15 +449,23 @@ export function useTransport() {
       if (lastClipEnd > 0) effectiveEnd = lastClipEnd;
     }
 
-    // Playback reads from stretchedBufferCache (populated on clip stretch mouseup).
-    // If Signalsmith/Rubber Band already finished → high quality buffer used.
-    // If neither finished yet → legacy fallback via _getProcessedBuffer.
-    bridge.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
-    if (bridge.backend === 'tauri') {
+    const useNativeClipPlayback = bridge.backend === 'tauri'
+      && canUseNativeClipPlayback(nextProject, clipBuffers);
+
+    if (useNativeClipPlayback) {
+      bridge.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
       // The native backend owns audio clip playback, but MIDI, synth,
       // sequencer, automation, and Strudel still use AudioEngine's
       // RAF clock until the Rust engine reaches full feature parity.
       engine.schedulePlayback([], startFrom, effectiveEnd);
+    } else if (bridge.backend === 'tauri') {
+      bridge.stopAllSources();
+      engine.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
+    } else {
+      // Playback reads from stretchedBufferCache (populated on clip stretch mouseup).
+      // If Signalsmith/Rubber Band already finished → high quality buffer used.
+      // If neither finished yet → legacy fallback via _getProcessedBuffer.
+      bridge.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
     }
 
     const { metronomeEnabled, metronomeSound, metronomeVolume } = useTransportStore.getState();
@@ -978,6 +1034,9 @@ export function useTransport() {
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
     const onEnded = () => {
+      const now = Date.now();
+      if (now - lastEndedAtRef.current < 250) return;
+      lastEndedAtRef.current = now;
       const {
         loopEnabled,
         isRecording,
@@ -1000,11 +1059,9 @@ export function useTransport() {
         useTransportStore.getState().stop();
       }
     };
+    engine.setOnEndedCallback(onEnded);
     if (bridge.backend === 'tauri') {
-      engine.setOnEndedCallback(() => {});
       bridge.setOnEndedCallback(onEnded);
-    } else {
-      engine.setOnEndedCallback(onEnded);
     }
     return () => {
       engine.setOnEndedCallback(() => {});

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -1142,6 +1142,22 @@ export function useTransport() {
     engine.masterVolume = masterVolume;
     engine.setPlaybackLatencyCompensation(getPlaybackLatencyCompensationSeconds(playbackLatency));
     engine.applyMastering(mastering);
+    if (
+      bridge.backend === 'tauri'
+      && getTauriPlaybackClockOwner() === 'native'
+      && (
+        mastering?.enabled
+        || (playbackReturnTracks?.length ?? 0) > 0
+        || (useProjectStore.getState().project?.automationLanes?.some((lane) => lane.points.length > 0) ?? false)
+        || playbackTracks.some(trackNeedsWebAudio)
+      )
+    ) {
+      setTauriPlaybackClockOwner('web-audio');
+      bridge.stopAllSources();
+      engine.stop();
+      void play(useTransportStore.getState().currentTime);
+      return;
+    }
     for (const track of playbackTracks) {
       bridge.ensureTrack(track.id);
       bridge.setTrackParams(track.id, {
@@ -1185,7 +1201,7 @@ export function useTransport() {
     if (playbackTracks) {
       engine.syncSends(playbackTracks, playbackReturnTracks ?? []);
     }
-  }, [isPlaying, masterVolume, mastering, playbackLatency, playbackTracks, playbackReturnTracks]);
+  }, [isPlaying, masterVolume, mastering, play, playbackLatency, playbackTracks, playbackReturnTracks]);
 
   return {
     isPlaying,

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -3,6 +3,7 @@ import { useTransportStore } from '../store/transportStore';
 import { useProjectStore } from '../store/projectStore';
 import { useUIStore } from '../store/uiStore';
 import { getAudioEngine } from './useAudioEngine';
+import { getAudioBridge } from '../engine/bridge';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { synthEngine } from '../engine/SynthEngine';
 import { subtractiveEngine } from '../engine/SubtractiveEngine';
@@ -170,9 +171,14 @@ export function useTransport() {
 
   const play = useCallback(async (fromTime?: number) => {
     const engine = getAudioEngine();
+    const bridge = getAudioBridge(engine);
     stopStrudelEditorPlayback();
     stopAllStrudelTracks();
-    await engine.resume();
+    if (bridge.backend === 'tauri') {
+      await bridge.resume();
+    } else {
+      await engine.resume();
+    }
     await synthEngine.ensureStarted();
     await subtractiveEngine.ensureStarted();
     await samplerEngine.ensureStarted();
@@ -190,9 +196,13 @@ export function useTransport() {
     // Sync master volume
     const nextProject = useProjectStore.getState().project;
     if (!nextProject) return;
+    const playbackLatencySeconds = getPlaybackLatencyCompensationSeconds(nextProject.playbackLatency);
     engine.masterVolume = nextProject.masterVolume ?? 1.0;
-    engine.setPlaybackLatencyCompensation(getPlaybackLatencyCompensationSeconds(nextProject.playbackLatency));
+    engine.setPlaybackLatencyCompensation(playbackLatencySeconds);
     engine.applyMastering(nextProject.mastering);
+    bridge.setMasterVolume(nextProject.masterVolume ?? 1.0);
+    bridge.setPlaybackLatencyCompensation(playbackLatencySeconds);
+    bridge.applyMastering(nextProject.mastering);
 
     interface ScheduleEntry {
       clipId: string;
@@ -220,8 +230,24 @@ export function useTransport() {
     // First pass: create all TrackNodes (groups first so children can route to them)
     for (const track of proj.tracks.filter((t) => t.isGroup)) {
       engine.getOrCreateTrackNode(track.id);
+      bridge.ensureTrack(track.id);
     }
     for (const track of proj.tracks) {
+      bridge.ensureTrack(track.id);
+      bridge.setTrackParams(track.id, {
+        volume: track.volume,
+        muted: track.muted,
+        soloed: track.soloed,
+        pan: track.pan ?? 0,
+        eqLowGain: track.eqLowGain ?? 0,
+        eqMidGain: track.eqMidGain ?? 0,
+        eqHighGain: track.eqHighGain ?? 0,
+        compressorEnabled: track.compressorEnabled ?? false,
+        compressorThreshold: track.compressorThreshold ?? -24,
+        compressorRatio: track.compressorRatio ?? 4,
+        reverbMix: track.reverbMix ?? 0,
+        reverbRoomSize: track.reverbRoomSize ?? 0.5,
+      });
       const trackNode = engine.getOrCreateTrackNode(track.id);
       trackNode.volume = track.volume;
       trackNode.muted = track.muted;
@@ -238,12 +264,13 @@ export function useTransport() {
       trackNode.setReverb(track.reverbMix ?? 0, track.reverbRoomSize ?? 0.5);
       // Route child tracks through their parent group bus
       engine.setTrackGroupRouting(track.id, track.parentTrackId ?? null);
+      bridge.setTrackGroupRouting(track.id, track.parentTrackId ?? null);
 
       // Frozen track: play frozen bounce instead of individual clips/MIDI
       if (track.frozen && track.frozenAudioKey && mainView !== 'session') {
         const frozenBlob = await loadAudioBlobByKey(track.frozenAudioKey);
         if (frozenBlob) {
-          const frozenBuffer = await engine.decodeAudioData(frozenBlob);
+          const frozenBuffer = await bridge.decodeAudioData(frozenBlob);
           clipBuffers.push({
             clipId: `frozen-${track.id}`,
             trackId: track.id,
@@ -280,7 +307,7 @@ export function useTransport() {
         }
         if (!blob) continue;
 
-        const rawBuffer = await engine.decodeAudioData(blob);
+        const rawBuffer = await bridge.decodeAudioData(blob);
         const buffer = alreadyTrimmed
           ? rawBuffer
           : trimBuffer(engine.ctx, rawBuffer, audibleStartTime, audibleDuration);
@@ -351,6 +378,7 @@ export function useTransport() {
     }
 
     engine.updateSoloState();
+    bridge.updateSoloState();
 
     // Wire aux sends to return tracks
     engine.syncSends(proj.tracks, proj.returnTracks ?? []);
@@ -377,7 +405,7 @@ export function useTransport() {
     // Playback reads from stretchedBufferCache (populated on clip stretch mouseup).
     // If Signalsmith/Rubber Band already finished → high quality buffer used.
     // If neither finished yet → legacy fallback via _getProcessedBuffer.
-    engine.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
+    bridge.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
 
     const { metronomeEnabled, metronomeSound, metronomeVolume } = useTransportStore.getState();
     if (metronomeEnabled) {
@@ -745,11 +773,13 @@ export function useTransport() {
       await stopRecording();
     }
     const engine = getAudioEngine();
-    const time = engine.getCurrentTime();
+    const bridge = getAudioBridge(engine);
+    const time = bridge.getCurrentTime();
     finalizeSessionArrangementRecording(time);
     stopStrudelEditorPlayback();
     stopAllStrudelTracks();
     engine.stop();
+    bridge.pauseAllSources();
     synthEngine.releaseAll();
     subtractiveEngine.releaseAll();
     wavetableEngine.releaseAll();
@@ -767,10 +797,14 @@ export function useTransport() {
       await stopRecording();
     }
     const engine = getAudioEngine();
-    const time = engine.playing ? engine.getCurrentTime() : useTransportStore.getState().currentTime;
+    const bridge = getAudioBridge(engine);
+    const time = engine.playing || bridge.backend === 'tauri'
+      ? bridge.getCurrentTime()
+      : useTransportStore.getState().currentTime;
     finalizeSessionArrangementRecording(time);
     stopStrudelEditorPlayback();
     engine.stop();
+    bridge.stopAllSources();
     synthEngine.releaseAll();
     subtractiveEngine.releaseAll();
     wavetableEngine.releaseAll();
@@ -784,10 +818,12 @@ export function useTransport() {
 
   const seek = useCallback((time: number) => {
     const engine = getAudioEngine();
+    const bridge = getAudioBridge(engine);
     stopStrudelEditorPlayback();
     stopAllStrudelTracks();
-    if (engine.playing) {
+    if (engine.playing || (bridge.backend === 'tauri' && useTransportStore.getState().isPlaying)) {
       engine.stop();
+      bridge.stopAllSources();
       synthEngine.releaseAll();
       subtractiveEngine.releaseAll();
       wavetableEngine.releaseAll();
@@ -935,7 +971,8 @@ export function useTransport() {
   // Register the onEnded callback — respect loopEnabled
   useEffect(() => {
     const engine = getAudioEngine();
-    engine.setOnEndedCallback(() => {
+    const bridge = getAudioBridge(engine);
+    const onEnded = () => {
       const {
         loopEnabled,
         isRecording,
@@ -957,9 +994,16 @@ export function useTransport() {
       } else {
         useTransportStore.getState().stop();
       }
-    });
+    };
+    engine.setOnEndedCallback(onEnded);
+    if (bridge.backend === 'tauri') {
+      bridge.setOnEndedCallback(onEnded);
+    }
     return () => {
       engine.setOnEndedCallback(() => {});
+      if (bridge.backend === 'tauri') {
+        bridge.setOnEndedCallback(() => {});
+      }
     };
   }, [play, onLoopCycle]);
 

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -1018,10 +1018,30 @@ export function useTransport() {
   useEffect(() => {
     if (!playbackTracks || !isPlaying) return;
     const engine = getAudioEngine();
+    const bridge = getAudioBridge(engine);
+    bridge.setMasterVolume(masterVolume);
+    bridge.setPlaybackLatencyCompensation(getPlaybackLatencyCompensationSeconds(playbackLatency));
+    bridge.applyMastering(mastering);
     engine.masterVolume = masterVolume;
     engine.setPlaybackLatencyCompensation(getPlaybackLatencyCompensationSeconds(playbackLatency));
     engine.applyMastering(mastering);
     for (const track of playbackTracks) {
+      bridge.ensureTrack(track.id);
+      bridge.setTrackParams(track.id, {
+        volume: track.volume,
+        muted: track.muted,
+        soloed: track.soloed,
+        pan: track.pan ?? 0,
+        eqLowGain: track.eqLowGain ?? 0,
+        eqMidGain: track.eqMidGain ?? 0,
+        eqHighGain: track.eqHighGain ?? 0,
+        compressorEnabled: track.compressorEnabled ?? false,
+        compressorThreshold: track.compressorThreshold ?? -24,
+        compressorRatio: track.compressorRatio ?? 4,
+        reverbMix: track.reverbMix ?? 0,
+        reverbRoomSize: track.reverbRoomSize ?? 0.5,
+      });
+      bridge.setTrackGroupRouting(track.id, track.parentTrackId ?? null);
       const trackNode = engine.trackNodes.get(track.id);
       if (trackNode) {
         trackNode.volume = track.volume;
@@ -1042,6 +1062,7 @@ export function useTransport() {
       }
     }
     engine.updateSoloState();
+    bridge.updateSoloState();
 
     // Sync aux send routing (handles amount, pre/post, and return track params)
     if (playbackTracks) {

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -933,7 +933,7 @@ export function useTransport() {
     useTransportStore.getState().stop();
   }, [finalizeSessionArrangementRecording, isRecording, stopRecording]);
 
-  const seek = useCallback((time: number) => {
+  const seek = useCallback(async (time: number) => {
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
     stopStrudelEditorPlayback();
@@ -941,7 +941,7 @@ export function useTransport() {
     if (engine.playing || (bridge.backend === 'tauri' && useTransportStore.getState().isPlaying)) {
       engine.stop();
       setTauriPlaybackClockOwner('web-audio');
-      bridge.stopAllSources();
+      await bridge.stopAllSources();
       synthEngine.releaseAll();
       subtractiveEngine.releaseAll();
       wavetableEngine.releaseAll();
@@ -949,7 +949,7 @@ export function useTransport() {
       granularEngine.releaseAll();
       modulationEngine.releaseAll();
       useTransportStore.getState().seek(time);
-      play(time);
+      await play(time);
     } else {
       useTransportStore.getState().seek(time);
     }

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -176,9 +176,8 @@ export function useTransport() {
     stopAllStrudelTracks();
     if (bridge.backend === 'tauri') {
       await bridge.resume();
-    } else {
-      await engine.resume();
     }
+    await engine.resume();
     await synthEngine.ensureStarted();
     await subtractiveEngine.ensureStarted();
     await samplerEngine.ensureStarted();
@@ -406,6 +405,12 @@ export function useTransport() {
     // If Signalsmith/Rubber Band already finished → high quality buffer used.
     // If neither finished yet → legacy fallback via _getProcessedBuffer.
     bridge.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
+    if (bridge.backend === 'tauri') {
+      // The native backend owns audio clip playback, but MIDI, synth,
+      // sequencer, automation, and Strudel still use AudioEngine's
+      // RAF clock until the Rust engine reaches full feature parity.
+      engine.schedulePlayback([], startFrom, effectiveEnd);
+    }
 
     const { metronomeEnabled, metronomeSound, metronomeVolume } = useTransportStore.getState();
     if (metronomeEnabled) {
@@ -995,9 +1000,11 @@ export function useTransport() {
         useTransportStore.getState().stop();
       }
     };
-    engine.setOnEndedCallback(onEnded);
     if (bridge.backend === 'tauri') {
+      engine.setOnEndedCallback(() => {});
       bridge.setOnEndedCallback(onEnded);
+    } else {
+      engine.setOnEndedCallback(onEnded);
     }
     return () => {
       engine.setOnEndedCallback(() => {});

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -76,6 +76,8 @@ const DRUM_PAD_INDEX_BY_SAMPLE_KEY: Record<string, number> = {
 };
 
 interface NativePlaybackEntry {
+  trackId?: string;
+  buffer?: Pick<AudioBuffer, 'numberOfChannels'>;
   fadeInDuration?: number;
   fadeOutDuration?: number;
   fadeInCurvePoint?: { x: number; y: number };
@@ -104,8 +106,14 @@ function clipNeedsWebAudio(entry: NativePlaybackEntry): boolean {
 }
 
 function trackNeedsWebAudio(track: Track): boolean {
-  return track.isGroup === true
+  const trackType = track.trackType ?? 'stems';
+  return !['stems', 'sample', 'mix'].includes(trackType)
+    || track.isGroup === true
     || track.parentTrackId !== undefined
+    || (typeof track.volume === 'number' && track.volume > 1.000001)
+    || track.panMode === 'dual-mono'
+    || hasNonZero(track.panLeft)
+    || hasNonZero(track.panRight)
     || hasNonZero(track.eqLowGain)
     || hasNonZero(track.eqMidGain)
     || hasNonZero(track.eqHighGain)
@@ -121,6 +129,12 @@ export function canUseNativeClipPlayback(project: Project, entries: NativePlayba
   if ((project.returnTracks?.length ?? 0) > 0) return false;
   if (project.automationLanes?.some((lane) => lane.points.length > 0)) return false;
   if (entries.some(clipNeedsWebAudio)) return false;
+  const tracksById = new Map(project.tracks.map((track) => [track.id, track]));
+  if (entries.some((entry) => {
+    if (!entry.trackId || !entry.buffer) return false;
+    const track = tracksById.get(entry.trackId);
+    return entry.buffer.numberOfChannels > 1 && hasNonZero(track?.pan);
+  })) return false;
   return !project.tracks.some(trackNeedsWebAudio);
 }
 

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -491,7 +491,7 @@ export function useTransport() {
 
     if (useNativeClipPlayback) {
       setTauriPlaybackClockOwner('native');
-      bridge.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
+      await bridge.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
       // The native backend owns audio clip playback, but MIDI, synth,
       // sequencer, automation, and Strudel still use AudioEngine's
       // RAF clock until the Rust engine reaches full feature parity.

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -77,7 +77,9 @@ const DRUM_PAD_INDEX_BY_SAMPLE_KEY: Record<string, number> = {
 
 interface NativePlaybackEntry {
   trackId?: string;
-  buffer?: Pick<AudioBuffer, 'numberOfChannels'>;
+  buffer?: Pick<AudioBuffer, 'length' | 'numberOfChannels' | 'sampleRate'>;
+  audioOffset?: number;
+  clipDuration?: number;
   fadeInDuration?: number;
   fadeOutDuration?: number;
   fadeInCurvePoint?: { x: number; y: number };
@@ -90,6 +92,7 @@ interface NativePlaybackEntry {
 }
 
 const NATIVE_MAX_CLIPS = 1024;
+const NATIVE_MAX_PCM_FRAMES = 48000 * 10;
 
 function hasNonZero(value: number | undefined | null): boolean {
   return typeof value === 'number' && Number.isFinite(value) && Math.abs(value) > 0.000001;
@@ -105,6 +108,18 @@ function clipNeedsWebAudio(entry: NativePlaybackEntry): boolean {
     || entry.stretchMode !== undefined
     || (entry.gainEnvelope?.length ?? 0) > 0
     || (entry.warpMarkers?.length ?? 0) > 0;
+}
+
+function getNativePcmFrameCount(entry: NativePlaybackEntry): number {
+  if (!entry.buffer) return 0;
+  const sourceRate = entry.buffer.sampleRate || 48000;
+  const sourceStart = Math.max(0, Math.round((entry.audioOffset ?? 0) * sourceRate));
+  const availableFrames = Math.max(0, entry.buffer.length - sourceStart);
+  const sourceDuration = Math.min(
+    Math.max(0, entry.clipDuration ?? availableFrames / sourceRate),
+    availableFrames / sourceRate,
+  );
+  return Math.max(0, Math.round(sourceDuration * 48000));
 }
 
 function trackNeedsWebAudio(track: Track): boolean {
@@ -128,6 +143,8 @@ function trackNeedsWebAudio(track: Track): boolean {
 
 export function canUseNativeClipPlayback(project: Project, entries: NativePlaybackEntry[]): boolean {
   if (entries.length > NATIVE_MAX_CLIPS) return false;
+  const totalNativeFrames = entries.reduce((sum, entry) => sum + getNativePcmFrameCount(entry), 0);
+  if (totalNativeFrames > NATIVE_MAX_PCM_FRAMES) return false;
   if (project.mastering?.enabled) return false;
   if ((project.returnTracks?.length ?? 0) > 0) return false;
   if (project.automationLanes?.some((lane) => lane.points.length > 0)) return false;

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -115,9 +115,10 @@ function trackNeedsWebAudio(track: Track): boolean {
     || (track.sends?.some((send) => send.amount > 0.000001) ?? false);
 }
 
-function canUseNativeClipPlayback(project: Project, entries: NativePlaybackEntry[]): boolean {
+export function canUseNativeClipPlayback(project: Project, entries: NativePlaybackEntry[]): boolean {
   if (project.mastering?.enabled) return false;
   if ((project.returnTracks?.length ?? 0) > 0) return false;
+  if (project.automationLanes?.some((lane) => lane.points.length > 0)) return false;
   if (entries.some(clipNeedsWebAudio)) return false;
   return !project.tracks.some(trackNeedsWebAudio);
 }
@@ -922,6 +923,7 @@ export function useTransport() {
 
   const startScrub = useCallback(async (time: number) => {
     const engine = getAudioEngine();
+    const bridge = getAudioBridge(engine);
     const transport = useTransportStore.getState();
     const scrubProject = useProjectStore.getState().project;
     if (!scrubProject) return;
@@ -932,6 +934,8 @@ export function useTransport() {
     const resumePlayback = transport.isPlaying || engine.playing;
     if (resumePlayback) {
       engine.stop();
+      setTauriPlaybackClockOwner('web-audio');
+      bridge.stopAllSources();
       synthEngine.releaseAll();
       subtractiveEngine.releaseAll();
       wavetableEngine.releaseAll();

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -2,8 +2,13 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useTransportStore } from '../store/transportStore';
 import { useProjectStore } from '../store/projectStore';
 import { useUIStore } from '../store/uiStore';
-import { getAudioEngine } from './useAudioEngine';
+import {
+  getAudioEngine,
+  getTauriPlaybackClockOwner,
+  setTauriPlaybackClockOwner,
+} from './useAudioEngine';
 import { getAudioBridge } from '../engine/bridge';
+import type { AudioBridge } from '../engine/bridge/types';
 import { loadAudioBlobByKey } from '../services/audioFileManager';
 import { synthEngine } from '../engine/SynthEngine';
 import { subtractiveEngine } from '../engine/SubtractiveEngine';
@@ -115,6 +120,19 @@ function canUseNativeClipPlayback(project: Project, entries: NativePlaybackEntry
   if ((project.returnTracks?.length ?? 0) > 0) return false;
   if (entries.some(clipNeedsWebAudio)) return false;
   return !project.tracks.some(trackNeedsWebAudio);
+}
+
+function getActivePlaybackTime(
+  engine: ReturnType<typeof getAudioEngine>,
+  bridge: AudioBridge,
+): number {
+  if (!useTransportStore.getState().isPlaying) {
+    return useTransportStore.getState().currentTime;
+  }
+  if (bridge.backend === 'tauri' && getTauriPlaybackClockOwner() === 'native') {
+    return bridge.getCurrentTime();
+  }
+  return engine.getCurrentTime();
 }
 
 /**
@@ -453,15 +471,18 @@ export function useTransport() {
       && canUseNativeClipPlayback(nextProject, clipBuffers);
 
     if (useNativeClipPlayback) {
+      setTauriPlaybackClockOwner('native');
       bridge.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
       // The native backend owns audio clip playback, but MIDI, synth,
       // sequencer, automation, and Strudel still use AudioEngine's
       // RAF clock until the Rust engine reaches full feature parity.
       engine.schedulePlayback([], startFrom, effectiveEnd);
     } else if (bridge.backend === 'tauri') {
+      setTauriPlaybackClockOwner('web-audio');
       bridge.stopAllSources();
       engine.schedulePlayback(clipBuffers, startFrom, effectiveEnd);
     } else {
+      setTauriPlaybackClockOwner('web-audio');
       // Playback reads from stretchedBufferCache (populated on clip stretch mouseup).
       // If Signalsmith/Rubber Band already finished → high quality buffer used.
       // If neither finished yet → legacy fallback via _getProcessedBuffer.
@@ -835,11 +856,12 @@ export function useTransport() {
     }
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
-    const time = bridge.getCurrentTime();
+    const time = getActivePlaybackTime(engine, bridge);
     finalizeSessionArrangementRecording(time);
     stopStrudelEditorPlayback();
     stopAllStrudelTracks();
     engine.stop();
+    setTauriPlaybackClockOwner('web-audio');
     bridge.pauseAllSources();
     synthEngine.releaseAll();
     subtractiveEngine.releaseAll();
@@ -859,12 +881,11 @@ export function useTransport() {
     }
     const engine = getAudioEngine();
     const bridge = getAudioBridge(engine);
-    const time = engine.playing || bridge.backend === 'tauri'
-      ? bridge.getCurrentTime()
-      : useTransportStore.getState().currentTime;
+    const time = getActivePlaybackTime(engine, bridge);
     finalizeSessionArrangementRecording(time);
     stopStrudelEditorPlayback();
     engine.stop();
+    setTauriPlaybackClockOwner('web-audio');
     bridge.stopAllSources();
     synthEngine.releaseAll();
     subtractiveEngine.releaseAll();
@@ -884,6 +905,7 @@ export function useTransport() {
     stopAllStrudelTracks();
     if (engine.playing || (bridge.backend === 'tauri' && useTransportStore.getState().isPlaying)) {
       engine.stop();
+      setTauriPlaybackClockOwner('web-audio');
       bridge.stopAllSources();
       synthEngine.releaseAll();
       subtractiveEngine.releaseAll();

--- a/src/utils/__tests__/tauri.test.ts
+++ b/src/utils/__tests__/tauri.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { isTauri, invokeTauri } from '../tauri';
+import { isTauri, isTauriAudioBackendEnabled, invokeTauri } from '../tauri';
 
 describe('tauri bridge utilities', () => {
   afterEach(() => {
@@ -7,6 +7,7 @@ describe('tauri bridge utilities', () => {
       delete (window as Record<string, unknown>).__TAURI__;
       delete (window as Record<string, unknown>).__TAURI_INTERNALS__;
     }
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -23,6 +24,27 @@ describe('tauri bridge utilities', () => {
     it('returns true when __TAURI_INTERNALS__ is on window (v2)', () => {
       (window as Record<string, unknown>).__TAURI_INTERNALS__ = {};
       expect(isTauri()).toBe(true);
+    });
+  });
+
+  describe('isTauriAudioBackendEnabled', () => {
+    it('returns false outside Tauri even when the native backend gate is enabled', () => {
+      vi.stubEnv('VITE_ENABLE_TAURI_AUDIO_BACKEND', 'true');
+
+      expect(isTauriAudioBackendEnabled()).toBe(false);
+    });
+
+    it('returns false inside Tauri when the native backend gate is disabled', () => {
+      (window as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+
+      expect(isTauriAudioBackendEnabled()).toBe(false);
+    });
+
+    it('returns true only inside Tauri with the native backend gate enabled', () => {
+      (window as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+      vi.stubEnv('VITE_ENABLE_TAURI_AUDIO_BACKEND', 'true');
+
+      expect(isTauriAudioBackendEnabled()).toBe(true);
     });
   });
 

--- a/src/utils/tauri.ts
+++ b/src/utils/tauri.ts
@@ -13,6 +13,11 @@ export function isTauri(): boolean {
   return '__TAURI_INTERNALS__' in window || '__TAURI__' in window;
 }
 
+/** Returns true when desktop should use the native Rust audio backend. */
+export function isTauriAudioBackendEnabled(): boolean {
+  return isTauri() && import.meta.env.VITE_ENABLE_TAURI_AUDIO_BACKEND === 'true';
+}
+
 /** Invoke a Tauri command (no-op stub when running in browser). */
 export async function invokeTauri<T = unknown>(
   cmd: string,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_SOURCE_CODE_URL?: string;
   readonly VITE_LICENSE_URL?: string;
   readonly VITE_COPYRIGHT_NOTICE?: string;
+  readonly VITE_ENABLE_TAURI_AUDIO_BACKEND?: string;
 }
 
 interface ImportMeta {

--- a/tests/unit/levelMeter.test.tsx
+++ b/tests/unit/levelMeter.test.tsx
@@ -2,30 +2,71 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LevelMeter } from '../../src/components/mixer/LevelMeter';
 
-const engine = {
-  getTrackMeter: vi.fn(),
-  getMasterMeter: vi.fn(),
-  resetTrackClip: vi.fn(),
-  resetMasterClip: vi.fn(),
-  getTrackLevel: vi.fn(),
-  getMasterLevel: vi.fn(),
-};
+const mocks = vi.hoisted(() => ({
+  owner: 'web-audio' as 'native' | 'web-audio',
+  engine: {
+    getTrackMeter: vi.fn(),
+    getMasterMeter: vi.fn(),
+    resetTrackClip: vi.fn(),
+    resetMasterClip: vi.fn(),
+    getTrackLevel: vi.fn(),
+    getMasterLevel: vi.fn(),
+  },
+  bridge: {
+    backend: 'tauri' as const,
+    getTrackMeter: vi.fn(),
+    getMasterMeter: vi.fn(),
+    resetTrackClip: vi.fn(),
+    resetMasterClip: vi.fn(),
+  },
+}));
 
 vi.mock('../../src/hooks/useAudioEngine', () => ({
-  getAudioEngine: () => engine,
+  getAudioEngine: () => mocks.engine,
+  getTauriPlaybackClockOwner: () => mocks.owner,
+}));
+
+vi.mock('../../src/engine/bridge', () => ({
+  getAudioBridge: () => mocks.bridge,
 }));
 
 describe('LevelMeter', () => {
-  beforeEach(() => {
-    engine.getTrackMeter.mockReset();
-    engine.getMasterMeter.mockReset();
-    engine.resetTrackClip.mockReset();
-    engine.resetMasterClip.mockReset();
-    engine.getTrackLevel.mockReset();
-    engine.getMasterLevel.mockReset();
+  let rafCallbacks: Array<FrameRequestCallback>;
 
-    engine.getTrackMeter.mockReturnValue({ level: 0.5, leftLevel: 0.4, rightLevel: 0.6, clipped: false });
-    engine.getMasterMeter.mockReturnValue({ level: 0.3, clipped: false });
+  beforeEach(() => {
+    mocks.owner = 'web-audio';
+    rafCallbacks = [];
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => ({
+      createLinearGradient: () => ({ addColorStop: vi.fn() }),
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      save: vi.fn(),
+      beginPath: vi.fn(),
+      rect: vi.fn(),
+      clip: vi.fn(),
+      restore: vi.fn(),
+    }) as unknown as CanvasRenderingContext2D);
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    mocks.engine.getTrackMeter.mockReset();
+    mocks.engine.getMasterMeter.mockReset();
+    mocks.engine.resetTrackClip.mockReset();
+    mocks.engine.resetMasterClip.mockReset();
+    mocks.engine.getTrackLevel.mockReset();
+    mocks.engine.getMasterLevel.mockReset();
+    mocks.bridge.getTrackMeter.mockReset();
+    mocks.bridge.getMasterMeter.mockReset();
+    mocks.bridge.resetTrackClip.mockReset();
+    mocks.bridge.resetMasterClip.mockReset();
+
+    mocks.engine.getTrackMeter.mockReturnValue({ level: 0.5, leftLevel: 0.4, rightLevel: 0.6, clipped: false });
+    mocks.engine.getMasterMeter.mockReturnValue({ level: 0.3, clipped: false });
+    mocks.bridge.getTrackMeter.mockReturnValue({ level: 0.9, leftLevel: 0.8, rightLevel: 0.9, clipped: false });
+    mocks.bridge.getMasterMeter.mockReturnValue({ level: 0.7, clipped: false });
   });
 
   afterEach(() => {
@@ -57,5 +98,33 @@ describe('LevelMeter', () => {
     const container = screen.getByTestId('level-meter');
     // Stereo: BAR_WIDTH(4)*2 + BAR_GAP(1) + 6 = 15px
     expect(container.style.width).toBe('15px');
+  });
+
+  it('reads WebAudio meters when Tauri playback falls back to WebAudio', () => {
+    render(<LevelMeter trackId="track-1" />);
+    rafCallbacks.shift()?.(performance.now());
+
+    expect(mocks.engine.getTrackMeter).toHaveBeenCalledWith('track-1');
+    expect(mocks.bridge.getTrackMeter).not.toHaveBeenCalled();
+  });
+
+  it('reads native bridge meters when native playback owns the clock', () => {
+    mocks.owner = 'native';
+
+    render(<LevelMeter trackId="track-1" />);
+    rafCallbacks.shift()?.(performance.now());
+
+    expect(mocks.bridge.getTrackMeter).toHaveBeenCalledWith('track-1');
+    expect(mocks.engine.getTrackMeter).not.toHaveBeenCalled();
+  });
+
+  it('resets clip state on the active meter source', () => {
+    mocks.owner = 'native';
+
+    render(<LevelMeter trackId="track-1" />);
+    fireEvent.click(screen.getByTitle('Reset clip indicator'));
+
+    expect(mocks.bridge.resetTrackClip).toHaveBeenCalledWith('track-1');
+    expect(mocks.engine.resetTrackClip).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/useTransportScrubLifecycle.test.tsx
+++ b/tests/unit/useTransportScrubLifecycle.test.tsx
@@ -42,6 +42,8 @@ const engineMock = {
 
 vi.mock('../../src/hooks/useAudioEngine', () => ({
   getAudioEngine: () => engineMock,
+  getTauriPlaybackClockOwner: () => 'web-audio',
+  setTauriPlaybackClockOwner: vi.fn(),
 }));
 
 vi.mock('../../src/engine/SynthEngine', () => ({

--- a/tests/unit/useTransportScrubLifecycle.test.tsx
+++ b/tests/unit/useTransportScrubLifecycle.test.tsx
@@ -16,6 +16,7 @@ const engineMock = {
   startTimelineScrub: vi.fn().mockResolvedValue(undefined),
   updateTimelineScrub: vi.fn().mockResolvedValue(undefined),
   stopTimelineScrub: vi.fn(),
+  stopAllSources: vi.fn(),
   stop: vi.fn(),
   getCurrentTime: vi.fn(() => 6.5),
   setOnEndedCallback: vi.fn(),
@@ -133,6 +134,7 @@ describe('useTransport scrub lifecycle', () => {
     });
 
     expect(engineMock.stop).toHaveBeenCalledTimes(1);
+    expect(engineMock.stopAllSources).toHaveBeenCalledTimes(1);
     expect(useTransportStore.getState().isPlaying).toBe(false);
     expect(useTransportStore.getState().isScrubbing).toBe(true);
     expect(engineMock.startTimelineScrub).toHaveBeenCalledWith(expect.any(Array), expect.any(Array), 4, 0);


### PR DESCRIPTION
## Summary

Closes #1780.

This hotfix makes the native Rust/Tauri audio backend product-activatable behind an explicit desktop-only gate while preserving the existing WebAudio default path.

- Adds `VITE_ENABLE_TAURI_AUDIO_BACKEND=true` as the activation gate, only effective inside Tauri.
- Routes shared transport/clip playback through the AudioBridge singleton so desktop builds can select `TauriBackend`.
- Wires Tauri backend transport position events, play/pause/stop/seek scheduling, native meters, track params, master volume, and fallback webview decode into native clip scheduling.
- Preserves existing WebAudio clip features when routed through the bridge.
- Adds command ordering guards so stale async native play chains cannot resurrect playback after stop/pause/seek.
- Adds native meter Tauri commands and registers them in the app shell.

## Verification

- `npx tsc --noEmit --pretty false`
- `npx vitest run src/engine/bridge/__tests__ src/utils/__tests__/tauri.test.ts src/hooks/__tests__/useAudioEngine.test.ts src/hooks/__tests__/useTransport.test.ts src/hooks/__tests__/useTransport.strudel.test.ts`
- `npm test -- src/engine/bridge/__tests__ src/utils/__tests__/tauri.test.ts`
- `npm run test:coverage` — 740 files passed, 8731 tests passed, 3 skipped, 10 todo
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- Independent agent review after fixes: no blockers

## Notes

The native path remains explicitly gated because full Rust parity is still in progress. Current native clip scheduling applies initial track volume/pan/mute/solo and supports transport/meter integration, but true Rust-native decode and advanced WebAudio-only clip processing such as fades, envelopes, warp markers, pitch shift, and stretch modes should continue as follow-up native-engine work.
